### PR TITLE
feat: display profiles, e-ink-ready theme, and HUD perf

### DIFF
--- a/apps/frontend/src/App.svelte
+++ b/apps/frontend/src/App.svelte
@@ -3,11 +3,17 @@ import './app.css';
 
 import { isLocale, loadLocaleAsync } from '@ceraui/i18n';
 import { setLocale } from '@ceraui/i18n/svelte';
-import { ModeWatcher } from 'mode-watcher';
-import { onMount } from 'svelte';
+import { ModeWatcher, setTheme as setCustomTheme } from 'mode-watcher';
+import { onMount, untrack } from 'svelte';
 
 import BootShell from '$lib/components/custom/BootShell.svelte';
 import { getConnectionReady } from '$lib/rpc/subscriptions.svelte';
+import {
+	getDisplayProfile,
+	parseDisplayProfile,
+	prefersEinkTheme,
+	setDisplayProfile,
+} from '$lib/stores/display-profile.svelte';
 import { getLayoutMode, setLayoutMode } from '$lib/stores/layout-mode.svelte';
 import { getLocale } from '$lib/stores/locale.svelte';
 import { getShouldShowOfflinePage } from '$lib/stores/offline-state.svelte';
@@ -27,9 +33,31 @@ $effect(() => {
 	else if (mode === 'default') setLayoutMode('default');
 });
 
+// URL ?display=lcd|eink|mono overrides the persisted display profile on load.
+// Only applied when the param is present so an in-SPA reload without it keeps
+// the persisted profile (mirrors the ?mode handling above). Unknown values
+// normalize to the default (lcd) via parseDisplayProfile.
+$effect(() => {
+	const display = new URLSearchParams(window.location.search).get('display');
+	if (display !== null) setDisplayProfile(parseDisplayProfile(display));
+});
+
 // Reflect the active layout mode onto the document root for CSS token overrides.
 $effect(() => {
 	document.documentElement.dataset.layoutMode = getLayoutMode();
+});
+
+// Reflect the active display profile onto the document root: data-display always,
+// plus data-theme="eink" for the e-ink/mono profiles. mode-watcher owns the
+// <html> data-theme attribute (its $derived writer clobbers any direct write),
+// so route through its setTheme — cleared to '' for lcd. The setter performs
+// reactive reads internally; untrack keeps those out of this effect's
+// dependency set so writing the theme never re-triggers the effect (which would
+// otherwise read-and-write the same state → effect_update_depth_exceeded).
+$effect(() => {
+	const profile = getDisplayProfile();
+	document.documentElement.dataset.display = profile;
+	untrack(() => setCustomTheme(prefersEinkTheme(profile) ? 'eink' : ''));
 });
 
 onMount(async () => {

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -279,6 +279,97 @@
 		--gradient-destructive-to: oklch(0.5 0.18 15);
 		--gradient-warning-to: oklch(0.7 0.15 55);
 	}
+
+	/* ── E-ink / Mono ───────────────────────────────
+	   Pure grayscale token set for reflective e-paper and 1-bit/mono
+	   panels. Every color is chroma 0 (no hue), so the palette survives a
+	   grayscale render with no hue-collapse surprises. White paper, black
+	   ink, hard black borders. Covers BOTH the eink and mono display
+	   profiles: App.svelte sets data-theme="eink" for either, while
+	   data-display carries the raw profile. `html[...]` (specificity 0,1,1)
+	   beats the `.dark` / `:root` token blocks above (0,1,0) regardless of
+	   the underlying light/dark mode. Differentiation carried by HUE in
+	   dark/light (status, signal, bonded links) is re-expressed purely as a
+	   LIGHTNESS ramp so the roles stay distinguishable in grayscale. */
+	html[data-display='eink'],
+	html[data-theme='eink'] {
+		--background: oklch(1 0 0);
+		--foreground: oklch(0 0 0);
+
+		--card: oklch(0.98 0 0);
+		--card-foreground: oklch(0 0 0);
+		--popover: oklch(1 0 0);
+		--popover-foreground: oklch(0 0 0);
+
+		--primary: oklch(0 0 0);
+		--primary-foreground: oklch(1 0 0);
+
+		--secondary: oklch(0.9 0 0);
+		--secondary-foreground: oklch(0 0 0);
+
+		--muted: oklch(0.93 0 0);
+		--muted-foreground: oklch(0.3 0 0);
+
+		--accent: oklch(0.88 0 0);
+		--accent-foreground: oklch(0 0 0);
+
+		--destructive: oklch(0 0 0);
+		--destructive-foreground: oklch(1 0 0);
+
+		--border: oklch(0 0 0);
+		--input: oklch(0 0 0);
+		--ring: oklch(0 0 0);
+
+		--switch-off: oklch(0.6 0 0);
+		--switch-off-foreground: oklch(1 0 0);
+
+		--sidebar-background: oklch(0.96 0 0);
+		--sidebar-foreground: oklch(0 0 0);
+		--sidebar-primary: oklch(0 0 0);
+		--sidebar-primary-foreground: oklch(1 0 0);
+		--sidebar-accent: oklch(0.88 0 0);
+		--sidebar-accent-foreground: oklch(0 0 0);
+		--sidebar-border: oklch(0 0 0);
+		--sidebar-ring: oklch(0 0 0);
+
+		--status-success: oklch(0.2 0 0);
+		--status-success-foreground: oklch(1 0 0);
+		--status-info: oklch(0.3 0 0);
+		--status-info-foreground: oklch(1 0 0);
+		--status-warning: oklch(0.45 0 0);
+		--status-warning-foreground: oklch(1 0 0);
+		--status-error: oklch(0 0 0);
+		--status-error-foreground: oklch(1 0 0);
+		--status-neutral: oklch(0.5 0 0);
+		--status-neutral-foreground: oklch(1 0 0);
+
+		--status-live: oklch(0 0 0);
+		--status-standby: oklch(0.4 0 0);
+		--status-idle: oklch(0.62 0 0);
+
+		--signal-excellent: oklch(0.15 0 0);
+		--signal-good: oklch(0.3 0 0);
+		--signal-fair: oklch(0.45 0 0);
+		--signal-weak: oklch(0.55 0 0);
+
+		--link-1: oklch(0 0 0);
+		--link-2: oklch(0.2 0 0);
+		--link-3: oklch(0.35 0 0);
+		--link-4: oklch(0.45 0 0);
+		--link-5: oklch(0.55 0 0);
+		--link-6: oklch(0.65 0 0);
+		--link-bar-empty: color-mix(in oklab, var(--muted-foreground) 55%, transparent);
+
+		--shadow-sm: 0 0 0 1px oklch(0 0 0);
+		--shadow-md: 0 0 0 1px oklch(0 0 0);
+		--shadow-lg: 0 0 0 1px oklch(0 0 0);
+
+		--gradient-primary-to: oklch(0 0 0);
+		--gradient-success-to: oklch(0.2 0 0);
+		--gradient-info-to: oklch(0.3 0 0);
+		--gradient-destructive-to: oklch(0 0 0);
+		--gradient-warning-to: oklch(0.45 0 0);
+	}
 }
 
 /* ── Layout mode (touch / kiosk foundation) ──────
@@ -625,6 +716,24 @@
 	}
 }
 
+/* ── E-ink: kill all motion ──────────────────────
+   E-paper repaints ghost; any animation or transition smears. Unlike
+   `prefers-reduced-motion` (which uses a 0.01ms shrink so reduced-but-present
+   motion still completes), e-ink needs motion fully OFF — `none`, not near-zero.
+   Unlayered + !important so it overrides every component transition regardless
+   of cascade layer. Covers both display profiles via the shared
+   data-theme="eink" plus the raw data-display="eink". */
+html[data-display='eink'] *,
+html[data-display='eink'] *::before,
+html[data-display='eink'] *::after,
+html[data-theme='eink'] *,
+html[data-theme='eink'] *::before,
+html[data-theme='eink'] *::after {
+	animation: none !important;
+	transition: none !important;
+	scroll-behavior: auto !important;
+}
+
 /* ── Sonner Toasts ──────────────────────────────
    Graphite popover base + semantic accent per data-type. Tokens
    auto-flip light/dark, so no separate .dark rules. sonner's
@@ -808,6 +917,51 @@ label[for],
 [data-disabled],
 [aria-disabled='true'] {
 	cursor: not-allowed;
+}
+
+/* ── Short-viewport dialog collapse (on-screen keyboard) ────────────
+   On very short viewports (≤500px tall) — e.g. an 800×480 kiosk panel,
+   especially with the on-screen keyboard raised reducing the usable area —
+   the AppDialog surface collapses to a minimal, full-height scrollable form so
+   the footer actions (Save/Cancel) stay on-screen. Unlayered so it beats the
+   `max-h-[85svh]` / `rounded-*` / centering utilities on the surface. Pairs with
+   DESKTOP_CHROME_QUERY's short-landscape branch ($lib/layout): those panels are
+   ≤600px tall, so they render the centered Dialog and hit this at ≤500px. The
+   Sheet branch covers the rare narrow-and-short case (<768px ∧ ≤500px). */
+@media (max-height: 500px) {
+
+	/* Centered Dialog: pin to the full viewport height (top/bottom:0) and drop the
+	   max-h-[85svh] cap + translateY centering, so the surface is EXACTLY the
+	   viewport tall. The flex column then shrinks the scrollable body and keeps the
+	   header and footer fully on-screen, with nothing clipped at the edges the way
+	   a centered, taller-than-viewport box would be. */
+	[data-slot='dialog-content'] {
+		top: 0;
+		bottom: 0;
+		max-height: none;
+		/* Tailwind v4 `-translate-y-1/2` rides the independent `translate` property
+		   (not `transform`), so cancel the vertical shift here: keep the -50% inline
+		   centering (paired with left:50%), zero the vertical. */
+		translate: -50% 0;
+		border-radius: 0;
+	}
+
+	/* Bottom Sheet is already bottom-anchored; just let it fill the short height. */
+	[data-slot='sheet-content'] {
+		max-height: 100svh;
+		border-radius: 0;
+	}
+
+	[data-app-dialog-header] {
+		padding-top: 0.625rem;
+		padding-bottom: 0.625rem;
+	}
+
+	/* Footer padding-bottom is set inline (safe-area aware), so only trim the top
+	   here; the inline rule keeps the bottom inset for the home-indicator. */
+	[data-app-dialog-footer] {
+		padding-top: 0.625rem;
+	}
 }
 
 /* ── Svelte Inspector ── */

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -707,12 +707,64 @@
 	}
 }
 
-/* ── High contrast mode ── */
+/* ── High contrast mode ──
+   Both keywords listed: the spec value is `more`; `high` is the legacy alias
+   some engines still match. Brand hues stay put; only neutral contrast tokens,
+   border weights, shadows, and gradients are pushed to their extremes. */
 
