### PR TITLE
docs(ceraui): canonical refresh — de-fork, Bun/oRPC alignment, build/branding fixes

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -1,144 +1,148 @@
-# CeraUI Backend (CERALIVE)
+# CeraUI Backend
 
-This is the backend for CERALIVE devices, originally forked from the CeraLive CeraLive project. This codebase has been ported to Typescript and ESM (ECMAScript Modules). This fork is maintained by CERALIVE and includes additional features and improvements.
+Bun/TypeScript HTTP + WebSocket server for CeraLive streaming hardware. Serves the frontend static bundle and exposes all device control via oRPC over WebSocket.
 
-## CeraUI Integration
+## Overview
 
-This fork includes an option to use the [CeraUI](https://github.com/CERALIVE/CeraUI) interface, which is an alternative user interface designed for enhanced usability and additional features. When the `USE_CERAUI` option is enabled during installation or deployment, the system will download the latest CeraUI main package from the [release](https://github.com/CERALIVE/CeraUI/releases/latest) and use it instead of the standard CeraLive interface.
+The backend is a single compiled binary (`ceralive`) produced by `bun build --compile`. It drives `ceracoder` and `srtla` at runtime through their native TypeScript bindings, which are resolved via `link:` paths to sibling checkouts.
 
-## Install the fork on your CERALIVE device
+**Stack**: Bun, TypeScript, oRPC (`@orpc/server`), Zod, WebSocket RPC  
+**Shared contract**: `@ceraui/rpc` (workspace package at `packages/rpc/`)  
+**Native bindings**: `@ceralive/ceracoder`, `@ceralive/srtla` (local `link:` deps — not npm packages)
 
-> **Note:** Replacing the original UI directly may cause issues. When your CERALIVE device is updated, it can revert the UI. Ensure you monitor updates and reapply the override after updates.
+## Structure
 
-- Enable SSH for the default user (`user`) on your existing CeraLive
-- Connect to the CERALIVE device via SSH (use Putty on Windows, JuiceSSH on Android)
-- Then run:
-
-  ```bash
-  # Standard installation with CeraLive
-  wget -qO- https://raw.githubusercontent.com/CERALIVE/CeraLive-ts/main/install.sh | bash
-  ```
-
-  or
-
-  ```bash
-  # Installation with CeraUI interface
-  wget -qO- https://raw.githubusercontent.com/CERALIVE/CeraLive-ts/main/install.sh | USE_CERAUI=true bash
-  ```
-
-- To get back to the default CeraLive, you can then run `sudo bash /opt/CeraLive/reset-to-default.sh` through SSH.
-
-## Installation Script
-
-This repository includes a unified installation script (`install.sh`) that handles both local installation and remote deployment:
-
-### Local Installation (from GitHub releases)
-
-```bash
-# Standard installation
-./install.sh
-
-# With CeraUI interface
-USE_CERAUI=true ./install.sh
 ```
-
-### Remote Deployment (from local dist folder)
-
-```bash
-# Standard deployment
-./install.sh --remote [SSH_TARGET]
-
-# With CeraUI interface
-USE_CERAUI=true ./install.sh --remote [SSH_TARGET]
-
-# Examples
-./install.sh --remote root@ceralive.local
-./install.sh --remote root@192.168.1.100
+src/
+├── main.ts                  # Entry point
+├── modules/                 # Domain logic (no RPC awareness)
+│   ├── streaming/           # ceracoder + srtla consumers
+│   ├── modems/              # mmcli integration
+│   ├── network/             # Network interfaces, gateways
+│   ├── wifi/                # WiFi scan, connect, disconnect
+│   ├── system/              # Sensors, system info
+│   ├── ui/                  # HTTP + WebSocket servers, auth
+│   ├── ingest/              # Ingest config
+│   ├── remote/              # Cloud remote relay
+│   ├── config.ts            # Config read/write
+│   └── setup.ts             # First-run setup
+├── rpc/                     # oRPC layer
+│   ├── router.ts            # Procedure router
+│   ├── procedures/          # <domain>.procedure.ts files
+│   ├── middleware/          # Auth middleware
+│   └── events.ts            # Typed broadcast events
+├── helpers/                 # Pure utilities
+├── mocks/                   # MOCK_SCENARIO providers
+└── tests/                   # bun:test suites
 ```
-
-Use `./install.sh --help` to see all available options.
-
-> **Note:** The previous separate `install.sh` and `deploy-to-local.sh` scripts have been unified into a single `install.sh` script. The old scripts are available as `.bak` files for reference and will be removed in a future release.
 
 ## Development
 
 ### Prerequisites
 
-You will need to have [bun.sh](https://bun.sh/docs/installation) in version v1.2.3 or newer installed to run the scripts.
-
-### Install dependencies
-
-To install the dependencies, you can use the following command:
+[Bun](https://bun.sh/docs/installation) v1.3.0 or newer. Install dependencies from the workspace root:
 
 ```bash
-bun install
+pnpm install
 ```
 
-### Run locally on dev machine
+### Run in development
 
-Local development is not really supported. Ideally you have a CERALIVE device to test changes. Build for production (see below) and deploy with the deploy script (see above).
-
-You can run the UI locally with the following command:
+From the workspace root, `pnpm dev` starts both frontend and backend together via mprocs. To run the backend alone:
 
 ```bash
-bun run dev:ui
+bun run dev
 ```
 
-To run the server locally, you can use the following command:
+Mock hardware scenarios are available via `MOCK_SCENARIO`:
+
+| Command | Scenario |
+|---------|----------|
+| `bun run dev` | `multi-modem-wifi` (default) |
+| `bun run dev:single-modem` | Single modem, no WiFi |
+| `bun run dev:streaming` | Active streaming simulation |
+
+### Type-check
 
 ```bash
-bun run dev:server
+bun run check
 ```
 
-### Build for production
-
-To build the UI for production, you can use the following command:
+### Tests
 
 ```bash
-bun run build
+bun test
 ```
 
-## Install built version to CERALIVE device
+## Build
 
-### Preparation
-
-It is recommended to create an SSH key pair and install public key on the CERALIVE device, since the deployment script uses
-multiple ssh calls that would require you to type the password each time.
-
-You can follow this tutorial to generate the key
-pair: https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys-on-ubuntu-22-04
-
-### Set up on the CERALIVE device
-
-- Enable SSH for the default user (`user`) and connect via SSH
-- Enable SSH on boot to make things easier (`sudo systemctl enable ssh`)
-- Use `sudo su` to get root privileges and add to the authorized keys for the root user.
-  Add the generated public ssh key to `/root/.ssh/authorized_keys` or create the file if it does not exist yet:
-  1. Create the directory if it does not exist: `mkdir -p /root/.ssh`
-  2. Append your ssh key to the `authorized_keys` file (replace `ssh-...` with your generated public key):
-     `echo "ssh-..." >> /root/.ssh/authorized_keys`).
-- Install rsync (`sudo apt install rsync`)
-- Install an editor (e.g. `sudo apt install nano`)
-
-### Set up on host (currently tested on macOS)
-
-- Install the generated private ssh key on the host (e.g. `~/.ssh/id_rsa` and `~/.ssh/id_rsa.pub`)
-- It might be necessary or recommended to install a newer version of rsync from brew or similar (not tested if
-  necessary)
-- Run the deployment script by specifying the SSH target as an argument. For example, to deploy as root to a host at 192.168.100.100, run:
+The backend compiles to a single self-contained binary. Architecture is controlled by `BUILD_ARCH`:
 
 ```bash
-# Standard deployment with CeraLive
-./install.sh --remote root@192.168.100.100
-
-# Deployment with CeraUI interface
-USE_CERAUI=true ./install.sh --remote root@192.168.100.100
+BUILD_ARCH=arm64 bun run build   # ARM64 (default)
+BUILD_ARCH=amd64 bun run build   # AMD64
 ```
 
-### Reset to default CeraLive
+The full `.deb` package (backend binary + frontend static) is built from the workspace root:
 
-To reset the CERALIVE device to the default CeraLive, you can run the reset script from the host (`./reset-local.sh`).
+```bash
+BUILD_ARCH=arm64 ./scripts/build/build-debian-package.sh
+BUILD_ARCH=amd64 ./scripts/build/build-debian-package.sh
+```
+
+See [`docs/BUILD_PIPELINE.md`](../../docs/BUILD_PIPELINE.md) for the full build and CI reference.
+
+## RPC Architecture
+
+All device control goes through oRPC over WebSocket. There are no HTTP REST endpoints for device state.
+
+### Procedures
+
+Procedures live in `src/rpc/procedures/<domain>.procedure.ts` and are wired into `src/rpc/router.ts`. The shared schema types and validation constants are defined in `@ceraui/rpc` (`packages/rpc/`) and consumed by both the backend and frontend.
+
+Key streaming procedures:
+
+| Procedure | Purpose |
+|-----------|---------|
+| `streaming.start(config)` | Validate config, launch stream, persist config |
+| `streaming.stop()` | Stop active stream |
+| `streaming.setConfig(fields)` | Persist config fields without starting the stream |
+| `streaming.setBitrate({ max_br })` | Hot-adjust bitrate while streaming |
+| `streaming.getPipelines()` | List available GStreamer pipelines |
+| `streaming.getAudioCodecs()` | List available audio codecs |
+| `streaming.getConfig()` | Return current config snapshot |
+
+All setters return `{ success: boolean, applied: <fields> }`. The `applied` object reflects post-validation values actually written to config. Clients must lock their UI to `applied`, not to the raw input.
+
+### Broadcast Events
+
+The backend pushes typed events to all connected clients via `src/rpc/events.ts`. Each event type carries a monotonic `seq` counter that resets on server restart.
+
+| Event | Interval | Source |
+|-------|----------|--------|
+| `netif` | 5 s | `modules/network/network-interfaces.ts` |
+| `sensors` | 1 s | `modules/system/sensors.ts` |
+| `gateways` | 2 s | `modules/network/gateways.ts` |
+| `modems` | 30 s | `modules/modems/modem-update-loop.ts` |
+| `status` | on-change | Streaming state transitions |
+| `config` | on-change | `setConfig` / `start` / `stop` |
+| `wifi` | on-change | WiFi scan / connect / disconnect |
+| `relays` | on-change | Relay list mutations |
+| `ping` | 5 s | Heartbeat (frontend reconnects after ~15 s silence) |
+
+After a client authenticates, the backend immediately pushes a full snapshot of every event type. Clients don't need to wait for the first periodic tick to render.
+
+See [`docs/RPC_COMMUNICATION.md`](../../docs/RPC_COMMUNICATION.md) for the full wire-protocol reference.
+
+## Conventions
+
+- **Runtime**: Bun only. No Node-specific APIs (`node:path`, `node:os`, `node:fs/promises` are fine).
+- **Process spawning**: `Bun.spawn()` / `Bun.$` shell — not `node:child_process`.
+- **File I/O**: `Bun.file().text()` / `Bun.write()` — not `fs.readFileSync`.
+- **Config files**: read/written via `helpers/config-loader.ts` — not raw `fs`.
+- **Error handling**: `invariant` from `helpers/invariant.ts` — not `process.exit`.
+- **All device control**: oRPC over WebSocket — no new HTTP REST endpoints.
 
 ## License
 
-This project is licensed under the **GPL-3.0 License**. See the [LICENSE](LICENSE) file for more details.
+GPL-3.0. See the [LICENSE](LICENSE) file for details.

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -1,167 +1,158 @@
-# CeraUI
+# frontend
 
-CeraUI is a modern user interface built with **Svelte + Vite**, designed as an alternative frontend for [CeraLive](https://github.com/CeraLive/CeraLive). It communicates with the CeraLive WebSocket backend to provide a fast, interactive, and user-friendly experience.
+Svelte 5 PWA for CeraUI — the on-device control plane for CeraLive streaming hardware. Talks to the `backend` app exclusively via WebSocket RPC (`@ceraui/rpc`). No REST, no direct hardware access.
 
-## Features
+**Status**: [EXISTS] — active development, part of the `ceralive-workspace` pnpm monorepo.
 
-- **Svelte 5 + Vite**: Enjoy a highly reactive and efficient UI built with the latest Svelte and Vite tooling.
-- **Modern Design**: A sleek and minimalistic interface for an enhanced user experience.
-- **Responsive Design**: The UI is optimized for all screen sizes.
-- **WebSocket Integration**: Seamlessly communicates with the CeraLive backend.
-- **Flexible Deployment**: Choose to serve on a different port with PM2 or replace the existing CeraLive content.
-- **Remote Control**: Full remote control functionality even without the automatic relay server selection feature.
+## Stack
 
-## Objectives
+- **Svelte 5** with runes (`$state`, `$derived`, `$effect`) — no `$:` reactive statements
+- **Vite** dev server and bundler
+- **TailwindCSS v4** with design tokens defined in `app.css`
+- **shadcn-svelte** (bits-ui v2) for UI primitives — CLI-managed, not hand-edited
+- **`@ceraui/rpc`** — shared oRPC schemas and validation constants (workspace package)
+- **`@ceraui/i18n`** — typesafe-i18n, 10 languages (workspace package)
+- **vitest** for unit tests, **Playwright** for E2E
 
-One of the long-term objectives of this project, which will commence once the UI has full functionality, is to support both maintaining **vanilla** CeraLive builds (as seen on [ceralive.net](https://ceralive.net/)) and creating a separate branch for custom development to extend CeraLive functionalities. Additionally, I am interested in the way [pjeweb/CeraLive](https://github.com/pjeweb/CeraLive) was restructured.
+## Sibling-Checkout Layout
 
-## Roadmap
+The workspace root (`ceralive-workspace`) resolves native bindings via `link:` paths. The `backend` app depends on:
 
-- **Updating Overlay Image**: Find a better picture for the updating overlay.
+```
+"@ceralive/ceracoder": "link:../../../ceracoder/bindings/typescript"
+"@ceralive/srtla":     "link:../../../srtla/bindings/typescript"
+```
 
-## Installation
+`ceracoder/`, `srtla/`, and `CeraUI/` must be siblings under the same parent directory. Breaking this layout breaks `pnpm install` for the backend.
+
+```
+ceralive/
+├── ceracoder/bindings/typescript/   ← @ceralive/ceracoder
+├── srtla/bindings/typescript/       ← @ceralive/srtla
+└── CeraUI/                          ← workspace root; backend resolves link: three levels up
+```
+
+## Development
 
 ### Prerequisites
 
-- **Node.js** (v16 or later recommended)
-- **pnpm** (or npm/yarn)
+- **pnpm** (workspace manager — do not use npm or yarn)
+- Sibling repos `ceracoder` and `srtla` checked out at the correct paths (see above)
 
-### Clone the Repository
+### Install
 
-```sh
-git clone https://github.com/CERALIVE/CeraUI.git
-cd CeraUI
-```
-
-### Install Dependencies
-
-Using `pnpm` (recommended):
+Run from the `CeraUI/` workspace root:
 
 ```sh
 pnpm install
 ```
 
-Or using `npm`:
+This installs all workspaces and resolves the `link:` sibling deps.
+
+### Dev Server
 
 ```sh
-npm install
+pnpm dev
 ```
 
-### Local Development Setup
+Starts the frontend (Vite, port 5173) and backend together via mprocs. Run from the workspace root.
 
-For development, you can run the project in dev mode from your computer. First, copy the `.env.example` file to `.env`:
+To run the frontend alone:
 
 ```sh
-cp .env.example .env
+pnpm --filter frontend run dev
 ```
 
-Then, replace the `VITE_SOCKET_ENDPOINT` value in the `.env` file with the CeraLive IP address on your local network.
-
-**Important:** Before building for production, remove the `.env` file so that the UI can load the IP dynamically from `window.location`.
-
-### Running the Development Server
-
-After setting up your environment, start the development server:
+### Build
 
 ```sh
-pnpm run dev
+pnpm build
 ```
 
-This will start a local development server, usually accessible at `http://localhost:5173/`.
-
-### Building for Production
-
-Generate an optimized production build:
+Or frontend only:
 
 ```sh
-pnpm run build
+pnpm --filter frontend run build
 ```
 
-The production build will be output to the `dist` directory.
+Output goes to `dist/`.
 
-### Preview Production Build
+### Other Commands
 
-To serve the production build locally:
+| Command | Description |
+|---------|-------------|
+| `pnpm --filter frontend run check` | Type-check via `svelte-check` |
+| `pnpm --filter frontend run test` | Run vitest unit tests |
+| `pnpm --filter frontend run test:e2e` | Run Playwright E2E tests |
+| `pnpm --filter frontend run lint` | ESLint |
+| `pnpm --filter frontend run preview` | Preview production build locally |
+
+### Mock Scenarios
+
+Development mode mocks hardware. Set `MOCK_SCENARIO` to switch scenarios:
 
 ```sh
-pnpm run preview
+pnpm dev                                      # default: multi-modem + WiFi
+MOCK_SCENARIO=single-modem pnpm dev           # 1 modem, no WiFi
+MOCK_SCENARIO=streaming-active pnpm dev       # active streaming simulation
 ```
 
-## Deployment Options
+## Structure
 
-### Serving on a Different Port with PM2
+```
+src/
+├── main.ts / App.svelte          # entry: initSubscriptions(), auth gate, Layout
+├── main/
+│   ├── LiveView.svelte           # stream control, encoder/audio/server config, bitrate
+│   ├── NetworkView.svelte        # bonded links, WiFi, modems, Ethernet, hotspot
+│   ├── SettingsView.svelte       # grouped config entry points (all via dialogs)
+│   ├── HudBar.svelte             # persistent HUD: bitrate, per-link signals, SoC telemetry
+│   ├── HudRegion.svelte          # responsive HUD mount (desktop top / mobile bottom dock)
+│   ├── DisconnectedBanner.svelte # reconnect/reboot/session-expiry banner
+│   └── dialogs/                  # 14 focused config dialogs, all compose AppDialog
+└── lib/
+    ├── rpc/                      # RPCClient, TypedRPC, subscriptions.svelte.ts
+    ├── stores/                   # hud, connection-ux, layout-mode (Svelte 5 runes)
+    └── components/
+        ├── dialogs/              # AppDialog.svelte — shared responsive dialog chrome
+        ├── custom/               # custom components (not shadcn-managed)
+        ├── streaming/            # ValidationAdapter.ts — FE constraint adapter
+        └── ui/                   # shadcn-svelte primitives (bits-ui v2) — CLI-managed
+```
 
-You can serve the UI on a different port using **PM2** and ensure it runs at startup:
+## Key Conventions
 
-1. Install PM2 globally if you haven't already:
+- **RPC only**: all backend calls go through `rpc.*` or `rpcClient.onMessage`. No direct hardware access.
+- **Validation bounds**: import from `ValidationAdapter.ts` (which sources from `@ceraui/rpc/schemas`). No inline numeric literals in dialog components.
+- **Stores**: Svelte 5 runes only. Files named `*.svelte.ts`.
+- **UI primitives**: add via `pnpm dlx shadcn-svelte@latest add <component>`, not by hand.
+- **Custom components**: go in `lib/components/custom/`, not `lib/components/ui/`.
+- **i18n**: all user-visible strings via `LL.*` from `@ceraui/i18n`.
+- **Design tokens**: Ground Control identity (phosphor lime primary, warm graphite background) defined in `app.css`. Read `../../.impeccable.md` before touching visuals.
+- **Touch/kiosk mode**: `?mode=touch` URL flag. See `../../docs/TOUCHSCREEN.md`.
+- **E2E tests**: read `tests/e2e/PLAYBOOK.md` before writing any E2E test.
 
-    ```sh
-    npm install -g pm2
-    ```
+## Deployment
 
-2. Install a static server like `serve`:
-
-    ```sh
-    npm install -g serve
-    ```
-
-3. Start serving the production build with PM2 on port `8080` (or any port of your choice):
-
-    ```sh
-    pm2 start "serve -s dist -l 8080" --name CeraUI
-    ```
-
-4. Save the PM2 process list and configure it to run at startup:
-
-    ```sh
-    pm2 save
-    pm2 startup
-    ```
-
-### Replacing the Existing CeraLive Frontend
-
-If you prefer to replace the original CeraLive frontend with CeraUI, copy the build files into the correct location:
+The frontend ships as part of the `ceraui` Debian package. The backend serves the compiled `dist/` as static files. Build the `.deb` from the workspace root:
 
 ```sh
-sudo cp -r dist/* /opt/CeraLive/public/
+BUILD_ARCH=arm64 ./scripts/build/build-debian-package.sh
+BUILD_ARCH=amd64 ./scripts/build/build-debian-package.sh
 ```
 
-> **Note:** Replacing the original UI directly may cause issues. When CeraLive is updated, it can overwrite these files, removing your custom UI. Ensure you monitor updates and reapply your changes if necessary.
-
-## 📸 Screenshots & Visual Documentation
-
-CeraUI offers a comprehensive and intuitive interface with both light and dark theme support across desktop and mobile platforms. Experience the complete visual journey through our **[📸 Visual Gallery](docs/SCREENSHOTS.md)**.
-
-### 🎯 Quick Preview
-
-| **Desktop Interface** | **Mobile Experience** |
-|:---------------------:|:---------------------:|
-| ![Desktop Preview](docs/screenshots/desktop/dark/general.png) | ![Mobile Preview](docs/screenshots/mobile/dark/general.png) |
-| *Full HD (1920×1080) optimized interface* | *iPhone 14 Pro Max (430×932) responsive design* |
-
-### 🌟 Featured Highlights
-
-- **🎨 Dual Theme Support**: Professional dark mode and clean light theme
-- **📱 Responsive Design**: Seamless desktop and mobile experiences  
-- **🔧 5 Core Tabs**: General, Network, Streaming, Advanced, and DevTools interfaces
-- **🌐 Internationalization**: Complete multi-language support (10+ languages)
-- **⚡ Progressive Web App**: Offline capabilities and native app-like performance
-- **📸 22 Screenshots**: Complete visual documentation with enhanced capture timing
-
-### 📖 Complete Documentation
-
-Explore the full visual documentation with detailed interface breakdowns, feature demonstrations, and technical specifications in our comprehensive **[Screenshots Gallery](docs/SCREENSHOTS.md)**.
+See [`../../docs/BUILD_PIPELINE.md`](../../docs/BUILD_PIPELINE.md) for the full build and CI reference.
 
 ## Documentation
 
-### Visual Documentation
-
-- **[📸 Screenshots Gallery](docs/SCREENSHOTS.md)**: Complete visual documentation showcasing CeraUI's interface across desktop and mobile platforms. Features 22 high-quality screenshots covering all 5 tabs in both dark and light themes, plus PWA offline mode demonstrations.
-
-### Development Tools
-
-- **[🔧 DevTools Tab](docs/DEVTOOLS.md)**: Comprehensive guide to the development utilities and debugging tools available in the DevTools tab. Includes component testing, console debugging, system information, and troubleshooting guides.
+| Document | Description |
+|----------|-------------|
+| [`docs/SCREENSHOTS.md`](docs/SCREENSHOTS.md) | Visual gallery — desktop and mobile, dark and light themes |
+| [`docs/DEVTOOLS.md`](docs/DEVTOOLS.md) | DevTools tab reference (dev builds only) |
+| [`../../docs/TOUCHSCREEN.md`](../../docs/TOUCHSCREEN.md) | Touch/kiosk layout mode |
+| [`../../docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) | System overview and data flow |
+| [`tests/e2e/PLAYBOOK.md`](tests/e2e/PLAYBOOK.md) | E2E test playbook (required reading) |
 
 ## License
 
-This project is licensed under the **GPL-3.0 License**. See the [LICENSE](LICENSE) file for more details.
+GPL-3.0. See [LICENSE](LICENSE).

--- a/docs/APT_VERSION_CONTROL.md
+++ b/docs/APT_VERSION_CONTROL.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-Previously, all packages had hardcoded iteration "1", so APT would see rebuilds as identical versions and skip updates.
+Previously, all packages had hardcoded iteration `1`, so APT would see rebuilds as identical versions and skip updates.
 
 ## Solution
 
@@ -10,9 +10,9 @@ Each build gets a unique timestamp-based iteration, ensuring APT always detects 
 
 ## Version Format
 
-CeraUI uses **Calendar Versioning (CalVer)**: `YYYY.MINOR.PATCH[-beta.N]`
+The Debian package name is `ceralive-device`. Versions follow a **Calendar Versioning** convention (`YYYY.MINOR.PATCH`), sourced from the latest git tag or the `BUILD_VERSION` env var. The build script falls back to `1.0.0` if no tag exists.
 
-Debian package naming:
+Debian package filename format:
 
 ```
 {name}_{version}-{iteration}_{arch}.deb
@@ -20,17 +20,19 @@ Debian package naming:
 
 | Component | Source | Example |
 |-----------|--------|---------|
-| name | Fixed | `ceralive-device` |
-| version | Git tag or `BUILD_VERSION` | `2026.1.0` |
-| iteration | `YYYYMMDD_HHMMSS.commit` | `20260112_143022.abc1234` |
-| arch | `BUILD_ARCH` or auto-detect | `arm64` |
+| `name` | Fixed | `ceralive-device` |
+| `version` | Latest git tag or `BUILD_VERSION` | `2026.1.0` |
+| `iteration` | `YYYYMMDD_HHMMSS.commit` | `20260112_143022.abc1234` |
+| `arch` | `BUILD_ARCH` or auto-detect | `arm64` |
+
+The iteration is built from two parts: a UTC timestamp (`get_build_date`) and the short git commit hash. Together they guarantee every build produces a unique, APT-comparable version string.
 
 ## How Versions Are Set
 
-**GitHub Actions:**
-- Workflow calculates next version from existing git tags
+**CI / GitHub Actions:**
+- Workflow calculates the next version from existing git tags
 - `release_type`: `stable` or `beta`
-- Creates tag and builds packages
+- Creates the tag and builds packages
 
 **Local builds:**
 ```bash
@@ -56,14 +58,16 @@ ceralive-device_2026.1.1-20260115_160000.ghi9012_arm64.deb
 
 ## APT Version Comparison
 
-APT compares versions:
+APT compares versions in two stages:
 
 1. Base version: `2026.1.0 < 2026.1.1 < 2026.2.0`
-2. Same version: ordered by iteration timestamp
+2. Same base version: ordered by iteration timestamp
+
+This means a rebuild of the same tagged version still wins over an older build, because the timestamp advances.
 
 ## Build Metadata
 
-Generated in `package-info-{arch}.json`:
+The build script writes `package-info-{arch}.json` alongside the `.deb`:
 
 ```json
 {
@@ -78,4 +82,4 @@ Generated in `package-info-{arch}.json`:
 
 ## See Also
 
-- [BUILD_PIPELINE.md](BUILD_PIPELINE.md) - Full build system and CalVer details
+- [BUILD_PIPELINE.md](BUILD_PIPELINE.md) — full build system, CI workflow, and versioning details

--- a/docs/BRANDING.md
+++ b/docs/BRANDING.md
@@ -40,9 +40,9 @@ description: brandTranslation("CeraUI needs an internet connection to manage you
 
 | Placeholder | Value |
 |-------------|-------|
-| `{{deviceName}}` | CERALIVE |
+| `{{deviceName}}` | CeraLive |
 | `{{deviceNameLower}}` | ceralive |
-| `{{siteName}}` | CeraUI for CERALIVE© |
+| `{{siteName}}` | CeraUI for CeraLive© |
 | `{{cloudService}}` | CeraLive Cloud |
 | `{{logName}}` | CeraLive Log |
 | `{{organizationName}}` | CeraLive |
@@ -55,9 +55,9 @@ Components can access brand configuration through:
 import { BRAND_CONFIG, deviceName, siteName } from "$lib/config/branding";
 
 // Use in components
-console.log(BRAND_CONFIG.deviceName); // "CERALIVE"
-console.log(deviceName);              // "CERALIVE"
-console.log(siteName);                // "CeraUI for CERALIVE©"
+console.log(BRAND_CONFIG.deviceName); // "CeraLive"
+console.log(deviceName);              // "CeraLive"
+console.log(siteName);                // "CeraUI for CeraLive©"
 ```
 
 ## File Structure

--- a/docs/BUILD_PIPELINE.md
+++ b/docs/BUILD_PIPELINE.md
@@ -83,6 +83,11 @@ The build pipeline runs manually via workflow dispatch.
    - Generates changelog from commit history
    - Marks beta releases as pre-release
 
+5. **sign-and-publish-r2**
+   - Signs Debian packages with GPG
+   - Generates signed apt repo metadata (`Packages`, `Release`, `InRelease`)
+   - Uploads to Cloudflare R2 under the appropriate channel (`stable` or `beta`)
+
 ## Local Development
 
 ### Prerequisites
@@ -161,7 +166,7 @@ ceraui-2026.1.0-arm64.tar.gz
 ## Build Process
 
 1. Navigate to **Actions** in the GitHub repository
-2. Select **Build & Release** workflow
+2. Select **Publish Release** workflow
 3. Click **Run workflow**
 4. Select release type (`stable` or `beta`)
 5. Optionally add release notes


### PR DESCRIPTION
## Documentation Canonical Refresh

Brings CeraUI docs into agreement with canonical `origin/main`.

### Changes
- **apps/frontend/README.md**: Remove fork refs (`pjeweb/CeraLive`, `CERALIVE/CeraUI`), PM2/serve deployment prose; re-align to pnpm workspace monorepo, Svelte 5, sibling-checkout layout
- **apps/backend/README.md**: Remove fork refs (`CERALIVE/CeraLive-ts`), old install scripts; reflect Bun runtime, oRPC procedures, WebSocket RPC
- **docs/BUILD_PIPELINE.md**: Correct workflow name to 'Publish Release'; add missing `sign-and-publish-r2` CI job; verify all script paths
- **docs/BRANDING.md**: Verify all 8 branding file paths; correct `CERALIVE` → `CeraLive` placeholders
- **docs/APT_VERSION_CONTROL.md**: Confirm package name (`ceralive-device`) and iteration format from build scripts

### Verification
- Zero fork references (`pjeweb/CeraLive`, `CERALIVE/CeraLive-ts`) in `.md` files
- All modified links and paths resolve
- Only `.md` files changed