### PR TITLE
fix(frontend): resolve Svelte reactivity warnings and NaN transition errors

### DIFF
--- a/apps/frontend/src/lib/components/ui/mobile-link.svelte
+++ b/apps/frontend/src/lib/components/ui/mobile-link.svelte
@@ -25,9 +25,9 @@ button:focus-visible {
 
 <script lang="ts">
 import { cubicInOut } from 'svelte/easing';
-import { fly, scale } from 'svelte/transition';
+import { fly } from 'svelte/transition';
 
-import { cn } from '$lib/utils.js';
+import { cn, safeScale } from '$lib/utils.js';
 
 interface Props {
 	class?: string;
@@ -95,8 +95,8 @@ const handleMouseLeave = () => {
 			class="bg-primary absolute top-1/2 left-0 w-1 -translate-y-1/2 rounded-r-full transition-all duration-300"
 			class:h-10={isHovered}
 			class:h-8={!isHovered}
-			in:scale={{ duration: 300, start: isFinite(0.5) ? 0.5 : 1, easing: cubicInOut }}
-			out:scale={{ duration: 200, start: isFinite(1) ? 1 : 1, easing: cubicInOut }}
+			in:safeScale={{ duration: 300, start: 0.5, easing: cubicInOut }}
+			out:safeScale={{ duration: 200, start: 1, easing: cubicInOut }}
 		></div>
 
 		<!-- Subtle pulse effect for active items -->

--- a/apps/frontend/src/lib/stores/pwa.svelte.ts
+++ b/apps/frontend/src/lib/stores/pwa.svelte.ts
@@ -137,13 +137,19 @@ if (typeof window !== "undefined") {
 	}
 
 	// iOS Safari: Show install instructions
-	if (isIOSSafari && !isScreenshotModeState) {
-		const isStandalone =
-			window.matchMedia("(display-mode: standalone)").matches ||
-			(window.navigator as unknown as { standalone?: boolean }).standalone;
-		if (!isStandalone) {
-			showIOSInstallPromptState = true;
-		}
+	// Delayed via queueMicrotask to allow screenshot mode to be set before checking
+	if (isIOSSafari) {
+		queueMicrotask(() => {
+			// Check screenshot mode at execution time, not at module load
+			if (getIsScreenshotMode()) return;
+
+			const isStandalone =
+				window.matchMedia("(display-mode: standalone)").matches ||
+				(window.navigator as unknown as { standalone?: boolean }).standalone;
+			if (!isStandalone) {
+				showIOSInstallPromptState = true;
+			}
+		});
 	}
 }
 

--- a/apps/frontend/src/lib/transitions.ts
+++ b/apps/frontend/src/lib/transitions.ts
@@ -1,0 +1,182 @@
+/**
+ * Safe Svelte Transitions
+ *
+ * These utilities prevent NaN errors in Svelte transitions when elements
+ * have zero dimensions (during rapid mount/unmount cycles).
+ */
+
+import { cubicOut } from "svelte/easing";
+import type { TransitionConfig } from "svelte/transition";
+
+// ============================================
+// Shared Helpers
+// ============================================
+
+/** Check if a DOMRect has valid, finite dimensions */
+function hasValidDimensions(rect: DOMRect): boolean {
+	return (
+		rect.width > 0 &&
+		rect.height > 0 &&
+		isFinite(rect.width) &&
+		isFinite(rect.height)
+	);
+}
+
+/** Get existing CSS transform from an element, or empty string if none */
+function getExistingTransform(node: Element): string {
+	const style = getComputedStyle(node);
+	return style.transform === "none" ? "" : style.transform;
+}
+
+/** Create a simple fade transition config (used as fallback when dimensions are invalid) */
+function createFadeTransition(
+	duration: number,
+	easing: (t: number) => number,
+	delay = 0,
+): TransitionConfig {
+	return { duration, delay, easing, css: (t) => `opacity: ${t}` };
+}
+
+/** Ensure a number is finite, returning a fallback if not */
+function safeNumber(value: number, fallback: number): number {
+	return isFinite(value) ? value : fallback;
+}
+
+// ============================================
+// Transition Parameters Type
+// ============================================
+
+export type SafeTransitionParams = {
+	start?: number;
+	duration?: number;
+	delay?: number;
+	easing?: (t: number) => number;
+};
+
+export type FlyAndScaleParams = {
+	y?: number;
+	x?: number;
+	start?: number;
+	duration?: number;
+};
+
+// ============================================
+// Safe Transitions
+// ============================================
+
+/**
+ * Safe scale transition that prevents NaN errors when element has zero dimensions.
+ * Svelte's built-in scale() calculates Math.sqrt(width * height) which produces NaN
+ * when either dimension is 0 (e.g., element not yet rendered or being destroyed).
+ */
+export function safeScale(
+	node: Element,
+	params: SafeTransitionParams = {},
+): TransitionConfig {
+	const { start = 0.95, duration = 150, delay = 0, easing = cubicOut } = params;
+	const rect = node.getBoundingClientRect();
+
+	if (!hasValidDimensions(rect)) {
+		return createFadeTransition(duration, easing, delay);
+	}
+
+	const transform = getExistingTransform(node);
+	const safeStart = safeNumber(start, 1);
+
+	return {
+		duration,
+		delay,
+		easing,
+		css: (t) => {
+			const scale = safeNumber(safeStart + (1 - safeStart) * t, 1);
+			return `transform: ${transform} scale(${scale}); opacity: ${t}`;
+		},
+	};
+}
+
+/**
+ * Safe crossfade that prevents NaN errors in FLIP animations.
+ * Standard crossfade calculates scale ratios between elements which can produce
+ * NaN when elements have zero dimensions during mount/unmount.
+ */
+export function safeCrossfade(options: {
+	duration?: number;
+	easing?: (t: number) => number;
+}): [
+	(node: Element, params: { key: string }) => TransitionConfig,
+	(node: Element, params: { key: string }) => TransitionConfig,
+] {
+	const { duration = 200, easing = cubicOut } = options;
+	const items = new Map<string, { rect: DOMRect }>();
+
+	function getTransition(
+		node: Element,
+		params: { key: string },
+		isOut: boolean,
+	): TransitionConfig {
+		const rect = node.getBoundingClientRect();
+		const valid = hasValidDimensions(rect);
+
+		if (isOut) {
+			if (valid) items.set(params.key, { rect });
+			return createFadeTransition(duration / 2, easing);
+		}
+
+		const match = items.get(params.key);
+		items.delete(params.key);
+
+		if (!match || !valid) {
+			return createFadeTransition(duration / 2, easing, duration / 2);
+		}
+
+		const dx = safeNumber(match.rect.left - rect.left, 0);
+		const dy = safeNumber(match.rect.top - rect.top, 0);
+
+		return {
+			duration,
+			easing,
+			css: (t, u) =>
+				`transform: translate(${dx * u}px, ${dy * u}px); opacity: ${t};`,
+		};
+	}
+
+	return [
+		(node, params) => getTransition(node, params, false), // receive/in
+		(node, params) => getTransition(node, params, true), // send/out
+	];
+}
+
+/**
+ * Combined fly and scale transition for smooth enter/exit animations.
+ * Used primarily by UI components like dropdowns and popovers.
+ */
+export function flyAndScale(
+	node: Element,
+	params: FlyAndScaleParams = { y: -8, x: 0, start: 0.95, duration: 150 },
+): TransitionConfig {
+	const rect = node.getBoundingClientRect();
+
+	// Fallback to fade if dimensions are invalid
+	if (!hasValidDimensions(rect)) {
+		return createFadeTransition(params.duration ?? 150, cubicOut);
+	}
+
+	const transform = getExistingTransform(node);
+	const { y = -8, x = 0, start = 0.95, duration = 150 } = params;
+
+	// Linear interpolation helper
+	const lerp = (from: number, to: number, t: number) => from + (to - from) * t;
+
+	return {
+		duration,
+		delay: 0,
+		easing: cubicOut,
+		css: (t) => {
+			const translateY = lerp(y, 0, t);
+			const translateX = lerp(x, 0, t);
+			const scale = safeNumber(lerp(start, 1, t), 1);
+
+			return `transform: ${transform} translate3d(${translateX}px, ${translateY}px, 0) scale(${scale}); opacity: ${t}`;
+		},
+	};
+}

--- a/apps/frontend/src/lib/utils.ts
+++ b/apps/frontend/src/lib/utils.ts
@@ -1,69 +1,16 @@
 import { type ClassValue, clsx } from "clsx";
-import { cubicOut } from "svelte/easing";
-import type { TransitionConfig } from "svelte/transition";
 import { twMerge } from "tailwind-merge";
+
+// Re-export transitions for backwards compatibility
+export { flyAndScale, safeCrossfade, safeScale } from "./transitions";
 
 export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));
 }
 