-@media (prefers-contrast: high) {
+@media (prefers-contrast: more), (prefers-contrast: high) {
+	:root,
+	.dark {
+		--border: var(--foreground);
+		--input: var(--foreground);
+		--ring: var(--foreground);
+		--sidebar-border: var(--foreground);
+		--muted-foreground: var(--foreground);
+
+		--shadow-sm: 0 0 0 1px var(--foreground);
+		--shadow-md: 0 0 0 1px var(--foreground);
+		--shadow-lg: 0 0 0 1px var(--foreground);
+
+		--gradient-primary-to: var(--primary);
+		--gradient-success-to: var(--status-success);
+		--gradient-info-to: var(--status-info);
+		--gradient-destructive-to: var(--destructive);
+		--gradient-warning-to: var(--status-warning);
+
+		--contrast-mode: high;
+	}
+
 	:focus-visible {
 		outline-width: 3px;
 		outline-color: var(--foreground);
+	}
+
+	/* Per-side widths: Tailwind's preflight sets `border: 0 solid`, so bumping
+	   the shorthand on a single-edge utility (border-t/-b/-l/-r) would render
+	   three phantom solid edges. Widen only the edge each utility owns. */
+	.border {
+		border-width: 2px;
+	}
+
+	.border-t {
+		border-top-width: 2px;
+	}
+
+	.border-b {
+		border-bottom-width: 2px;
+	}
+
+	.border-l {
+		border-left-width: 2px;
+	}
+
+	.border-r {
+		border-right-width: 2px;
+	}
+
+	.loading-shimmer {
+		background: none;
+		animation: none;
 	}
 }
 

--- a/apps/frontend/src/lib/components/custom/DisplayRefresh.svelte
+++ b/apps/frontend/src/lib/components/custom/DisplayRefresh.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+import { LL } from '@ceraui/i18n/svelte';
+import RefreshCwIcon from '@lucide/svelte/icons/refresh-cw';
+
+import { getDisplayProfile, prefersEinkTheme } from '$lib/stores/display-profile.svelte';
+import { requestDisplayRefresh } from '$lib/stores/display-refresh.svelte';
+import { cn } from '$lib/utils';
+
+// Visible ONLY under the e-ink / mono profiles. The lcd profile renders nothing
+// (no DOM node, no tab stop) — its HUD updates live, so a manual refresh would
+// be noise. `data-display` on <html> is derived from this same store, so the
+// gate stays in lock-step with the [data-display='eink'|'mono'] CSS contract.
+const showRefresh = $derived(prefersEinkTheme(getDisplayProfile()));
+</script>
+
+{#if showRefresh}
+	<button
+		type="button"
+		data-testid="display-refresh"
+		aria-label={$LL.hud.refresh()}
+		title={$LL.hud.refresh()}
+		onclick={requestDisplayRefresh}
+		class={cn(
+			'fixed end-4 top-1/2 z-50 -translate-y-1/2',
+			'flex size-14 items-center justify-center rounded-full',
+			'border-border bg-background text-foreground border shadow-md',
+			'hover:bg-accent focus-visible:ring-ring/50 transition-colors focus-visible:ring-2 focus-visible:outline-none',
+		)}
+	>
+		<RefreshCwIcon class="size-6" aria-hidden="true" />
+	</button>
+{/if}

--- a/apps/frontend/src/lib/components/custom/LinkIndicator.svelte
+++ b/apps/frontend/src/lib/components/custom/LinkIndicator.svelte
@@ -13,6 +13,8 @@ import WifiLowIcon from '@lucide/svelte/icons/wifi-low';
 import WifiOffIcon from '@lucide/svelte/icons/wifi-off';
 import WifiZeroIcon from '@lucide/svelte/icons/wifi-zero';
 
+import { LL } from '@ceraui/i18n/svelte';
+
 import { getSignalCategory, linkVisualState, signalTextClass } from '$lib/helpers/signal';
 import { cn } from '$lib/utils';
 
@@ -68,6 +70,14 @@ const identityColor = $derived(
 );
 
 const qualityClass = $derived(signalTextClass(signal));
+
+// Non-color cue (a11y / colorblind / monochrome e-ink): each of the 6 spectral
+// link levels carries its 1-based ordinal as a `data-link-level` test hook and
+// an accessible "Link N" label, so the link is identifiable without relying on
+// the --link-{n} hue alone. Only set when this indicator represents a numbered
+// bonded link (linkIndex present); decorative signal glyphs stay aria-hidden.
+const linkLevel = $derived(linkIndex != null ? linkIndex + 1 : null);
+const linkAriaLabel = $derived(linkLevel != null ? `${$LL.hud.link()} ${linkLevel}` : undefined);
 </script>
 
 {#snippet barCluster(filled: number)}
@@ -112,7 +122,10 @@ const qualityClass = $derived(signalTextClass(signal));
 	</span>
 {:else}
 	<span
-		aria-hidden="true"
+		role={linkLevel != null ? 'img' : undefined}
+		aria-label={linkAriaLabel}
+		aria-hidden={linkLevel != null ? undefined : 'true'}
+		data-link-level={linkLevel ?? undefined}
 		style:width="{sizeConfig.w}px"
 		style:height="{sizeConfig.h}px"
 		class={cn('inline-flex items-end justify-center', className)}

--- a/apps/frontend/src/lib/components/custom/mode-toggle.svelte
+++ b/apps/frontend/src/lib/components/custom/mode-toggle.svelte
@@ -5,12 +5,17 @@ import { resetMode, setMode } from 'mode-watcher';
 
 import { Button } from '$lib/components/ui/button/index.js';
 import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
-import { getTheme, resolveSystemMode, setTheme, type ThemeMode } from '$lib/stores/theme.svelte';
+import { getTheme, resolveSystemMode, setTheme } from '$lib/stores/theme.svelte';
 import { cn } from '$lib/utils';
 
 let theme = $state(getTheme());
 
-const handleModeChange = (mode: ThemeMode) => {
+// The toggle only offers the three color modes; "mono" is a display-profile
+// value (theme.svelte.ts) that is never user-selectable here, so it is excluded
+// from this handler — mode-watcher's setMode rejects anything but these three.
+type ColorMode = 'light' | 'dark' | 'system';
+
+const handleModeChange = (mode: ColorMode) => {
 	if (mode === 'system') {
 		// resetMode hands control back to mode-watcher, which resolves the system
 		// preference the same way resolveSystemMode does: headless → dark.

--- a/apps/frontend/src/lib/components/dialogs/AppDialog.svelte
+++ b/apps/frontend/src/lib/components/dialogs/AppDialog.svelte
@@ -8,9 +8,14 @@
 
   Behaviour
   ----------
-  • Responsive: renders as a centered Dialog on desktop (>= lg, 1024px) and as a
-    bottom Sheet (drawer) on mobile. The breakpoint is reactive — resizing across
-    it re-renders the correct surface while preserving `open`.
+  • Responsive: renders as a centered Dialog under "desktop chrome" and as a
+    bottom Sheet (drawer) otherwise. Desktop chrome = `lg` (≥1024px) OR a short
+    landscape panel (≥768px wide ∧ ≤600px tall) — see `$lib/layout`'s
+    DESKTOP_CHROME_QUERY. The latter case is the kiosk touchscreen (e.g. 800×480):
+    a bottom Sheet there is unusable with the on-screen keyboard raised, so it
+    gets the centered Dialog (which the `@media (max-height: 500px)` rule in
+    app.css collapses to a full-height scrollable form). The breakpoint is
+    reactive — resizing across it re-renders the correct surface, preserving `open`.
   • Chrome: sticky header (title + optional icon + description + close button),
     scrollable body, optional pinned footer.
   • Close affordances: ESC, overlay click, and the header close button — all
@@ -55,6 +60,7 @@ import { MediaQuery } from 'svelte/reactivity';
 import { Button } from '$lib/components/ui/button';
 import * as Dialog from '$lib/components/ui/dialog';
 import * as Sheet from '$lib/components/ui/sheet';
+import { DESKTOP_CHROME_QUERY } from '$lib/layout';
 import { cn } from '$lib/utils';
 
 interface Props {
@@ -95,8 +101,10 @@ let {
 	contentClass,
 }: Props = $props();
 
-// lg breakpoint — Tailwind's `lg` is 1024px. Desktop => Dialog, mobile => Sheet.
-const isDesktop = new MediaQuery('(min-width: 1024px)');
+// Desktop chrome => centered Dialog; mobile (narrow/tall) => bottom Sheet.
+// Short landscape kiosk panels (≥768px ∧ ≤600px tall) count as desktop chrome
+// so the dialog stays usable with the on-screen keyboard. See $lib/layout.
+const isDesktop = new MediaQuery(DESKTOP_CHROME_QUERY);
 
 const Icon = $derived(icon);
 
@@ -119,7 +127,10 @@ const surfaceClass = cn(
 
 {#snippet body()}
 	<!-- Header -->
-	<div class="bg-card relative flex shrink-0 flex-col gap-1.5 border-b px-5 py-4 pe-14">
+	<div
+		class="bg-card relative flex shrink-0 flex-col gap-1.5 border-b px-5 py-4 pe-14"
+		data-app-dialog-header
+	>
 		<DialogPrimitive.Title class="flex items-center gap-2.5 text-base leading-tight font-semibold">
 			{#if Icon}
 				<Icon class="text-primary size-5 shrink-0" />
@@ -158,6 +169,7 @@ const surfaceClass = cn(
 		<div
 			class="bg-muted/40 flex shrink-0 flex-col-reverse gap-2 border-t px-5 py-4 sm:flex-row sm:justify-end"
 			style="padding-bottom: max(1rem, env(safe-area-inset-bottom));"
+			data-app-dialog-footer
 		>
 			{#if actions}
 				{@render actions()}

--- a/apps/frontend/src/lib/layout.ts
+++ b/apps/frontend/src/lib/layout.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared responsive pivot for the app shell.
+ *
+ * "Desktop chrome" = the rail-nav + top-HUD + centered-Dialog layout. The mobile
+ * alternative is the bottom-dock nav + bottom Sheet (drawer) layout.
+ *
+ * Desktop chrome applies in two cases:
+ *   1. The normal large breakpoint (Tailwind `lg`, 1024px wide) — phones/tablets
+ *      in portrait stay below this and keep the mobile layout, unchanged.
+ *   2. Short LANDSCAPE panels: at least 768px wide AND at most 600px tall. These
+ *      are attached kiosk touchscreens (e.g. an 800×480 panel). They are too
+ *      short for the bottom Sheet / bottom-dock layout to be usable — a bottom
+ *      drawer on a 480px-tall screen with the on-screen keyboard raised buries
+ *      the form behind the keyboard. The centered Dialog (which the
+ *      `@media (max-height: 500px)` rule in app.css collapses to a full-height
+ *      scrollable form) is the correct surface there.
+ *
+ * The standard desktop/mobile semantics for non-kiosk use are unchanged: only
+ * the short-landscape band (≥768px wide ∧ ≤600px tall) — which previously fell
+ * into the mobile layout — now resolves to desktop chrome.
+ *
+ * The comma is a media-query LIST (logical OR), honoured by `window.matchMedia`
+ * and `svelte/reactivity`'s `MediaQuery`.
+ *
+ * KEEP IN SYNC with the short-viewport `@media` rules in `app.css`. Components
+ * (`AppDialog`, `MainView`, `MainNav`) each instantiate their own `MediaQuery`
+ * from this single string so the nav and the dialog pivot together.
+ */
+export const DESKTOP_CHROME_QUERY =
+	'(min-width: 1024px), (min-width: 768px) and (max-height: 600px)';
+
+/**
+ * The wide-desktop breakpoint (Tailwind `lg`, 1024px) on its own.
+ *
+ * Used for chrome that needs the FULL desktop width, not just desktop chrome:
+ * the header toolbar (locale + theme dropdowns). On a short landscape kiosk panel
+ * (e.g. 800×480) the header is too narrow to hold the rail nav AND the toolbar
+ * without horizontal overflow, so the toolbar is hidden there and those controls
+ * surface in the Settings Appearance group instead, exactly as on mobile.
+ * `SettingsView` already shows that group below 1024px, so the two agree without
+ * extra coordination.
+ */
+export const WIDE_DESKTOP_QUERY = '(min-width: 1024px)';

--- a/apps/frontend/src/lib/stores/display-profile.svelte.ts
+++ b/apps/frontend/src/lib/stores/display-profile.svelte.ts
@@ -51,6 +51,14 @@ export function prefersEinkTheme(profile: DisplayProfile): boolean {
 	return profile === "eink" || profile === "mono";
 }
 
+// Re-exported from the dedicated `display-refresh` module so the manual e-ink
+// refresh hook (Task 12) is reachable from the display-profile store.
+export {
+	getDisplayRefreshNonce,
+	onDisplayRefresh,
+	requestDisplayRefresh,
+} from "./display-refresh.svelte";
+
 // Legacy-compatible store-like object for easier migration
 export const displayProfileStore = {
 	get value() {

--- a/apps/frontend/src/lib/stores/display-profile.svelte.ts
+++ b/apps/frontend/src/lib/stores/display-profile.svelte.ts
@@ -1,0 +1,60 @@
+// Display-profile store using Svelte 5 runes with persistence.
+// Mirrors layout-mode.svelte.ts. Drives the DC-4 URL contract
+// (?display=lcd|eink|mono): App.svelte parses the param, persists it here, and
+// reflects it onto <html> as data-display (always) plus data-theme="eink" for
+// the e-ink/mono profiles. CSS tokens for those themes are authored in Task 10.
+import "svelte-persistent-runes";
+
+export type DisplayProfile = "lcd" | "eink" | "mono";
+
+// Known profiles, in canonical order. Source of truth for both the URL-param
+// allow-list and the union above — keeps the contract free of inline literals.
+export const DISPLAY_PROFILES = [
+	"lcd",
+	"eink",
+	"mono",
+] as const satisfies readonly DisplayProfile[];
+
+export const DEFAULT_DISPLAY_PROFILE: DisplayProfile = "lcd";
+
+let displayProfile = $persist<DisplayProfile>(
+	DEFAULT_DISPLAY_PROFILE,
+	"display-profile",
+);
+
+export function getDisplayProfile(): DisplayProfile {
+	return displayProfile;
+}
+
+export function setDisplayProfile(profile: DisplayProfile): void {
+	displayProfile = profile;
+}
+
+/**
+ * Normalize a raw `?display=` URL value to a known profile. Anything absent or
+ * unrecognized falls back to {@link DEFAULT_DISPLAY_PROFILE} (`lcd`), so a bogus
+ * param can never leave the app in an undefined visual state.
+ */
+export function parseDisplayProfile(
+	value: string | null | undefined,
+): DisplayProfile {
+	return (DISPLAY_PROFILES as readonly string[]).includes(value ?? "")
+		? (value as DisplayProfile)
+		: DEFAULT_DISPLAY_PROFILE;
+}
+
+/**
+ * Whether the profile should activate the e-ink theme (`data-theme="eink"`):
+ * true for the `eink` and `mono` profiles, false for `lcd`.
+ */
+export function prefersEinkTheme(profile: DisplayProfile): boolean {
+	return profile === "eink" || profile === "mono";
+}
+
+// Legacy-compatible store-like object for easier migration
+export const displayProfileStore = {
+	get value() {
+		return displayProfile;
+	},
+	set: setDisplayProfile,
+};

--- a/apps/frontend/src/lib/stores/display-refresh.svelte.ts
+++ b/apps/frontend/src/lib/stores/display-refresh.svelte.ts
@@ -1,0 +1,86 @@
+// Display-refresh hook — Task 12.
+//
+// The single, testable release path for the e-ink display freeze (Task 10).
+// Under the `eink`/`mono` profiles the HUD/live fields are intentionally frozen
+// (the staleness clock is gated, nothing re-renders on its own) so the e-ink
+// panel is not driven by continuous repaints. `requestDisplayRefresh()` is the
+// ONE call that releases that freeze for a single render: it bumps a reactive
+// nonce that frozen derivations read, then fans out to imperative subscribers
+// (the freeze itself, the HUD staleness clock) so each can re-pull current
+// state and re-render exactly once.
+//
+// There are deliberately NO timers in this module. A refresh only ever happens
+// because something explicitly CALLED `requestDisplayRefresh()` — never on a
+// schedule. Auto-refresh would defeat the entire point of the e-ink freeze, so
+// this module exposes no interval/auto path by construction.
+//
+// Architecture mirrors the rest of the stores: the pub/sub core is rune-free
+// (a plain `Set` of listeners) so it is unit-testable under the node vitest
+// env; only the reactive nonce uses a rune, and it is read through a thin
+// getter so consumers re-derive when a refresh is requested.
+
+type DisplayRefreshListener = () => void;
+
+/** Imperative subscribers notified on each {@link requestDisplayRefresh}. */
+const listeners = new Set<DisplayRefreshListener>();
+
+/**
+ * Reactive refresh nonce. Frozen rune-based derivations read this (via
+ * {@link getDisplayRefreshNonce}) so a manual refresh forces them to re-derive
+ * exactly once. Monotonic; bumped once per request and never reset in normal
+ * operation (only {@link resetDisplayRefresh} for tests/HMR touches it).
+ */
+let refreshNonce = $state(0);
+
+/**
+ * Reactive read of the refresh nonce. A component or store that wants to
+ * re-derive on every manual refresh can read this; it changes once per
+ * {@link requestDisplayRefresh} call.
+ */
+export function getDisplayRefreshNonce(): number {
+	return refreshNonce;
+}
+
+/**
+ * Subscribe to manual-refresh requests. The returned function unsubscribes.
+ *
+ * Used by the e-ink freeze (Task 10) and the HUD staleness clock to re-pull and
+ * re-render once per refresh. Listeners fire synchronously, AFTER the reactive
+ * nonce has been bumped, so a listener that reads {@link getDisplayRefreshNonce}
+ * sees the new value.
+ */
+export function onDisplayRefresh(listener: DisplayRefreshListener): () => void {
+	listeners.add(listener);
+	return () => {
+		listeners.delete(listener);
+	};
+}
+
+/**
+ * Request a one-shot display refresh: re-pull current state and re-render the
+ * frozen HUD/live fields. This is the single release path for the e-ink freeze.
+ *
+ * Bumps the reactive nonce first (so rune consumers re-derive), then notifies
+ * every imperative subscriber. Safe to call repeatedly — each call is exactly
+ * one refresh tick, with no scheduling or coalescing.
+ */
+export function requestDisplayRefresh(): void {
+	refreshNonce += 1;
+	// Observability seam (mirrors window.__ceraAppMounted): mirror the monotonic
+	// count so E2E can prove a tap increments it and that nothing auto-refreshes.
+	if (typeof window !== "undefined") {
+		window.__ceraDisplayRefreshCount = refreshNonce;
+	}
+	// Iterate a snapshot so a listener that unsubscribes (or subscribes) during
+	// its own callback cannot mutate the live set mid-iteration.
+	for (const listener of [...listeners]) listener();
+}
+
+/**
+ * Drop every subscriber and reset the nonce. For unit tests and HMR teardown so
+ * a fresh module state is observable; never needed in normal app flow.
+ */
+export function resetDisplayRefresh(): void {
+	listeners.clear();
+	refreshNonce = 0;
+}

--- a/apps/frontend/src/lib/stores/hud.svelte.ts
+++ b/apps/frontend/src/lib/stores/hud.svelte.ts
@@ -483,6 +483,36 @@ function createHudStore(): HudStore {
 		nowTick = Date.now();
 	});
 
+	// One-shot sensor-staleness latch (frozen-stream dimming).
+	//
+	// A FROZEN telemetry stream — WS frames stop arriving WITHOUT a disconnect, so
+	// `connectionLostAt` never sets and the gated interval clock above stays parked —
+	// must still dim live SoC values once they age past STALE_THRESHOLD_MS. Gating the
+	// interval clock on sensor freshness instead would re-tick every second forever
+	// (the exact foot-gun `isClockTickNeeded` deliberately avoids), so we use a single
+	// deferred check, not an interval: every new sensor frame reschedules it, so in
+	// steady state it is perpetually deferred and never fires; the instant frames stop
+	// it fires exactly once, advancing `nowTick` so the derivation re-runs and
+	// `isSensorsStale` flips. Disconnect staleness stays covered by the gated clock via
+	// `connectionLostAt` -> `isFullyStale`.
+	let sensorStaleLatch: ReturnType<typeof setTimeout> | null = null;
+	const clearSensorStaleLatch = (): void => {
+		if (sensorStaleLatch !== null) {
+			clearTimeout(sensorStaleLatch);
+			sensorStaleLatch = null;
+		}
+	};
+	const armSensorStaleLatch = (sensorsAt: number): void => {
+		clearSensorStaleLatch();
+		// Fire one tick the moment this frame would age past the threshold. A fresher
+		// frame before then re-arms (clearing this), so healthy data never ticks.
+		const delay = Math.max(0, sensorsAt + STALE_THRESHOLD_MS - Date.now());
+		sensorStaleLatch = setTimeout(() => {
+			sensorStaleLatch = null;
+			nowTick = Date.now();
+		}, delay);
+	};
+
 	const stopRoot = $effect.root(() => {
 		$effect(() => {
 			const t = Date.now();
@@ -499,6 +529,7 @@ function createHudStore(): HudStore {
 			if (sensors !== prevSensors) {
 				timestamps.sensors = t;
 				prevSensors = sensors;
+				armSensorStaleLatch(t);
 			}
 
 			const modems = getModems();
@@ -558,6 +589,7 @@ function createHudStore(): HudStore {
 		},
 		destroy: () => {
 			clock.stop();
+			clearSensorStaleLatch();
 			stopRoot();
 			releaseRefresh();
 			if (typeof document !== "undefined") {

--- a/apps/frontend/src/lib/stores/hud.svelte.ts
+++ b/apps/frontend/src/lib/stores/hud.svelte.ts
@@ -238,6 +238,44 @@ export function isTimestampStale(ts: number | null, now: number): boolean {
 }
 
 /**
+ * Whether the staleness clock needs to keep ticking. The clock only advances
+ * `now` so a staleness flag can flip; once nothing can transition, ticking is
+ * waste — a foot-gun on an always-foreground kiosk with no `visibilitychange`
+ * relief. A tick is needed while `streaming`, or while a dropped link is still
+ * inside the {@link STALE_THRESHOLD_MS} window counting toward `isFullyStale`.
+ *
+ * `connectionLostAt` is the one timestamp safe to gate on: set once on
+ * disconnect and never refreshed, it ages out deterministically. Refresh-driven
+ * sources (sensors/modems/wifi) are intentionally excluded — gating on them
+ * would keep an idle-connected device awake forever (the wakeup we remove); their
+ * staleness still resolves while streaming, and `isFullyStale` covers disconnect.
+ */
+export function isClockTickNeeded(
+	streaming: boolean,
+	connectionLostAt: number | null,
+	now: number,
+): boolean {
+	if (streaming) return true;
+	return (
+		connectionLostAt != null && now - connectionLostAt < STALE_THRESHOLD_MS
+	);
+}
+
+/**
+ * The full clock gate: tick only when the document is visible AND a tick is
+ * actually {@link isClockTickNeeded | needed}. A hidden document never ticks,
+ * even mid-stream — there is no one watching for data to go stale.
+ */
+export function shouldClockRun(
+	visible: boolean,
+	streaming: boolean,
+	connectionLostAt: number | null,
+	now: number,
+): boolean {
+	return visible && isClockTickNeeded(streaming, connectionLostAt, now);
+}
+
+/**
  * Pure derivation: turn a point-in-time {@link HudSources} snapshot plus
  * {@link HudTimestamps} and a clock value into a complete {@link HudState}.
  *
@@ -302,6 +340,63 @@ export function deriveHudState(
 }
 
 // ============================================
+// Staleness clock (rune-free, gated)
+// ============================================
+
+/** Whether the document is currently visible (headless/SSR → treated visible). */
+function isDocumentVisible(): boolean {
+	return typeof document === "undefined" || document.hidden !== true;
+}
+
+export interface StalenessClock {
+	/** Re-evaluate the gate and start/stop the interval to match. */
+	sync(): void;
+	/** Whether the interval is currently running. */
+	isRunning(): boolean;
+	/** Stop the interval and dispose. */
+	stop(): void;
+}
+
+/**
+ * A self-gating staleness clock. Unlike a bare {@link setInterval} it only runs
+ * while `shouldRun()` holds: {@link StalenessClock.sync} starts or stops it on
+ * demand, and each tick re-checks `shouldRun()` so the interval stops itself the
+ * instant the staleness window elapses. Rune-free so the gating is unit-testable
+ * under plain vitest with fake timers.
+ */
+export function createStalenessClock(
+	shouldRun: () => boolean,
+	onTick: () => void,
+	intervalMs: number = CLOCK_INTERVAL_MS,
+): StalenessClock {
+	let handle: ReturnType<typeof setInterval> | null = null;
+
+	const stop = (): void => {
+		if (handle !== null) {
+			clearInterval(handle);
+			handle = null;
+		}
+	};
+
+	const start = (): void => {
+		if (handle !== null) return;
+		handle = setInterval(() => {
+			onTick();
+			if (!shouldRun()) stop();
+		}, intervalMs);
+	};
+
+	return {
+		sync: () => {
+			if (shouldRun()) start();
+			else stop();
+		},
+		isRunning: () => handle !== null,
+		stop,
+	};
+}
+
+// ============================================
 // Reactive store (runes — lazily created)
 // ============================================
 
@@ -360,6 +455,26 @@ function createHudStore(): HudStore {
 	let prevWifi: unknown;
 	let prevConnected: boolean | undefined;
 
+	const clock = createStalenessClock(
+		() =>
+			shouldClockRun(
+				isDocumentVisible(),
+				getIsStreaming(),
+				timestamps.connectionLostAt,
+				Date.now(),
+			),
+		() => {
+			nowTick = Date.now();
+		},
+	);
+
+	// A kiosk never backgrounds, but a phone/desktop tab does: pause the clock
+	// while hidden and re-evaluate the gate the moment it returns.
+	const onVisibilityChange = (): void => clock.sync();
+	if (typeof document !== "undefined") {
+		document.addEventListener("visibilitychange", onVisibilityChange);
+	}
+
 	const stopRoot = $effect.root(() => {
 		$effect(() => {
 			const t = Date.now();
@@ -399,11 +514,16 @@ function createHudStore(): HudStore {
 			}
 			prevConnected = connected;
 		});
-	});
 
-	const clock = setInterval(() => {
-		nowTick = Date.now();
-	}, CLOCK_INTERVAL_MS);
+		// Resume/stop the clock when a reactive gate input changes: `sync()` reads
+		// `getIsStreaming()` and `timestamps.connectionLostAt` as arguments, so
+		// this effect re-runs on streaming flips and link drops/recoveries. The
+		// visibility half is driven by the listener; the elapsed-window stop is
+		// the clock's own per-tick self-check.
+		$effect(() => {
+			clock.sync();
+		});
+	});
 
 	const snapshot = (): HudState =>
 		deriveHudState(readSources(), timestamps, nowTick);
@@ -429,8 +549,11 @@ function createHudStore(): HudStore {
 			};
 		},
 		destroy: () => {
-			clearInterval(clock);
+			clock.stop();
 			stopRoot();
+			if (typeof document !== "undefined") {
+				document.removeEventListener("visibilitychange", onVisibilityChange);
+			}
 		},
 	};
 }

--- a/apps/frontend/src/lib/stores/hud.svelte.ts
+++ b/apps/frontend/src/lib/stores/hud.svelte.ts
@@ -40,6 +40,7 @@ import {
 	getUpdating,
 	getWifi,
 } from "$lib/rpc/subscriptions.svelte";
+import { onDisplayRefresh } from "$lib/stores/display-refresh.svelte";
 import type {
 	HudConnectionState,
 	HudSources,
@@ -475,6 +476,13 @@ function createHudStore(): HudStore {
 		document.addEventListener("visibilitychange", onVisibilityChange);
 	}
 
+	// Manual refresh (Task 12): advancing `nowTick` re-derives the snapshot from
+	// freshly-read getters, which re-renders the frozen HUD/live fields once. The
+	// only path that ticks the clock outside the gated interval.
+	const releaseRefresh = onDisplayRefresh(() => {
+		nowTick = Date.now();
+	});
+
 	const stopRoot = $effect.root(() => {
 		$effect(() => {
 			const t = Date.now();
@@ -551,6 +559,7 @@ function createHudStore(): HudStore {
 		destroy: () => {
 			clock.stop();
 			stopRoot();
+			releaseRefresh();
 			if (typeof document !== "undefined") {
 				document.removeEventListener("visibilitychange", onVisibilityChange);
 			}

--- a/apps/frontend/src/lib/stores/theme.svelte.ts
+++ b/apps/frontend/src/lib/stores/theme.svelte.ts
@@ -1,7 +1,11 @@
 // Theme store using Svelte 5 runes with persistence
 import "svelte-persistent-runes";
 
-export type ThemeMode = "system" | "dark" | "light";
+// "system" | "dark" | "light" are the user-selectable color modes (the
+// mode-toggle surfaces these three). "mono" is the e-ink/mono display-profile
+// counterpart: selected by the display profile, not the toggle, and rendered via
+// the grayscale data-theme="eink" token set rather than a light/dark color mode.
+export type ThemeMode = "system" | "dark" | "light" | "mono";
 
 let theme = $persist<ThemeMode>("dark", "theme");
 

--- a/apps/frontend/src/main/HudRegion.svelte
+++ b/apps/frontend/src/main/HudRegion.svelte
@@ -1,13 +1,24 @@
 <script lang="ts">
+import DisplayRefresh from '$lib/components/custom/DisplayRefresh.svelte';
 import HudBar from './HudBar.svelte';
 
-let { class: className }: { class?: string } = $props();
+let { class: className, affordance = false }: { class?: string; affordance?: boolean } = $props();
 </script>
 
-<!--
-  Persistent HUD region. Mounts the live telemetry bar (HudBar) inside the
-  authenticated MainView shell so it persists across Live / Network / Settings.
-  Rendered in two responsive slots (desktop top bar / mobile bottom dock); each
-  slot owns its own HudBar instance, only one of which is visible at a time.
--->
-<HudBar class={className} />
+{#if affordance}
+	<!--
+	  Affordance slot: the manual e-ink refresh control (Task 12). DisplayRefresh
+	  is position:fixed and self-gates to the eink/mono profiles, so this slot is
+	  mounted ONCE at the MainView root — never inside a breakpoint-hidden HUD
+	  slot, which would `display:none` the fixed control at the wrong viewport.
+	-->
+	<DisplayRefresh />
+{:else}
+	<!--
+	  Persistent HUD region. Mounts the live telemetry bar (HudBar) inside the
+	  authenticated MainView shell so it persists across Live / Network / Settings.
+	  Rendered in two responsive slots (desktop top bar / mobile bottom dock); each
+	  slot owns its own HudBar instance, only one of which is visible at a time.
+	-->
+	<HudBar class={className} />
+{/if}

--- a/apps/frontend/src/main/MainView.svelte
+++ b/apps/frontend/src/main/MainView.svelte
@@ -28,6 +28,7 @@ const isDesktop = new MediaQuery('(min-width: 1024px)');
 
 <PullToRefresh onRefresh={handleRefresh}>
 	<div class="flex min-h-dvh flex-col">
+		<HudRegion affordance />
 		<header class="bg-background sticky top-0 z-40 w-full border-b">
 			<div class="container flex h-14 max-w-7xl items-center gap-4">
 				<button

--- a/apps/frontend/src/main/MainView.svelte
+++ b/apps/frontend/src/main/MainView.svelte
@@ -13,7 +13,6 @@ import HudRegion from './HudRegion.svelte';
 import MainNav from './navigation/MainNav.svelte';
 import MobileNav from './navigation/MobileNav.svelte';
 import NavigationRenderer from './navigation/NavigationRenderer.svelte';
-import NotificationsPanel from './notifications/NotificationsPanel.svelte';
 
 async function handleRefresh() {
 	window.location.reload();
@@ -55,11 +54,10 @@ const isWideDesktop = new MediaQuery(WIDE_DESKTOP_QUERY);
 					</span>
 				</button>
 
-				<MainNav />
+			<MainNav />
 
-				<div class="flex flex-1 items-center justify-end gap-1">
-					<NotificationsPanel />
-					{#if isWideDesktop.current}
+			<div class="flex flex-1 items-center justify-end gap-1">
+				{#if isWideDesktop.current}
 						<div role="toolbar" aria-label="Settings" class="flex items-center gap-1">
 							<span class="contents" data-testid="header-locale-selector">
 								<LocaleSelector />

--- a/apps/frontend/src/main/MainView.svelte
+++ b/apps/frontend/src/main/MainView.svelte
@@ -6,12 +6,14 @@ import ModeToggle from '$lib/components/custom/mode-toggle.svelte';
 import { PullToRefresh } from '$lib/components/custom/pwa';
 import Logo from '$lib/components/icons/Logo.svelte';
 import { liveNavElement, siteName } from '$lib/config';
+import { DESKTOP_CHROME_QUERY, WIDE_DESKTOP_QUERY } from '$lib/layout';
 import { navigateTo } from '$lib/stores/navigation.svelte';
 
 import HudRegion from './HudRegion.svelte';
 import MainNav from './navigation/MainNav.svelte';
 import MobileNav from './navigation/MobileNav.svelte';
 import NavigationRenderer from './navigation/NavigationRenderer.svelte';
+import NotificationsPanel from './notifications/NotificationsPanel.svelte';
 
 async function handleRefresh() {
 	window.location.reload();
@@ -19,11 +21,22 @@ async function handleRefresh() {
 
 const goHome = () => navigateTo({ live: liveNavElement });
 
-// Desktop (lg+) hosts the language + theme controls in the header toolbar.
-// On mobile they move into the Settings destination's Appearance group, so the
-// header stays uncluttered. Conditionally rendered (not just hidden) to avoid
-// mounting the dropdowns twice. Mirrors AppDialog's `(min-width: 1024px)` query.
-const isDesktop = new MediaQuery('(min-width: 1024px)');
+// "Desktop chrome" (rail nav + top HUD + header toolbar) vs the mobile layout
+// (bottom-dock nav + bottom HUD). Desktop chrome = `lg` (≥1024px) OR a short
+// landscape kiosk panel (≥768px wide ∧ ≤600px tall, e.g. 800×480) — see
+// $lib/layout. A single reactive boolean drives the WHOLE shell pivot (nav, HUD
+// dock, content padding, header toolbar) so the dialog (AppDialog, same query)
+// and the chrome flip together. The toolbar dropdowns are conditionally rendered
+// (not just hidden) to avoid mounting them twice; on mobile they live in the
+// Settings destination's Appearance group instead. Mirrors AppDialog's query.
+const isDesktop = new MediaQuery(DESKTOP_CHROME_QUERY);
+
+// The header toolbar (locale + theme) needs the FULL desktop width, not just
+// desktop chrome: a short landscape panel (e.g. 800x480) can't fit the rail nav
+// AND the toolbar without horizontal overflow. Below 1024px the toolbar is
+// hidden and those controls live in the Settings Appearance group (SettingsView
+// already renders it below 1024px, so the two stay in agreement). See $lib/layout.
+const isWideDesktop = new MediaQuery(WIDE_DESKTOP_QUERY);
 </script>
 
 <PullToRefresh onRefresh={handleRefresh}>
@@ -44,8 +57,9 @@ const isDesktop = new MediaQuery('(min-width: 1024px)');
 
 				<MainNav />
 
-				{#if isDesktop.current}
-					<div class="flex flex-1 items-center justify-end">
+				<div class="flex flex-1 items-center justify-end gap-1">
+					<NotificationsPanel />
+					{#if isWideDesktop.current}
 						<div role="toolbar" aria-label="Settings" class="flex items-center gap-1">
 							<span class="contents" data-testid="header-locale-selector">
 								<LocaleSelector />
@@ -54,25 +68,29 @@ const isDesktop = new MediaQuery('(min-width: 1024px)');
 								<ModeToggle />
 							</span>
 						</div>
-					</div>
-				{/if}
+					{/if}
+				</div>
 			</div>
 		</header>
 
-		<!-- Persistent HUD region (desktop): above the tab content, persists across destinations -->
-		<HudRegion class="hidden lg:flex" />
+		<!-- Persistent HUD region (desktop chrome): above the tab content, persists across destinations -->
+		{#if isDesktop.current}
+			<HudRegion class="flex" />
+		{/if}
 
-		<main class="flex-1 pb-28 lg:pb-0">
+		<main class="flex-1" class:pb-28={!isDesktop.current}>
 			<NavigationRenderer></NavigationRenderer>
 		</main>
 
 		<!-- Mobile dock: 3-destination tab bar sitting ABOVE the persistent HUD region -->
-		<div
-			class="bg-background fixed inset-x-0 bottom-0 z-40 lg:hidden"
-			style="padding-bottom: env(safe-area-inset-bottom);"
-		>
-			<MobileNav />
-			<HudRegion />
-		</div>
+		{#if !isDesktop.current}
+			<div
+				class="bg-background fixed inset-x-0 bottom-0 z-40"
+				style="padding-bottom: env(safe-area-inset-bottom);"
+			>
+				<MobileNav />
+				<HudRegion />
+			</div>
+		{/if}
 	</div>
 </PullToRefresh>

--- a/apps/frontend/src/main/navigation/MainNav.svelte
+++ b/apps/frontend/src/main/navigation/MainNav.svelte
@@ -38,6 +38,7 @@ const label = (nav: NavElements[string]) =>
 
 <nav
 	aria-label="Main navigation"
+	data-testid="rail-nav"
 	class="flex-1 items-center justify-center"
 	class:hidden={!isDesktop.current}
 	class:flex={isDesktop.current}

--- a/apps/frontend/src/main/navigation/MainNav.svelte
+++ b/apps/frontend/src/main/navigation/MainNav.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 import { LL } from '@ceraui/i18n/svelte';
+import { MediaQuery } from 'svelte/reactivity';
 
 import { type NavElements, navElements } from '$lib/config';
+import { DESKTOP_CHROME_QUERY } from '$lib/layout';
 import {
 	getCurrentNavigation,
 	isNavigationTransitioning,
@@ -11,6 +13,11 @@ import { cn } from '$lib/utils';
 
 let lastNavigationTime = 0;
 const NAVIGATION_THROTTLE_MS = 50;
+
+// Rail nav belongs to "desktop chrome": ≥1024px OR a short landscape kiosk panel
+// (≥768px ∧ ≤600px tall). Below that the mobile bottom dock (MobileNav) renders
+// instead. Reactive so the rail/dock swap on resize. Mirrors MainView's pivot.
+const isDesktop = new MediaQuery(DESKTOP_CHROME_QUERY);
 
 const currentNav = $derived(getCurrentNavigation() ?? { live: navElements.live });
 const activeKey = $derived(Object.keys(currentNav)[0] ?? 'live');
@@ -29,7 +36,12 @@ const label = (nav: NavElements[string]) =>
 	nav.title ?? $LL.navigation[nav.label as keyof typeof $LL.navigation]();
 </script>
 
-<nav aria-label="Main navigation" class="hidden flex-1 items-center justify-center lg:flex">
+<nav
+	aria-label="Main navigation"
+	class="flex-1 items-center justify-center"
+	class:hidden={!isDesktop.current}
+	class:flex={isDesktop.current}
+>
 	<div class="flex items-center gap-1">
 		{#each Object.entries(navElements) as [identifier, navigation] (identifier)}
 			{@const isActive = activeKey === identifier}

--- a/apps/frontend/src/main/navigation/MobileNav.svelte
+++ b/apps/frontend/src/main/navigation/MobileNav.svelte
@@ -31,6 +31,7 @@ const label = (nav: NavElements[string]) =>
 
 <nav
 	aria-label="Main navigation"
+	data-testid="dock-nav"
 	class="bg-sidebar flex items-stretch justify-around border-t"
 >
 	{#each Object.entries(navElements) as [identifier, navigation] (identifier)}

--- a/apps/frontend/src/tests/display-profile.test.ts
+++ b/apps/frontend/src/tests/display-profile.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+	DEFAULT_DISPLAY_PROFILE,
+	DISPLAY_PROFILES,
+	type DisplayProfile,
+	getDisplayProfile,
+	parseDisplayProfile,
+	prefersEinkTheme,
+	setDisplayProfile,
+} from "$lib/stores/display-profile.svelte";
+
+/**
+ * Display-profile store + URL contract (DC-4).
+ *
+ * Mirrors `layout-mode.svelte.ts`: a `$persist`-backed runes store with a
+ * getter/setter, defaulting to `lcd`. App.svelte parses `?display=lcd|eink|mono`
+ * and reflects the profile onto `<html>` (`data-display` always; `data-theme="eink"`
+ * for the e-ink/mono profiles). This suite pins the pure, node-testable surface:
+ * the default, the getter/setter round-trip, the param normalization (with
+ * fallback to `lcd`), and the eink-theme predicate that drives `data-theme`.
+ *
+ * The vitest environment is `node` (no `window`), so `svelte-persistent-runes`
+ * never touches localStorage and the store starts at its declared default.
+ */
+
+afterEach(() => {
+	// Module-level $persist state is shared across tests; reset to default so
+	// setter tests don't leak into ordering-sensitive default assertions.
+	setDisplayProfile(DEFAULT_DISPLAY_PROFILE);
+});
+
+describe("display-profile store", () => {
+	it("declares lcd as the default profile", () => {
+		expect(DEFAULT_DISPLAY_PROFILE).toBe("lcd");
+		expect(getDisplayProfile()).toBe("lcd");
+	});
+
+	it("exposes the three known profiles without duplicates", () => {
+		expect(DISPLAY_PROFILES).toEqual(["lcd", "eink", "mono"]);
+		expect(new Set(DISPLAY_PROFILES).size).toBe(DISPLAY_PROFILES.length);
+	});
+
+	it("round-trips every known profile through the getter/setter", () => {
+		for (const profile of DISPLAY_PROFILES) {
+			setDisplayProfile(profile);
+			expect(getDisplayProfile()).toBe(profile);
+		}
+	});
+});
+
+describe("parseDisplayProfile", () => {
+	it("accepts each known profile verbatim", () => {
+		for (const profile of DISPLAY_PROFILES) {
+			expect(parseDisplayProfile(profile)).toBe(profile);
+		}
+	});
+
+	it("falls back to lcd when the param is absent", () => {
+		expect(parseDisplayProfile(null)).toBe("lcd");
+		expect(parseDisplayProfile(undefined)).toBe("lcd");
+	});
+
+	it("falls back to lcd for unknown / malformed values", () => {
+		for (const bogus of ["bogus", "LCD", "e-ink", "", " mono", "0"]) {
+			expect(parseDisplayProfile(bogus)).toBe("lcd");
+		}
+	});
+});
+
+describe("prefersEinkTheme", () => {
+	it('is true for the e-ink and mono profiles (data-theme="eink")', () => {
+		expect(prefersEinkTheme("eink")).toBe(true);
+		expect(prefersEinkTheme("mono")).toBe(true);
+	});
+
+	it("is false for the lcd profile (no data-theme override)", () => {
+		expect(prefersEinkTheme("lcd")).toBe(false);
+	});
+
+	it("covers every profile in the union", () => {
+		const seen: Record<DisplayProfile, boolean> = {
+			lcd: prefersEinkTheme("lcd"),
+			eink: prefersEinkTheme("eink"),
+			mono: prefersEinkTheme("mono"),
+		};
+		expect(seen).toEqual({ lcd: false, eink: true, mono: true });
+	});
+});

--- a/apps/frontend/src/tests/display-refresh.test.ts
+++ b/apps/frontend/src/tests/display-refresh.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+	getDisplayRefreshNonce,
+	onDisplayRefresh,
+	requestDisplayRefresh,
+	resetDisplayRefresh,
+} from "$lib/stores/display-refresh.svelte";
+
+/**
+ * Display-refresh hook (Task 12) — the single release path for the e-ink freeze.
+ *
+ * This pins the rune-free pub/sub core plus the reactive nonce: subscribe /
+ * unsubscribe, fan-out to every listener, monotonic nonce, and the safety
+ * guarantee that a listener mutating the subscriber set mid-fire cannot break
+ * the iteration. The vitest env is `node`; the top-level `$state` nonce compiles
+ * and is read through `getDisplayRefreshNonce`, the same pattern as the
+ * display-profile store's `$persist` state.
+ */
+
+afterEach(() => {
+	// Module-level subscriber set + nonce are shared across tests.
+	resetDisplayRefresh();
+});
+
+describe("requestDisplayRefresh", () => {
+	it("notifies a subscribed listener once per call", () => {
+		const listener = vi.fn();
+		onDisplayRefresh(listener);
+
+		requestDisplayRefresh();
+		requestDisplayRefresh();
+
+		expect(listener).toHaveBeenCalledTimes(2);
+	});
+
+	it("fans out to every subscribed listener", () => {
+		const a = vi.fn();
+		const b = vi.fn();
+		onDisplayRefresh(a);
+		onDisplayRefresh(b);
+
+		requestDisplayRefresh();
+
+		expect(a).toHaveBeenCalledTimes(1);
+		expect(b).toHaveBeenCalledTimes(1);
+	});
+
+	it("bumps the reactive nonce by exactly one per call", () => {
+		const before = getDisplayRefreshNonce();
+		requestDisplayRefresh();
+		expect(getDisplayRefreshNonce()).toBe(before + 1);
+		requestDisplayRefresh();
+		expect(getDisplayRefreshNonce()).toBe(before + 2);
+	});
+
+	it("does not throw with no subscribers", () => {
+		expect(() => requestDisplayRefresh()).not.toThrow();
+	});
+});
+
+describe("onDisplayRefresh", () => {
+	it("stops notifying after the returned unsubscribe runs", () => {
+		const listener = vi.fn();
+		const unsubscribe = onDisplayRefresh(listener);
+
+		requestDisplayRefresh();
+		unsubscribe();
+		requestDisplayRefresh();
+
+		expect(listener).toHaveBeenCalledTimes(1);
+	});
+
+	it("lets a listener unsubscribe itself mid-fire without skipping others", () => {
+		const order: string[] = [];
+		const self = onDisplayRefresh(() => {
+			order.push("self");
+			self();
+		});
+		onDisplayRefresh(() => order.push("other"));
+
+		requestDisplayRefresh();
+		requestDisplayRefresh();
+
+		// First fire reaches both; the self-unsubscribe only takes effect next time.
+		expect(order).toEqual(["self", "other", "other"]);
+	});
+});
+
+describe("resetDisplayRefresh", () => {
+	it("clears subscribers and resets the nonce to zero", () => {
+		const listener = vi.fn();
+		onDisplayRefresh(listener);
+		requestDisplayRefresh();
+
+		resetDisplayRefresh();
+
+		expect(getDisplayRefreshNonce()).toBe(0);
+		requestDisplayRefresh();
+		expect(listener).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/frontend/src/tests/hud-clock-gating.test.ts
+++ b/apps/frontend/src/tests/hud-clock-gating.test.ts
@@ -1,0 +1,382 @@
+/**
+ * HUD staleness-clock gating — Task 5 (perf, G1/D4).
+ *
+ * The HUD store used to run an *unconditional* 1 Hz `setInterval` whose only job
+ * is to advance `now` so a staleness flag can flip. On an always-foreground
+ * kiosk (which never receives `visibilitychange` relief) that timer fires
+ * forever, even while nothing can possibly transition — a real perf foot-gun.
+ *
+ * This suite pins the gated replacement. Mirroring `hud.test.ts` /
+ * `connection-ux.svelte.ts`, every decision lives in *pure*, rune-free exported
+ * functions ({@link isClockTickNeeded}, {@link shouldClockRun}) plus a rune-free,
+ * timer-injectable clock ({@link createStalenessClock}) — so the actual
+ * `setInterval` gating is unit-testable under plain vitest with fake timers, and
+ * the reactive runes wrapper is never executed here.
+ *
+ * `hud.svelte.ts` statically imports `subscriptions.svelte`, whose module body
+ * declares Svelte runes ($state). Mock it so importing the store never evaluates
+ * those runes.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("$lib/rpc/subscriptions.svelte", () => ({
+	getIsStreaming: vi.fn(() => false),
+	getConfig: vi.fn(() => undefined),
+	getModems: vi.fn(() => undefined),
+	getWifi: vi.fn(() => undefined),
+	getNetif: vi.fn(() => undefined),
+	getSensors: vi.fn(() => undefined),
+	getUpdating: vi.fn(() => null),
+	getIsConnected: vi.fn(() => false),
+	getConnectionState: vi.fn(() => "disconnected"),
+}));
+
+import type {
+	ConfigMessage,
+	Modem,
+	ModemList,
+	NetifMessage,
+	SensorsStatus,
+	WifiStatus,
+} from "@ceraui/rpc/schemas";
+import type { HudSources, HudTimestamps } from "$lib/types/hud";
+
+import {
+	createStalenessClock,
+	deriveHudState,
+	isClockTickNeeded,
+	shouldClockRun,
+	STALE_THRESHOLD_MS,
+} from "$lib/stores/hud.svelte";
+
+const T0 = 1_000_000;
+
+// ============================================
+// isClockTickNeeded — when a staleness tick is needed
+// ============================================
+
+describe("isClockTickNeeded — when a staleness tick is needed", () => {
+	it("is needed while streaming, regardless of connection age", () => {
+		expect(isClockTickNeeded(true, null, T0)).toBe(true);
+		// Streaming wins even past the staleness window.
+		expect(
+			isClockTickNeeded(true, T0 - STALE_THRESHOLD_MS * 10, T0),
+		).toBe(true);
+	});
+
+	it("is NOT needed when idle and freshly connected (no link-loss pending)", () => {
+		// Idle + fresh: not streaming, link is up (connectionLostAt === null).
+		expect(isClockTickNeeded(false, null, T0)).toBe(false);
+	});
+
+	it("is needed while a dropped link is still inside the staleness window (near-stale)", () => {
+		expect(isClockTickNeeded(false, T0, T0 + 1)).toBe(true);
+		expect(isClockTickNeeded(false, T0, T0 + STALE_THRESHOLD_MS - 1)).toBe(
+			true,
+		);
+	});
+
+	it("is NOT needed once the dropped link has aged out of the staleness window", () => {
+		// At/after the threshold the link is already fully stale — no further tick
+		// can change the output, so the clock must NOT keep waking.
+		expect(isClockTickNeeded(false, T0, T0 + STALE_THRESHOLD_MS)).toBe(false);
+		expect(isClockTickNeeded(false, T0, T0 + STALE_THRESHOLD_MS + 1)).toBe(
+			false,
+		);
+	});
+});
+
+// ============================================
+// shouldClockRun — visibility gates the clock
+// ============================================
+
+describe("shouldClockRun — visibility gates the clock", () => {
+	it("never runs while the document is hidden, even mid-stream", () => {
+		expect(shouldClockRun(false, true, null, T0)).toBe(false);
+	});
+
+	it("never runs while hidden, even with a link dropping inside the window", () => {
+		expect(shouldClockRun(false, false, T0, T0 + 1)).toBe(false);
+	});
+
+	it("runs when visible and a tick is needed (streaming)", () => {
+		expect(shouldClockRun(true, true, null, T0)).toBe(true);
+	});
+
+	it("runs when visible and a dropped link is near-stale", () => {
+		expect(shouldClockRun(true, false, T0, T0 + STALE_THRESHOLD_MS - 1)).toBe(
+			true,
+		);
+	});
+
+	it("stays idle when visible but nothing needs a tick", () => {
+		// Visible + idle + fresh → still no reason to tick.
+		expect(shouldClockRun(true, false, null, T0)).toBe(false);
+	});
+});
+
+// ============================================
+// createStalenessClock — gated interval lifecycle
+// ============================================
+
+describe("createStalenessClock — gated interval lifecycle", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(T0);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("does not start, and never ticks, while the gate is closed (hidden/idle)", () => {
+		const onTick = vi.fn();
+		const clock = createStalenessClock(() => false, onTick);
+
+		clock.sync();
+		expect(clock.isRunning()).toBe(false);
+
+		vi.advanceTimersByTime(10_000);
+		expect(onTick).not.toHaveBeenCalled();
+
+		clock.stop();
+	});
+
+	it("ticks once per interval while the gate is open (streaming/near-stale)", () => {
+		const onTick = vi.fn();
+		const clock = createStalenessClock(() => true, onTick);
+
+		clock.sync();
+		expect(clock.isRunning()).toBe(true);
+
+		vi.advanceTimersByTime(3000);
+		expect(onTick).toHaveBeenCalledTimes(3);
+
+		clock.stop();
+	});
+
+	it("self-stops the instant the staleness window elapses (no idle wakeups)", () => {
+		const onTick = vi.fn();
+		// Open until the link-loss window closes, then closed forever — exactly the
+		// `now - connectionLostAt < STALE_THRESHOLD_MS` shape from the real store.
+		const deadline = T0 + STALE_THRESHOLD_MS;
+		const clock = createStalenessClock(() => Date.now() < deadline, onTick);
+
+		clock.sync();
+		expect(clock.isRunning()).toBe(true);
+
+		// Ticks fire at +1s..+5s; the +5s tick crosses the deadline and self-stops.
+		vi.advanceTimersByTime(STALE_THRESHOLD_MS);
+		expect(onTick).toHaveBeenCalledTimes(STALE_THRESHOLD_MS / 1000);
+		expect(clock.isRunning()).toBe(false);
+
+		// No further wakeups once the window has elapsed.
+		vi.advanceTimersByTime(60_000);
+		expect(onTick).toHaveBeenCalledTimes(STALE_THRESHOLD_MS / 1000);
+
+		clock.stop();
+	});
+
+	it("resumes on demand after the gate reopens (visibility / stream restart)", () => {
+		const onTick = vi.fn();
+		let open = false;
+		const clock = createStalenessClock(() => open, onTick);
+
+		clock.sync();
+		expect(clock.isRunning()).toBe(false);
+		vi.advanceTimersByTime(3000);
+		expect(onTick).not.toHaveBeenCalled();
+
+		// Gate reopens (tab visible again, or streaming restarted).
+		open = true;
+		clock.sync();
+		expect(clock.isRunning()).toBe(true);
+		vi.advanceTimersByTime(2000);
+		expect(onTick).toHaveBeenCalledTimes(2);
+
+		clock.stop();
+	});
+
+	it("is idempotent: syncing repeatedly does not stack intervals", () => {
+		const onTick = vi.fn();
+		const clock = createStalenessClock(() => true, onTick);
+
+		clock.sync();
+		clock.sync();
+		clock.sync();
+
+		vi.advanceTimersByTime(1000);
+		// A single interval — three syncs must not triple the tick rate.
+		expect(onTick).toHaveBeenCalledTimes(1);
+
+		clock.stop();
+	});
+
+	it("stops cleanly: no ticks after stop()", () => {
+		const onTick = vi.fn();
+		const clock = createStalenessClock(() => true, onTick);
+
+		clock.sync();
+		vi.advanceTimersByTime(1000);
+		expect(onTick).toHaveBeenCalledTimes(1);
+
+		clock.stop();
+		expect(clock.isRunning()).toBe(false);
+		vi.advanceTimersByTime(10_000);
+		expect(onTick).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ============================================
+// deriveHudState — staleness output unchanged vs baseline
+//
+// Gating only changes WHEN `now` advances; the pure derivation (and the 5s
+// threshold) must be byte-for-byte unchanged. These mirror the canonical
+// `hud.test.ts` staleness fixtures and assert the same flags fall out.
+// ============================================
+
+function makeModem(overrides: Partial<Modem> = {}): Modem {
+	return {
+		ifname: "wwan0",
+		name: "CarrierA",
+		network_type: { supported: ["4g"], active: "4g" },
+		status: {
+			connection: "connected",
+			network_type: "4G",
+			signal: 80,
+			roaming: false,
+			network: "CarrierA",
+		},
+		...overrides,
+	};
+}
+
+const wifiFixture: WifiStatus = {
+	wlan0: {
+		ifname: "wlan0",
+		conn: "MyNet",
+		hw: "00:11:22",
+		available: [
+			{ active: true, ssid: "MyNet", signal: 65, security: "WPA2", freq: 5180 },
+		],
+		saved: {},
+		supports_hotspot: false,
+	},
+};
+
+const sensorsFixture: SensorsStatus = {
+	"SoC temperature": "43.2°C",
+	"SoC current": "1500 mA",
+	"SoC voltage": "5.1 V",
+};
+
+const configFixture: ConfigMessage = { max_br: 6000 };
+
+const netifFixture: NetifMessage = {
+	wwan0: { tp: 128_000, enabled: true, ip: "10.0.0.2" },
+	wlan0: { tp: 64_000, enabled: true, ip: "10.0.0.3" },
+};
+
+function makeSources(overrides: Partial<HudSources> = {}): HudSources {
+	return {
+		isStreaming: true,
+		isConnected: true,
+		connectionState: "connected",
+		config: configFixture,
+		modems: { modem1: makeModem() } as ModemList,
+		wifi: wifiFixture,
+		netif: netifFixture,
+		sensors: sensorsFixture,
+		updating: false,
+		...overrides,
+	};
+}
+
+function makeTimestamps(
+	value: number | null,
+	overrides: Partial<HudTimestamps> = {},
+): HudTimestamps {
+	return {
+		streaming: value,
+		sensors: value,
+		modems: value,
+		wifi: value,
+		connectionLostAt: null,
+		...overrides,
+	};
+}
+
+describe("deriveHudState — staleness output unchanged vs baseline", () => {
+	it("connected + fresh: nothing is stale (happy path)", () => {
+		const state = deriveHudState(makeSources(), makeTimestamps(T0), T0);
+		expect(state.isSensorsStale).toBe(false);
+		expect(state.isStreamingStale).toBe(false);
+		expect(state.isBitrateStale).toBe(false);
+		expect(state.isFullyStale).toBe(false);
+		expect(state.links.every((l) => !l.isStale)).toBe(true);
+	});
+
+	it("connected: only fast sensors dim past the 5s threshold", () => {
+		const now = T0 + STALE_THRESHOLD_MS + 1;
+		const state = deriveHudState(makeSources(), makeTimestamps(T0), now);
+		expect(state.isSensorsStale).toBe(true);
+		// Connection-backed values must NOT dim on age while connected.
+		expect(state.isStreamingStale).toBe(false);
+		expect(state.isBitrateStale).toBe(false);
+		expect(state.links.every((l) => !l.isStale)).toBe(true);
+		expect(state.isFullyStale).toBe(false);
+	});
+
+	it("connected: sensors are NOT stale one ms before the threshold", () => {
+		const now = T0 + STALE_THRESHOLD_MS - 1;
+		const state = deriveHudState(makeSources(), makeTimestamps(T0), now);
+		expect(state.isSensorsStale).toBe(false);
+	});
+
+	it("disconnect: fully stale past the threshold, last-known values preserved", () => {
+		const now = T0 + STALE_THRESHOLD_MS + 1;
+		const sources = makeSources({
+			isConnected: false,
+			connectionState: "disconnected",
+		});
+		const state = deriveHudState(
+			sources,
+			makeTimestamps(T0, { connectionLostAt: T0 }),
+			now,
+		);
+		expect(state.isFullyStale).toBe(true);
+		expect(state.links.every((l) => l.isStale)).toBe(true);
+		// No nulling — last-known data is retained.
+		expect(state.bitrateKbps).toBe(6000);
+		expect(state.temperature).toBe(43.2);
+	});
+
+	it("disconnect: not fully stale within the grace window", () => {
+		const now = T0 + 100;
+		const sources = makeSources({
+			isConnected: false,
+			connectionState: "disconnected",
+		});
+		const state = deriveHudState(
+			sources,
+			makeTimestamps(T0, { connectionLostAt: T0 }),
+			now,
+		);
+		expect(state.isFullyStale).toBe(false);
+		expect(state.bitrateKbps).toBe(6000);
+	});
+
+	it("disconnect: the 5s boundary is inclusive (>=)", () => {
+		const now = T0 + STALE_THRESHOLD_MS;
+		const sources = makeSources({
+			isConnected: false,
+			connectionState: "disconnected",
+		});
+		const state = deriveHudState(
+			sources,
+			makeTimestamps(T0, { connectionLostAt: T0 }),
+			now,
+		);
+		expect(state.isFullyStale).toBe(true);
+	});
+});

--- a/apps/frontend/src/types/global.d.ts
+++ b/apps/frontend/src/types/global.d.ts
@@ -7,5 +7,6 @@ declare global {
 		) => void;
 		stopStreamingWithNotificationClear?: () => void;
 		__ceraAppMounted?: boolean;
+		__ceraDisplayRefreshCount?: number;
 	}
 }

--- a/apps/frontend/tests/e2e/display-profile.spec.ts
+++ b/apps/frontend/tests/e2e/display-profile.spec.ts
@@ -1,0 +1,149 @@
+import fs from "node:fs";
+
+import { expect, test } from "./fixtures/index.js";
+import { evidencePath } from "./helpers/index.js";
+
+/**
+ * Task 4 (DC-4) — display-profile URL contract (?display=lcd|eink|mono).
+ *
+ * Proves, against the REAL rendered app, the contract implemented in
+ * `apps/frontend/src/App.svelte` + `src/lib/stores/display-profile.svelte.ts`:
+ *
+ *   - `?display=eink` reflects onto <html> as data-display="eink" AND
+ *     data-theme="eink" (the e-ink theme hook authored in Task 10), and the
+ *     profile survives an in-SPA reload to a param-less URL (persisted store).
+ *   - `?display=bogus` normalizes to the default `lcd`: data-display="lcd",
+ *     NO data-theme override, and no console error / uncaught exception.
+ *
+ * These assertions read attributes on <html>, which App.svelte sets in an
+ * $effect at mount — independent of the auth gate — so no login is required.
+ * Restricted to the desktop project so the evidence files are written once.
+ */
+
+test.describe("display-profile URL contract (DC-4)", () => {
+	test.skip(
+		({ browserName }) => browserName !== "chromium",
+		"single-engine contract proof (cage/Chromium parity)",
+	);
+
+	test("?display=eink sets data-display + data-theme and persists across reload", async ({
+		page,
+	}, testInfo) => {
+		test.skip(testInfo.project.name !== "desktop", "run once, on desktop");
+
+		const html = page.locator("html");
+
+		// 1. Param applied on load.
+		await page.goto("/?display=eink");
+		await expect(html).toHaveAttribute("data-display", "eink");
+		await expect(html).toHaveAttribute("data-theme", "eink");
+		const afterParam = {
+			dataDisplay: await html.getAttribute("data-display"),
+			dataTheme: await html.getAttribute("data-theme"),
+		};
+
+		// 2. Reload to a param-less URL: the persisted store keeps the profile.
+		await page.goto("/");
+		await expect(html).toHaveAttribute("data-display", "eink");
+		await expect(html).toHaveAttribute("data-theme", "eink");
+		const afterReload = {
+			dataDisplay: await html.getAttribute("data-display"),
+			dataTheme: await html.getAttribute("data-theme"),
+		};
+
+		const pass =
+			afterParam.dataDisplay === "eink" &&
+			afterParam.dataTheme === "eink" &&
+			afterReload.dataDisplay === "eink" &&
+			afterReload.dataTheme === "eink";
+
+		fs.writeFileSync(
+			evidencePath("task-4-display-param.txt"),
+			[
+				"Task 4 (DC-4) — ?display=eink contract",
+				"",
+				"Scenario: load /?display=eink, then reload to / (no param).",
+				`viewport: ${JSON.stringify(testInfo.project.use.viewport)}`,
+				"",
+				"After /?display=eink:",
+				`  <html data-display> = ${afterParam.dataDisplay} (expect: eink)`,
+				`  <html data-theme>   = ${afterParam.dataTheme} (expect: eink)`,
+				"",
+				"After reload to / (persisted store, no param):",
+				`  <html data-display> = ${afterReload.dataDisplay} (expect: eink)`,
+				`  <html data-theme>   = ${afterReload.dataTheme} (expect: eink)`,
+				"",
+				`RESULT: ${pass ? "PASS" : "FAIL"}`,
+				`generated: ${new Date().toISOString()}`,
+				"",
+			].join("\n"),
+			"utf8",
+		);
+
+		expect(pass).toBe(true);
+	});
+
+	test("?display=bogus falls back to lcd with no console error", async ({
+		page,
+	}, testInfo) => {
+		test.skip(testInfo.project.name !== "desktop", "run once, on desktop");
+
+		const consoleErrors: string[] = [];
+		const pageErrors: string[] = [];
+		page.on("console", (msg) => {
+			if (msg.type() === "error") consoleErrors.push(msg.text());
+		});
+		page.on("pageerror", (err) => pageErrors.push(err.message));
+
+		const html = page.locator("html");
+
+		await page.goto("/?display=bogus");
+		// Bogus value normalizes to the default profile.
+		await expect(html).toHaveAttribute("data-display", "lcd");
+		// No e-ink theme override for the lcd profile. mode-watcher owns the
+		// data-theme attribute and clears it to "" (not absent) for the default
+		// custom theme, so assert the absence of the "eink" override, not null.
+		await expect(html).not.toHaveAttribute("data-theme", "eink");
+		const dataTheme = await html.getAttribute("data-theme");
+
+		const dataDisplay = await html.getAttribute("data-display");
+		const pass =
+			dataDisplay === "lcd" &&
+			dataTheme !== "eink" &&
+			consoleErrors.length === 0 &&
+			pageErrors.length === 0;
+
+		fs.writeFileSync(
+			evidencePath("task-4-display-fallback.txt"),
+			[
+				"Task 4 (DC-4) — ?display=bogus fallback",
+				"",
+				"Scenario: load /?display=bogus (unknown value).",
+				`viewport: ${JSON.stringify(testInfo.project.use.viewport)}`,
+				"",
+				`  <html data-display> = ${dataDisplay} (expect: lcd)`,
+				`  <html data-theme>   = ${JSON.stringify(dataTheme)} (expect: not "eink"; mode-watcher clears to "")`,
+				`  console errors      = ${consoleErrors.length} (expect: 0)`,
+				`  uncaught pageerrors = ${pageErrors.length} (expect: 0)`,
+				consoleErrors.length > 0
+					? `  console error texts: ${JSON.stringify(consoleErrors)}`
+					: "",
+				pageErrors.length > 0
+					? `  pageerror texts: ${JSON.stringify(pageErrors)}`
+					: "",
+				"",
+				`RESULT: ${pass ? "PASS" : "FAIL"}`,
+				`generated: ${new Date().toISOString()}`,
+				"",
+			]
+				.filter((line) => line !== "")
+				.join("\n"),
+			"utf8",
+		);
+
+		expect(dataDisplay).toBe("lcd");
+		expect(dataTheme).not.toBe("eink");
+		expect(consoleErrors).toEqual([]);
+		expect(pageErrors).toEqual([]);
+	});
+});

--- a/apps/frontend/tests/e2e/display-refresh.spec.ts
+++ b/apps/frontend/tests/e2e/display-refresh.spec.ts
@@ -1,0 +1,154 @@
+import fs from "node:fs";
+
+import { expect, test } from "./fixtures/index.js";
+import { ensureAuthenticated, evidencePath } from "./helpers/index.js";
+
+/**
+ * Task 12 — manual e-ink refresh affordance + requestDisplayRefresh() hook.
+ *
+ * Proves, against the REAL rendered app, the contract implemented in
+ * `DisplayRefresh.svelte` (mounted once at the MainView root via
+ * `HudRegion affordance`) + `display-refresh.svelte.ts`:
+ *
+ *   - The refresh control is HIDDEN under the `lcd` profile (no DOM node) and
+ *     VISIBLE + functional under `eink`. A tap drives requestDisplayRefresh(),
+ *     observed via the monotonic `window.__ceraDisplayRefreshCount` seam.
+ *   - NOTHING auto-refreshes: with no interaction the count stays put for 5s
+ *     (the e-ink freeze must never be released on a timer). Proven by waiting
+ *     for an increment that must never arrive.
+ *
+ * The control lives inside the authenticated shell, so each test authenticates.
+ * Single-engine (chromium) and desktop-only so the evidence files write once.
+ */
+
+const REFRESH = "display-refresh";
+
+test.describe("manual e-ink refresh affordance (Task 12)", () => {
+	test.skip(
+		({ browserName }) => browserName !== "chromium",
+		"single-engine contract proof (cage/Chromium parity)",
+	);
+
+	test("hidden on lcd, visible + functional on eink", async ({
+		page,
+	}, testInfo) => {
+		test.skip(testInfo.project.name !== "desktop", "run once, on desktop");
+
+		const control = page.getByTestId(REFRESH);
+
+		// 1. lcd profile: the control must not be rendered at all.
+		await page.goto("/?display=lcd");
+		await ensureAuthenticated(page);
+		await expect(page.locator("html")).toHaveAttribute("data-display", "lcd");
+		await expect(control).toHaveCount(0);
+		const hiddenOnLcd = (await control.count()) === 0;
+
+		// 2. eink profile: exactly one control, visible and enabled.
+		await page.goto("/?display=eink");
+		await ensureAuthenticated(page);
+		await expect(page.locator("html")).toHaveAttribute("data-display", "eink");
+		await expect(control).toHaveCount(1);
+		await expect(control).toBeVisible();
+		await expect(control).toBeEnabled();
+		const visibleOnEink = await control.isVisible();
+
+		// 3. Functional: each tap increments the refresh count (drives the hook
+		//    that re-pulls state + releases the freeze for one render).
+		const before = await page.evaluate(
+			() => window.__ceraDisplayRefreshCount ?? 0,
+		);
+		await control.click();
+		await control.click();
+		await expect
+			.poll(() => page.evaluate(() => window.__ceraDisplayRefreshCount ?? 0), {
+				message: "tapping refresh should drive requestDisplayRefresh()",
+			})
+			.toBe(before + 2);
+		const after = await page.evaluate(
+			() => window.__ceraDisplayRefreshCount ?? 0,
+		);
+
+		const pass = hiddenOnLcd && visibleOnEink && after === before + 2;
+
+		fs.writeFileSync(
+			evidencePath("task-12-refresh.txt"),
+			[
+				"Task 12 — manual e-ink refresh affordance",
+				"",
+				"Scenario: load /?display=lcd then /?display=eink (authed shell).",
+				`viewport: ${JSON.stringify(testInfo.project.use.viewport)}`,
+				"",
+				`lcd profile  — control count = ${hiddenOnLcd ? 0 : "≥1"} (expect: 0, hidden)`,
+				`eink profile — control visible = ${visibleOnEink} (expect: true)`,
+				`eink profile — control count   = 1 (single mount, not double)`,
+				"",
+				"Functional tap:",
+				`  __ceraDisplayRefreshCount before = ${before}`,
+				`  after 2 taps                     = ${after} (expect: ${before + 2})`,
+				"",
+				`RESULT: ${pass ? "PASS" : "FAIL"}`,
+				`generated: ${new Date().toISOString()}`,
+				"",
+			].join("\n"),
+			"utf8",
+		);
+
+		expect(pass).toBe(true);
+	});
+
+	test("no auto-refresh: count stays put for 5s without interaction", async ({
+		page,
+	}, testInfo) => {
+		test.skip(testInfo.project.name !== "desktop", "run once, on desktop");
+
+		await page.goto("/?display=eink");
+		await ensureAuthenticated(page);
+		await expect(page.getByTestId(REFRESH)).toBeVisible();
+
+		const baseline = await page.evaluate(
+			() => window.__ceraDisplayRefreshCount ?? 0,
+		);
+
+		// Wait for an auto-increment that must NEVER arrive. If the freeze were
+		// released on a timer, the count would climb and waitForFunction would
+		// resolve early — so a 5s timeout (rejection) is the PASS. No sleep.
+		let autoRefreshed = false;
+		try {
+			await page.waitForFunction(
+				(base) => (window.__ceraDisplayRefreshCount ?? 0) > base,
+				baseline,
+				{ timeout: 5000, polling: 250 },
+			);
+			autoRefreshed = true;
+		} catch {
+			autoRefreshed = false;
+		}
+
+		const afterWindow = await page.evaluate(
+			() => window.__ceraDisplayRefreshCount ?? 0,
+		);
+		const pass = !autoRefreshed && afterWindow === baseline;
+
+		fs.writeFileSync(
+			evidencePath("task-12-no-auto.txt"),
+			[
+				"Task 12 — no auto-refresh (e-ink freeze is never released on a timer)",
+				"",
+				"Scenario: load /?display=eink, then observe for 5s with NO interaction.",
+				`viewport: ${JSON.stringify(testInfo.project.use.viewport)}`,
+				"",
+				`  __ceraDisplayRefreshCount baseline = ${baseline}`,
+				`  after 5s, no interaction           = ${afterWindow} (expect: ${baseline})`,
+				`  auto-refresh observed              = ${autoRefreshed} (expect: false)`,
+				"",
+				`RESULT: ${pass ? "PASS" : "FAIL"}`,
+				`generated: ${new Date().toISOString()}`,
+				"",
+			].join("\n"),
+			"utf8",
+		);
+
+		expect(autoRefreshed).toBe(false);
+		expect(afterWindow).toBe(baseline);
+	});
+});

--- a/apps/frontend/tests/e2e/high-contrast.spec.ts
+++ b/apps/frontend/tests/e2e/high-contrast.spec.ts
@@ -1,0 +1,111 @@
+import fs from "node:fs";
+
+import { expect, test } from "./fixtures/index.js";
+import { evidencePath } from "./helpers/index.js";
+
+/**
+ * Task 11 — prefers-contrast completion.
+ *
+ * Proves the high-contrast block in `apps/frontend/src/app.css` is no longer
+ * focus-ring-only: emulating the preference must produce a MEASURABLE increase
+ * in border weight and text contrast, and flip the `--contrast-mode` sentinel.
+ *
+ * Chromium matches `prefers-contrast: more` (the spec value); the CSS lists both
+ * `more` and the legacy `high` keyword, so `emulateMedia({ contrast: 'more' })`
+ * activates the block.
+ */
+
+interface Probe {
+	contrastMode: string;
+	borderTopWidth: number;
+	mutedColor: string;
+	foreground: string;
+}
+
+async function probe(page: import("@playwright/test").Page): Promise<Probe> {
+	return page.evaluate(() => {
+		const root = getComputedStyle(document.documentElement);
+		const bordered = document.querySelector("main section.border");
+		const muted = document.querySelector("main .text-muted-foreground");
+		const px = (v: string): number => Number.parseFloat(v) || 0;
+		return {
+			contrastMode: root.getPropertyValue("--contrast-mode").trim(),
+			borderTopWidth: bordered
+				? px(getComputedStyle(bordered).borderTopWidth)
+				: -1,
+			mutedColor: muted ? getComputedStyle(muted).color : "",
+			foreground: root.getPropertyValue("--foreground").trim(),
+		};
+	});
+}
+
+test.describe("prefers-contrast: high completion", () => {
+	test.skip(
+		({ browserName }) => browserName !== "chromium",
+		"single-engine contrast proof (cage/Chromium parity)",
+	);
+
+	test("emulating high contrast thickens borders and boosts text contrast", async ({
+		authedPage: page,
+	}, testInfo) => {
+		test.skip(testInfo.project.name !== "desktop", "run once, on desktop");
+
+		// Network view renders bordered cards (.border) and muted labels.
+		const { navigateTo } = await import("./helpers/index.js");
+		await navigateTo(page, "network");
+		await expect(page.locator("main section.border").first()).toBeVisible({
+			timeout: 15_000,
+		});
+
+		await page.emulateMedia({ contrast: "no-preference" });
+		const before = await probe(page);
+
+		await page.emulateMedia({ contrast: "more" });
+		const after = await probe(page);
+
+		// Restore so later tests in the worker are unaffected.
+		await page.emulateMedia({ contrast: "no-preference" });
+
+		const borderIncreased = after.borderTopWidth > before.borderTopWidth;
+		const sentinelFlipped =
+			before.contrastMode !== "high" && after.contrastMode === "high";
+		const textContrastChanged = after.mutedColor !== before.mutedColor;
+
+		const pass = borderIncreased && sentinelFlipped && textContrastChanged;
+
+		fs.writeFileSync(
+			evidencePath("task-11-contrast.txt"),
+			[
+				"Task 11 — prefers-contrast: high completion",
+				"",
+				"Scenario: measure border weight + muted-text color with the",
+				"high-contrast preference off, then emulated on.",
+				`viewport: ${JSON.stringify(testInfo.project.use.viewport)}`,
+				"",
+				"prefers-contrast OFF (no-preference):",
+				`  --contrast-mode      = ${JSON.stringify(before.contrastMode)} (expect "")`,
+				`  card border-top      = ${before.borderTopWidth}px`,
+				`  muted text color     = ${before.mutedColor}`,
+				"",
+				"prefers-contrast ON (more):",
+				`  --contrast-mode      = ${JSON.stringify(after.contrastMode)} (expect "high")`,
+				`  card border-top      = ${after.borderTopWidth}px (expect > before)`,
+				`  muted text color     = ${after.mutedColor} (expect != before, toward foreground)`,
+				`  --foreground         = ${after.foreground}`,
+				"",
+				`border weight increased : ${borderIncreased}`,
+				`sentinel flipped to high: ${sentinelFlipped}`,
+				`text contrast changed   : ${textContrastChanged}`,
+				"",
+				`RESULT: ${pass ? "PASS" : "FAIL"}`,
+				`generated: ${new Date().toISOString()}`,
+				"",
+			].join("\n"),
+			"utf8",
+		);
+
+		expect(sentinelFlipped).toBe(true);
+		expect(borderIncreased).toBe(true);
+		expect(textContrastChanged).toBe(true);
+	});
+});

--- a/apps/frontend/tests/e2e/responsive-touch.spec.ts
+++ b/apps/frontend/tests/e2e/responsive-touch.spec.ts
@@ -1,0 +1,234 @@
+/**
+ * Task 13 — responsive multi-resolution hardening.
+ *
+ * Proves, against the REAL rendered app, the small/portrait touchscreen layouts
+ * hardened in this task:
+ *
+ *   1. 800×480 landscape (the minimum supported landscape resolution): the panel
+ *      resolves to DESKTOP CHROME (rail nav, not the mobile bottom dock) and the
+ *      ServerDialog renders as a centered Dialog (NOT a bottom Sheet). With a
+ *      simulated 250px on-screen-keyboard inset (viewport shrunk to 800×230) the
+ *      dialog collapses (`@media (max-height: 500px)`) and the Save action stays
+ *      on-screen / reachable. No horizontal overflow throughout.
+ *
+ *   2. 600×1024 portrait: the panel resolves to the MOBILE layout — bottom-dock
+ *      nav + bottom HUD + main content all visible, no clipped controls, no
+ *      horizontal overflow.
+ *
+ * Conventions (PLAYBOOK.md): assert via roles/labels/ARIA + web-first assertions,
+ * never screenshots; no fixed-delay waits. Restricted to chromium + the desktop
+ * project so the evidence files are written exactly once (the spec drives the
+ * viewport itself via setViewportSize, so the project's own viewport is moot).
+ */
+import fs from 'node:fs';
+
+import { expect, test } from './fixtures/index.js';
+import { hudStructure } from './helpers/aria.js';
+import { evidencePath, navigateTo } from './helpers/index.js';
+
+test.beforeEach(({ browserName }, testInfo) => {
+	test.skip(browserName !== 'chromium', 'single-engine layout proof (cage/Chromium parity)');
+	test.skip(testInfo.project.name !== 'desktop', 'spec drives its own viewport; run once');
+});
+
+/** documentElement is not wider than its viewport (allow 1px sub-pixel rounding). */
+async function horizontalOverflowPx(page: import('@playwright/test').Page): Promise<number> {
+	return page.evaluate(() => {
+		const el = document.documentElement;
+		return el.scrollWidth - el.clientWidth;
+	});
+}
+
+// Containment-in-viewport reader for evidence (1px tolerance). Playwright exposes
+// no `locator.isInViewport()`, only the `toBeInViewport()` assertion, so compute
+// it from the bounding box.
+async function inViewport(
+	page: import('@playwright/test').Page,
+	locator: import('@playwright/test').Locator,
+): Promise<boolean> {
+	const box = await locator.boundingBox();
+	const vp = page.viewportSize();
+	if (!box || !vp) return false;
+	return (
+		box.x >= -1 &&
+		box.y >= -1 &&
+		box.x + box.width <= vp.width + 1 &&
+		box.y + box.height <= vp.height + 1
+	);
+}
+
+async function openServerDialog(page: import('@playwright/test').Page) {
+	await navigateTo(page, 'live');
+	const byTestId = page.getByTestId('open-server-dialog');
+	if ((await byTestId.count()) > 0) {
+		await byTestId.first().click();
+	} else {
+		await page.getByRole('button', { name: 'Edit Settings' }).first().click();
+	}
+	const dialog = page.getByRole('dialog', { name: 'Receiver Server' });
+	await expect(dialog).toBeVisible();
+	return dialog;
+}
+
+test.describe('Task 13 — responsive multi-resolution hardening', () => {
+	test('800×480 landscape: desktop chrome, centered Dialog, Save reachable with 250px OSK inset', async ({
+		authedPage: page,
+	}) => {
+		// Minimum supported landscape resolution.
+		await page.setViewportSize({ width: 800, height: 480 });
+
+		// Pivot: the 800×480 panel must take DESKTOP CHROME, NOT the mobile dock.
+		// (Old lg=1024 pivot would have shown the mobile bottom nav here.)
+		await navigateTo(page, 'live');
+		const railTab = page.locator('#nav-tab-live');
+		const dockTab = page.locator('#mobile-nav-tab-live');
+		await expect(railTab).toBeVisible();
+		await expect(dockTab).toBeHidden();
+
+		const overflowBefore = await horizontalOverflowPx(page);
+		expect(overflowBefore).toBeLessThanOrEqual(1);
+
+		// The ServerDialog (largest form) renders as a centered Dialog, not a Sheet.
+		const dialog = await openServerDialog(page);
+		await expect(page.locator("[data-slot='dialog-content']")).toBeVisible();
+		await expect(page.locator("[data-slot='sheet-content']")).toHaveCount(0);
+
+		const overflowDialog = await horizontalOverflowPx(page);
+		expect(overflowDialog).toBeLessThanOrEqual(1);
+
+		// Simulate the on-screen keyboard claiming the bottom 250px: the usable
+		// area shrinks to 800×230. The `@media (max-height: 500px)` collapse keeps
+		// the footer on-screen, so Save stays reachable.
+		await page.setViewportSize({ width: 800, height: 230 });
+
+		const save = dialog.getByRole('button', { name: 'Save' });
+		await expect(save).toBeVisible();
+		await expect(save).toBeInViewport();
+
+		const overflowOsk = await horizontalOverflowPx(page);
+		expect(overflowOsk).toBeLessThanOrEqual(1);
+
+		// The collapsed dialog never exceeds the (reduced) viewport height.
+		const dialogContent = page.locator("[data-slot='dialog-content']");
+		const box = await dialogContent.boundingBox();
+		const fitsHeight = box !== null && box.y >= -1 && box.y + box.height <= 230 + 1;
+
+		const saveInViewport = await inViewport(page, save);
+		const pass =
+			overflowBefore <= 1 &&
+			overflowDialog <= 1 &&
+			overflowOsk <= 1 &&
+			(await save.isVisible()) &&
+			saveInViewport &&
+			fitsHeight;
+
+		fs.writeFileSync(
+			evidencePath('task-13-800x480.txt'),
+			[
+				'Task 13 — 800×480 landscape (minimum supported landscape resolution)',
+				'',
+				'Pivot: short-landscape panel resolves to DESKTOP CHROME (rail nav),',
+				'dialogs render as a centered Dialog (not a bottom Sheet).',
+				'',
+				`  #nav-tab-live (rail)        visible = true (expect: true)`,
+				`  #mobile-nav-tab-live (dock) hidden  = true (expect: true)`,
+				`  ServerDialog surface        = [data-slot=dialog-content] (expect: Dialog, not Sheet)`,
+				'',
+				'Horizontal overflow (documentElement.scrollWidth - clientWidth):',
+				`  at 800×480 (shell)          = ${overflowBefore}px (expect: ≤1)`,
+				`  at 800×480 (dialog open)    = ${overflowDialog}px (expect: ≤1)`,
+				`  at 800×230 (OSK inset)      = ${overflowOsk}px (expect: ≤1)`,
+				'',
+				'On-screen keyboard simulation — viewport shrunk to 800×230 (250px bottom inset):',
+				`  Save button visible         = ${await save.isVisible()} (expect: true)`,
+				`  Save button in viewport     = ${saveInViewport} (expect: true)`,
+				`  dialog fits within 230px    = ${fitsHeight} (expect: true)`,
+				box
+					? `  dialog box                  = { y: ${Math.round(box.y)}, h: ${Math.round(box.height)} } (bottom ${Math.round(box.y + box.height)} ≤ 230)`
+					: '  dialog box                  = (none)',
+				'',
+				`RESULT: ${pass ? 'PASS' : 'FAIL'}`,
+				`generated: ${new Date().toISOString()}`,
+				'',
+			].join('\n'),
+			'utf8',
+		);
+
+		expect(pass).toBe(true);
+	});
+
+	test('600×1024 portrait: mobile nav + HUD + content visible, no clipped controls', async ({
+		authedPage: page,
+	}) => {
+		// Minimum supported portrait resolution.
+		await page.setViewportSize({ width: 600, height: 1024 });
+
+		await navigateTo(page, 'live');
+
+		// Portrait stays on the MOBILE layout: bottom dock nav, not the rail.
+		const dockTab = page.locator('#mobile-nav-tab-live');
+		const railTab = page.locator('#nav-tab-live');
+		await expect(dockTab).toBeVisible();
+		await expect(railTab).toBeHidden();
+
+		// All three destination tabs present and within the viewport (not clipped).
+		const tabIds = ['#mobile-nav-tab-live', '#mobile-nav-tab-network', '#mobile-nav-tab-settings'];
+		for (const id of tabIds) {
+			await expect(page.locator(id)).toBeVisible();
+			await expect(page.locator(id)).toBeInViewport();
+		}
+
+		// Persistent HUD (bottom dock) is mounted and visible.
+		const hud = await hudStructure(page);
+		await expect(hud).toBeInViewport();
+
+		// Main content region renders. MainView's content <main> is the inner one
+		// (the PullToRefresh wrapper also renders a <main>), so scope to the last.
+		const main = page.getByRole('main').last();
+		await expect(main).toBeVisible();
+
+		const overflow = await horizontalOverflowPx(page);
+		expect(overflow).toBeLessThanOrEqual(1);
+
+		const tabsInViewport: Record<string, boolean> = {};
+		for (const id of tabIds) {
+			tabsInViewport[id] = await inViewport(page, page.locator(id));
+		}
+		const allTabsInViewport = Object.values(tabsInViewport).every(Boolean);
+		const hudInViewport = await inViewport(page, hud);
+
+		const pass =
+			(await dockTab.isVisible()) &&
+			(await railTab.isHidden()) &&
+			allTabsInViewport &&
+			hudInViewport &&
+			(await main.isVisible()) &&
+			overflow <= 1;
+
+		fs.writeFileSync(
+			evidencePath('task-13-portrait.txt'),
+			[
+				'Task 13 — 600×1024 portrait (minimum supported portrait resolution)',
+				'',
+				'Pivot: portrait panel resolves to the MOBILE layout (bottom-dock nav + bottom HUD).',
+				'',
+				`  #mobile-nav-tab-live (dock) visible = ${await dockTab.isVisible()} (expect: true)`,
+				`  #nav-tab-live (rail)        hidden  = ${await railTab.isHidden()} (expect: true)`,
+				'',
+				'Bottom-dock destination tabs in viewport (no clipped controls):',
+				...tabIds.map((id) => `  ${id} = ${tabsInViewport[id]} (expect: true)`),
+				'',
+				`  HUD region in viewport      = ${hudInViewport} (expect: true)`,
+				`  <main> visible              = ${await main.isVisible()} (expect: true)`,
+				`  horizontal overflow         = ${overflow}px (expect: ≤1)`,
+				'',
+				`RESULT: ${pass ? 'PASS' : 'FAIL'}`,
+				`generated: ${new Date().toISOString()}`,
+				'',
+			].join('\n'),
+			'utf8',
+		);
+
+		expect(pass).toBe(true);
+	});
+});

--- a/apps/frontend/tests/e2e/responsive-touch.spec.ts
+++ b/apps/frontend/tests/e2e/responsive-touch.spec.ts
@@ -77,13 +77,13 @@ test.describe('Task 13 — responsive multi-resolution hardening', () => {
 		// Minimum supported landscape resolution.
 		await page.setViewportSize({ width: 800, height: 480 });
 
-		// Pivot: the 800×480 panel must take DESKTOP CHROME, NOT the mobile dock.
-		// (Old lg=1024 pivot would have shown the mobile bottom nav here.)
-		await navigateTo(page, 'live');
-		const railTab = page.locator('#nav-tab-live');
-		const dockTab = page.locator('#mobile-nav-tab-live');
-		await expect(railTab).toBeVisible();
-		await expect(dockTab).toBeHidden();
+	// Pivot: the 800×480 panel must take DESKTOP CHROME, NOT the mobile dock.
+	// (Old lg=1024 pivot would have shown the mobile bottom nav here.)
+	await navigateTo(page, 'live');
+	const railTab = page.getByTestId('rail-nav').getByRole('button', { name: /live/i });
+	const dockTab = page.getByTestId('dock-nav').getByRole('button', { name: /live/i });
+	await expect(railTab).toBeVisible();
+	await expect(dockTab).toBeHidden();
 
 		const overflowBefore = await horizontalOverflowPx(page);
 		expect(overflowBefore).toBeLessThanOrEqual(1);
@@ -127,11 +127,11 @@ test.describe('Task 13 — responsive multi-resolution hardening', () => {
 			[
 				'Task 13 — 800×480 landscape (minimum supported landscape resolution)',
 				'',
-				'Pivot: short-landscape panel resolves to DESKTOP CHROME (rail nav),',
-				'dialogs render as a centered Dialog (not a bottom Sheet).',
-				'',
-				`  #nav-tab-live (rail)        visible = true (expect: true)`,
-				`  #mobile-nav-tab-live (dock) hidden  = true (expect: true)`,
+			'Pivot: short-landscape panel resolves to DESKTOP CHROME (rail nav),',
+			'dialogs render as a centered Dialog (not a bottom Sheet).',
+			'',
+			`  rail-nav "live" button      visible = true (expect: true)`,
+			`  dock-nav "live" button      hidden  = true (expect: true)`,
 				`  ServerDialog surface        = [data-slot=dialog-content] (expect: Dialog, not Sheet)`,
 				'',
 				'Horizontal overflow (documentElement.scrollWidth - clientWidth):',
@@ -165,18 +165,20 @@ test.describe('Task 13 — responsive multi-resolution hardening', () => {
 
 		await navigateTo(page, 'live');
 
-		// Portrait stays on the MOBILE layout: bottom dock nav, not the rail.
-		const dockTab = page.locator('#mobile-nav-tab-live');
-		const railTab = page.locator('#nav-tab-live');
-		await expect(dockTab).toBeVisible();
-		await expect(railTab).toBeHidden();
+	// Portrait stays on the MOBILE layout: bottom dock nav, not the rail.
+	const dockTab = page.getByTestId('dock-nav').getByRole('button', { name: /live/i });
+	const railTab = page.getByTestId('rail-nav').getByRole('button', { name: /live/i });
+	await expect(dockTab).toBeVisible();
+	await expect(railTab).toBeHidden();
 
-		// All three destination tabs present and within the viewport (not clipped).
-		const tabIds = ['#mobile-nav-tab-live', '#mobile-nav-tab-network', '#mobile-nav-tab-settings'];
-		for (const id of tabIds) {
-			await expect(page.locator(id)).toBeVisible();
-			await expect(page.locator(id)).toBeInViewport();
-		}
+	// All three destination tabs present and within the viewport (not clipped).
+	const tabNames = ['live', 'network', 'settings'];
+	const dockNav = page.getByTestId('dock-nav');
+	for (const name of tabNames) {
+		const tab = dockNav.getByRole('button', { name: new RegExp(name, 'i') });
+		await expect(tab).toBeVisible();
+		await expect(tab).toBeInViewport();
+	}
 
 		// Persistent HUD (bottom dock) is mounted and visible.
 		const hud = await hudStructure(page);
@@ -190,10 +192,11 @@ test.describe('Task 13 — responsive multi-resolution hardening', () => {
 		const overflow = await horizontalOverflowPx(page);
 		expect(overflow).toBeLessThanOrEqual(1);
 
-		const tabsInViewport: Record<string, boolean> = {};
-		for (const id of tabIds) {
-			tabsInViewport[id] = await inViewport(page, page.locator(id));
-		}
+	const tabsInViewport: Record<string, boolean> = {};
+	for (const name of tabNames) {
+		const tab = dockNav.getByRole('button', { name: new RegExp(name, 'i') });
+		tabsInViewport[name] = await inViewport(page, tab);
+	}
 		const allTabsInViewport = Object.values(tabsInViewport).every(Boolean);
 		const hudInViewport = await inViewport(page, hud);
 
@@ -210,13 +213,13 @@ test.describe('Task 13 — responsive multi-resolution hardening', () => {
 			[
 				'Task 13 — 600×1024 portrait (minimum supported portrait resolution)',
 				'',
-				'Pivot: portrait panel resolves to the MOBILE layout (bottom-dock nav + bottom HUD).',
+			'Pivot: portrait panel resolves to the MOBILE layout (bottom-dock nav + bottom HUD).',
+			'',
+			`  dock-nav "live" button      visible = ${await dockTab.isVisible()} (expect: true)`,
+			`  rail-nav "live" button      hidden  = ${await railTab.isHidden()} (expect: true)`,
 				'',
-				`  #mobile-nav-tab-live (dock) visible = ${await dockTab.isVisible()} (expect: true)`,
-				`  #nav-tab-live (rail)        hidden  = ${await railTab.isHidden()} (expect: true)`,
-				'',
-				'Bottom-dock destination tabs in viewport (no clipped controls):',
-				...tabIds.map((id) => `  ${id} = ${tabsInViewport[id]} (expect: true)`),
+			'Bottom-dock destination tabs in viewport (no clipped controls):',
+			...tabNames.map((name) => `  dock-nav "${name}" button = ${tabsInViewport[name]} (expect: true)`),
 				'',
 				`  HUD region in viewport      = ${hudInViewport} (expect: true)`,
 				`  <main> visible              = ${await main.isVisible()} (expect: true)`,

--- a/apps/frontend/tests/e2e/symbol-status.spec.ts
+++ b/apps/frontend/tests/e2e/symbol-status.spec.ts
@@ -1,0 +1,110 @@
+import fs from "node:fs";
+
+import { expect, type Page, test } from "./fixtures/index.js";
+import { evidencePath, navigateTo } from "./helpers/index.js";
+
+/**
+ * Task 11 — Symbol/text-coded status (a11y, colorblind, monochrome e-ink).
+ *
+ * Proves the non-color coding added to `LinkIndicator.svelte`: every bonded
+ * link in the 6-colour spectral ramp (`--link-1..--link-6`) also carries a
+ * distinct, color-independent cue — a `data-link-level` ordinal and a
+ * `role="img"` + "Link N" aria-label — so the six links stay tellable apart
+ * with hue removed (grayscale e-ink) or unperceived (colorblind users).
+ *
+ * The MOCK_SCENARIO=multi-modem-wifi backend (playwright.config default) renders
+ * the full six-link bond, so the ramp can be read straight from the network
+ * view without injecting state. The same link renders in both the compact HUD
+ * and the Bonded Links card; cues are deduped by ordinal, which both proves
+ * cross-surface consistency and yields one entry per distinct link.
+ */
+
+interface LinkCue {
+	level: number;
+	ariaLabel: string;
+	role: string | null;
+}
+
+async function readLinkCues(page: Page): Promise<LinkCue[]> {
+	const cues = await page.evaluate(() => {
+		const map: Record<number, { level: number; ariaLabel: string; role: string | null }> = {};
+		for (const el of Array.from(document.querySelectorAll("[data-link-level]"))) {
+			const level = Number(el.getAttribute("data-link-level"));
+			if (!Number.isFinite(level)) continue;
+			map[level] = {
+				level,
+				ariaLabel: el.getAttribute("aria-label") ?? "",
+				role: el.getAttribute("role"),
+			};
+		}
+		return Object.values(map);
+	});
+	return cues.sort((a, b) => a.level - b.level);
+}
+
+test.describe("symbol-coded link status (non-color cues)", () => {
+	test.skip(
+		({ browserName }) => browserName !== "chromium",
+		"single-engine a11y proof (cage/Chromium parity)",
+	);
+
+	test("each of 6 spectral links exposes a distinct ordinal + aria-label", async ({
+		authedPage: page,
+	}, testInfo) => {
+		test.skip(testInfo.project.name !== "desktop", "run once, on desktop");
+
+		await navigateTo(page, "network");
+
+		await expect
+			.poll(async () => (await readLinkCues(page)).length, {
+				timeout: 15_000,
+				message: "six distinct bonded-link levels should render",
+			})
+			.toBeGreaterThanOrEqual(6);
+
+		const cues = (await readLinkCues(page)).slice(0, 6);
+		const levels = cues.map((c) => c.level);
+		const labels = cues.map((c) => c.ariaLabel);
+
+		expect(levels).toEqual([1, 2, 3, 4, 5, 6]);
+		expect(new Set(levels).size).toBe(6);
+		expect(new Set(labels).size).toBe(6);
+		for (const cue of cues) {
+			expect(cue.role).toBe("img");
+			expect(cue.ariaLabel).toBe(`Link ${cue.level}`);
+		}
+
+		const pass =
+			levels.length === 6 &&
+			new Set(levels).size === 6 &&
+			new Set(labels).size === 6 &&
+			cues.every((c) => c.role === "img" && c.ariaLabel === `Link ${c.level}`);
+
+		fs.writeFileSync(
+			evidencePath("task-11-symbols.txt"),
+			[
+				"Task 11 — symbol/text-coded link status (non-color cue)",
+				"",
+				"Scenario: read every [data-link-level] indicator's color-independent",
+				"cue (ordinal + role + aria-label) across the rendered 6-link bond.",
+				`viewport: ${JSON.stringify(testInfo.project.use.viewport)}`,
+				"",
+				"Per-link cues (deduped by ordinal):",
+				...cues.map(
+					(c) => `  L${c.level}: role=${c.role} aria-label=${JSON.stringify(c.ariaLabel)}`,
+				),
+				"",
+				`distinct ordinals : ${new Set(levels).size} (expect 6)`,
+				`distinct labels   : ${new Set(labels).size} (expect 6)`,
+				`contiguous 1..6   : ${JSON.stringify(levels) === JSON.stringify([1, 2, 3, 4, 5, 6])}`,
+				"",
+				`RESULT: ${pass ? "PASS" : "FAIL"}`,
+				`generated: ${new Date().toISOString()}`,
+				"",
+			].join("\n"),
+			"utf8",
+		);
+
+		expect(pass).toBe(true);
+	});
+});

--- a/docs/KIOSK_STATE_MACHINE.md
+++ b/docs/KIOSK_STATE_MACHINE.md
@@ -1,0 +1,238 @@
+# Kiosk Toggle State Machine
+
+**Design Contract: DC-2**
+**Single source of truth for Tasks 23 and 25.**
+
+The kiosk feature runs `cage` (a Wayland compositor) with Chromium in `--kiosk` mode, pointed at the CeraUI loopback URL. The CeraUI backend owns the lifecycle: it persists the toggle, drives systemd, and surfaces the live state to the settings UI. The UI shows the actual state, not just an on/off switch.
+
+---
+
+## States
+
+Five states. No others exist.
+
+| State | Meaning |
+|---|---|
+| `disabled` | Kiosk is off. `kiosk_enabled = false` persisted. `kiosk.service` is stopped and masked. |
+| `enabled-stopped` | Toggle is on but the service is not running. Transient: occurs briefly after `toggle-on` before cage starts, or after a clean `toggle-off` before the config write completes. |
+| `enabled-running` | `kiosk.service` is active and cage + Chromium are running normally. |
+| `enabled-failed` | The service has entered systemd `failed` state due to a crash-loop (3 failures within 60 s). The persisted toggle is auto-disabled. |
+| `failed-no-display` | The service failed because no display was detected at startup (HDMI/DSI unplugged). Distinct from a crash-loop failure. |
+
+---
+
+## State Diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> disabled : initial install (kiosk_enabled = false)
+
+    disabled --> enabled-stopped : toggle-on\n(unmask + enable kiosk.service)
+    enabled-stopped --> enabled-running : start kiosk.service\n(cage + Chromium launch OK)
+    enabled-stopped --> enabled-failed : start kiosk.service\n(immediate failure / crash-loop)
+    enabled-stopped --> failed-no-display : start kiosk.service\n(no display detected)
+
+    enabled-running --> enabled-failed : crash-loop\n(3 failures / 60 s)
+    enabled-running --> enabled-stopped : toggle-off\n(stop kiosk.service)
+
+    enabled-failed --> disabled : auto-disable\n(kiosk_enabled = false persisted)
+    failed-no-display --> disabled : toggle-off\n(stop + mask + kiosk_enabled = false)
+
+    disabled --> enabled-stopped : toggle-on (retry)
+```
+
+---
+
+## Transitions
+
+Six transitions. Each entry lists the trigger, the systemd actions the backend takes, and the resulting state.
+
+### T1: `toggle-on`
+
+**From:** `disabled`
+**To:** `enabled-stopped` (immediately), then `enabled-running` or a failure state once the service resolves
+
+**Backend actions:**
+1. Write `kiosk_enabled = true` to persisted config.
+2. `systemctl unmask kiosk.service`
+3. `systemctl enable kiosk.service`
+4. `systemctl start kiosk.service`
+
+The backend transitions to `enabled-stopped` synchronously after issuing the start command, then polls (see Failure-Observation Channel) to confirm the service reached `active (running)`.
+
+---
+
+### T2: `start resolves OK`
+
+**From:** `enabled-stopped`
+**To:** `enabled-running`
+
+**Backend actions:** None. The backend observes `systemctl is-active kiosk.service` returning `active` and updates the broadcast state.
+
+---
+
+### T3: `toggle-off`
+
+**From:** `enabled-running` or `failed-no-display`
+**To:** `enabled-stopped` (transient) then `disabled`
+
+**Backend actions:**
+1. `systemctl stop kiosk.service`
+2. `systemctl disable kiosk.service`
+3. `systemctl mask kiosk.service`
+4. Write `kiosk_enabled = false` to persisted config.
+5. Delete the display-failure marker file if present (`/run/kiosk-no-display`).
+
+---
+
+### T4: `crash-loop`
+
+**From:** `enabled-running`
+**To:** `enabled-failed`
+
+**Trigger:** systemd's `StartLimitIntervalSec=60` / `StartLimitBurst=3` fires. The unit enters `failed` state after 3 restarts within 60 seconds.
+
+**Backend actions:** None triggered by the backend. The `OnFailure=kiosk-onfailure.service` handler (part of the unit, Task 26) writes a crash-loop marker. The backend detects the failure via the polling channel and transitions state.
+
+---
+
+### T5: `auto-disable after crash-loop`
+
+**From:** `enabled-failed`
+**To:** `disabled`
+
+**Trigger:** Backend detects `enabled-failed` state.
+
+**Backend actions:**
+1. Write `kiosk_enabled = false` to persisted config.
+2. `systemctl mask kiosk.service` (prevents accidental restart).
+3. Broadcast `kiosk` state event to all connected clients.
+
+**Rationale:** A crash-looping kiosk must not lock the operator out of the LAN browser UI. Auto-disabling the persisted toggle ensures the device is reachable from any browser on the LAN after a reboot, without requiring physical access.
+
+---
+
+### T6: `display unplugged`
+
+**From:** `enabled-stopped` (during start) or `enabled-running` (display removed while running)
+**To:** `failed-no-display`
+
+**Trigger:** cage exits immediately because no DRM/KMS output is available. The `OnFailure` handler writes `/run/kiosk-no-display` to distinguish this from a crash-loop.
+
+**Backend actions:** None triggered by the backend. The backend detects the marker file and sets state to `failed-no-display` rather than `enabled-failed`.
+
+---
+
+## Crash-Loop Auto-Disable Rule
+
+**This rule is non-negotiable.**
+
+When the backend observes `enabled-failed` (crash-loop, not display-unplug), it MUST:
+
+1. Immediately write `kiosk_enabled = false` to the persisted config file.
+2. Mask `kiosk.service` so it cannot be started by accident.
+3. Broadcast the updated state to all connected clients.
+
+The settings UI must reflect `disabled` after this transition, not `enabled-failed`. The user sees a failure banner explaining what happened, with a "Re-enable kiosk" action that goes through the normal `toggle-on` path (which will unmask the service).
+
+The purpose: if cage or Chromium is crash-looping, the device must remain reachable from a LAN browser. Leaving `kiosk_enabled = true` in persisted config would re-trigger the crash-loop on every reboot.
+
+---
+
+## Persisted Config Fields
+
+Both fields live in the backend's config file (same store as streaming config, managed via `helpers/config-loader.ts`).
+
+| Field | Type | Description |
+|---|---|---|
+| `kiosk_enabled` | `boolean` | Whether the user has toggled kiosk on. Written on every `toggle-on`, `toggle-off`, and auto-disable. |
+| `kiosk_last_state` | `string` (state enum) | Last-known state at shutdown. Written on every state transition. Used to restore the correct UI state on backend restart without waiting for the first poll cycle. |
+
+On backend startup, if `kiosk_enabled = true` and `kiosk_last_state` is `enabled-running`, the backend immediately polls systemd to confirm the service is still running before broadcasting state. It does not assume the persisted state is current.
+
+---
+
+## Failure-Observation Channel
+
+The backend detects `enabled-failed` and `failed-no-display` through three complementary signals. Tasks 23 and 26 implement both ends of this channel.
+
+### Signal 1: `systemctl is-failed kiosk.service`
+
+The backend polls `systemctl is-failed kiosk.service` on a 2-second interval whenever `kiosk_enabled = true`. The command exits `0` when the unit is in `failed` state.
+
+```
+systemctl is-failed kiosk.service
+# exit 0 → unit is failed
+# exit 1 → unit is not failed (active, inactive, etc.)
+```
+
+### Signal 2: `NRestarts` from `systemctl show`
+
+To distinguish a crash-loop from a one-shot failure, the backend reads `NRestarts` from the unit properties:
+
+```
+systemctl show kiosk.service --property=NRestarts
+# NRestarts=3
+```
+
+If `NRestarts >= 3` and the unit is in `failed` state, the backend classifies the failure as a crash-loop and applies the auto-disable rule (T5). If `NRestarts < 3`, the failure is treated as a single-shot failure and the state is held at `enabled-failed` pending user action.
+
+### Signal 3: Display-failure marker file
+
+The kiosk unit's `OnFailure=kiosk-onfailure.service` handler (Task 26) writes a marker file to distinguish display-unplug from a crash-loop:
+
+```
+/run/kiosk-no-display
+```
+
+This file is written by the `OnFailure` handler only when cage exits with the specific exit code that indicates no DRM output was found. The backend checks for this file's existence before classifying a `failed` unit as `enabled-failed` vs `failed-no-display`:
+
+```
+# Pseudo-logic in the backend poll loop:
+if systemctl is-failed kiosk.service:
+    if /run/kiosk-no-display exists:
+        state = "failed-no-display"
+    elif NRestarts >= 3:
+        state = "enabled-failed"
+        auto_disable()  # T5
+    else:
+        state = "enabled-failed"
+```
+
+The marker file lives on `tmpfs` (`/run/`) and is deleted on reboot and on `toggle-off` (T3). It is never written to persistent storage.
+
+---
+
+## UI Element Mapping
+
+The settings UI surfaces the live state, not just the toggle value. Each state maps to a specific UI presentation in the kiosk settings dialog (Task 25).
+
+| State | Toggle position | Status indicator | User action available |
+|---|---|---|---|
+| `disabled` | Off | None | Toggle on |
+| `enabled-stopped` | On | Spinner / "Starting..." | Toggle off |
+| `enabled-running` | On | Green dot / "Running" | Toggle off |
+| `enabled-failed` | Off (auto-disabled) | Red / "Crashed, auto-disabled" | Re-enable (toggle on) |
+| `failed-no-display` | On | Amber / "No display detected" | Toggle off, or plug in display and retry |
+
+The toggle reflects `kiosk_enabled` from persisted config. The status indicator reflects the live polled state. After auto-disable (T5), the toggle snaps to Off even though the user last set it to On.
+
+The backend broadcasts state changes via the existing `kiosk` event type on the WebSocket event bus (same pattern as `status` and `config` events in `rpc/events.ts`). The frontend subscribes and updates the store reactively.
+
+---
+
+## Implementation Notes for Tasks 23 and 25
+
+**Task 23 (backend kiosk RPC + polling):**
+- Implement the poll loop using `Bun.spawn(["systemctl", "is-failed", "kiosk.service"])` and `Bun.spawn(["systemctl", "show", "kiosk.service", "--property=NRestarts"])`.
+- Check `/run/kiosk-no-display` with `Bun.file("/run/kiosk-no-display").exists()`.
+- Persist config changes via `helpers/config-loader.ts` (same pattern as `setAutostart` in `modules/streaming/streamloop.ts`).
+- Broadcast state via `rpc/events.ts` `kiosk` event type.
+- The `toggle-on` and `toggle-off` RPC procedures follow the same shape as `sshStartProcedure` / `sshStopProcedure` in `rpc/procedures/system.procedure.ts`.
+
+**Task 25 (frontend kiosk settings dialog):**
+- The dialog composes `AppDialog.svelte`.
+- The toggle binds to `kiosk_enabled` from the RPC response.
+- The status indicator derives from the `kiosk` broadcast event state field.
+- All user-facing strings go through `LL.*` (typesafe-i18n).
+- No inline validation literals.

--- a/docs/KIOSK_TOKEN_CONTRACT.md
+++ b/docs/KIOSK_TOKEN_CONTRACT.md
@@ -1,0 +1,216 @@
+# Kiosk Token Contract
+
+**Status:** `[EXISTS]`
+**Scope:** CeraUI backend + image-building-pipeline `kiosk.service`
+**Design contract:** DC-3
+
+This document is the single source of truth for the loopback kiosk-token interface. Both the CeraUI backend (Task 24) and the image kiosk service (Task 26) are built to this spec. Any change here must be reflected in both repos in the same change (Rule A).
+
+---
+
+## Overview
+
+When the kiosk service launches Chromium, it needs to open the CeraUI web UI already authenticated, without prompting the user for a password. The mechanism is a short-lived, single-use token that the backend mints at kiosk-service start, writes to a tmpfs path, and accepts exactly once in exchange for a session cookie.
+
+The token is:
+- 32 bytes of cryptographic randomness, hex-encoded (64 hex characters)
+- Written only to tmpfs (`/run/`) — never to durable disk
+- Consumed over loopback only — LAN requests are rejected
+- Single-use: the first valid exchange invalidates it immediately
+- Not a PASETO token and not related to the device-token claim contract
+
+---
+
+## Fixed Loopback Port
+
+```
+CERAUI_BACKEND_PORT = 80
+```
+
+The CeraUI backend production HTTP port is **80**. This is the first entry in the production port list in `apps/backend/src/rpc/server.ts`:
+
+```typescript
+// apps/backend/src/rpc/server.ts
+const ports: number[] =
+    process.env.NODE_ENV === "development"
+        ? [3002, 8080, 8081]
+        : [80, 8080, 81];   // ← 80 is the production primary
+```
+
+The kiosk URL is therefore:
+
+```
+http://127.0.0.1:80/?mode=touch&display=<profile>&kiosk_token=<token>
+```
+
+Both repos consume this constant. Neither may hardcode a different port or derive it independently.
+
+---
+
+## Token Specification
+
+| Property | Value |
+|----------|-------|
+| Entropy | 32 bytes (`crypto.getRandomValues`) |
+| Encoding | lowercase hex (64 characters) |
+| Format | `[0-9a-f]{64}` |
+| Lifetime | single-use; invalidated on first valid exchange |
+| Storage | tmpfs only (`/run/ceralive/kiosk-token`) |
+| Transport | URL query parameter `kiosk_token` |
+
+### Why hex, not base64
+
+The token is embedded in a shell `ExecStart=` line and passed as a URL query parameter. Hex is unambiguous in both contexts. The `randomBase64` helper in `apps/backend/src/helpers/crypto.ts` produces base64; the kiosk token uses `crypto.getRandomValues` directly and encodes with `Buffer.from(buf).toString("hex")` instead.
+
+### What this is NOT
+
+- Not a PASETO v4.public token (see `packages/rpc/src/schemas/pairing.schema.ts` for the device-token contract)
+- Not a claim code (see `CLAIM_CODE_ALPHABET` in the same file)
+- Not a session cookie — it is exchanged for one
+- Not durable — it does not survive a backend restart
+
+---
+
+## tmpfs Path
+
+```
+/run/ceralive/kiosk-token
+```
+
+`/run` is a tmpfs mount on all systemd-based Linux systems. Files written here are lost on reboot and are never flushed to disk. The directory `/run/ceralive/` must be created by the backend (or a `RuntimeDirectory=ceralive` directive in the unit file) before the token is written.
+
+File contents: the 64-character hex token, no trailing newline.
+
+```
+# example file contents
+a3f8c2e1d4b7a09f6e5c3d2b1a0f9e8d7c6b5a4f3e2d1c0b9a8f7e6d5c4b3a2
+```
+
+File permissions: `0600`, owned by the user the backend runs as (typically `ceralive` or `root`).
+
+---
+
+## Exchange Flow
+
+The exchange happens over a single HTTP GET request. The backend validates the token, sets a session cookie, and invalidates the token before returning the response.
+
+```
+kiosk.service                    CeraUI backend
+     |                                |
+     |  mint token → write to tmpfs   |
+     |                                |
+     |  ExecStart: chromium           |
+     |    http://127.0.0.1:80/        |
+     |    ?mode=touch                 |
+     |    &display=lcd                |
+     |    &kiosk_token=<hex>          |
+     |                                |
+     |  GET /?...&kiosk_token=<hex>   |
+     |------------------------------->|
+     |                                | 1. Check source IP == 127.0.0.1
+     |                                | 2. Read token from /run/ceralive/kiosk-token
+     |                                | 3. Constant-time compare
+     |                                | 4. Invalidate token (delete file or zero memory)
+     |                                | 5. Issue session cookie
+     |  200 + Set-Cookie: session=... |
+     |<-------------------------------|
+     |                                |
+     |  All subsequent WS/HTTP reqs   |
+     |  carry the session cookie      |
+     |------------------------------->|
+```
+
+### Step-by-step
+
+1. **Backend startup**: on init, the backend generates a 32-byte random token, hex-encodes it, and writes it to `/run/ceralive/kiosk-token` with permissions `0600`.
+
+2. **kiosk.service ExecStart**: the image-side unit reads the token from `/run/ceralive/kiosk-token` and appends `&kiosk_token=<token>` to the Chromium launch URL (see [Image-side ExecStart Contract](#image-side-execstart-contract) below).
+
+3. **First request**: Chromium opens the URL. The backend receives the GET request.
+
+4. **Loopback check**: the backend inspects the remote IP. If it is not `127.0.0.1`, it returns `401 Unauthorized` immediately without reading the token file.
+
+5. **Token validation**: the backend reads `/run/ceralive/kiosk-token`, performs a constant-time comparison against the `kiosk_token` query parameter.
+
+6. **Invalidation**: the token is invalidated immediately — the file is deleted (or overwritten with zeros) — before the response is sent. This happens regardless of whether the comparison succeeded.
+
+7. **Session issuance**: on a valid match, the backend sets a `session` cookie (same mechanism as password-based login) and returns `200`.
+
+8. **Rejection on reuse**: any subsequent request carrying the same `kiosk_token` value finds no token file and returns `401 Unauthorized`.
+
+---
+
+## Error Responses
+
+| Condition | HTTP status | Body |
+|-----------|-------------|------|
+| Request from non-loopback IP | `401 Unauthorized` | `{"error":"loopback_only"}` |
+| Token already used (file absent) | `401 Unauthorized` | `{"error":"token_invalid"}` |
+| Token mismatch | `401 Unauthorized` | `{"error":"token_invalid"}` |
+| Token file unreadable | `401 Unauthorized` | `{"error":"token_invalid"}` |
+| `kiosk_token` param absent | ignored (normal auth flow) | — |
+
+All 401 responses from the kiosk-token path use the same `token_invalid` body for mismatch and reuse — no oracle distinguishing the two.
+
+---
+
+## Image-side ExecStart Contract
+
+The image `kiosk.service` unit is responsible for:
+
+1. Waiting until the CeraUI backend is ready (e.g. `After=ceraui.service`, `ExecStartPre` health check against `http://127.0.0.1:80/status`).
+
+2. Reading the token from the tmpfs path:
+
+```bash
+KIOSK_TOKEN=$(cat /run/ceralive/kiosk-token)
+```
+
+3. Constructing the launch URL with the token appended:
+
+```bash
+KIOSK_URL="http://127.0.0.1:80/?mode=touch&display=${DISPLAY_PROFILE:-lcd}&kiosk_token=${KIOSK_TOKEN}"
+```
+
+4. Launching Chromium in kiosk mode:
+
+```bash
+ExecStart=/usr/bin/chromium \
+  --kiosk \
+  --ozone-platform=wayland \
+  --no-sandbox \
+  "${KIOSK_URL}"
+```
+
+The unit must not cache or log the token value. The token is consumed on first use; if Chromium crashes and relaunches, the backend must mint a fresh token (or the kiosk service must restart the backend to trigger a fresh mint).
+
+### Port constant
+
+The port `80` is fixed. The image unit must not derive it from any other source. If the port ever changes, this document and `apps/backend/src/rpc/server.ts` are updated together, and the image unit is updated in the same change.
+
+---
+
+## Security Properties
+
+**Loopback-only enforcement**: the backend checks the remote IP on every kiosk-token exchange request. A request arriving from any IP other than `127.0.0.1` returns `401` without touching the token file. This means a device on the LAN cannot use the kiosk token even if it somehow learns the value.
+
+**Single-use**: the token file is deleted before the response is sent. There is no window where a second request could race the deletion and succeed — the invalidation is synchronous with the response path.
+
+**tmpfs-only**: `/run` is a tmpfs mount. The token is never written to the eMMC, SD card, or any durable storage. It does not appear in logs, config files, or crash dumps.
+
+**Not PASETO**: the kiosk token has no claims, no signature, and no expiry field. It is raw entropy. The PASETO device-token contract (`deviceTokenClaimsSchema` in `packages/rpc/src/schemas/pairing.schema.ts`) is a separate, unrelated mechanism for cloud pairing.
+
+**No logging**: the token value must not appear in any log output. Log lines may record that a kiosk-token exchange occurred (success or failure) but must not include the token itself.
+
+---
+
+## Invariants (both repos must uphold)
+
+- `127.0.0.1` is the only accepted source IP for kiosk-token exchanges
+- The tmpfs path is exactly `/run/ceralive/kiosk-token`
+- The query parameter name is exactly `kiosk_token`
+- The token is invalidated before the response is returned (not after)
+- The token is single-use: reuse returns `401`
+- The token is not PASETO and carries no structured claims
+- The token is never written to durable disk
+- The loopback port is `80`

--- a/docs/TOUCHSCREEN.md
+++ b/docs/TOUCHSCREEN.md
@@ -74,18 +74,73 @@ touchscreen attached to the device). All three destinations — **Live**,
 overflow**, in both default and touch modes. This is verified with Playwright
 (see `.omo/evidence/task-36-default.png` and `task-36-touch.png`).
 
+## Minimum Supported Resolution
+
+| Orientation | Minimum | Verified |
+|---|---|---|
+| Landscape | **800×480** | `.omo/evidence/task-13-800x480.txt` |
+| Portrait | **600×1024** | `.omo/evidence/task-13-portrait.txt` |
+
+**800×480 landscape is the floor.** Below this the chrome and the larger config
+dialogs (notably `ServerDialog`) can no longer be laid out without clipping. At
+800×480 the panel renders the **desktop chrome** (see Breakpoints) and every
+dialog renders as a centered, collapsible Dialog rather than a bottom Sheet, so
+the form stays usable with the on-screen keyboard raised (verified against a
+simulated 250px bottom inset — the `ServerDialog` Save action remains on-screen).
+
+Portrait panels down to **600×1024** render the mobile layout (bottom-dock nav +
+bottom HUD) with no clipped controls. Narrower or shorter viewports are not a
+supported device target.
+
 ## Breakpoints
 
-CeraUI uses Tailwind's `lg` breakpoint (1024px) as the nav pivot:
+The shell pivots between two layouts. The single source of truth is
+`DESKTOP_CHROME_QUERY` in `apps/frontend/src/lib/layout.ts`, consumed by
+`MainView.svelte`, `MainNav.svelte`, and `AppDialog.svelte` (each instantiates
+its own reactive `MediaQuery` from that string, so the nav and the dialog flip
+together):
 
-- **< 1024px** — mobile bottom nav (`MobileNav.svelte`), HUD docked at the
-  bottom.
-- **≥ 1024px** — desktop rail nav (`MainNav.svelte`), HUD below the header. The
-  1024×600 kiosk therefore renders the **desktop layout**.
+```
+(min-width: 1024px), (min-width: 768px) and (max-height: 600px)
+```
 
-Layout mode is **orthogonal** to these breakpoints: touch mode only scales
-tokens; it does not change which nav renders. A 1024-wide kiosk gets the desktop
-nav whether or not touch mode is on.
+- **Desktop chrome** — rail nav (`MainNav.svelte`), HUD below the header,
+  centered Dialog surfaces. Applies when the viewport is **≥1024px wide** (normal
+  desktop / the 1024×600 kiosk) **OR** is a **short landscape panel** (≥768px
+  wide ∧ ≤600px tall, e.g. **800×480**).
+- **Mobile layout** — bottom-dock nav (`MobileNav.svelte`), HUD docked at the
+  bottom, bottom Sheet (drawer) surfaces. Applies to everything else: narrow
+  and/or tall viewports such as phones and **portrait panels (e.g. 600×1024)**.
+
+The short-landscape branch is the fix for the old `lg=1024` pivot, where an
+800×480 panel fell into the mobile layout and got a bottom Sheet — unusable with
+the on-screen keyboard. Standard desktop/mobile semantics for non-kiosk use are
+unchanged: only the ≥768px-wide ∧ ≤600px-tall band moved from mobile to desktop
+chrome.
+
+### Short-viewport dialog collapse
+
+`app.css` adds an unlayered `@media (max-height: 500px)` rule: on very short
+viewports the AppDialog surface collapses to a **minimal, full-height scrollable
+form**. It overrides the default `max-h-[85svh]` to fill the (small) viewport
+(`max-height: 100svh`), squares off the corners, and trims the header/footer
+padding so more of the height goes to the scrollable body. The footer
+(Save/Cancel) stays pinned on-screen. The `100svh` basis tracks the *small*
+viewport, so when the browser reports a reduced viewport (e.g. an on-screen
+keyboard that resizes the visual viewport) the dialog shrinks with it and Save
+stays reachable.
+
+> **OSK integration note.** The kiosk on-screen keyboard (`wvkbd`, see the image
+> pipeline) is a Wayland compositor overlay and does **not** resize the Chromium
+> viewport or set `env(keyboard-inset-height)`. The collapse rule keeps the
+> dialog usable in the space the viewport reports; reserving space for an overlay
+> keyboard that does not shrink the viewport is a device-integration concern
+> tracked outside CeraUI.
+
+Layout mode (touch/default) is **orthogonal** to these breakpoints: touch mode
+only scales hit-target tokens; it does not change which nav renders or which
+dialog surface is used. A 1024-wide kiosk gets the desktop chrome whether or not
+touch mode is on.
 
 ## Remaining Work for a Full Touch UI
 

--- a/packages/i18n/src/ar/index.ts
+++ b/packages/i18n/src/ar/index.ts
@@ -715,6 +715,7 @@ const ar = {
 		healthDegraded: "متدهور",
 		healthDead: "متوقف",
 		healthUnknown: "غير معروف",
+		link: "رابط",
 	},
 	live: {
 		title: "مباشر",

--- a/packages/i18n/src/ar/index.ts
+++ b/packages/i18n/src/ar/index.ts
@@ -703,6 +703,7 @@ const ar = {
 		noData: "لا توجد بيانات",
 		stale: "قديم",
 		expandDetails: "توسيع التفاصيل",
+		refresh: "تحديث",
 		lastUpdated: "آخر تحديث",
 		idle: "خامل",
 		voltage: "الجهد",

--- a/packages/i18n/src/de/index.ts
+++ b/packages/i18n/src/de/index.ts
@@ -258,6 +258,7 @@ const de = {
 		healthDegraded: "Beeinträchtigt",
 		healthDead: "Ausgefallen",
 		healthUnknown: "Unbekannt",
+		link: "Verbindung",
 	},
 	live: {
 		title: "Live",

--- a/packages/i18n/src/de/index.ts
+++ b/packages/i18n/src/de/index.ts
@@ -246,6 +246,7 @@ const de = {
 		noData: "Keine Daten",
 		stale: "Veraltet",
 		expandDetails: "Details anzeigen",
+		refresh: "Aktualisieren",
 		lastUpdated: "Zuletzt aktualisiert",
 		idle: "Leerlauf",
 		voltage: "Spannung",

--- a/packages/i18n/src/en/index.ts
+++ b/packages/i18n/src/en/index.ts
@@ -237,6 +237,7 @@ const en = {
 		noData: "No data",
 		stale: "Stale",
 		expandDetails: "Expand details",
+		refresh: "Refresh",
 		lastUpdated: "Last updated",
 		idle: "Idle",
 		voltage: "Voltage",

--- a/packages/i18n/src/en/index.ts
+++ b/packages/i18n/src/en/index.ts
@@ -249,6 +249,7 @@ const en = {
 		healthDegraded: "Degraded",
 		healthDead: "Dead",
 		healthUnknown: "Unknown",
+		link: "Link",
 	},
 	live: {
 		title: "Live",

--- a/packages/i18n/src/es/index.ts
+++ b/packages/i18n/src/es/index.ts
@@ -258,6 +258,7 @@ const es = {
 		healthDegraded: "Degradado",
 		healthDead: "Caído",
 		healthUnknown: "Desconocido",
+		link: "Enlace",
 	},
 	live: {
 		title: "Live",

--- a/packages/i18n/src/es/index.ts
+++ b/packages/i18n/src/es/index.ts
@@ -246,6 +246,7 @@ const es = {
 		noData: "Sin datos",
 		stale: "Obsoleto",
 		expandDetails: "Expandir detalles",
+		refresh: "Actualizar",
 		lastUpdated: "Última actualización",
 		idle: "Inactivo",
 		voltage: "Voltaje",

--- a/packages/i18n/src/fr/index.ts
+++ b/packages/i18n/src/fr/index.ts
@@ -749,6 +749,7 @@ const fr = {
 		healthDegraded: "Dégradé",
 		healthDead: "Hors service",
 		healthUnknown: "Inconnu",
+		link: "Liaison",
 	},
 	live: {
 		title: "Live",

--- a/packages/i18n/src/fr/index.ts
+++ b/packages/i18n/src/fr/index.ts
@@ -737,6 +737,7 @@ const fr = {
 		noData: "Aucune donnée",
 		stale: "Obsolète",
 		expandDetails: "Afficher les détails",
+		refresh: "Actualiser",
 		lastUpdated: "Dernière mise à jour",
 		idle: "Inactif",
 		voltage: "Tension",

--- a/packages/i18n/src/hi/index.ts
+++ b/packages/i18n/src/hi/index.ts
@@ -564,6 +564,7 @@ const hi = {
 		noData: "कोई डेटा नहीं",
 		stale: "पुरानी",
 		expandDetails: "विवरण विस्तृत करें",
+		refresh: "रिफ्रेश करें",
 		lastUpdated: "अंतिम अपडेट",
 		idle: "निष्क्रिय",
 		voltage: "वोल्टेज",

--- a/packages/i18n/src/hi/index.ts
+++ b/packages/i18n/src/hi/index.ts
@@ -576,6 +576,7 @@ const hi = {
 		healthDegraded: "घटिया",
 		healthDead: "बंद",
 		healthUnknown: "अज्ञात",
+		link: "लिंक",
 	},
 	live: {
 		title: "लाइव",

--- a/packages/i18n/src/ja/index.ts
+++ b/packages/i18n/src/ja/index.ts
@@ -590,6 +590,7 @@ const ja = {
 		healthDegraded: "劣化",
 		healthDead: "停止",
 		healthUnknown: "不明",
+		link: "リンク",
 	},
 	live: {
 		title: "ライブ",

--- a/packages/i18n/src/ja/index.ts
+++ b/packages/i18n/src/ja/index.ts
@@ -578,6 +578,7 @@ const ja = {
 		noData: "データなし",
 		stale: "古い",
 		expandDetails: "詳細を展開",
+		refresh: "更新",
 		lastUpdated: "最終更新",
 		idle: "アイドル",
 		voltage: "電圧",

--- a/packages/i18n/src/ko/index.ts
+++ b/packages/i18n/src/ko/index.ts
@@ -570,6 +570,7 @@ const ko = {
 		noData: "데이터 없음",
 		stale: "오래됨",
 		expandDetails: "세부정보 펼치기",
+		refresh: "새로고침",
 		lastUpdated: "마지막 업데이트",
 		idle: "유휴",
 		voltage: "전압",

--- a/packages/i18n/src/ko/index.ts
+++ b/packages/i18n/src/ko/index.ts
@@ -582,6 +582,7 @@ const ko = {
 		healthDegraded: "저하",
 		healthDead: "중단",
 		healthUnknown: "알 수 없음",
+		link: "링크",
 	},
 	live: {
 		title: "라이브",

--- a/packages/i18n/src/pt-BR/index.ts
+++ b/packages/i18n/src/pt-BR/index.ts
@@ -712,6 +712,7 @@ const ptBR = {
 		noData: "Sem dados",
 		stale: "Obsoleto",
 		expandDetails: "Expandir detalhes",
+		refresh: "Atualizar",
 		lastUpdated: "Última atualização",
 		idle: "Ocioso",
 		voltage: "Tensão",

--- a/packages/i18n/src/pt-BR/index.ts
+++ b/packages/i18n/src/pt-BR/index.ts
@@ -724,6 +724,7 @@ const ptBR = {
 		healthDegraded: "Degradado",
 		healthDead: "Inativo",
 		healthUnknown: "Desconhecido",
+		link: "Link",
 	},
 	live: {
 		title: "Live",

--- a/packages/i18n/src/zh/index.ts
+++ b/packages/i18n/src/zh/index.ts
@@ -546,6 +546,7 @@ const zh = {
 		healthDegraded: "降级",
 		healthDead: "中断",
 		healthUnknown: "未知",
+		link: "链路",
 	},
 	live: {
 		title: "直播",

--- a/packages/i18n/src/zh/index.ts
+++ b/packages/i18n/src/zh/index.ts
@@ -534,6 +534,7 @@ const zh = {
 		noData: "无数据",
 		stale: "陈旧",
 		expandDetails: "展开详情",
+		refresh: "刷新",
 		lastUpdated: "最后更新",
 		idle: "空闲",
 		voltage: "电压",


### PR DESCRIPTION
## What
Introduces the `?display=lcd|eink|mono` URL contract and store (DC-4), gates the unconditional 1 Hz HUD staleness clock, adds a full monochrome OKLCH token set for e-ink/mono panels with `animation:none!important`, symbol-codes link/status indicators for colorblind and mono legibility, adds a manual e-ink refresh FAB, and hardens layouts for 800×480 and portrait touchscreens.

## Why
- The 1 Hz `setInterval` in `hud.svelte.ts` ran unconditionally — a kiosk browser never backgrounds, so it fired forever and caused e-ink ghosting. Gating it on visibility + need is the highest-ROI perf fix.
- E-ink panels ghost on per-second DOM mutation and can't animate. The monochrome token set + `animation:none!important` + frozen HUD live fields are mandatory before any on-device display work ships.
- 800×480 (the target kiosk panel size) was untested and broken — the `lg=1024` pivot put it on the mobile bottom-dock layout, and the header toolbar overflowed by 43px.
- Color-only status indicators are inaccessible on mono panels and for colorblind users.

## How to verify
```bash
pnpm --filter frontend run test
CI=true E2E_PASSWORD=12345678 pnpm --filter frontend exec playwright test display-profile.spec.ts responsive-touch.spec.ts --project=desktop
```
Navigate to `http://localhost:5173/?display=eink` — page should be monochrome, no animations, refresh FAB visible in the right margin.

## Risks
- The `DESKTOP_CHROME_QUERY` media-query change affects the shell pivot for all users, not just kiosk. Tested at 800×480, 1280×800, and 600×1024 (portrait). Desktop (≥1024px) behaviour is unchanged.
- `animation:none!important` under `[data-display=eink]` is intentionally aggressive — it overrides all Tailwind utilities. Correct for e-paper; would break any future animated component under that selector.

Refs: #34
Stack: base PR — PR-C2a, PR-C4, PR-C5 stack on top of this.
Cross-repo: PR-I3 (image kiosk stack) consumes the `?display` URL contract from this PR.
