### PR TITLE
docs: add group-aware AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# CeraUI — Agent Knowledge Base
+
+Parent: [`../AGENTS.md`](../AGENTS.md)
+
+## ROLE IN THE GROUP
+
+Device control plane. Svelte 5 PWA (frontend) + Bun/TypeScript WebSocket-RPC backend. Drives `ceracoder` and `srtla` at runtime via their native TS bindings. Produces the `ceraui` .deb for ARM64 and AMD64 device images.
+
+The backend resolves `@ceralive/ceracoder` and `@ceralive/srtla` via pnpm `link:` paths that point three levels up:
+
+```
+"@ceralive/ceracoder": "link:../../../ceracoder/bindings/typescript"
+"@ceralive/srtla":     "link:../../../srtla/bindings/typescript"
+```
+
+**LOAD-BEARING layout.** CI must check out `ceracoder`, `srtla`, and `CeraUI` as siblings under the same parent. These paths are correct as-is — do not rename or restructure them.
+
+The srtla binding API may be in flux while the upstream srtla merge is in progress. Check `../srtla/AGENTS.md` before touching anything that calls `@ceralive/srtla`.
+
+## STRUCTURE
+
+```
+CeraUI/
+├── apps/
+│   ├── frontend/     # Svelte 5 PWA — Vite, TailwindCSS v4, shadcn-svelte, vitest
+│   └── backend/      # Bun server — WebSocket RPC via oRPC, serves frontend static
+├── packages/
+│   ├── rpc/          # Shared oRPC schemas (workspace:*)
+│   └── i18n/         # typesafe-i18n, 10 languages (workspace:*)
+├── scripts/build/    # build-debian-package.sh — produces ceraui .deb
+├── docs/             # ARCHITECTURE, BUILD_PIPELINE, APT_VERSION_CONTROL, BRANDING
+└── .impeccable.md    # UI/UX design constraints — read before touching frontend visuals
+```
+
+## WHERE TO LOOK
+
+| Task | Location |
+|------|----------|
+| Frontend UI components | `apps/frontend/src/` |
+| Backend RPC handlers | `apps/backend/src/` |
+| Shared RPC contract | `packages/rpc/` |
+| i18n strings | `packages/i18n/` |
+| .deb build | `scripts/build/build-debian-package.sh` |
+| Build system / CI | `docs/BUILD_PIPELINE.md` |
+| Debian versioning | `docs/APT_VERSION_CONTROL.md` |
+| System data flow | `docs/ARCHITECTURE.md` |
+| Design rules | `.impeccable.md` |
+
+## COMMANDS
+
+```bash
+pnpm install          # installs all workspaces; resolves link: deps (siblings must exist)
+pnpm dev              # frontend + backend via mprocs TUI (port 5173 + 3001)
+pnpm build            # compile backend binary + frontend static
+BUILD_ARCH=arm64 ./scripts/build/build-debian-package.sh   # .deb for ARM64
+BUILD_ARCH=amd64 ./scripts/build/build-debian-package.sh   # .deb for AMD64
+bun tsc --noEmit      # type-check backend (run from apps/backend/)
+pnpm --filter frontend run test   # vitest frontend unit tests
+```
+
+## CONVENTIONS
+
+- Linting: Biome at workspace root (`biome.json`). ESLint only in `apps/frontend/`.
+- Mock hardware in dev via `MOCK_SCENARIO` env var (`multi-modem-wifi` default).
+- Backend binary compiled with `bun build --compile`; target set by `BUILD_ARCH`.
+- Frontend is a PWA — service worker via `vite-plugin-pwa`.
+
+## ANTI-PATTERNS
+
+- Don't run `npm install` or `yarn` — pnpm workspaces only.
+- Don't add `@ceralive/ceracoder` or `@ceralive/srtla` to `package.json` as npm packages — they are local `link:` deps by design.
+- Don't edit `.impeccable.md` for code changes — it's a design reference, not config.
+- Don't touch srtla binding call sites without checking `../srtla/AGENTS.md` first (API in flux).

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -1,0 +1,38 @@
+# CeraUI Backend — Agent Knowledge Base
+
+Parent: [`../../AGENTS.md`](../../AGENTS.md)
+
+## OVERVIEW
+
+Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, exposes all device control via oRPC over WebSocket, and drives `ceracoder` + `srtla` via `link:` bindings.
+
+## STRUCTURE
+
+`src/main.ts` — entry. `src/modules/` — domain logic (no RPC awareness): `streaming/` (ceracoder + srtla consumers), `modems/` (mmcli), `network/`, `wifi/`, `system/`, `ui/` (HTTP + WS servers, auth), `ingest/`, `remote/`, `config.ts`, `setup.ts`. `src/rpc/` — oRPC layer: `router.ts`, `procedures/<domain>.procedure.ts`, `middleware/`, `events.ts`. `src/helpers/` — pure utils. `src/mocks/` — MOCK_SCENARIO providers. `src/tests/` — bun:test.
+
+## WHERE TO LOOK
+
+| Task | Location |
+|------|----------|
+| Add/change an RPC procedure | `rpc/procedures/<domain>.procedure.ts` + `rpc/router.ts` |
+| ceracoder binding calls | `modules/streaming/ceracoder.ts` |
+| srtla binding calls (flux — check `../../../srtla/AGENTS.md` first) | `modules/streaming/srtla.ts` |
+| WebSocket server wiring | `modules/ui/websocket-server.ts` + `rpc/server.ts` |
+| Auth token logic | `modules/ui/auth.ts` + `rpc/middleware/auth.middleware.ts` |
+| Mock hardware data | `mocks/providers/` |
+| Shared RPC schema types | `../../../packages/rpc/` (`@ceraui/rpc`) |
+
+## CONVENTIONS
+
+- Runtime: Bun only. No Node-specific APIs (`fs/promises` ok; `node:cluster` not).
+- Build: `bun build --compile --minify --bytecode --target=bun-linux-{arm64|amd64}` — single binary, no runtime on device.
+- Tests: `bun test` (not vitest). Files in `src/tests/`.
+- Config files (`config.json`, `setup.json`, `auth_tokens.json`) read/written from working dir — path-sensitive in production.
+- `MOCK_SCENARIO` env activates mock providers. Scenarios: `single-modem`, `streaming-active`, `multi-modem-wifi` (default dev).
+
+## ANTI-PATTERNS
+
+- Don't import from `@ceralive/srtla` without checking upstream merge status — binding API is in flux.
+- Don't add HTTP REST endpoints — all device control goes through oRPC over WebSocket.
+- Don't use `process.exit` directly — use `invariant` from `helpers/invariant.ts`.
+- Don't read config files with raw `fs` — use `helpers/config-loader.ts`.

