### PR TITLE
docs: Add sponsor/funding information

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# These are supported funding model platforms
+
+ko_fi: andrescera
+custom: ["https://www.paypal.com/donate/?business=7KKQS9KBSAMNE&no_recurring=0&item_name=CERALIVE+Development+Support&currency_code=USD"]

--- a/README.md
+++ b/README.md
@@ -96,3 +96,10 @@ pnpm clean                            # Clean all build artifacts
 - **Frontend**: Svelte 5, TailwindCSS, shadcn-svelte, Vite
 - **Backend**: Bun, TypeScript, WebSocket RPC
 - **Build**: pnpm workspaces, mprocs
+
+## Support the Project
+
+If you find CeraUI useful, consider supporting CeraLive development:
+
+- ☕ [Ko-fi](https://ko-fi.com/andrescera)
+- 💳 [PayPal](https://www.paypal.com/donate/?business=7KKQS9KBSAMNE&no_recurring=0&item_name=CERALIVE+Development+Support&currency_code=USD)


### PR DESCRIPTION
## Summary

Add sponsor links for CeraLive development support.

### Changes

- **`.github/FUNDING.yml`**: Enables the "Sponsor" button on GitHub
  - Ko-fi: andrescera
  - PayPal: CeraLive Development Support

- **`README.md`**: Added "Support the Project" section with links

## Test Plan

- [ ] Verify FUNDING.yml syntax is correct
- [ ] Check sponsor button appears on repo page after merge