### PR TITLE
Tweak styles

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -64,6 +64,10 @@
     @apply border-border;
   }
 
+  html {
+    scrollbar-gutter: stable;
+  }
+
   body {
     @apply bg-background text-foreground;
     /* font-feature-settings: "rlig" 1, "calt" 1; */

--- a/src/lib/components/ui/button/index.ts
+++ b/src/lib/components/ui/button/index.ts
@@ -3,7 +3,7 @@ import { type VariantProps, tv } from 'tailwind-variants';
 import type { Button as ButtonPrimitive } from 'bits-ui';
 
 const buttonVariants = tv({
-  base: 'focus-visible:ring-ring inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50',
+  base: 'focus-visible:ring-ring inline-flex gap-2 items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50',
   variants: {
     variant: {
       default: 'bg-primary text-primary-foreground hover:bg-primary/90 shadow',

--- a/src/lib/components/ui/label/label.svelte
+++ b/src/lib/components/ui/label/label.svelte
@@ -9,7 +9,7 @@ export { className as class };
 </script>
 
 <LabelPrimitive.Root
-  class={cn('text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70', className)}
+  class={cn('block mb-1.5 text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70', className)}
   {...$$restProps}>
   <slot />
 </LabelPrimitive.Root>

--- a/src/main/Tabs/Advanced.svelte
+++ b/src/main/Tabs/Advanced.svelte
@@ -75,12 +75,13 @@ StatusMessages.subscribe(statusMessage => {
         <Card.Content>
           <div>
             <div>
-              <Label class="block text-sm font-medium">{$_('advanced.lanPassword')}</Label>
+              <Label for="lanPassword">{$_('advanced.lanPassword')}</Label>
               {#if password.length < 8}
-                <p class="text-xs text-red-500">{$_('advanced.minLength')}</p>
+                <p class="text-xs text-red-500 my-1">{$_('advanced.minLength')}</p>
               {/if}
               <div class="relative">
                 <Input
+                  id="lanPassword"
                   bind:value={password}
                   type={showPassword ? 'text' : 'password'}
                   placeholder={$_('advanced.newPassword')} />
@@ -110,12 +111,18 @@ StatusMessages.subscribe(statusMessage => {
             </div>
 
             <div class="mt-2">
-              <a
-                class="block cursor-pointer text-sm font-medium text-blue-400 hover:underline"
-                href="https://cloud.belabox.net"
-                target="_blank">{$_('advanced.cloudRemoteKey')}</a>
+              <Label for="remoteKey">{$_('advanced.cloudRemoteKey')}</Label>
+              <p>
+                <a
+                  class="block cursor-pointer text-sm font-medium text-blue-400 hover:underline"
+                  href="https://cloud.belabox.net"
+                  target="_blank"
+                >
+                  https://cloud.belabox.net
+                </a>
+              </p>
               <div class="relative">
-                <Input name="remote-key" type={showRemoteKey ? 'text' : 'password'} bind:value={remoteKey} />
+                <Input id="remoteKey" name="remote-key" type={showRemoteKey ? 'text' : 'password'} bind:value={remoteKey} />
                 <div class="absolute inset-y-0 right-0 flex">
                   <Button
                     variant="outline"
@@ -199,11 +206,12 @@ StatusMessages.subscribe(statusMessage => {
           <div>
             <div>
               <!-- SSH Password Section -->
-              <Label class="block text-sm font-medium">
+              <Label for="sshPassword">
                 {$_('advanced.sshPassword', { values: { sshUser } })}
               </Label>
               <div class="relative">
                 <Input
+                  id="sshPassword"
                   on:focus={event => {
                     event.preventDefault();
                     navigator.clipboard.writeText(sshPassword).then(() => {

--- a/src/main/Tabs/Settings.svelte
+++ b/src/main/Tabs/Settings.svelte
@@ -369,8 +369,8 @@ const startStreamingWithCurrentConfig = () => {
       {/if}
     </form>
 
-    <div class="grid grid-rows-2 gap-4 md:grid-cols-3 lg:grid-cols-2">
-      <Card.Root class="row-span-2">
+    <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      <Card.Root class="md:row-span-2">
         <Card.Header class="flex flex-row items-center justify-between space-y-0 pb-2">
           <Card.Title class="text-sm font-medium">{$_('settings.encoderSettings')}</Card.Title>
           <Binary class="h-4 w-4 text-muted-foreground" />

--- a/src/main/Tabs/Settings.svelte
+++ b/src/main/Tabs/Settings.svelte
@@ -538,7 +538,7 @@ const startStreamingWithCurrentConfig = () => {
                 <Label for="bitrate">{$_('settings.bitrate')}</Label>
                 <Slider
                   id="bitrate"
-                  class="mb-2 mt-2"
+                  class="my-6"
                   value={[selectedBitrate]}
                   max={12000}
                   min={500}
@@ -620,7 +620,7 @@ const startStreamingWithCurrentConfig = () => {
                   <Label for="audioDelay">{$_('settings.audioDelay')}</Label>
                   <Slider
                     id="audioDelay"
-                    class="mb-2 mt-2"
+                    class="my-6"
                     value={[selectedAudioDelay]}
                     onValueChange={value => (selectedAudioDelay = value[0])}
                     disabled={isStreaming}
@@ -733,7 +733,7 @@ const startStreamingWithCurrentConfig = () => {
                 <Label for="srtLatency">{$_('settings.srtLatency')}</Label>
                 <Slider
                   id="srtLatency"
-                  class="mb-2 mt-2"
+                  class="my-6"
                   value={[srtLatency]}
                   max={12000}
                   min={2000}

--- a/src/main/Tabs/Settings.svelte
+++ b/src/main/Tabs/Settings.svelte
@@ -379,7 +379,7 @@ const startStreamingWithCurrentConfig = () => {
           <div class="grid gap-4">
             <!-- Input Mode Selection -->
             <div class="grid gap-1">
-              <Label for="inputMode" class="mb-2">{$_('settings.inputMode')}</Label>
+              <Label for="inputMode">{$_('settings.inputMode')}</Label>
               <Select.Root
                 disabled={isStreaming}
                 selected={selectedInputMode}
@@ -417,7 +417,7 @@ const startStreamingWithCurrentConfig = () => {
 
             <!-- Encoding Format Selection -->
             <div class="grid gap-1">
-              <Label for="encodingFormat" class="mb-2">{$_('settings.encodingFormat')}</Label>
+              <Label for="encodingFormat">{$_('settings.encodingFormat')}</Label>
               <Select.Root
                 disabled={isStreaming || !selectedInputMode?.value}
                 selected={selectedEncoder}
@@ -448,7 +448,7 @@ const startStreamingWithCurrentConfig = () => {
 
             <!-- Encoding Resolution Selection -->
             <div class="grid gap-1">
-              <Label for="encodingResolution" class="mb-2">{$_('settings.encodingResolution')}</Label>
+              <Label for="encodingResolution">{$_('settings.encodingResolution')}</Label>
               <Select.Root
                 disabled={isStreaming || !selectedEncoder?.value}
                 selected={selectedResolution}
@@ -493,7 +493,7 @@ const startStreamingWithCurrentConfig = () => {
 
             <!-- Framerate Selection -->
             <div class="grid gap-1">
-              <Label for="framerate" class="mb-2">{$_('settings.framerate')}</Label>
+              <Label for="framerate">{$_('settings.framerate')}</Label>
               <Select.Root
                 disabled={isStreaming || !selectedResolution?.value}
                 selected={selectedFramerate}
@@ -577,7 +577,7 @@ const startStreamingWithCurrentConfig = () => {
           <div class="grid gap-4">
             {#if audioCodecs && unparsedPipelines && selectedPipeline && unparsedPipelines[selectedPipeline].asrc}
               <div class="grid gap-1">
-                <Label for="audioSource" class="mb-2">{$_('settings.audioSource')}</Label>
+                <Label for="audioSource">{$_('settings.audioSource')}</Label>
                 <Select.Root
                   disabled={isStreaming}
                   selected={selectedAudioSource}
@@ -600,7 +600,7 @@ const startStreamingWithCurrentConfig = () => {
 
             {#if audioCodecs && unparsedPipelines && selectedPipeline && unparsedPipelines[selectedPipeline].acodec}
               <div class="grid gap-1">
-                <Label for="audioCodec" class="mb-2">{$_('settings.audioCodec')}</Label>
+                <Label for="audioCodec">{$_('settings.audioCodec')}</Label>
                 <Select.Root
                   disabled={isStreaming}
                   selected={selectedAudioCodec}

--- a/src/main/shared/HotspotConfigurator.svelte
+++ b/src/main/shared/HotspotConfigurator.svelte
@@ -56,7 +56,7 @@ const resetHotSpotProperties = () => {
   {#snippet description()}
     <div class="grid gap-2">
       <div class="grid gap-1">
-        <Label for="name" class="mb-1">{$_('hotspotConfigurator.hotspot.name')}</Label>
+        <Label for="name">{$_('hotspotConfigurator.hotspot.name')}</Label>
         <Input
           bind:value={hotspotProperties.name}
           id="name"
@@ -66,10 +66,10 @@ const resetHotSpotProperties = () => {
           autocorrect="off" />
       </div>
       <div class="grid gap-1">
-        <Label for="password" class="mb-1">{$_('hotspotConfigurator.hotspot.password')}</Label>
+        <Label for="hotspotPassword">{$_('hotspotConfigurator.hotspot.password')}</Label>
         <Input
           bind:value={hotspotProperties.password}
-          id="password"
+          id="hotspotPassword"
           type="password"
           placeholder={$_('hotspotConfigurator.hotspot.placeholderPassword')}
           autocapitalize="none"
@@ -77,7 +77,7 @@ const resetHotSpotProperties = () => {
           autocorrect="off" />
       </div>
       <div class="grid gap-1">
-        <Label for="channel" class="mb-2 ml-1">{$_('hotspotConfigurator.hotspot.channel')}</Label>
+        <Label for="channel">{$_('hotspotConfigurator.hotspot.channel')}</Label>
         <Select.Root
           onSelectedChange={selected => {
             if (hotspotProperties && selected !== undefined) hotspotProperties.selectedChannel = selected;

--- a/src/main/shared/HotspotConfigurator.svelte
+++ b/src/main/shared/HotspotConfigurator.svelte
@@ -54,7 +54,7 @@ const resetHotSpotProperties = () => {
     {$_('hotspotConfigurator.dialog.configureHotspot')}
   {/snippet}
   {#snippet description()}
-    <div class="grid gap-2">
+    <div class="grid gap-4 py-2 text-foreground">
       <div class="grid gap-1">
         <Label for="name">{$_('hotspotConfigurator.hotspot.name')}</Label>
         <Input

--- a/src/main/shared/ModemConfigurator.svelte
+++ b/src/main/shared/ModemConfigurator.svelte
@@ -291,7 +291,7 @@ function resetForm() {
 <div class="grid gap-2">
   <form onsubmit={onSubmit} class="grid gap-4">
     <div class="mt-1 grid gap-1">
-      <Label for="networkType" class="mb-1 ml-1">{$_('network.modem.networkType')}</Label>
+      <Label for="networkType">{$_('network.modem.networkType')}</Label>
       <Select.Root
         selected={formData.selectedNetwork}
         onSelectedChange={val => {
@@ -338,7 +338,7 @@ function resetForm() {
 
     {#if formData.roaming}
       <div class="mt-1">
-        <Label for="roamingNetwork" class="mb-2 ml-1">{$_('network.modem.roamingNetwork')}</Label>
+        <Label for="roamingNetwork">{$_('network.modem.roamingNetwork')}</Label>
         <div class="flex items-start gap-2">
           <div class="flex-1">
             <Select.Root
@@ -402,7 +402,7 @@ function resetForm() {
 
     {#if !formData.autoconfig}
       <div class="grid gap-1">
-        <Label for="apn" class="mb-1">{$_('network.modem.apn')}</Label>
+        <Label for="apn">{$_('network.modem.apn')}</Label>
         <Input
           id="apn"
           autocapitalize="none"
@@ -417,7 +417,7 @@ function resetForm() {
       </div>
 
       <div class="grid gap-1">
-        <Label for="username" class="mb-1">{$_('network.modem.username')}</Label>
+        <Label for="username">{$_('network.modem.username')}</Label>
         <Input
           id="username"
           type="text"
@@ -428,9 +428,9 @@ function resetForm() {
       </div>
 
       <div class="grid gap-1">
-        <Label for="password" class="mb-1">{$_('network.modem.password')}</Label>
+        <Label for="modemPassword">{$_('network.modem.password')}</Label>
         <Input
-          id="password"
+          id="modemPassword"
           type="text"
           autocapitalize="none"
           autocomplete="off"


### PR DESCRIPTION
- Change streaming tab layout
  - use two cols for medium viewports, three for large viewports
  - use auto height for rows for a more compact layout
- Increase vertical margin around sliders
- Add gap between icons and text in buttons
- Harmonize labels (all clickable, same margin)
- Tweak hotspot configurator styles
- Prevent document scrollbar from moving layout