--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -1,0 +1,51 @@
+# CeraUI Frontend — Agent Knowledge Base
+
+Parent: [`../../AGENTS.md`](../../AGENTS.md)
+
+## ROLE
+
+Svelte 5 PWA. Talks to the backend exclusively via WebSocket RPC — no REST, no direct hardware access.
+
+## STRUCTURE
+
+```
+src/
+├── main.ts / App.svelte      # entry: initRPC(), auth gate, Layout
+├── main/tabs/                # Streaming, Network, General, Advanced, DevTools
+├── lib/rpc/                  # RPCClient + TypedRPC + subscriptions.svelte.ts
+├── lib/stores/               # runes stores (*.svelte.ts)
+├── lib/components/ui/        # shadcn-svelte primitives (bits-ui)
+├── lib/components/streaming/ # StreamingStateManager, ConfigService, Validation
+└── lib/env/ lib/helpers/ lib/config/ lib/types/
+```
+
+## RPC PATTERN
+
+```ts
+import { rpc, rpcClient } from '$lib/rpc';
+await rpc.streaming.start(config);          // typed via TypedRPC in client.ts
+rpcClient.onMessage((type, data) => { }); // raw push events
+```
+
+New procedures: add to `@ceraui/rpc` schemas first, then extend `TypedRPC` in `client.ts`.
+
+## COMMANDS
+
+```bash
+pnpm dev / build / check / test / lint   # Vite :5173 / dist/ / svelte-check / vitest / ESLint
+```
+
+## CONVENTIONS
+
+- Stores: Svelte 5 runes only (`$state`, `$derived`, `$effect`) — files named `*.svelte.ts`.
+- UI primitives: extend via shadcn-svelte CLI, not by hand.
+- Mock scenarios: `MOCK_SCENARIO` env var. Runtime switching via `rpc.streaming.setMockHardware`.
+- Design: read `../../.impeccable.md` before touching visuals.
+- i18n: `@ceraui/i18n` workspace package — all user strings via `LL.*`.
+
+## ANTI-PATTERNS
+
+- No direct backend calls — everything through `rpc.*` or `rpcClient.onMessage`.
+- No manual UI primitive files — use `pnpm dlx shadcn-svelte@latest add <component>`.
+- No `$:` reactive statements — Svelte 5 runes only.
+- No hardcoded socket URL — use `ENV_VARIABLES` from `$lib/env`.