-type FlyAndScaleParams = {
-	y?: number;
-	x?: number;
-	start?: number;
-	duration?: number;
-};
-
 export function capitalizeFirstLetter(str: string) {
 	return String(str).charAt(0).toUpperCase() + String(str).slice(1);
 }
-
-export const flyAndScale = (
-	node: Element,
-	params: FlyAndScaleParams = { y: -8, x: 0, start: 0.95, duration: 150 },
-): TransitionConfig => {
-	const style = getComputedStyle(node);
-	const transform = style.transform === "none" ? "" : style.transform;
-
-	const scaleConversion = (
-		valueA: number,
-		scaleA: [number, number],
-		scaleB: [number, number],
-	) => {
-		const [minA, maxA] = scaleA;
-		const [minB, maxB] = scaleB;
-
-		const percentage = (valueA - minA) / (maxA - minA);
-		const valueB = percentage * (maxB - minB) + minB;
-
-		return valueB;
-	};
-
-	const styleToString = (
-		style: Record<string, number | string | undefined>,
-	): string => {
-		return Object.keys(style).reduce((str, key) => {
-			if (style[key] === undefined) return str;
-			return `${str}${key}:${style[key]};`;
-		}, "");
-	};
-
-	return {
-		duration: params.duration ?? 200,
-		delay: 0,
-		css: (t) => {
-			const y = scaleConversion(t, [0, 1], [params.y ?? 5, 0]);
-			const x = scaleConversion(t, [0, 1], [params.x ?? 0, 0]);
-			const scale = scaleConversion(t, [0, 1], [params.start ?? 0.95, 1]);
-
-			return styleToString({
-				transform: `${transform} translate3d(${x}px, ${y}px, 0) scale(${scale})`,
-				opacity: t,
-			});
-		},
-		easing: cubicOut,
-	};
-};
 
 export type WithoutChild<T> = T extends { child?: unknown }
 	? Omit<T, "child">

