### PR TITLE
docs: Add GitHub Sponsors to funding options

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,5 @@
 # These are supported funding model platforms
 
+github: andrescera
 ko_fi: andrescera
 custom: ["https://www.paypal.com/donate/?business=7KKQS9KBSAMNE&no_recurring=0&item_name=CERALIVE+Development+Support&currency_code=USD"]


### PR DESCRIPTION
Add GitHub Sponsors (andrescera) to FUNDING.yml alongside existing Ko-fi and PayPal options.