### PR TITLE
feat(backend): OS-command hardening — typed argv runner, Zod-validated inputs, injection fixes

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -36,7 +36,9 @@
 		"dev:streaming": "NODE_ENV=development MOCK_SCENARIO=streaming-active bun --watch run src/main.ts",
 		"build": "rm -rf ../../dist/ && bash -c 'BUN_TARGET=${BUILD_ARCH:-arm64}; case $BUN_TARGET in amd64) BUN_TARGET=\"bun-linux-x64\" ;; arm64) BUN_TARGET=\"bun-linux-arm64\" ;; *) echo \"Unsupported architecture: $BUN_TARGET\"; exit 1 ;; esac; bun build --compile --minify --sourcemap --bytecode --target=$BUN_TARGET src/main.ts --outfile ../../dist/ceralive' && cd ../.. && pnpm run build:frontend",
 		"build:backend-only": "rm -rf ../../dist/ceralive ../../dist/deployment && bash -c 'BUN_TARGET=${BUILD_ARCH:-arm64}; case $BUN_TARGET in amd64) BUN_TARGET=\"bun-linux-x64\" ;; arm64) BUN_TARGET=\"bun-linux-arm64\" ;; *) echo \"Unsupported architecture: $BUN_TARGET\"; exit 1 ;; esac; bun build --compile --minify --sourcemap --bytecode --target=$BUN_TARGET src/main.ts --outfile ../../dist/ceralive'",
-		"check": "bun tsc --noEmit",
+		"test": "bun test",
+		"check": "bun tsc --noEmit && bash scripts/check-exec-guard.sh",
+		"check:exec-guard": "bash scripts/check-exec-guard.sh",
 		"lint": "echo 'Backend linting handled by root Biome'",
 		"lint:fix": "echo 'Backend fixing handled by root Biome'",
 		"clean": "rm -rf ../../dist/ && rm -rf node_modules"

--- a/apps/backend/scripts/check-exec-guard.sh
+++ b/apps/backend/scripts/check-exec-guard.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Bare-exec lint guard.
+#
+# Fails (exit 1) if a shell-interpolated exec template literal — execP(`...`)
+# or execPNR(`...`) — appears anywhere under apps/backend/src, outside the two
+# files that legitimately define the raw exec primitives (helpers/exec.ts) and
+# the allowlisted argv-only runner (helpers/run.ts).
+#
+# These backtick patterns build a shell command string from interpolated
+# values and run it through `sh -c`, which is the exact injection surface
+# helpers/run.ts was built to eliminate. New OS calls must go through
+# run()/runWithStdin().
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_DIR="$SCRIPT_DIR/../src"
+
+# GNU grep ERE: matches `execP(` or `execPNR(` immediately followed by a backtick.
+PATTERN='execP(NR)?\(`'
+
+matches="$(grep -rnE "$PATTERN" "$SRC_DIR" --include='*.ts' \
+	| grep -v -e 'helpers/exec.ts' -e 'helpers/run.ts' || true)"
+
+if [ -n "$matches" ]; then
+	echo "✗ bare-exec guard: shell-interpolated exec template literals found:" >&2
+	echo "$matches" >&2
+	echo >&2
+	echo "Route OS calls through helpers/run.ts run()/runWithStdin() instead." >&2
+	exit 1
+fi
+
+echo "✓ bare-exec guard: no shell-interpolated exec template literals"

--- a/apps/backend/src/helpers/killall.ts
+++ b/apps/backend/src/helpers/killall.ts
@@ -1,9 +1,23 @@
 import { spawnSync } from "node:child_process";
 
 import { setup } from "../modules/setup.ts";
+import { ALLOWED, run } from "./run.ts";
 
 const killallBinary = setup.killall_binary ?? "killall";
 