--- a/apps/frontend/src/main/navigation/MainNav.svelte
+++ b/apps/frontend/src/main/navigation/MainNav.svelte
@@ -24,7 +24,7 @@ button:focus-visible {
 <script lang="ts">
 import { LL } from '@ceraui/i18n/svelte';
 import { cubicInOut } from 'svelte/easing';
-import { crossfade, fly, scale } from 'svelte/transition';
+import { fly } from 'svelte/transition';
 
 import Logo from '$lib/components/icons/Logo.svelte';
 import { ScrollArea } from '$lib/components/ui/scroll-area';
@@ -37,27 +37,12 @@ import {
 	isNavigationTransitioning,
 	navigateTo,
 } from '$lib/stores/navigation.svelte';
-import { cn } from '$lib/utils';
+import { cn, safeCrossfade, safeScale } from '$lib/utils';
 
-const [send, receive] = crossfade({
+// Use safeCrossfade to prevent NaN errors in FLIP animations
+const [receive, send] = safeCrossfade({
 	duration: 200,
 	easing: cubicInOut,
-	fallback(node) {
-		// Validate node exists and has dimensions to prevent NaN values
-		if (!node || !node.getBoundingClientRect) {
-			return { duration: 0, css: () => '' };
-		}
-
-		const startValue = 0.95;
-		// Ensure start value is a valid number to prevent scale(NaN, NaN)
-		const safeStart = isFinite(startValue) ? startValue : 1;
-
-		return scale(node, {
-			duration: 120,
-			start: safeStart,
-			easing: cubicInOut,
-		});
-	},
 });
 
 let isLogoHovered = $state(false);
@@ -164,8 +149,8 @@ const handleLogoClick = () => {
 			{#if $canGoBack && isLogoHovered}
 				<div
 					class="bg-primary absolute -top-1 -right-1 h-3 w-3 rounded-full"
-					in:scale={{ duration: 120, start: 0.8 }}
-					out:scale={{ duration: 100, start: 1 }}
+					in:safeScale={{ duration: 120, start: 0.8 }}
+					out:safeScale={{ duration: 100, start: 1 }}
 				>
 					<div class="bg-primary/60 h-full w-full animate-ping rounded-full"></div>
 				</div>

--- a/apps/frontend/src/main/navigation/MobileNav.svelte
+++ b/apps/frontend/src/main/navigation/MobileNav.svelte
@@ -24,7 +24,7 @@ button:focus-visible {
 import { LL } from '@ceraui/i18n/svelte';
 import { ChevronLeft, Menu, X } from '@lucide/svelte';
 import { cubicInOut } from 'svelte/easing';
-import { fade, fly, scale } from 'svelte/transition';
+import { fade, fly } from 'svelte/transition';
 
 import Logo from '$lib/components/icons/Logo.svelte';
 import { Button } from '$lib/components/ui/button';
@@ -40,7 +40,7 @@ import {
 	isNavigationTransitioning,
 	navigateTo,
 } from '$lib/stores/navigation.svelte';
-import { cn } from '$lib/utils';
+import { cn, safeScale } from '$lib/utils';
 
 let open = $state(false);
 let isMenuHovered = $state(false);
@@ -350,7 +350,7 @@ $effect(() => {
 								{#if isSelected}
 									<div
 										class="bg-primary/5 pointer-events-none absolute inset-0 rounded-lg"
-										in:scale={{ duration: 120, start: isFinite(0.95) ? 0.95 : 1 }}
+										in:safeScale={{ duration: 120, start: 0.95 }}
 										out:fade={{ duration: 100 }}
 									></div>
 								{/if}

--- a/apps/frontend/src/main/shared/AudioCard.svelte
+++ b/apps/frontend/src/main/shared/AudioCard.svelte
@@ -40,13 +40,12 @@ const {
 	normalizeValue,
 }: Props = $props();
 
-// Local state for slider binding
-let localAudioDelay = $state(properties.audioDelay ?? 0);
+// Local state for slider binding (initialized empty, synced via effect)
+let localAudioDelay = $state(0);
 
 // Sync local state with props
 $effect(() => {
-	const newValue = properties.audioDelay ?? 0;
-	localAudioDelay = newValue;
+	localAudioDelay = properties.audioDelay ?? 0;
 });
 
 const hasAudioSupport = $derived(

--- a/apps/frontend/src/main/shared/EncoderCard.svelte
+++ b/apps/frontend/src/main/shared/EncoderCard.svelte
@@ -53,12 +53,12 @@ const {
 	getSortedFramerates,
 }: Props = $props();
 
-// Local state for all select fields
-let localInputMode = $state(properties.inputMode ?? '');
-let localEncoder = $state(properties.encoder ?? '');
-let localResolution = $state(properties.resolution ?? '');
-let localFramerate = $state(properties.framerate ?? '');
-let localBitrate = $state(properties.bitrate ?? 5000);
+// Local state for all select fields (initialized with defaults, synced via effects)
+let localInputMode = $state('');
+let localEncoder = $state('');
+let localResolution = $state('');
+let localFramerate = $state('');
+let localBitrate = $state(5000);
 
 // Track if user has touched each field
 let inputModeTouched = $state(false);

--- a/apps/frontend/src/main/shared/HotspotConfigurator.svelte
+++ b/apps/frontend/src/main/shared/HotspotConfigurator.svelte
@@ -14,12 +14,26 @@ import { cn } from '$lib/utils';
 
 const { deviceId, wifi }: { deviceId: number; wifi: ValueOf<StatusMessage['wifi']> } = $props();
 
-// Enhanced state management with validation
+// Enhanced state management with validation (initialized with defaults, synced via effect)
 let hotspotProperties = $state({
-	selectedChannel: wifi.hotspot?.channel ?? 'auto',
-	password: wifi.hotspot?.password || '',
-	deviceId,
-	name: wifi.hotspot?.name || '',
+	selectedChannel: 'auto' as string,
+	password: '',
+	deviceId: 0,
+	name: '',
+});
+
+// Sync from props on initial mount
+let formInitialized = false;
+$effect.pre(() => {
+	if (!formInitialized) {
+		hotspotProperties = {
+			selectedChannel: wifi.hotspot?.channel ?? 'auto',
+			password: wifi.hotspot?.password || '',
+			deviceId,
+			name: wifi.hotspot?.name || '',
+		};
+		formInitialized = true;
+	}
 });
 
 let showPassword = $state(false);
@@ -54,6 +68,7 @@ const validation = $derived({
 const isFormValid = $derived(validation.name.isValid && validation.password.isValid);
 
 const resetHotSpotProperties = () => {
+	// Re-sync from current props when dialog is cancelled/reopened
 	hotspotProperties = {
 		selectedChannel: wifi.hotspot?.channel ?? 'auto',
 		password: wifi.hotspot?.password || '',

--- a/apps/frontend/src/main/shared/ModemConfigurator.svelte
+++ b/apps/frontend/src/main/shared/ModemConfigurator.svelte
@@ -61,7 +61,8 @@ $effect.pre(() => {
 	}
 });
 
-let lastModemState: string = JSON.stringify(modem);
+// Track modem state for change detection (initialized empty, first update will sync)
+let lastModemState = '';
 
 function updateFormFromModem() {
 	const currentModemState = JSON.stringify(modem);

--- a/apps/frontend/src/main/shared/ServerCard.svelte
+++ b/apps/frontend/src/main/shared/ServerCard.svelte
@@ -44,13 +44,13 @@ const {
 	normalizeValue,
 }: Props = $props();
 
-// Local state for all fields to prevent binding undefined values
-let localSrtlaServerAddress = $state(properties.srtlaServerAddress ?? '');
-let localSrtlaServerPort = $state(properties.srtlaServerPort?.toString() ?? '');
-let localSrtStreamId = $state(properties.srtStreamId ?? '');
-let localSrtLatency = $state(properties.srtLatency ?? 2000);
-let localRelayServer = $state(properties.relayServer ?? '');
-let localRelayAccount = $state(properties.relayAccount ?? '');
+// Local state for all fields (initialized with defaults, synced via effects)
+let localSrtlaServerAddress = $state('');
+let localSrtlaServerPort = $state('');
+let localSrtStreamId = $state('');
+let localSrtLatency = $state(2000);
+let localRelayServer = $state('');
+let localRelayAccount = $state('');
 
 // Track if user has touched each field
 let addressTouched = $state(false);


### PR DESCRIPTION
## Summary

This PR fixes Svelte 5 `state_referenced_locally` warnings and eliminates `NaN` errors in CSS transitions that appeared in the console.

## Changes

### Safe Transition Utilities (`transitions.ts`)
- Created dedicated `transitions.ts` with NaN-safe transition utilities:
  - `safeScale`: Prevents `scale(NaN, NaN)` when elements have zero dimensions
  - `safeCrossfade`: NaN-safe FLIP animations for crossfade transitions
  - `flyAndScale`: Combined fly+scale with dimension validation
- Extracted shared helpers: `hasValidDimensions`, `getExistingTransform`, `createFadeTransition`, `safeNumber`

### Component Fixes
- **pwa.svelte.ts**: Use getter for `isScreenshotMode` in `queueMicrotask` to ensure reactive read
- **AudioCard.svelte**: Initialize `localAudioDelay` with default value
- **EncoderCard.svelte**: Initialize 5 local states with defaults
- **ServerCard.svelte**: Initialize 6 local states with defaults
- **ModemConfigurator.svelte**: Initialize `lastModemState` as empty string
- **HotspotConfigurator.svelte**: Use `$effect.pre` for property syncing

### Navigation Updates
- Updated `MainNav.svelte`, `MobileNav.svelte`, `mobile-link.svelte` to use safe transitions
- Simplified `utils.ts` to re-export transitions for backwards compatibility

## Testing
- ✅ All 52 unit tests pass
- ✅ `svelte-check` reports 0 errors, 0 warnings
- ✅ Production build succeeds
- ✅ Browser testing confirms no NaN errors in console