--- a/packages/i18n/AGENTS.md
+++ b/packages/i18n/AGENTS.md
@@ -1,0 +1,49 @@
+# @ceraui/i18n — Agent Knowledge Base
+
+Parent: [`../../AGENTS.md`](../../AGENTS.md)
+
+## OVERVIEW
+
+`typesafe-i18n` package with 10 locales and a custom Svelte 5 runes adapter. Codegen runs at install time via `postinstall`. Never hand-edit generated files.
+
+## STRUCTURE
+
+```
+src/
+├── en/index.ts             # Base locale — source of truth for all keys
+├── {locale}/index.ts       # ar, de, es, fr, hi, ja, ko, pt-BR, zh
+├── i18n-types.ts           # GENERATED — Locales union, Translation type
+├── i18n-util*.ts           # GENERATED — don't edit
+├── i18n-svelte5.svelte.ts  # Custom Svelte 5 runes adapter ($state/$derived)
+├── i18n-node.ts            # Node/backend adapter
+├── formatters.ts           # Locale-aware formatters (currently stubbed)
+└── branding.ts             # Brand names — not translated, kept separate
+```
+
+## IMPORT PATHS
+
+```typescript
+import { LL, locale, setLocale } from '@ceraui/i18n/svelte';  // frontend (Svelte 5)
+import { i18nNode } from '@ceraui/i18n/node';                  // backend
+import type { Locales, Translation } from '@ceraui/i18n';      // types only
+```
+
+## LOCALES + CODEGEN
+
+10 locales: `en` (base), `ar`, `de`, `es`, `fr`, `hi`, `ja`, `ko`, `pt-BR`, `zh`. Add one: create `src/{locale}/index.ts` satisfying `Translation`, then run codegen.
+
+```bash
+pnpm --filter @ceraui/i18n run typesafe-i18n   # regenerate; also runs via postinstall
+```
+
+Generated: `i18n-types.ts`, `i18n-util*.ts` — overwritten on next run, don't edit.
+
+## CONVENTIONS + ANTI-PATTERNS
+
+- New keys go into `en/index.ts` first. Other locales follow.
+- `branding.ts` holds brand names that don't get translated — import from there, not locale files.
+- `formatters.ts` is for locale-aware number/date formatters. Currently stubbed.
+- Svelte 5 adapter uses `$state`/`$derived` runes — don't convert to stores.
+- Don't edit generated `i18n-util*.ts` or `i18n-types.ts` by hand.
+- Don't import locale files directly — use the typed `LL` proxy from the adapter.
+- Don't use the node adapter in frontend code or the svelte adapter in backend code.

--- a/packages/rpc/AGENTS.md
+++ b/packages/rpc/AGENTS.md
@@ -1,0 +1,47 @@
+# @ceraui/rpc — Agent Knowledge Base
+
+Parent: [`../../AGENTS.md`](../../AGENTS.md)
+
+## OVERVIEW
+
+Shared oRPC contract + Zod schema layer. The single source of truth for the WebSocket RPC surface between frontend and backend. Both consumers import from here — never define contracts inline.
+
+## STRUCTURE
+
+```
+src/
+├── contracts/   # oRPC oc.router() defs — auth, streaming, modems, wifi, network, system, status, notifications
+│   └── index.ts # appContract root router + AppContract type
+└── schemas/     # Zod v4 schemas mirroring contracts/ + common.schema.ts, relay.schema.ts
+```
+
+## WHERE TO LOOK
+
+| Task | Location |
+|------|----------|
+| Add a new RPC procedure | `contracts/{domain}.contract.ts` → wire into `contracts/index.ts` |
+| Add/change input or output shape | `schemas/{domain}.schema.ts` |
+| Root router type (client inference) | `contracts/index.ts` → `AppContract` |
+| New domain (e.g. `audio`) | New `audio.contract.ts` + `audio.schema.ts`, add to `appContract` router |
+
+## IMPORT PATHS
+
+```typescript
+import { appContract, type AppContract } from '@ceraui/rpc';           // root router
+import { streamingContract } from '@ceraui/rpc/contracts';             // granular
+import { loginInputSchema } from '@ceraui/rpc/schemas';                // validation
+```
+
+## CONVENTIONS
+
+- Contracts use `@orpc/contract` (`oc.*`). No runtime logic here — contracts are pure type/schema declarations.
+- Schemas use Zod v4 (`zod@^4`). Import from `zod`, not `zod/v4`.
+- One contract file per domain. One schema file per domain. Names must match (`streaming.contract.ts` ↔ `streaming.schema.ts`).
+- `appContract` in `contracts/index.ts` is the only router — don't create sub-routers elsewhere.
+
+## ANTI-PATTERNS
+
+- Don't import `@ceraui/rpc` from within this package itself — circular.
+- Don't add runtime handlers here. Handlers live in `apps/backend/src/`.
+- Don't duplicate schema definitions in `apps/` — always import from this package.
+- Don't use Zod v3 APIs (`z.string().nonempty()` etc.) — project is on Zod v4.


### PR DESCRIPTION
Adds hierarchical AGENTS.md for CeraUI and scored app/package subdirs. Documents load-bearing sibling link:../../../ constraint as a fact.