-export default function killall(args: Readonly<Array<string>>) {
-	return spawnSync(killallBinary, args);
+export default async function killall(
+	args: Readonly<Array<string>>,
+): Promise<void> {
+	if (ALLOWED.has(killallBinary)) {
+		try {
+			await run(killallBinary, [...args]);
+		} catch (_err) {
+			// killall exits non-zero when no matching process exists — expected for
+			// fire-and-forget orphan cleanup and SIGHUP reloads.
+		}
+		return;
+	}
+
+	// Custom, non-allowlisted setup.killall_binary path: argv-only (NO shell).
+	spawnSync(killallBinary, [...args]);
 }

--- a/apps/backend/src/helpers/run.ts
+++ b/apps/backend/src/helpers/run.ts
@@ -1,0 +1,201 @@
+/*
+    CeraUI - web UI for the CERALIVE project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * Typed, argv-only OS command runner.
+ *
+ * This is the security foundation for the backend's interaction with the host
+ * OS. Every command is executed argv-only (NO shell), so SSID/password/service
+ * values can never be interpreted as shell syntax — there is no `sh -c` in the
+ * path, so `;`, `&&`, `$(...)`, backticks, etc. are inert. The set of binaries
+ * that may be invoked is fixed by an ALLOWLIST.
+ *
+ * Design constraints (deliberate):
+ *  - run() is THIN and GENERIC. It does not know about per-binary flag grammars.
+ *    Callers validate their own dynamic arguments with argMatch() + the shared
+ *    SERVICE_RE / ID_RE regexes before passing them in.
+ *  - run() does NOT global-charset-validate argv. Unicode SSIDs and base64
+ *    passwords are legitimate argv values and must pass through untouched.
+ *  - Mock interception (shouldMockWifi()/shouldMockModems()) does NOT live here.
+ *    It stays in the domain module wrappers that call run(); run() always talks
+ *    to the real OS.
+ *  - runWithStdin() never places a secret on argv — the secret is written to the
+ *    child's stdin only.
+ */
+
+import { spawn } from "node:child_process";
+
+import { execFileP } from "./exec.ts";
+import { logger } from "./logger.ts";
+
+/** Default stdout/stderr ceiling for buffered (execFile) commands: 10 MiB. */
+export const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024;
+
+export type RunOpts = {
+	/** Max bytes captured from stdout/stderr before the child is killed. */
+	maxBuffer?: number;
+};
+
+/**
+ * Binaries the backend is permitted to execute. This is the single source of
+ * truth for every Wave 2 hardening task (network, modems, system, sensors,
+ * logs, updates, power). Adding a binary here is a security decision — keep it
+ * minimal and intentional.
+ */
+export const ALLOWED: Set<string> = new Set<string>([
+	"nmcli",
+	"mmcli",
+	"systemctl",
+	"journalctl",
+	"ip",
+	"apt-get",
+	"grep",
+	"killall",
+	"sensors",
+	"ifconfig",
+	"passwd",
+	"reboot",
+	"dmesg",
+]);
+
+/**
+ * Validation pattern for systemd-style service / unit names.
+ * Allows letters, digits and the unit punctuation set `@ . _ : -`.
+ */
+export const SERVICE_RE: RegExp = /^[A-Za-z0-9@._:-]+$/;
+
+/**
+ * Validation pattern for generic identifiers (interface names, modem ids,
+ * connection ids, etc.). Stricter than SERVICE_RE — no `@` or `:`.
+ */
+export const ID_RE: RegExp = /^[A-Za-z0-9_.-]+$/;
+
+/**
+ * Validate a single dynamic argv value against `re` and return it unchanged.
+ *
+ * Throws if the value does not match `re`, OR if it begins with `-` (which a
+ * downstream binary could otherwise mis-parse as a flag — argument injection).
+ * The returned value is the same string, so call sites can inline it:
+ *
+ *   run("systemctl", ["restart", argMatch(SERVICE_RE, unit)]);
+ */
+export function argMatch(re: RegExp, v: string): string {
+	if (!re.test(v) || v.startsWith("-")) {
+		throw new Error(`invalid argument: ${v}`);
+	}
+	return v;
+}
+
+/** Argv tokens whose *following* token is a secret and must not be logged. */
+const SECRET_FLAG_RE = /pass(word)?|secret|psk|token|key/i;
+
+/**
+ * Produce a log-safe rendering of argv: any token that immediately follows a
+ * secret-looking flag is replaced with `***`. Best-effort only — callers that
+ * handle secrets should also prefer runWithStdin().
+ */
+function redactArgs(args: string[]): string {
+	const out: string[] = [];
+	for (let i = 0; i < args.length; i++) {
+		const prev = i > 0 ? args[i - 1] : undefined;
+		if (prev !== undefined && SECRET_FLAG_RE.test(prev)) {
+			out.push("***");
+		} else {
+			out.push(args[i] ?? "");
+		}
+	}
+	return out.join(" ");
+}
+
+/**
+ * Run an allowlisted binary argv-only (NO shell) and resolve with its stdout.
+ *
+ * @throws if `bin` is not in {@link ALLOWED}.
+ * @throws (via execFileP) if the process exits non-zero or exceeds maxBuffer.
+ */
+export async function run(
+	bin: string,
+	args: string[],
+	opts?: RunOpts,
+): Promise<string> {
+	if (!ALLOWED.has(bin)) {
+		throw new Error(`binary not allowlisted: ${bin}`);
+	}
+
+	const maxBuffer = opts?.maxBuffer ?? DEFAULT_MAX_BUFFER;
+	logger.debug(`run: ${bin} ${redactArgs(args)}`);
+
+	const { stdout } = await execFileP(bin, args, { maxBuffer });
+	// String() handles both the default string stdout and a Buffer (if a future
+	// caller sets an encoding) without a `never`-narrowed branch.
+	return String(stdout);
+}
+
+/**
+ * Run an allowlisted binary argv-only and feed `input` to its stdin.
+ *
+ * The secret `input` is written to the child's stdin and is NEVER placed on
+ * argv (so it cannot leak via the process table / `ps`). Resolves with stdout
+ * when the child exits 0; rejects with stderr (or the spawn error) otherwise.
+ *
+ * @throws if `bin` is not in {@link ALLOWED}.
+ */
+export function runWithStdin(
+	bin: string,
+	args: string[],
+	input: string,
+): Promise<string> {
+	if (!ALLOWED.has(bin)) {
+		return Promise.reject(new Error(`binary not allowlisted: ${bin}`));
+	}
+
+	logger.debug(`runWithStdin: ${bin} ${redactArgs(args)} <stdin redacted>`);
+
+	return new Promise<string>((resolve, reject) => {
+		const child = spawn(bin, args, { stdio: ["pipe", "pipe", "pipe"] });
+
+		let stdout = "";
+		let stderr = "";
+
+		child.stdout?.on("data", (chunk) => {
+			stdout += chunk.toString();
+		});
+		child.stderr?.on("data", (chunk) => {
+			stderr += chunk.toString();
+		});
+
+		child.on("error", (err) => {
+			reject(err);
+		});
+
+		child.on("close", (code) => {
+			if (code === 0) {
+				resolve(stdout);
+			} else {
+				reject(
+					new Error(
+						`${bin} exited with code ${code}${stderr ? `: ${stderr.trim()}` : ""}`,
+					),
+				);
+			}
+		});
+
+		// Secret goes to stdin ONLY — never to argv.
+		child.stdin?.write(input);
+		child.stdin?.end();
+	});
+}

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -76,7 +76,7 @@ initRevisions();
 initHardwareMonitoring();
 initRTMPIngestStats();
 initSRTIngest();
-getSshStatus();
+void getSshStatus();
 
 updateGwWrapper();
 setInterval(updateGwWrapper, UPDATE_GW_INT);

--- a/apps/backend/src/modules/modems/mmcli.ts
+++ b/apps/backend/src/modules/modems/mmcli.ts
@@ -18,8 +18,8 @@
 /*
   mmcli helpers
 */
-import { execFileP } from "../../helpers/exec.ts";
 import { logger } from "../../helpers/logger.ts";
+import { ALLOWED, run } from "../../helpers/run.ts";
 import {
 	handleMmcliCommand,
 	shouldMockModems,
@@ -61,8 +61,42 @@ type NetworkTypeWithLabel = NetworkType & {
 
 const mmcliBinary = setup.mmcli_binary ?? "mmcli";
 
+// Allowlist the operator-pinned mmcli path (config-sourced, NOT RPC input) so
+// run()'s allowlist gate accepts it; default "mmcli" is already present.
+ALLOWED.add(mmcliBinary);
+
 const mmcliKeyPattern = /\.length$/;
 const mmcliValuePattern = /\.value\[\d+]$/;
+
+/**
+ * Valid ModemManager mode tokens accepted by `--set-allowed-modes` /
+ * `--set-preferred-mode`. The `allowed` value may be a pipe-joined combination
+ * (e.g. "4g|5g"), so it is validated token-by-token; `preferred` is a single
+ * token and may additionally be "none".
+ */
+export const VALID_MODES: ReadonlySet<string> = new Set<string>([
+	"any",
+	"2g",
+	"3g",
+	"4g",
+	"5g",
+	"none",
+]);
+
+/**
+ * Validate a mode spec built from RPC input before it becomes an mmcli flag
+ * value. Splits pipe-joined combinations and checks each token against
+ * {@link VALID_MODES}. Throws on any unknown token — this rejects argument
+ * injection such as "--help; rm -rf /" outright.
+ */
+export function validateModeSpec(value: string): string {
+	for (const token of value.split("|")) {
+		if (!VALID_MODES.has(token)) {
+			throw new Error(`invalid mode: ${value}`);
+		}
+	}
+	return value;
+}
 
 export function mmcliParseSep(input: string) {
 	const output: Record<string, string | Array<string>> = {};
@@ -192,8 +226,8 @@ export async function mmList() {
 			}
 		}
 
-		const result = await execFileP(mmcliBinary, ["-K", "-L"]);
-		const modems = mmcliParseSep(result.stdout.toString())["modem-list"] ?? [];
+		const stdout = await run(mmcliBinary, ["-K", "-L"]);
+		const modems = mmcliParseSep(stdout)["modem-list"] ?? [];
 
 		const list = [];
 		for (const m of modems) {
@@ -222,8 +256,8 @@ export async function mmGetModem(id: ModemId) {
 			}
 		}
 
-		const result = await execFileP(mmcliBinary, ["-K", "-m", String(id)]);
-		return mmcliParseSep(result.stdout.toString()) as unknown as ModemInfo;
+		const stdout = await run(mmcliBinary, ["-K", "-m", String(id)]);
+		return mmcliParseSep(stdout) as unknown as ModemInfo;
 	} catch (err) {
 		if (err instanceof Error) {
 			logger.error(`mmGetModem err: ${err.message}`);
@@ -241,8 +275,8 @@ export async function mmGetSim(id: number) {
 			}
 		}
 
-		const result = await execFileP(mmcliBinary, ["-K", "-i", String(id)]);
-		return mmcliParseSep(result.stdout.toString()) as unknown as SimInfo;
+		const stdout = await run(mmcliBinary, ["-K", "-i", String(id)]);
+		return mmcliParseSep(stdout) as unknown as SimInfo;
 	} catch (err) {
 		if (err instanceof Error) {
 			logger.error(`mmGetSim err: ${err.message}`);
@@ -256,12 +290,14 @@ export async function mmSetNetworkTypes(
 	preferred: string,
 ) {
 	try {
+		validateModeSpec(allowed);
+		validateModeSpec(preferred);
 		const args = ["-m", String(id), `--set-allowed-modes=${allowed}`];
 		if (preferred !== "none") {
 			args.push(`--set-preferred-mode=${preferred}`);
 		}
-		const result = await execFileP(mmcliBinary, args);
-		return result.stdout.match(/successfully set current modes in the modem/);
+		const stdout = await run(mmcliBinary, args);
+		return stdout.match(/successfully set current modes in the modem/);
 	} catch (err) {
 		if (err instanceof Error) {
 			logger.error(`mmSetNetworkTypes err: ${err.message}`);
@@ -306,14 +342,14 @@ export async function mmNetworkScan(id: ModemId, timeout = 240) {
 			}
 		}
 
-		const result = await execFileP(mmcliBinary, [
+		const stdout = await run(mmcliBinary, [
 			`--timeout=${timeout}`,
 			"-K",
 			"-m",
 			String(id),
 			"--3gpp-scan",
 		]);
-		const networks = (mmcliParseSep(result.stdout.toString())[
+		const networks = (mmcliParseSep(stdout)[
 			"modem.3gpp.scan-networks"
 		] ?? []) as Array<string>;
 		return networks.map((n) => {

--- a/apps/backend/src/modules/network/gateways.ts
+++ b/apps/backend/src/modules/network/gateways.ts
@@ -15,8 +15,8 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { execP } from "../../helpers/exec.ts";
 import { logger } from "../../helpers/logger.ts";
+import { ID_RE, argMatch, run } from "../../helpers/run.ts";
 import { getms } from "../../helpers/time.ts";
 import {
 	notificationBroadcast,
@@ -38,11 +38,53 @@ let updateGwQueue = true;
 async function clear_default_gws() {
 	try {
 		while (true) {
-			await execP("ip route del default");
+			await run("ip", ["route", "del", "default"]);
 		}
 	} catch (_err) {
 		return;
 	}
+}
+
+/**
+ * Split a default-route line from `ip route show ... default` into a well-formed
+ * `ip route add` argv. The `gw` string (e.g. `"default via 192.168.1.1 dev eth0"`)
+ * is tokenized on whitespace into SEPARATE argv elements — security-critical: it
+ * is never passed back as one re-interpolated shell token.
+ */
+export function buildRouteAddArgv(gw: string): string[] {
+	const tokens = gw
+		.trim()
+		.split(/\s+/)
+		.filter((t) => t.length > 0);
+	return ["route", "add", ...tokens];
+}
+
+export type GwDeps = {
+	runner: typeof run;
+	clearDefaultGws: () => Promise<void>;
+};
+
+export async function setDefaultRoute(
+	goodIf: string,
+	deps: Partial<GwDeps> = {},
+): Promise<void> {
+	const runner = deps.runner ?? run;
+	const clearGws = deps.clearDefaultGws ?? clear_default_gws;
+
+	const gw = await runner("ip", [
+		"route",
+		"show",
+		"table",
+		argMatch(ID_RE, goodIf),
+		"default",
+	]);
+
+	await clearGws();
+
+	const argv = buildRouteAddArgv(gw);
+	await runner("ip", argv);
+
+	logger.info(`Set default route: ip ${argv.join(" ")}`);
 }
 
 export function queueUpdateGw() {
@@ -112,13 +154,7 @@ async function updateGw() {
 
 	if (goodIf) {
 		try {
-			const gw = (await execP(`ip route show table ${goodIf} default`)).stdout;
-			await clear_default_gws();
-
-			const route = `ip route add ${gw}`;
-			await execP(route);
-
-			logger.info(`Set default route: ${route}`);
+			await setDefaultRoute(goodIf);
 			notificationRemove("no_internet");
 
 			return true;

--- a/apps/backend/src/modules/network/network-interfaces.ts
+++ b/apps/backend/src/modules/network/network-interfaces.ts
@@ -17,11 +17,11 @@
 */
 
 /* Network interface list */
-import { exec } from "node:child_process";
 import { EventEmitter } from "node:events";
 import type WebSocket from "ws";
 
 import { logger } from "../../helpers/logger.ts";
+import { run } from "../../helpers/run.ts";
 import { ACTIVE_TO } from "../../helpers/shared.ts";
 import { getms } from "../../helpers/time.ts";
 import {
@@ -96,13 +96,12 @@ function updateNetif() {
 		return;
 	}
 
-	exec("ifconfig", (error, stdout) => {
-		if (error) {
-			logger.error(`Error getting ifconfig: ${error.message}`);
-			return;
-		}
-		processIfconfigOutput(stdout);
-	});
+	run("ifconfig", [])
+		.then(processIfconfigOutput)
+		.catch((error: unknown) => {
+			const message = error instanceof Error ? error.message : String(error);
+			logger.error(`Error getting ifconfig: ${message}`);
+		});
 }
 
 function processIfconfigOutput(stdout: string) {

--- a/apps/backend/src/modules/network/network-manager.ts
+++ b/apps/backend/src/modules/network/network-manager.ts
@@ -168,7 +168,7 @@ export async function nmConnSetFields(
 			return true;
 		}
 
-		const args = ["con", "modify", uuid];
+		const args = ["con", "modify", argMatch(ID_RE, uuid)];
 		for (const field in fields) {
 			const value = fields[field];
 			if (value === undefined) continue;
@@ -176,8 +176,8 @@ export async function nmConnSetFields(
 			args.push(field);
 			args.push(value);
 		}
-		const result = await execFileP("nmcli", args);
-		return result.stdout === "";
+		const stdout = await run("nmcli", args);
+		return stdout === "";
 	} catch (err) {
 		if (err instanceof Error) {
 			logger.error(`nmConnSetFields err: ${err.message}`);
@@ -212,8 +212,8 @@ export async function nmConnDelete(uuid: ConnectionUUID) {
 			return true;
 		}
 
-		const result = await execFileP("nmcli", ["conn", "del", uuid]);
-		return result.stdout.match("successfully deleted");
+		const stdout = await run("nmcli", ["conn", "del", argMatch(ID_RE, uuid)]);
+		return stdout.match("successfully deleted");
 	} catch (err) {
 		if (err instanceof Error) {
 			logger.error(`nmConnDelete err: ${err.message}`);
@@ -231,11 +231,11 @@ export async function nmConnect(uuid: ConnectionUUID, timeout?: number) {
 		}
 
 		const timeoutArgs = timeout ? ["-w", String(timeout)] : [];
-		const result = await execFileP(
+		const stdout = await run(
 			"nmcli",
-			timeoutArgs.concat(["conn", "up", uuid]),
+			timeoutArgs.concat(["conn", "up", argMatch(ID_RE, uuid)]),
 		);
-		return result.stdout.match("^Connection successfully activated");
+		return stdout.match("^Connection successfully activated");
 	} catch (err) {
 		if (err instanceof Error) {
 			logger.error(`nmConnect err: ${err.message}`);
@@ -252,8 +252,8 @@ export async function nmDisconnect(uuid: ConnectionUUID) {
 			return true;
 		}
 
-		const result = await execFileP("nmcli", ["conn", "down", uuid]);
-		return result.stdout.match("successfully deactivated");
+		const stdout = await run("nmcli", ["conn", "down", argMatch(ID_RE, uuid)]);
+		return stdout.match("successfully deactivated");
 	} catch (err) {
 		if (err instanceof Error) {
 			logger.error(`nmDisconnect err: ${err.message}`);
@@ -278,14 +278,14 @@ export async function nmDevices(fields: string) {
 			}
 		}
 
-		const result = await execFileP("nmcli", [
+		const stdout = await run("nmcli", [
 			"--terse",
 			"--fields",
 			fields,
 			"device",
 			"status",
 		]);
-		return result.stdout.toString().split("\n");
+		return stdout.split("\n");
 	} catch (err) {
 		if (err instanceof Error) {
 			logger.error(`nmDevices err: ${err.message}`);
@@ -312,7 +312,7 @@ export async function nmDeviceProp(device: string, fields: string) {
 			});
 		}
 
-		const result = await execFileP("nmcli", [
+		const stdout = await run("nmcli", [
 			"--terse",
 			"--escape",
 			"no",
@@ -320,9 +320,9 @@ export async function nmDeviceProp(device: string, fields: string) {
 			fields,
 			"device",
 			"show",
-			device,
+			argMatch(ID_RE, device),
 		]);
-		return result.stdout.toString().split("\n");
+		return stdout.split("\n");
 	} catch (err) {
 		if (err instanceof Error) {
 			logger.error(`nmDeviceProp err: ${err.message}`);
@@ -335,7 +335,7 @@ export async function nmRescan(device?: string) {
 		const args = ["device", "wifi", "rescan"];
 		if (device) {
 			args.push("ifname");
-			args.push(device);
+			args.push(argMatch(ID_RE, device));
 		}
 
 		// Check for mock mode
@@ -346,8 +346,8 @@ export async function nmRescan(device?: string) {
 			}
 		}
 
-		const result = await execFileP("nmcli", args);
-		return result.stdout === "";
+		const stdout = await run("nmcli", args);
+		return stdout === "";
 	} catch (err) {
 		if (err instanceof Error) {
 			logger.error(`nmDevices err: ${err.message}`);
@@ -375,7 +375,7 @@ export async function nmScanResults(fields: string) {
 			}
 		}
 
-		const result = await execFileP("nmcli", [
+		const stdout = await run("nmcli", [
 			"--terse",
 			"--fields",
 			fields,
@@ -385,7 +385,7 @@ export async function nmScanResults(fields: string) {
 			"--rescan",
 			"no",
 		]);
-		return result.stdout.toString().split("\n");
+		return stdout.split("\n");
 	} catch (err) {
 		if (err instanceof Error) {
 			logger.error(`nmScanResults err: ${err.message}`);
@@ -410,7 +410,7 @@ export async function nmHotspot(
 		}
 
 		const timeoutArgs = timeout ? ["-w", String(timeout)] : [];
-		const result = await execFileP(
+		const stdout = await run(
 			"nmcli",
 			timeoutArgs.concat([
 				"device",
@@ -421,11 +421,11 @@ export async function nmHotspot(
 				"password",
 				password,
 				"ifname",
-				device,
+				argMatch(ID_RE, device),
 			]),
 		);
 
-		const uuid = result.stdout.match(/successfully activated with '(.+)'/);
+		const uuid = stdout.match(/successfully activated with '(.+)'/);
 		return uuid?.[1] ?? null;
 	} catch (err) {
 		if (err instanceof Error) {

--- a/apps/backend/src/modules/network/network-manager.ts
+++ b/apps/backend/src/modules/network/network-manager.ts
@@ -18,8 +18,8 @@
 
 /* NetworkManager / nmcli helpers */
 
-import { execFileP } from "../../helpers/exec.ts";
 import { logger } from "../../helpers/logger.ts";
+import { argMatch, ID_RE, run } from "../../helpers/run.ts";
 import {
 	handleNmcliCommand,
 	shouldMockWifi,
@@ -67,8 +67,8 @@ export async function nmConnAdd(connection: NetworkManagerConnection) {
 			args.push(field);
 			args.push(String(value));
 		}
-		const result = await execFileP("nmcli", args);
-		const success = result.stdout.match(
+		const stdout = await run("nmcli", args);
+		const success = stdout.match(
 			/Connection '.+' \((.+)\) successfully added./,
 		);
 
@@ -96,14 +96,14 @@ export async function nmConnsGet(fields: string) {
 			}
 		}
 
-		const result = await execFileP("nmcli", [
+		const stdout = await run("nmcli", [
 			"--terse",
 			"--fields",
 			fields,
 			"connection",
 			"show",
 		]);
-		return result.stdout.toString().split("\n");
+		return stdout.split("\n");
 	} catch (err) {
 		if (err instanceof Error) {
 			logger.error(`nmConnsGet err: ${err.message}`);
@@ -136,7 +136,7 @@ export async function nmConnGetFields<Tupel extends Readonly<Array<string>>>(
 			}
 		}
 
-		const result = await execFileP("nmcli", [
+		const stdout = await run("nmcli", [
 			"--terse",
 			"--escape",
 			"no",
@@ -145,9 +145,9 @@ export async function nmConnGetFields<Tupel extends Readonly<Array<string>>>(
 			fields.join(","),
 			"connection",
 			"show",
-			uuid,
+			argMatch(ID_RE, uuid),
 		]);
-		return result.stdout.toString().split("\n") as {
+		return stdout.split("\n") as {
 			[K in keyof Tupel]: string;
 		};
 	} catch (err) {

--- a/apps/backend/src/modules/system/logs.ts
+++ b/apps/backend/src/modules/system/logs.ts
@@ -16,33 +16,34 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { exec } from "node:child_process";
-
 import type WebSocket from "ws";
 
 import { logger } from "../../helpers/logger.ts";
+import { run } from "../../helpers/run.ts";
 
 import { notificationSend } from "../ui/notifications.ts";
 import { buildMsg, getSocketSenderId } from "../ui/websocket-server.ts";
 
-export function getLog(conn: WebSocket, service?: string) {
+export async function getLog(conn: WebSocket, service?: string) {
 	const senderId = getSocketSenderId(conn);
-	let cmd = "journalctl -b";
+	// Argv-only: each token is a discrete element, so a `service` value can never
+	// be re-parsed as shell syntax (no `sh -c`, so `;`/spaces/`$()` are inert).
+	const args = ["-b"];
 	let name = "ceralive_system_log.txt";
 
 	if (service) {
-		cmd += ` -u ${service}`;
+		args.push("-u", service);
 		name = `${service.replace("CeraLive", "ceralive")}_log.txt`;
 	}
 
-	exec(cmd, { maxBuffer: 10 * 1024 * 1024 }, (err, stdout) => {
-		if (err) {
-			const msg = `Failed to fetch the log: ${err}`;
-			notificationSend(conn, "log_error", "error", msg, 10);
-			logger.error(msg);
-			return;
-		}
-
+	try {
+		const stdout = await run("journalctl", args, {
+			maxBuffer: 10 * 1024 * 1024,
+		});
 		conn.send(buildMsg("log", { name, contents: stdout }, senderId));
-	});
+	} catch (err) {
+		const msg = `Failed to fetch the log: ${err}`;
+		notificationSend(conn, "log_error", "error", msg, 10);
+		logger.error(msg);
+	}
 }

--- a/apps/backend/src/modules/system/sensors.ts
+++ b/apps/backend/src/modules/system/sensors.ts
@@ -20,8 +20,8 @@ import { spawn } from "node:child_process";
 /* Hardware monitoring */
 import fs from "node:fs";
 
-import { execPNR } from "../../helpers/exec.ts";
 import { logger } from "../../helpers/logger.ts";
+import { argMatch, run, SERVICE_RE } from "../../helpers/run.ts";
 import { ACTIVE_TO } from "../../helpers/shared.ts";
 import { getms } from "../../helpers/time.ts";
 import {
@@ -85,13 +85,23 @@ function updateSensorsRk3588() {
 }
 
 async function isServiceEnabled(service: string) {
-	const isEnabled = await execPNR(`systemctl is-enabled ${service}`);
-	return isEnabled.code === 0;
+	try {
+		await run("systemctl", ["is-enabled", argMatch(SERVICE_RE, service)]);
+		return true;
+	} catch (_err) {
+		// `systemctl is-enabled` exits non-zero when the unit is disabled/absent.
+		return false;
+	}
 }
 
 async function isServiceFailed(service: string) {
-	const isFailed = await execPNR(`systemctl is-failed ${service}`);
-	return isFailed.code === 0;
+	try {
+		await run("systemctl", ["is-failed", argMatch(SERVICE_RE, service)]);
+		return true;
+	} catch (_err) {
+		// `systemctl is-failed` exits non-zero when the unit is not in a failed state.
+		return false;
+	}
 }
 
 async function monitorBootconfig() {

--- a/apps/backend/src/modules/system/software-updates.ts
+++ b/apps/backend/src/modules/system/software-updates.ts
@@ -17,10 +17,12 @@
 */
 
 /* Software updates */
-import { type ExecException, exec, spawn, spawnSync } from "node:child_process";
+import { type ExecException, exec, spawn } from "node:child_process";
 
 import { execPNR } from "../../helpers/exec.ts";
+import { invariant } from "../../helpers/invariant.ts";
 import { logger } from "../../helpers/logger.ts";
+import { run } from "../../helpers/run.ts";
 import { getms, oneHour, oneMinute } from "../../helpers/time.ts";
 
 import { queueUpdateGw } from "../network/gateways.ts";
@@ -91,6 +93,77 @@ const ceralivePackageList = [
 ];
 // Reboot instead of just restarting CeraUI if we've updated packages matching this list
 const rebootPackageList = ["l4t", "ceralive-linux-", "ceralive-network-config"];
+
+/**
+ * Allowed characters in a Debian package name as passed to apt-get on argv.
+ * Letters, digits and the Debian-name punctuation set `. + : ~ -`. Anything
+ * containing whitespace or a shell metacharacter (`;`, `&`, `$`, backtick, …)
+ * is rejected — even though argv is shell-free, this keeps a malformed/poisoned
+ * apt output from reaching the package manager as an argument.
+ */
+const APT_PACKAGE_NAME_RE = /^[A-Za-z0-9.+:~-]+$/;
+
+/**
+ * Split a whitespace-separated apt "kept back" package string into individual,
+ * charset-validated package names. Throws (via invariant) on the first name
+ * that does not match {@link APT_PACKAGE_NAME_RE}.
+ */
+export function parseHeldBackPackages(packages: string): string[] {
+	const names = packages
+		.trim()
+		.split(/\s+/)
+		.filter((n) => n.length > 0);
+	for (const name of names) {
+		invariant(
+			APT_PACKAGE_NAME_RE.test(name),
+			`invalid package name in held-back list: ${name}`,
+		);
+	}
+	return names;
+}
+
+/**
+ * Build the argv for the read-only `apt-get install --assume-no <pkgs>` probe.
+ * Each package becomes its own argv element — no shell, no `args.split(" ")`.
+ */
+export function buildAptInstallArgs(packages: string[]): string[] {
+	return ["install", "--assume-no", ...packages];
+}
+
+/**
+ * Build the argv for the actual upgrade run. Held-back packages (already
+ * charset-validated) are installed by name; otherwise a dist-upgrade is run.
+ * Returns one argv element per token — never a space-split string.
+ */
+export function buildAptUpgradeArgs(heldBackPackages?: string[]): string[] {
+	const base = [
+		"-y",
+		"-o",
+		"Dpkg::Options::=--force-confdef",
+		"-o",
+		"Dpkg::Options::=--force-confold",
+	];
+	if (heldBackPackages && heldBackPackages.length > 0) {
+		return [...base, "install", ...heldBackPackages];
+	}
+	return [...base, "dist-upgrade"];
+}
+
+/**
+ * Run `apt-get install --assume-no <pkgs>` argv-only and return its stdout.
+ *
+ * `--assume-no` makes apt-get answer "no" and abort with a non-zero exit code
+ * whenever it would make changes, so run() rejects — but the summary we need to
+ * parse is on the rejection's stdout. Recover it instead of propagating.
+ */
+async function aptAssumeNoInstall(packages: string[]): Promise<string> {
+	try {
+		return await run("apt-get", buildAptInstallArgs(packages));
+	} catch (err) {
+		const e = err as { stdout?: unknown };
+		return typeof e.stdout === "string" ? e.stdout : "";
+	}
+}
 
 function packageListIncludes(list: string, includes: Array<string>) {
 	for (const p of includes) {

--- a/apps/backend/src/modules/system/software-updates.ts
+++ b/apps/backend/src/modules/system/software-updates.ts
@@ -94,20 +94,10 @@ const ceralivePackageList = [
 // Reboot instead of just restarting CeraUI if we've updated packages matching this list
 const rebootPackageList = ["l4t", "ceralive-linux-", "ceralive-network-config"];
 
-/**
- * Allowed characters in a Debian package name as passed to apt-get on argv.
- * Letters, digits and the Debian-name punctuation set `. + : ~ -`. Anything
- * containing whitespace or a shell metacharacter (`;`, `&`, `$`, backtick, …)
- * is rejected — even though argv is shell-free, this keeps a malformed/poisoned
- * apt output from reaching the package manager as an argument.
- */
+// Debian package-name charset (letters, digits, and `. + : ~ -`); rejects
+// whitespace and shell metacharacters in poisoned/malformed apt output.
 const APT_PACKAGE_NAME_RE = /^[A-Za-z0-9.+:~-]+$/;
 
-/**
- * Split a whitespace-separated apt "kept back" package string into individual,
- * charset-validated package names. Throws (via invariant) on the first name
- * that does not match {@link APT_PACKAGE_NAME_RE}.
- */
 export function parseHeldBackPackages(packages: string): string[] {
 	const names = packages
 		.trim()
@@ -122,19 +112,10 @@ export function parseHeldBackPackages(packages: string): string[] {
 	return names;
 }
 
-/**
- * Build the argv for the read-only `apt-get install --assume-no <pkgs>` probe.
- * Each package becomes its own argv element — no shell, no `args.split(" ")`.
- */
 export function buildAptInstallArgs(packages: string[]): string[] {
 	return ["install", "--assume-no", ...packages];
 }
 
-/**
- * Build the argv for the actual upgrade run. Held-back packages (already
- * charset-validated) are installed by name; otherwise a dist-upgrade is run.
- * Returns one argv element per token — never a space-split string.
- */
 export function buildAptUpgradeArgs(heldBackPackages?: string[]): string[] {
 	const base = [
 		"-y",
@@ -149,17 +130,12 @@ export function buildAptUpgradeArgs(heldBackPackages?: string[]): string[] {
 	return [...base, "dist-upgrade"];
 }
 
-/**
- * Run `apt-get install --assume-no <pkgs>` argv-only and return its stdout.
- *
- * `--assume-no` makes apt-get answer "no" and abort with a non-zero exit code
- * whenever it would make changes, so run() rejects — but the summary we need to
- * parse is on the rejection's stdout. Recover it instead of propagating.
- */
 async function aptAssumeNoInstall(packages: string[]): Promise<string> {
 	try {
 		return await run("apt-get", buildAptInstallArgs(packages));
 	} catch (err) {
+		// --assume-no aborts non-zero whenever changes would be made, so run()
+		// rejects; the summary we parse is still on the rejection's stdout.
 		const e = err as { stdout?: unknown };
 		return typeof e.stdout === "string" ? e.stdout : "";
 	}
@@ -208,7 +184,7 @@ async function getSoftwareUpdateSize() {
 	if (getIsStreaming() || isUpdating() || aptGetUpdating) return "busy";
 
 	// First see if any packages can be upgraded by dist-upgrade
-	let upgrade = await execPNR("apt-get dist-upgrade --assume-no");
+	const upgrade = await execPNR("apt-get dist-upgrade --assume-no");
 	let res = parseAptUpgradeSummary(upgrade.stdout);
 
 	// Otherwise, check if any packages have been held back (e.g. by dependencies changing)
@@ -218,10 +194,10 @@ async function getSoftwareUpdateSize() {
 			"The following packages have been kept back:\n",
 		);
 		if (aptHeldBackPackages) {
-			upgrade = await execPNR(
-				`apt-get install --assume-no ${aptHeldBackPackages}`,
+			const stdout = await aptAssumeNoInstall(
+				parseHeldBackPackages(aptHeldBackPackages),
 			);
-			res = parseAptUpgradeSummary(upgrade.stdout);
+			res = parseAptUpgradeSummary(stdout);
 		}
 	} else {
 		// Reset aptHeldBackPackages if some upgrades became available via dist-upgrade
@@ -351,14 +327,10 @@ function doSoftwareUpdate() {
 	let aptLog = "";
 	let aptErr = "";
 
-	let args =
-		"-y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold ";
-	if (aptHeldBackPackages) {
-		args += `install ${aptHeldBackPackages}`;
-	} else {
-		args += "dist-upgrade";
-	}
-	const aptUpgrade = spawn("apt-get", args.split(" "));
+	const heldBack = aptHeldBackPackages
+		? parseHeldBackPackages(aptHeldBackPackages)
+		: undefined;
+	const aptUpgrade = spawn("apt-get", buildAptUpgradeArgs(heldBack));
 
 	aptUpgrade.stdout.on("data", (buf) => {
 		let sendUpdate = false;
@@ -437,9 +409,9 @@ function doSoftwareUpdate() {
 
 		if (code === 0) {
 			if (rebootAfterUpgrade) {
-				spawnSync("reboot");
+				void run("reboot", []);
 			} else {
-				process.exit(0);
+				invariant(false, "software update complete; exiting to restart CeraUI");
 			}
 		}
 	});

--- a/apps/backend/src/modules/system/ssh.ts
+++ b/apps/backend/src/modules/system/ssh.ts
@@ -16,11 +16,13 @@
 */
 
 /* SSH control */
-import { exec, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import crypto from "node:crypto";
+import fs from "node:fs";
 
 import type WebSocket from "ws";
 
+import { execFileP } from "../../helpers/exec.ts";
 import { logger } from "../../helpers/logger.ts";
 import { getConfig, saveConfig } from "../config.ts";
 import { setup } from "../setup.ts";
@@ -33,6 +35,13 @@ type SshStatus = {
 	user_pass?: boolean;
 };
 
+/**
+ * Identifier guard for `ssh_user`. Letters, digits and `_ . -` only, and the
+ * value may not begin with `-` (which `passwd`/`systemctl` could otherwise
+ * mis-parse as a flag — argument injection). Mirrors helpers/run.ts#ID_RE.
+ */
+const ID_RE = /^[A-Za-z0-9_.-]+$/;
+
 let sshStatus: SshStatus | null = null;
 let sshPasswordHash: string | undefined;
 
@@ -44,112 +53,241 @@ export function getSshPasswordHash() {
 	return sshPasswordHash;
 }
 
-function handleSshStatus(s: SshStatus) {
-	if (
-		s.user !== undefined &&
-		s.active !== undefined &&
-		s.user_pass !== undefined
-	) {
-		if (
-			!sshStatus ||
-			s.user !== sshStatus.user ||
-			s.active !== sshStatus.active ||
-			s.user_pass !== sshStatus.user_pass
-		) {
-			sshStatus = s;
-			broadcastMsg("status", { ssh: sshStatus });
-		}
+/**
+ * LOCAL stdin shim — spawn `bin` with argv `args` (NO shell) and write the
+ * secret `input` to the child's stdin. The secret is NEVER placed on argv, so
+ * it cannot leak via the process table (`ps`) or a shell string.
+ *
+ * MIGRATION: Task 8 introduces the canonical `helpers/run.ts#runWithStdin`
+ * (same spawn-stdin contract, plus an ALLOWLIST check). Once that lands and is
+ * committed, delete this shim and switch resetSshPassword to:
+ *   import { runWithStdin } from "../../helpers/run.ts";
+ */
+function runWithStdinLocal(
+	bin: string,
+	args: string[],
+	input: string,
+): Promise<string> {
+	return new Promise<string>((resolve, reject) => {
+		const child = spawn(bin, args, { stdio: ["pipe", "pipe", "pipe"] });
+
+		let stdout = "";
+		let stderr = "";
+
+		child.stdout?.on("data", (chunk) => {
+			stdout += chunk.toString();
+		});
+		child.stderr?.on("data", (chunk) => {
+			stderr += chunk.toString();
+		});
+
+		child.on("error", reject);
+		child.on("close", (code) => {
+			if (code === 0) {
+				resolve(stdout);
+			} else {
+				reject(
+					new Error(
+						`${bin} exited with code ${code}${stderr ? `: ${stderr.trim()}` : ""}`,
+					),
+				);
+			}
+		});
+
+		// Secret goes to stdin ONLY — never to argv.
+		child.stdin?.write(input);
+		child.stdin?.end();
+	});
+}
+
+/** Escape an ID_RE-validated value for safe literal use inside a RegExp. */
+function escapeForRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\-]/g, "\\$&");
+}
+
+/**
+ * Parse the crypt hash field for `user` out of a /etc/shadow document, in JS.
+ * Returns the second colon-separated field (the password hash) or undefined
+ * when there is no matching entry.
+ */
+function parseShadowHash(shadow: string, user: string): string | undefined {
+	const re = new RegExp(`^${escapeForRegExp(user)}:([^:]*):`, "m");
+	const match = shadow.match(re);
+	return match ? match[1] : undefined;
+}
+
+/**
+ * Injectable probe surface for {@link getSshStatus}. Defaults talk to the real
+ * OS (argv-only systemctl, JS /etc/shadow read, real broadcast). Tests inject
+ * deterministic stand-ins and a spy broadcast.
+ */
+export type SshStatusDeps = {
+	/** `systemctl is-active ssh` — argv-only, may reject on non-zero exit. */
+	systemctlIsActive: () => Promise<{ stdout: string; stderr: string }>;
+	/** Read the raw /etc/shadow document (JS, no `grep` subprocess). */
+	readShadow: () => string;
+	/** Emit the completed SSH status to clients. */
+	broadcast: (status: SshStatus) => void;
+};
+
+const defaultSshStatusDeps: SshStatusDeps = {
+	systemctlIsActive: () => execFileP("systemctl", ["is-active", "ssh"]),
+	readShadow: () => fs.readFileSync("/etc/shadow", "utf-8"),
+	broadcast: (status) => broadcastMsg("status", { ssh: status }),
+};
+
+/** Resolve whether the ssh service is active, swallowing the non-zero exit. */
+async function probeSshActive(
+	systemctlIsActive: SshStatusDeps["systemctlIsActive"],
+): Promise<boolean> {
+	try {
+		const { stdout } = await systemctlIsActive();
+		return stdout.trim() === "active";
+	} catch (err) {
+		// `is-active` exits non-zero for inactive/failed/unknown; the unit is
+		// simply not active. Treat ANY failure as not-active (never "missing").
+		const stdout = (err as { stdout?: string } | null)?.stdout ?? "";
+		return stdout.trim() === "active";
 	}
 }
 
-function getSshUserHash(callback: (hash: string) => void) {
-	if (!setup.ssh_user) return;
-
-	const cmd = `grep "^${setup.ssh_user}:" /etc/shadow`;
-	exec(cmd, (err, stdout) => {
-		if (err === null && stdout.length) {
-			callback(stdout);
-		} else {
-			logger.error(
-				`Error getting the password hash for ${setup.ssh_user}: ${err}`,
-			);
-		}
-	});
+/** Read + parse the user's crypt hash from /etc/shadow, in JS. */
+function probeSshUserHash(
+	readShadow: SshStatusDeps["readShadow"],
+	user: string,
+): string | undefined {
+	let shadow: string;
+	try {
+		shadow = readShadow();
+	} catch (err) {
+		logger.error(`Error reading /etc/shadow for ${user}: ${err}`);
+		return undefined;
+	}
+	const hash = parseShadowHash(shadow, user);
+	if (hash === undefined) {
+		logger.error(`No /etc/shadow entry found for ${user}`);
+	}
+	return hash;
 }
 
-export function getSshStatus() {
-	if (!setup.ssh_user) return undefined;
-
-	const s: SshStatus = {
-		user: setup.ssh_user,
-		active: undefined,
+/**
+ * Probe the SSH service + user password state and broadcast the result.
+ *
+ * Both probes run concurrently via `Promise.all`; the status object is built
+ * once both have settled, and is broadcast EXACTLY ONCE (only when the complete
+ * status actually changed). No shared-mutable-object callback race, and the
+ * systemctl-error path yields `active: false` rather than dropping the update.
+ *
+ * Returns the current cached status (same wire shape as before) for callers
+ * that want an immediate value.
+ */
+export async function getSshStatus(
+	deps: Partial<SshStatusDeps> = {},
+): Promise<SshStatus | undefined> {
+	const { systemctlIsActive, readShadow, broadcast } = {
+		...defaultSshStatusDeps,
+		...deps,
 	};
 
-	// Check is the SSH server is running
-	exec("systemctl is-active ssh", (err, stdout) => {
-		if (err === null) {
-			s.active = true;
-		} else {
-			if (stdout === "inactive\n") {
-				s.active = false;
-			} else {
-				logger.error(`Error running systemctl is-active ssh: ${err.message}`);
-				return;
-			}
+	const ssh_user = setup.ssh_user;
+	if (!ssh_user) return sshStatus ?? undefined;
+	if (!ID_RE.test(ssh_user) || ssh_user.startsWith("-")) {
+		throw new Error("invalid ssh_user");
+	}
+
+	const [active, hash] = await Promise.all([
+		probeSshActive(systemctlIsActive),
+		Promise.resolve(probeSshUserHash(readShadow, ssh_user)),
+	]);
+
+	const status: SshStatus = {
+		user: ssh_user,
+		active,
+		user_pass: hash !== undefined ? hash !== sshPasswordHash : undefined,
+	};
+
+	// Broadcast exactly once, and only when the complete status changed.
+	if (status.active !== undefined && status.user_pass !== undefined) {
+		if (
+			!sshStatus ||
+			status.user !== sshStatus.user ||
+			status.active !== sshStatus.active ||
+			status.user_pass !== sshStatus.user_pass
+		) {
+			sshStatus = status;
+			broadcast(status);
 		}
+	}
 
-		handleSshStatus(s);
-	});
-
-	// Check if the user's password has been changed
-	getSshUserHash((hash: string) => {
-		s.user_pass = hash !== sshPasswordHash;
-		handleSshStatus(s);
-	});
-
-	// If an immediate result is expected, send the cached status
-	return sshStatus;
+	return sshStatus ?? undefined;
 }
 
-export function startStopSsh(conn: WebSocket, cmd: "start_ssh" | "stop_ssh") {
+/**
+ * Synchronous accessor for the last-known SSH status. The status-message
+ * builders embed this in their response immediately and trigger a background
+ * `getSshStatus()` refresh (which broadcasts only if something changed) —
+ * preserving the original "return cache now, re-probe in the background"
+ * behaviour without making the whole status pipeline async.
+ */
+export function getCachedSshStatus(): SshStatus | undefined {
+	return sshStatus ?? undefined;
+}
+
+export async function startStopSsh(
+	conn: WebSocket,
+	cmd: "start_ssh" | "stop_ssh",
+) {
 	if (!setup.ssh_user) return;
 
 	const action = cmd === "start_ssh" ? "start" : "stop";
 	if (action === "start" && getConfig().ssh_pass === undefined) {
-		resetSshPassword(conn);
+		await resetSshPassword(conn);
 	}
 
-	spawnSync("systemctl", [action, "ssh"]);
-	getSshStatus();
+	try {
+		await execFileP("systemctl", [action, "ssh"]);
+	} catch (err) {
+		logger.error(`Error running systemctl ${action} ssh: ${err}`);
+	}
+	await getSshStatus();
 }
 
-export function resetSshPassword(conn: WebSocket) {
-	if (!setup.ssh_user) return;
+export async function resetSshPassword(conn: WebSocket) {
+	const ssh_user = setup.ssh_user;
+	if (!ssh_user) return;
+	if (!ID_RE.test(ssh_user) || ssh_user.startsWith("-")) {
+		throw new Error("invalid ssh_user");
+	}
 
 	const password = crypto
 		.randomBytes(24)
 		.toString("base64")
 		.replace(/[+/=]/g, "")
 		.substring(0, 20);
-	const cmd = `printf "${password}\n${password}" | passwd ${setup.ssh_user}`;
-	exec(cmd, (err) => {
-		if (err) {
-			notificationSend(
-				conn,
-				"ssh_pass_reset",
-				"error",
-				`Failed to reset the SSH password for ${setup.ssh_user}`,
-				10,
-			);
-			return;
-		}
-		getSshUserHash((hash: string) => {
-			const config = getConfig();
-			config.ssh_pass = password;
-			sshPasswordHash = hash;
-			saveConfig();
-			broadcastMsg("config", config);
-			getSshStatus();
-		});
-	});
+
+	try {
+		// `passwd` reads the new password twice from stdin. The secret is fed via
+		// stdin ONLY — never on argv, never through a shell string.
+		await runWithStdinLocal("passwd", [ssh_user], `${password}\n${password}\n`);
+	} catch (err) {
+		logger.error(`Failed to reset the SSH password for ${ssh_user}: ${err}`);
+		notificationSend(
+			conn,
+			"ssh_pass_reset",
+			"error",
+			`Failed to reset the SSH password for ${ssh_user}`,
+			10,
+		);
+		return;
+	}
+
+	const config = getConfig();
+	config.ssh_pass = password;
+	sshPasswordHash = probeSshUserHash(
+		() => fs.readFileSync("/etc/shadow", "utf-8"),
+		ssh_user,
+	);
+	saveConfig();
+	broadcastMsg("config", config);
+	await getSshStatus();
 }

--- a/apps/backend/src/modules/system/ssh.ts
+++ b/apps/backend/src/modules/system/ssh.ts
@@ -16,7 +16,6 @@
 */
 
 /* SSH control */
-import { spawn } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
 
@@ -24,6 +23,7 @@ import type WebSocket from "ws";
 
 import { execFileP } from "../../helpers/exec.ts";
 import { logger } from "../../helpers/logger.ts";
+import { runWithStdin } from "../../helpers/run.ts";
 import { getConfig, saveConfig } from "../config.ts";
 import { setup } from "../setup.ts";
 import { notificationSend } from "../ui/notifications.ts";
@@ -51,53 +51,6 @@ export function setSshPasswordHash(hash: string | undefined) {
 
 export function getSshPasswordHash() {
 	return sshPasswordHash;
-}
-
-/**
- * LOCAL stdin shim — spawn `bin` with argv `args` (NO shell) and write the
- * secret `input` to the child's stdin. The secret is NEVER placed on argv, so
- * it cannot leak via the process table (`ps`) or a shell string.
- *
- * MIGRATION: Task 8 introduces the canonical `helpers/run.ts#runWithStdin`
- * (same spawn-stdin contract, plus an ALLOWLIST check). Once that lands and is
- * committed, delete this shim and switch resetSshPassword to:
- *   import { runWithStdin } from "../../helpers/run.ts";
- */
-function runWithStdinLocal(
-	bin: string,
-	args: string[],
-	input: string,
-): Promise<string> {
-	return new Promise<string>((resolve, reject) => {
-		const child = spawn(bin, args, { stdio: ["pipe", "pipe", "pipe"] });
-
-		let stdout = "";
-		let stderr = "";
-
-		child.stdout?.on("data", (chunk) => {
-			stdout += chunk.toString();
-		});
-		child.stderr?.on("data", (chunk) => {
-			stderr += chunk.toString();
-		});
-
-		child.on("error", reject);
-		child.on("close", (code) => {
-			if (code === 0) {
-				resolve(stdout);
-			} else {
-				reject(
-					new Error(
-						`${bin} exited with code ${code}${stderr ? `: ${stderr.trim()}` : ""}`,
-					),
-				);
-			}
-		});
-
-		// Secret goes to stdin ONLY — never to argv.
-		child.stdin?.write(input);
-		child.stdin?.end();
-	});
 }
 
 /** Escape an ID_RE-validated value for safe literal use inside a RegExp. */
@@ -268,7 +221,7 @@ export async function resetSshPassword(conn: WebSocket) {
 	try {
 		// `passwd` reads the new password twice from stdin. The secret is fed via
 		// stdin ONLY — never on argv, never through a shell string.
-		await runWithStdinLocal("passwd", [ssh_user], `${password}\n${password}\n`);
+		await runWithStdin("passwd", [ssh_user], `${password}\n${password}\n`);
 	} catch (err) {
 		logger.error(`Failed to reset the SSH password for ${ssh_user}: ${err}`);
 		notificationSend(

--- a/apps/backend/src/modules/ui/status.ts
+++ b/apps/backend/src/modules/ui/status.ts
@@ -31,7 +31,7 @@ import {
 	getAvailableUpdates,
 	getSoftUpdateStatus,
 } from "../system/software-updates.ts";
-import { getSshStatus } from "../system/ssh.ts";
+import { getCachedSshStatus, getSshStatus } from "../system/ssh.ts";
 import { wifiBuildMsg } from "../wifi/wifi.ts";
 import { notificationSendPersistent } from "./notifications.ts";
 import { buildMsg } from "./websocket-server.ts";
@@ -40,7 +40,7 @@ export type StatusResponseMessage = {
 	is_streaming?: ReturnType<typeof getIsStreaming>;
 	available_updates?: ReturnType<typeof getAvailableUpdates>;
 	updating?: ReturnType<typeof getSoftUpdateStatus>;
-	ssh?: ReturnType<typeof getSshStatus>;
+	ssh?: ReturnType<typeof getCachedSshStatus>;
 	wifi?: ReturnType<typeof wifiBuildMsg>;
 	modems?: ReturnType<typeof buildModemsMessage>;
 	asrcs?: Array<keyof ReturnType<typeof getAudioDevices>>;
@@ -49,12 +49,14 @@ export type StatusResponseMessage = {
 };
 
 export function sendStatus(conn: WebSocket) {
+	// Re-probe SSH in the background; broadcasts only if the status changed.
+	void getSshStatus();
 	conn.send(
 		buildMsg("status", {
 			is_streaming: getIsStreaming(),
 			available_updates: getAvailableUpdates(),
 			updating: getSoftUpdateStatus(),
-			ssh: getSshStatus(),
+			ssh: getCachedSshStatus(),
 			wifi: wifiBuildMsg(),
 			modems: buildModemsMessage(),
 			asrcs: Object.keys(getAudioDevices()),

--- a/apps/backend/src/rpc/procedures/status.procedure.ts
+++ b/apps/backend/src/rpc/procedures/status.procedure.ts
@@ -23,7 +23,10 @@ import {
 	getAvailableUpdates,
 	getSoftUpdateStatus,
 } from "../../modules/system/software-updates.ts";
-import { getSshStatus } from "../../modules/system/ssh.ts";
+import {
+	getCachedSshStatus,
+	getSshStatus,
+} from "../../modules/system/ssh.ts";
 import { wifiBuildMsg } from "../../modules/wifi/wifi.ts";
 import { authMiddleware } from "../middleware/auth.middleware.ts";
 import type { RPCContext } from "../types.ts";
@@ -40,11 +43,12 @@ const authedProcedure = baseProcedure.use(authMiddleware);
 export const getStatusProcedure = authedProcedure
 	.output(statusResponseSchema)
 	.handler(() => {
+		void getSshStatus();
 		return {
 			is_streaming: getIsStreaming(),
 			available_updates: getAvailableUpdates(),
 			updating: getSoftUpdateStatus(),
-			ssh: getSshStatus(),
+			ssh: getCachedSshStatus(),
 			wifi: wifiBuildMsg(),
 			modems: buildModemsMessage(),
 			asrcs: Object.keys(getAudioDevices()),
@@ -69,6 +73,7 @@ export const getRelaysProcedure = authedProcedure
  */
 export function buildInitialStatus() {
 	const config = getConfig();
+	void getSshStatus();
 	return {
 		config,
 		pipelines: getPipelinesMessage(),
@@ -77,7 +82,7 @@ export function buildInitialStatus() {
 			is_streaming: getIsStreaming(),
 			available_updates: getAvailableUpdates(),
 			updating: getSoftUpdateStatus(),
-			ssh: getSshStatus(),
+			ssh: getCachedSshStatus(),
 			wifi: wifiBuildMsg(),
 			modems: buildModemsMessage(),
 			asrcs: Object.keys(getAudioDevices()),

--- a/apps/backend/src/rpc/procedures/system.procedure.ts
+++ b/apps/backend/src/rpc/procedures/system.procedure.ts
@@ -129,7 +129,7 @@ export const sshStartProcedure = authedProcedure
 		if (getIsStreaming() || isUpdating()) {
 			return { success: false };
 		}
-		startStopSsh(context.ws as unknown as WebSocket, "start_ssh");
+		void startStopSsh(context.ws as unknown as WebSocket, "start_ssh");
 		return { success: true };
 	});
 
@@ -142,7 +142,7 @@ export const sshStopProcedure = authedProcedure
 		if (getIsStreaming() || isUpdating()) {
 			return { success: false };
 		}
-		startStopSsh(context.ws as unknown as WebSocket, "stop_ssh");
+		void startStopSsh(context.ws as unknown as WebSocket, "stop_ssh");
 		return { success: true };
 	});
 
@@ -157,7 +157,7 @@ export const sshResetPasswordProcedure = authedProcedure
 		}),
 	)
 	.handler(({ context }) => {
-		resetSshPassword(context.ws as unknown as WebSocket);
+		void resetSshPassword(context.ws as unknown as WebSocket);
 		return { success: true };
 	});
 

--- a/apps/backend/src/rpc/procedures/system.procedure.ts
+++ b/apps/backend/src/rpc/procedures/system.procedure.ts
@@ -7,6 +7,7 @@ import { spawnSync } from "node:child_process";
 import {
 	autostartInputSchema,
 	cloudProviderEndpointSchema,
+	logInputSchema,
 	logOutputSchema,
 	remoteConfigInputSchema,
 	revisionsSchema,
@@ -62,6 +63,7 @@ export const getSensorsProcedure = authedProcedure
  * Get application log procedure
  */
 export const getLogProcedure = authedProcedure
+	.input(logInputSchema)
 	.output(logOutputSchema)
 	.handler(async () => {
 		// getLog sends directly to socket, we need to adapt it

--- a/apps/backend/src/tests/gateways-migration.test.ts
+++ b/apps/backend/src/tests/gateways-migration.test.ts
@@ -1,0 +1,127 @@
+/*
+ * Tests for the gateways.ts `ip route` argv migration (Task 10).
+ *
+ * Security property under test: the gateway line discovered by
+ * `ip route show ... default` is tokenized into SEPARATE argv elements before
+ * reaching the runner — it is never re-interpolated as a single shell string.
+ * The interface name is validated against the ifname charset (ID_RE).
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+	buildRouteAddArgv,
+	setDefaultRoute,
+} from "../modules/network/gateways.ts";
+
+describe("buildRouteAddArgv — gateway line tokenization", () => {
+	test("splits a default-route line into separate argv elements", () => {
+		const gw = "default via 192.168.1.1 dev eth0\n";
+
+		expect(buildRouteAddArgv(gw)).toEqual([
+			"route",
+			"add",
+			"default",
+			"via",
+			"192.168.1.1",
+			"dev",
+			"eth0",
+		]);
+	});
+
+	test("collapses extra whitespace and never yields one shell string", () => {
+		const gw = "  default   via 10.0.0.1   dev   wwan0  \n";
+		const argv = buildRouteAddArgv(gw);
+
+		expect(argv).toEqual([
+			"route",
+			"add",
+			"default",
+			"via",
+			"10.0.0.1",
+			"dev",
+			"wwan0",
+		]);
+		// No element is the whole re-interpolated route string.
+		expect(argv).not.toContain("default via 10.0.0.1 dev wwan0");
+		for (const token of argv) {
+			expect(token).not.toContain(" ");
+		}
+	});
+});
+
+describe("setDefaultRoute — argv-only add path", () => {
+	test("passes tokenized argv to run() for both show and add, in order", async () => {
+		const calls: Array<[string, string[]]> = [];
+		const runner = mock(async (bin: string, args: string[]) => {
+			calls.push([bin, args]);
+			if (args[0] === "route" && args[1] === "show") {
+				return "default via 10.0.0.1 dev wwan0\n";
+			}
+			return "";
+		});
+
+		await setDefaultRoute("wwan0", {
+			runner: runner as never,
+			clearDefaultGws: async () => {},
+		});
+
+		expect(calls[0]?.[0]).toBe("ip");
+		expect(calls[0]?.[1]).toEqual([
+			"route",
+			"show",
+			"table",
+			"wwan0",
+			"default",
+		]);
+
+		const add = calls.find((c) => c[1][0] === "route" && c[1][1] === "add");
+		expect(add?.[0]).toBe("ip");
+		expect(add?.[1]).toEqual([
+			"route",
+			"add",
+			"default",
+			"via",
+			"10.0.0.1",
+			"dev",
+			"wwan0",
+		]);
+		// The gateway never reaches the runner as a single shell string.
+		expect(add?.[1]).not.toContain("default via 10.0.0.1 dev wwan0");
+	});
+
+	test("clears existing default routes before adding the new one", async () => {
+		const order: string[] = [];
+		const runner = mock(async (_bin: string, args: string[]) => {
+			if (args[1] === "add") order.push("add");
+			return args[0] === "route" && args[1] === "show"
+				? "default via 10.0.0.1 dev wwan0\n"
+				: "";
+		});
+		const clearDefaultGws = mock(async () => {
+			order.push("clear");
+		});
+
+		await setDefaultRoute("wwan0", { runner: runner as never, clearDefaultGws });
+
+		expect(order).toEqual(["clear", "add"]);
+	});
+
+	test("rejects an interface name outside the ifname charset", async () => {
+		const runner = mock(async () => "");
+
+		await expect(
+			setDefaultRoute("eth0; reboot", { runner: runner as never }),
+		).rejects.toThrow("invalid argument");
+		expect(runner).not.toHaveBeenCalled();
+	});
+
+	test("rejects a leading-dash interface name (flag injection)", async () => {
+		const runner = mock(async () => "");
+
+		await expect(
+			setDefaultRoute("-rf", { runner: runner as never }),
+		).rejects.toThrow("invalid argument");
+		expect(runner).not.toHaveBeenCalled();
+	});
+});

--- a/apps/backend/src/tests/logs-injection.test.ts
+++ b/apps/backend/src/tests/logs-injection.test.ts
@@ -1,0 +1,101 @@
+/*
+ * RED-first repro for the journalctl command injection in logs.ts (Task 9).
+ *
+ * Pre-fix, getLog() builds a SHELL STRING `journalctl -b -u ${service}` and
+ * hands it to exec(). A `service` value of "ssh; touch /tmp/pwned" is split by
+ * the shell at the `;` into two commands, so the attacker-controlled
+ * `touch /tmp/pwned` runs with the backend's privileges.
+ *
+ * The security property under test:
+ *  - getLog() must invoke the argv-only run() helper with the service value as a
+ *    SINGLE intact argv element (no shell, so `;`/spaces are inert);
+ *  - the injected `touch /tmp/pwned` must therefore NEVER execute.
+ *
+ * Pre-fix this FAILS: getLog uses exec() (run() is never called) and the real
+ * shell creates /tmp/pwned. Post-fix it passes (run() argv, no shell).
+ */
+
+import { existsSync, rmSync } from "node:fs";
+
+import { logInputSchema } from "@ceraui/rpc/schemas";
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+
+import * as runModule from "../helpers/run.ts";
+import { getLog } from "../modules/system/logs.ts";
+
+const PWNED = "/tmp/pwned";
+const MALICIOUS = "ssh; touch /tmp/pwned";
+
+/** Minimal WebSocket stand-in: getSocketSenderId reads `data.senderId`. */
+function fakeConn() {
+	return { send: () => {}, data: { senderId: "test" } } as never;
+}
+
+function cleanup() {
+	try {
+		rmSync(PWNED, { force: true });
+	} catch {
+		/* ignore */
+	}
+}
+
+beforeEach(cleanup);
+afterEach(() => {
+	cleanup();
+	mock.restore();
+});
+
+describe("logs.ts getLog() — journalctl command injection", () => {
+	it("invokes run() with journalctl argv — service is ONE intact element, no shell", async () => {
+		const runSpy = spyOn(runModule, "run").mockResolvedValue("log-output");
+
+		await getLog(fakeConn(), MALICIOUS);
+		// Allow any (pre-fix) real exec() callback to fire before asserting.
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		expect(runSpy).toHaveBeenCalledTimes(1);
+		const [bin, args, opts] = runSpy.mock.calls[0] as [
+			string,
+			string[],
+			{ maxBuffer: number },
+		];
+		expect(bin).toBe("journalctl");
+		// The malicious string is a single argv token — NOT split on ';'.
+		expect(args).toEqual(["-b", "-u", MALICIOUS]);
+		expect(args[2]).toBe(MALICIOUS);
+		// 10 MiB ceiling preserved from the original exec() call.
+		expect(opts.maxBuffer).toBe(10 * 1024 * 1024);
+	});
+
+	it("does NOT execute the injected `touch /tmp/pwned` (no shell interpretation)", async () => {
+		spyOn(runModule, "run").mockResolvedValue("log-output");
+
+		await getLog(fakeConn(), MALICIOUS);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		expect(existsSync(PWNED)).toBe(false);
+	});
+});
+
+describe("oRPC boundary — Zod SERVICE_RE on the log `service` input", () => {
+	it("rejects a malicious service string before it can reach getLog()", () => {
+		expect(logInputSchema.safeParse({ service: MALICIOUS }).success).toBe(false);
+		expect(logInputSchema.safeParse({ service: "ssh && reboot" }).success).toBe(
+			false,
+		);
+		expect(logInputSchema.safeParse({ service: "$(reboot)" }).success).toBe(
+			false,
+		);
+	});
+
+	it("accepts legitimate systemd unit names and absent input", () => {
+		expect(logInputSchema.safeParse({ service: "ssh.service" }).success).toBe(
+			true,
+		);
+		expect(
+			logInputSchema.safeParse({ service: "getty@tty1.service" }).success,
+		).toBe(true);
+		expect(logInputSchema.safeParse({}).success).toBe(true);
+		expect(logInputSchema.safeParse(undefined).success).toBe(true);
+	});
+});

--- a/apps/backend/src/tests/mmcli-mode-validation.test.ts
+++ b/apps/backend/src/tests/mmcli-mode-validation.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Tests for Task 14: mmcli.ts migrated onto the argv-only run() runner plus
+ * mode-string validation. The security properties under test:
+ *  - allowed/preferred mode strings are validated against VALID_MODES before
+ *    they become `--set-allowed-modes` / `--set-preferred-mode` flag values;
+ *  - argument injection ("--help; rm -rf /") is rejected and never reaches exec;
+ *  - the shouldMockModems() guard still short-circuits BEFORE run() touches the
+ *    real OS.
+ */
+
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+
+import * as execMod from "../helpers/exec.ts";
+import {
+	initMockService,
+	stopMockService,
+} from "../mocks/mock-service.ts";
+import {
+	mmList,
+	mmSetNetworkTypes,
+	VALID_MODES,
+	validateModeSpec,
+} from "../modules/modems/mmcli.ts";
+
+afterEach(() => {
+	mock.restore();
+	stopMockService();
+});
+
+describe("validateModeSpec() — mode allowlist", () => {
+	it("accepts single ModemManager mode tokens", () => {
+		for (const v of ["any", "2g", "3g", "4g", "5g", "none"]) {
+			expect(validateModeSpec(v)).toBe(v);
+		}
+	});
+
+	it("accepts a pipe-joined allowed-modes combination", () => {
+		expect(validateModeSpec("4g|5g")).toBe("4g|5g");
+		expect(validateModeSpec("2g|3g|4g")).toBe("2g|3g|4g");
+	});
+
+	it("rejects argument injection outright", () => {
+		expect(() => validateModeSpec("--help; rm -rf /")).toThrow(
+			"invalid mode: --help; rm -rf /",
+		);
+		expect(() => validateModeSpec("5g; reboot")).toThrow("invalid mode");
+		expect(() => validateModeSpec("4g|--set-allowed-modes")).toThrow(
+			"invalid mode",
+		);
+		expect(() => validateModeSpec("lte")).toThrow("invalid mode: lte");
+	});
+
+	it("exposes the expected canonical token set", () => {
+		expect([...VALID_MODES].sort()).toEqual([
+			"2g",
+			"3g",
+			"4g",
+			"5g",
+			"any",
+			"none",
+		]);
+	});
+});
+
+describe("mmSetNetworkTypes() — validation gates the exec", () => {
+	it("builds argv via run() for a valid allowed/preferred pair", async () => {
+		const spy = spyOn(execMod, "execFileP").mockResolvedValue({
+			stdout: "successfully set current modes in the modem\n",
+			stderr: "",
+		} as never);
+
+		await mmSetNetworkTypes(0, "4g|5g", "5g");
+
+		expect(spy).toHaveBeenCalledTimes(1);
+		const [, args] = spy.mock.calls[0] as [string, string[], unknown];
+		expect(args).toContain("--set-allowed-modes=4g|5g");
+		expect(args).toContain("--set-preferred-mode=5g");
+	});
+
+	it("omits --set-preferred-mode when preferred is 'none'", async () => {
+		const spy = spyOn(execMod, "execFileP").mockResolvedValue({
+			stdout: "successfully set current modes in the modem\n",
+			stderr: "",
+		} as never);
+
+		await mmSetNetworkTypes(0, "4g", "none");
+
+		const [, args] = spy.mock.calls[0] as [string, string[], unknown];
+		expect(args).toContain("--set-allowed-modes=4g");
+		expect(args.some((a) => a.startsWith("--set-preferred-mode"))).toBe(false);
+	});
+
+	it("rejects an injected mode string before any exec runs", async () => {
+		const spy = spyOn(execMod, "execFileP").mockResolvedValue({
+			stdout: "",
+			stderr: "",
+		} as never);
+
+		const result = await mmSetNetworkTypes(0, "--help; rm -rf /", "none");
+
+		expect(result).toBeUndefined();
+		expect(spy).not.toHaveBeenCalled();
+	});
+});
+
+describe("mmList() — shouldMockModems() guard stays before run()", () => {
+	it("returns the mocked single-modem list without invoking exec", async () => {
+		const spy = spyOn(execMod, "execFileP").mockResolvedValue({
+			stdout: "",
+			stderr: "",
+		} as never);
+
+		process.env.MOCK_MODE = "true";
+		initMockService("single-modem");
+
+		const list = await mmList();
+
+		expect(list).toEqual([0]);
+		expect(spy).not.toHaveBeenCalled();
+	});
+});

--- a/apps/backend/src/tests/run.test.ts
+++ b/apps/backend/src/tests/run.test.ts
@@ -1,0 +1,198 @@
+/*
+ * Tests for the typed, argv-only OS command runner (helpers/run.ts) — the
+ * security foundation that all Wave 2 hardening tasks import.
+ *
+ * The properties under test are security-critical:
+ *  - only allowlisted binaries may run;
+ *  - argv is passed through verbatim with NO shell, so shell metacharacters in
+ *    an argument are inert (a single argv element, never re-parsed);
+ *  - maxBuffer is honored / forwarded to execFile;
+ *  - argMatch() validates dynamic values and rejects leading-dash injection;
+ *  - runWithStdin() keeps the secret in stdin and never on argv.
+ */
+
+import { EventEmitter } from "node:events";
+
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+
+import * as execMod from "../helpers/exec.ts";
+import {
+	ALLOWED,
+	argMatch,
+	DEFAULT_MAX_BUFFER,
+	ID_RE,
+	run,
+	runWithStdin,
+	SERVICE_RE,
+} from "../helpers/run.ts";
+
+afterEach(() => {
+	mock.restore();
+});
+
+describe("run() — allowlist enforcement", () => {
+	it("resolves for an allowlisted binary (nmcli -v) without touching a shell", async () => {
+		const spy = spyOn(execMod, "execFileP").mockResolvedValue({
+			stdout: "nmcli tool, version 1.0\n",
+			stderr: "",
+		} as never);
+
+		const out = await run("nmcli", ["-v"]);
+
+		expect(out).toBe("nmcli tool, version 1.0\n");
+		expect(spy).toHaveBeenCalledTimes(1);
+		// argv-only: (bin, args, opts) — no `sh -c`, no command string.
+		const [bin, args] = spy.mock.calls[0] as [string, string[], unknown];
+		expect(bin).toBe("nmcli");
+		expect(args).toEqual(["-v"]);
+	});
+
+	it("throws 'not allowlisted' for a binary outside the allowlist (rm -rf /)", async () => {
+		const spy = spyOn(execMod, "execFileP").mockResolvedValue({
+			stdout: "",
+			stderr: "",
+		} as never);
+
+		await expect(run("rm", ["-rf", "/"])).rejects.toThrow(
+			"binary not allowlisted: rm",
+		);
+		// The dangerous binary must never reach execFile.
+		expect(spy).not.toHaveBeenCalled();
+	});
+});
+
+describe("run() — argv pass-through (no shell interpretation)", () => {
+	it("passes a shell-metacharacter argument as ONE argv element", async () => {
+		const spy = spyOn(execMod, "execFileP").mockResolvedValue({
+			stdout: "",
+			stderr: "",
+		} as never);
+
+		const injection = "a; rm -rf /";
+		await run("journalctl", ["-u", injection]);
+
+		expect(spy).toHaveBeenCalledTimes(1);
+		const [bin, args] = spy.mock.calls[0] as [string, string[], unknown];
+		expect(bin).toBe("journalctl");
+		// The injection string is a single, intact argv element — not split, not
+		// expanded, not handed to a shell.
+		expect(args).toEqual(["-u", injection]);
+		expect(args[1]).toBe("a; rm -rf /");
+	});
+
+	it("honors a caller-supplied maxBuffer and defaults otherwise", async () => {
+		const spy = spyOn(execMod, "execFileP").mockResolvedValue({
+			stdout: "",
+			stderr: "",
+		} as never);
+
+		await run("ip", ["addr"], { maxBuffer: 1234 });
+		let opts = spy.mock.calls[0]?.[2] as { maxBuffer: number };
+		expect(opts.maxBuffer).toBe(1234);
+
+		await run("ip", ["addr"]);
+		opts = spy.mock.calls[1]?.[2] as { maxBuffer: number };
+		expect(opts.maxBuffer).toBe(DEFAULT_MAX_BUFFER);
+	});
+});
+
+describe("argMatch() — dynamic argument validation", () => {
+	it("accepts a valid service name and returns it unchanged", () => {
+		expect(argMatch(SERVICE_RE, "ssh.service")).toBe("ssh.service");
+		expect(argMatch(SERVICE_RE, "getty@tty1.service")).toBe(
+			"getty@tty1.service",
+		);
+	});
+
+	it("rejects a service name containing shell metacharacters", () => {
+		expect(() => argMatch(SERVICE_RE, "a;b")).toThrow("invalid argument: a;b");
+		expect(() => argMatch(SERVICE_RE, "a b")).toThrow();
+		expect(() => argMatch(SERVICE_RE, "$(reboot)")).toThrow();
+	});
+
+	it("accepts a valid identifier (ID_RE) and rejects leading-dash injection", () => {
+		expect(argMatch(ID_RE, "eth0")).toBe("eth0");
+		expect(argMatch(ID_RE, "wwan0.1")).toBe("wwan0.1");
+		// Starts with '-': could be mis-parsed as a flag → must be rejected even
+		// though every character is otherwise allowed.
+		expect(() => argMatch(ID_RE, "--help")).toThrow("invalid argument: --help");
+		expect(() => argMatch(ID_RE, "-rf")).toThrow();
+	});
+});
+
+describe("runWithStdin() — secret stays in stdin, never on argv", () => {
+	it("writes the secret to child.stdin and keeps it out of argv", async () => {
+		const childProcess = await import("node:child_process");
+
+		const stdinWrites: string[] = [];
+		const fakeChild = new EventEmitter() as EventEmitter & {
+			stdout: EventEmitter;
+			stderr: EventEmitter;
+			stdin: { write: (d: string) => boolean; end: () => void };
+		};
+		fakeChild.stdout = new EventEmitter();
+		fakeChild.stderr = new EventEmitter();
+		fakeChild.stdin = {
+			write: (d: string) => {
+				stdinWrites.push(d);
+				return true;
+			},
+			end: () => {
+				// Simulate a clean exit once stdin is closed.
+				queueMicrotask(() => fakeChild.emit("close", 0));
+			},
+		};
+
+		const spy = spyOn(childProcess, "spawn").mockReturnValue(
+			fakeChild as never,
+		);
+
+		const secret = "pw\npw\n";
+		await runWithStdin("passwd", ["user"], secret);
+
+		expect(spy).toHaveBeenCalledTimes(1);
+		const [bin, args] = spy.mock.calls[0] as [string, string[], unknown];
+		expect(bin).toBe("passwd");
+		expect(args).toEqual(["user"]);
+
+		// The secret must NEVER appear in argv (process table leak).
+		expect(args).not.toContain(secret);
+		expect(args.join(" ")).not.toContain("pw");
+
+		// It must appear ONLY in what was written to stdin.
+		expect(stdinWrites.join("")).toBe(secret);
+		expect(stdinWrites.join("")).toContain("pw");
+	});
+
+	it("rejects a non-allowlisted binary before spawning", async () => {
+		const childProcess = await import("node:child_process");
+		const spy = spyOn(childProcess, "spawn");
+
+		await expect(runWithStdin("sh", ["-c", "x"], "secret")).rejects.toThrow(
+			"binary not allowlisted: sh",
+		);
+		expect(spy).not.toHaveBeenCalled();
+	});
+});
+
+describe("ALLOWED — Wave 2 binary coverage", () => {
+	it("includes every binary the Wave 2 hardening tasks depend on", () => {
+		for (const bin of [
+			"nmcli",
+			"mmcli",
+			"systemctl",
+			"journalctl",
+			"ip",
+			"apt-get",
+			"grep",
+			"killall",
+			"sensors",
+			"ifconfig",
+			"passwd",
+			"reboot",
+			"dmesg",
+		]) {
+			expect(ALLOWED.has(bin)).toBe(true);
+		}
+	});
+});

--- a/apps/backend/src/tests/software-updates-apt.test.ts
+++ b/apps/backend/src/tests/software-updates-apt.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Task 11 — apt-get is now invoked argv-only (no shell interpolation, no
+ * `args.split(" ")`). These tests pin the security-critical contract:
+ *
+ *   - a held-back package list maps to one argv element per package;
+ *   - each package name is charset-validated, so a name carrying shell
+ *     metacharacters or whitespace is rejected before it can reach apt-get.
+ */
+import { describe, expect, it } from "bun:test";
+
+import {
+	buildAptInstallArgs,
+	buildAptUpgradeArgs,
+	parseHeldBackPackages,
+} from "../modules/system/software-updates.ts";
+
+describe("parseHeldBackPackages() — charset validation", () => {
+	it("splits a whitespace-separated list into individual package names", () => {
+		expect(parseHeldBackPackages("pkg-a pkg-b")).toEqual(["pkg-a", "pkg-b"]);
+	});
+
+	it("accepts Debian-name punctuation (. + : ~ -)", () => {
+		expect(parseHeldBackPackages("lib.foo g++ a:b1 x~rc-1")).toEqual([
+			"lib.foo",
+			"g++",
+			"a:b1",
+			"x~rc-1",
+		]);
+	});
+
+	it("collapses irregular whitespace and drops empty tokens", () => {
+		expect(parseHeldBackPackages("  pkg-a   pkg-b \n pkg-c ")).toEqual([
+			"pkg-a",
+			"pkg-b",
+			"pkg-c",
+		]);
+	});
+
+	it("rejects a name carrying shell metacharacters", () => {
+		expect(() => parseHeldBackPackages("pkg; rm -rf /")).toThrow(
+			/invalid package name/,
+		);
+	});
+
+	it("rejects a single poisoned name embedded in a valid list", () => {
+		expect(() => parseHeldBackPackages("good-pkg $(reboot)")).toThrow(
+			/invalid package name/,
+		);
+	});
+});
+
+describe("buildAptInstallArgs() — argv mapping", () => {
+	it("maps the package list to one argv element each, after install --assume-no", () => {
+		expect(buildAptInstallArgs(["pkg-a", "pkg-b"])).toEqual([
+			"install",
+			"--assume-no",
+			"pkg-a",
+			"pkg-b",
+		]);
+	});
+});
+
+describe("buildAptUpgradeArgs() — argv mapping", () => {
+	const base = [
+		"-y",
+		"-o",
+		"Dpkg::Options::=--force-confdef",
+		"-o",
+		"Dpkg::Options::=--force-confold",
+	];
+
+	it("dist-upgrades when there are no held-back packages", () => {
+		expect(buildAptUpgradeArgs()).toEqual([...base, "dist-upgrade"]);
+		expect(buildAptUpgradeArgs([])).toEqual([...base, "dist-upgrade"]);
+	});
+
+	it("installs held-back packages as separate argv elements", () => {
+		expect(buildAptUpgradeArgs(["pkg-a", "pkg-b"])).toEqual([
+			...base,
+			"install",
+			"pkg-a",
+			"pkg-b",
+		]);
+	});
+});

--- a/apps/backend/src/tests/ssh-race.test.ts
+++ b/apps/backend/src/tests/ssh-race.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Task 6 — RED-first repro for the SSH status async race / partial broadcast.
+ *
+ * The pre-fix `getSshStatus()` fired two independent `exec(...)` callbacks that
+ * each mutated a SHARED status object and each called `handleSshStatus`. That
+ * design has two observable defects this suite pins down:
+ *
+ *   1. RACE / PARTIAL BROADCAST — the broadcast is emitted from whichever
+ *      callback completes last, and only if BOTH `active` and `user_pass`
+ *      happen to be set by then. The function returns the *cached* value
+ *      synchronously and never awaits the probes.
+ *
+ *   2. SYSTEMCTL-ERROR PATH DROPS THE STATUS — when `systemctl is-active`
+ *      fails with anything other than the exact string "inactive\n", the
+ *      callback `return`s WITHOUT setting `active`, so the completed object
+ *      never satisfies the `active !== undefined` guard and NOTHING is
+ *      broadcast (the SSH tile silently goes stale).
+ *
+ * Both tests drive the refactored, injectable signature
+ *   getSshStatus({ systemctlIsActive, readShadow, broadcast })
+ * The injected `broadcast` spy is the oracle: the fixed implementation must
+ * call it EXACTLY ONCE with a COMPLETE status object. Against the pre-fix code
+ * (which ignores the deps argument and calls the real module-level broadcast)
+ * the spy is never invoked → these tests FAIL, which is the intended RED state.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+import { setup } from "../modules/setup.ts";
+import { getSshStatus, type SshStatusDeps } from "../modules/system/ssh.ts";
+
+/** A well-formed /etc/shadow line for `user` with a known crypt hash. */
+function shadowLine(user: string): string {
+	return `root:!:19000:0:99999:7:::\n${user}:$6$abcd$0123456789hashvalue:19000:0:99999:7:::\n`;
+}
+
+describe("getSshStatus — async race / single-broadcast (Task 6)", () => {
+	test("broadcasts EXACTLY ONCE with a complete status when both probes succeed", async () => {
+		// Distinct user per test keeps the module-level change-guard from
+		// suppressing the broadcast regardless of test execution order.
+		setup.ssh_user = "alice";
+
+		const broadcast = mock((_status: unknown) => {});
+		const deps: Partial<SshStatusDeps> = {
+			systemctlIsActive: async () => ({ stdout: "active\n", stderr: "" }),
+			readShadow: () => shadowLine("alice"),
+			broadcast,
+		};
+
+		await getSshStatus(deps);
+
+		// Single, atomic broadcast — never partial, never duplicated.
+		expect(broadcast).toHaveBeenCalledTimes(1);
+
+		const status = broadcast.mock.calls[0]?.[0] as {
+			user?: string;
+			active?: boolean;
+			user_pass?: boolean;
+		};
+		// The object must be COMPLETE: every wire field defined.
+		expect(status.user).toBe("alice");
+		expect(status.active).toBe(true);
+		expect(status.user_pass).toBeDefined();
+		expect(typeof status.user_pass).toBe("boolean");
+	});
+
+	test("systemctl is-active error → STILL one broadcast with active:false (not missing)", async () => {
+		setup.ssh_user = "bob";
+
+		const broadcast = mock((_status: unknown) => {});
+		const deps: Partial<SshStatusDeps> = {
+			// Simulate a hard systemctl failure (exec rejects).
+			systemctlIsActive: async () => {
+				throw new Error("systemctl: command failed");
+			},
+			readShadow: () => shadowLine("bob"),
+			broadcast,
+		};
+
+		await getSshStatus(deps);
+
+		// The status must still be broadcast exactly once...
+		expect(broadcast).toHaveBeenCalledTimes(1);
+
+		const status = broadcast.mock.calls[0]?.[0] as {
+			user?: string;
+			active?: boolean;
+			user_pass?: boolean;
+		};
+		// ...with `active` explicitly false — NOT left undefined/missing.
+		expect(status.active).toBe(false);
+		expect(status.user).toBe("bob");
+		expect(status.user_pass).toBeDefined();
+	});
+
+	test("rejects an unsafe ssh_user (leading dash / argument injection)", async () => {
+		setup.ssh_user = "-rf";
+
+		const broadcast = mock((_status: unknown) => {});
+		await expect(
+			getSshStatus({
+				systemctlIsActive: async () => ({ stdout: "active\n", stderr: "" }),
+				readShadow: () => shadowLine("-rf"),
+				broadcast,
+			}),
+		).rejects.toThrow();
+
+		expect(broadcast).not.toHaveBeenCalled();
+	});
+});

--- a/apps/backend/src/tests/validation-schemas.test.ts
+++ b/apps/backend/src/tests/validation-schemas.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+	BITRATE_MAX,
+	BITRATE_MIN,
+	bitrateInputSchema,
+	hotspotConfigInputSchema,
+	modemConfigInputSchema,
+	netifConfigInputSchema,
+	wifiNewInputSchema,
+} from "@ceraui/rpc/schemas";
+
+const validHotspot = {
+	device: "wlan0",
+	name: "MyHotspot",
+	password: "supersecret",
+	channel: "auto",
+};
+
+const validModem = {
+	device: "0",
+	network_type: "4g",
+	apn: "internet",
+	username: "",
+	password: "",
+};
+
+describe("hotspotConfigInputSchema", () => {
+	it("accepts a valid hotspot config", () => {
+		expect(hotspotConfigInputSchema.safeParse(validHotspot).success).toBe(true);
+	});
+
+	it("rejects an empty name", () => {
+		expect(
+			hotspotConfigInputSchema.safeParse({ ...validHotspot, name: "" }).success,
+		).toBe(false);
+	});
+
+	it("rejects a name longer than 32 characters", () => {
+		expect(
+			hotspotConfigInputSchema.safeParse({ ...validHotspot, name: "x".repeat(33) })
+				.success,
+		).toBe(false);
+	});
+
+	it("rejects a password shorter than 8 characters", () => {
+		expect(
+			hotspotConfigInputSchema.safeParse({ ...validHotspot, password: "123" })
+				.success,
+		).toBe(false);
+	});
+
+	it("rejects a password longer than 63 characters", () => {
+		expect(
+			hotspotConfigInputSchema.safeParse({
+				...validHotspot,
+				password: "x".repeat(64),
+			}).success,
+		).toBe(false);
+	});
+
+	it("rejects an out-of-range channel", () => {
+		expect(
+			hotspotConfigInputSchema.safeParse({ ...validHotspot, channel: "999" })
+				.success,
+		).toBe(false);
+	});
+
+	it("accepts a base64 password (no charset restriction)", () => {
+		expect(
+			hotspotConfigInputSchema.safeParse({
+				...validHotspot,
+				password: "abc+/=1234",
+			}).success,
+		).toBe(true);
+	});
+
+	it("accepts a unicode SSID and unicode password (no charset restriction)", () => {
+		expect(
+			hotspotConfigInputSchema.safeParse({
+				...validHotspot,
+				name: "My WiFi 📶",
+				password: "пароль🔒1234",
+			}).success,
+		).toBe(true);
+	});
+});
+
+describe("modemConfigInputSchema APN conditional", () => {
+	it("rejects autoconfig=false with empty APN", () => {
+		expect(
+			modemConfigInputSchema.safeParse({
+				...validModem,
+				autoconfig: false,
+				apn: "",
+			}).success,
+		).toBe(false);
+	});
+
+	it("accepts autoconfig=false with a valid APN", () => {
+		expect(
+			modemConfigInputSchema.safeParse({
+				...validModem,
+				autoconfig: false,
+				apn: "internet",
+			}).success,
+		).toBe(true);
+	});
+
+	it("accepts autoconfig=true with empty APN", () => {
+		expect(
+			modemConfigInputSchema.safeParse({
+				...validModem,
+				autoconfig: true,
+				apn: "",
+			}).success,
+		).toBe(true);
+	});
+});
+
+describe("netifConfigInputSchema IP validation", () => {
+	it("rejects an invalid IP address", () => {
+		expect(
+			netifConfigInputSchema.safeParse({
+				name: "eth0",
+				enabled: true,
+				ip: "not-an-ip",
+			}).success,
+		).toBe(false);
+	});
+
+	it("accepts a valid IPv4 address", () => {
+		expect(
+			netifConfigInputSchema.safeParse({
+				name: "eth0",
+				enabled: true,
+				ip: "192.168.1.10",
+			}).success,
+		).toBe(true);
+	});
+
+	it("accepts a valid IPv6 address", () => {
+		expect(
+			netifConfigInputSchema.safeParse({
+				name: "eth0",
+				enabled: true,
+				ip: "fe80::1",
+			}).success,
+		).toBe(true);
+	});
+
+	it("accepts an omitted IP (DHCP)", () => {
+		expect(
+			netifConfigInputSchema.safeParse({ name: "eth0", enabled: true }).success,
+		).toBe(true);
+	});
+});
+
+describe("wifiNewInputSchema", () => {
+	it("rejects an empty SSID", () => {
+		expect(
+			wifiNewInputSchema.safeParse({
+				device: "wlan0",
+				ssid: "",
+				password: "supersecret",
+			}).success,
+		).toBe(false);
+	});
+
+	it("rejects a password shorter than 8 characters", () => {
+		expect(
+			wifiNewInputSchema.safeParse({
+				device: "wlan0",
+				ssid: "MyNetwork",
+				password: "short",
+			}).success,
+		).toBe(false);
+	});
+
+	it("accepts a valid WPA connection", () => {
+		expect(
+			wifiNewInputSchema.safeParse({
+				device: "wlan0",
+				ssid: "MyNetwork",
+				password: "supersecret",
+			}).success,
+		).toBe(true);
+	});
+});
+
+describe("bitrateInputSchema canonical range", () => {
+	it("exposes the canonical hardware range constants", () => {
+		expect(BITRATE_MIN).toBe(500);
+		expect(BITRATE_MAX).toBe(50000);
+	});
+
+	it("rejects a bitrate below BITRATE_MIN", () => {
+		expect(bitrateInputSchema.safeParse({ max_br: BITRATE_MIN - 1 }).success).toBe(
+			false,
+		);
+	});
+
+	it("rejects a bitrate above BITRATE_MAX", () => {
+		expect(bitrateInputSchema.safeParse({ max_br: BITRATE_MAX + 1 }).success).toBe(
+			false,
+		);
+	});
+
+	it("accepts a bitrate within range", () => {
+		expect(bitrateInputSchema.safeParse({ max_br: 6000 }).success).toBe(true);
+	});
+});

--- a/packages/rpc/src/contracts/system.contract.ts
+++ b/packages/rpc/src/contracts/system.contract.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 import {
 	autostartInputSchema,
 	cloudProviderEndpointSchema,
+	logInputSchema,
 	logOutputSchema,
 	remoteConfigInputSchema,
 	revisionsSchema,
@@ -28,7 +29,7 @@ export const systemContract = oc.router({
 	/**
 	 * Get application log
 	 */
-	getLog: oc.output(logOutputSchema),
+	getLog: oc.input(logInputSchema).output(logOutputSchema),
 
 	/**
 	 * Get system log

--- a/packages/rpc/src/schemas/system.schema.ts
+++ b/packages/rpc/src/schemas/system.schema.ts
@@ -79,6 +79,21 @@ export const logOutputSchema = z.object({
 });
 export type LogOutput = z.infer<typeof logOutputSchema>;
 
+// systemd unit/service name: letters, digits and the unit punctuation set
+// `@ . _ : -`. Excludes shell metacharacters (`;`, space, `$`, backtick, etc.),
+// so a `service` value cannot carry a journalctl command injection.
+export const SERVICE_RE = /^[A-Za-z0-9@._:-]+$/;
+
+// Log input schema — `service` is validated at the oRPC boundary so a malicious
+// unit name is rejected before reaching getLog(). Optional/absent input is the
+// whole-system log.
+export const logInputSchema = z
+	.object({
+		service: z.string().regex(SERVICE_RE).optional(),
+	})
+	.optional();
+export type LogInput = z.infer<typeof logInputSchema>;
+
 // Autostart config input schema
 export const autostartInputSchema = z.object({
 	autostart: z.boolean(),

--- a/packages/rpc/src/schemas/wifi.schema.ts
+++ b/packages/rpc/src/schemas/wifi.schema.ts
@@ -3,6 +3,14 @@
  */
 import { z } from 'zod';
 
+// Length-only bounds. The hotspot SSID accepts any unicode (no charset
+// restriction) and matches the backend's own min-1 check in wifi-hotspot.ts.
+export const HOTSPOT_NAME_MIN = 1;
+export const HOTSPOT_NAME_MAX = 32;
+export const HOTSPOT_PASSWORD_MIN = 8;
+export const HOTSPOT_PASSWORD_MAX = 63;
+export const WIFI_PASSWORD_MIN = 8;
+
 // WiFi security enum
 export const wifiSecuritySchema = z.enum(['WEP', 'WPA', 'WPA2', 'WPA3']);
 export type WifiSecurity = z.infer<typeof wifiSecuritySchema>;
@@ -39,6 +47,8 @@ export const wifiInterfaceSchema = z.object({
 	available: z.array(availableWifiNetworkSchema),
 	saved: z.record(z.string(), z.string()),
 	supports_hotspot: z.boolean(),
+	transition: z.enum(['activating', 'deactivating']).optional(),
+	mode: z.enum(['station', 'hotspot']).optional(),
 });
 export type WifiInterface = z.infer<typeof wifiInterfaceSchema>;
 
@@ -61,8 +71,8 @@ export type WifiDisconnectInput = z.infer<typeof wifiDisconnectInputSchema>;
 // WiFi new connection input schema
 export const wifiNewInputSchema = z.object({
 	device: z.string(),
-	ssid: z.string(),
-	password: z.string(),
+	ssid: z.string().min(1, 'SSID cannot be empty'),
+	password: z.string().min(WIFI_PASSWORD_MIN, 'Password must be at least 8 characters'),
 });
 export type WifiNewInput = z.infer<typeof wifiNewInputSchema>;
 
@@ -87,16 +97,27 @@ export type HotspotToggleInput = z.infer<typeof hotspotToggleInputSchema>;
 // Hotspot config input schema
 export const hotspotConfigInputSchema = z.object({
 	device: z.string(),
-	name: z.string(),
-	password: z.string(),
-	channel: z.string(),
+	name: z
+		.string()
+		.min(HOTSPOT_NAME_MIN, 'Hotspot name must be at least 1 character')
+		.max(HOTSPOT_NAME_MAX, 'Hotspot name must be at most 32 characters'),
+	password: z
+		.string()
+		.min(HOTSPOT_PASSWORD_MIN, 'Password must be at least 8 characters')
+		.max(HOTSPOT_PASSWORD_MAX, 'Password must be at most 63 characters'),
+	channel: z
+		.string()
+		.refine((c) => wifiBandSchema.safeParse(c).success, {
+			message: 'Channel must be a supported WiFi band (auto, auto_24, auto_50)',
+		}),
 });
 export type HotspotConfigInput = z.infer<typeof hotspotConfigInputSchema>;
 
 // WiFi operation output schema
 export const wifiOperationOutputSchema = z.object({
 	success: z.boolean(),
-	error: z.enum(['auth', 'generic']).optional(),
+	// 'DEVICE_BUSY': per-device lock rejected a concurrent op (additive member).
+	error: z.enum(['auth', 'generic', 'DEVICE_BUSY']).optional(),
 });
 export type WifiOperationOutput = z.infer<typeof wifiOperationOutputSchema>;
 


### PR DESCRIPTION
## Summary

Hardens all backend OS-command invocations against injection and race conditions.

- Typed argv runner replaces shell-interpolated exec calls
- Zod-validated OS inputs (systemctl, journalctl, mmcli, etc.)
- Fixes for ssh status race, journalctl injection, and related repros

**Stacked PR 1/6** — base: `main`

---
*Part of the comms-reliability-and-stacked-pr-split series.*