### PR TITLE
test: write artifacts to repo-local test-results, not external .omo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ build-test-outputs*/
 # Development analysis files
 BUILD_SYSTEM_IMPROVEMENTS.md
 
+# Test artifacts (Playwright traces + E2E evidence) — never tracked
+test-results/
+
 # Agent orchestration state (local only)
 .omo/
 *.tsbuildinfo

--- a/apps/backend/src/tests/mock-modems-output.test.ts
+++ b/apps/backend/src/tests/mock-modems-output.test.ts
@@ -20,7 +20,7 @@ describe("Mock Modems Output — Task 8 Evidence", () => {
 		}
 
 		// Write to evidence file
-		const evidencePath = ".omo/evidence/task-8-mock-modems.json";
+		const evidencePath = "test-results/task-8-mock-modems.json";
 		Bun.write(evidencePath, JSON.stringify(output, null, 2));
 
 		console.log(`✅ Evidence written to ${evidencePath}`);

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -41,7 +41,10 @@ if (process.env.CI || !fs.existsSync(configPath)) {
 const DEV_PORT = Number(process.env.E2E_PORT ?? 6173);
 const DEV_URL = `http://localhost:${DEV_PORT}`;
 
-export const EVIDENCE_DIR = path.resolve(import.meta.dirname, '../../../.omo/evidence');
+// Repo-local test-artifact dir. Playwright traces/screenshots AND human-readable
+// evidence files land here; gitignored. Never write outside the repo — tests must
+// not depend on the orchestration workspace that may sit above this checkout.
+export const EVIDENCE_DIR = path.resolve(import.meta.dirname, 'test-results');
 
 export default defineConfig({
   testDir: 'tests/e2e',

--- a/apps/frontend/tests/e2e/PLAYBOOK.md
+++ b/apps/frontend/tests/e2e/PLAYBOOK.md
@@ -211,7 +211,7 @@ Key patterns it demonstrates:
 - **`expect.poll`** instead of `waitForTimeout` for async state that has no immediate DOM signal
 - **`emit(page, type, payload)`** to inject server echoes at known times, making timing deterministic
 - **Serial test ordering** (`test.describe.configure({ mode: 'serial' })`) for stateful integration sequences
-- **Evidence files** written to `.omo/evidence/` via `evidencePath()` from `helpers/index.ts`
+- **Evidence files** written to the repo-local `test-results/` (gitignored) via `evidencePath()` from `helpers/index.ts`
 
 Do not modify `field-lock.spec.ts`. It is a deterministic integration proof and a reference implementation.
 

--- a/apps/frontend/tests/e2e/bond-toggle-flash.spec.ts
+++ b/apps/frontend/tests/e2e/bond-toggle-flash.spec.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { expect, type Locator, type Page, test } from "@playwright/test";
 
-import { navigateTo } from "./helpers";
+import { EVIDENCE_DIR, navigateTo } from "./helpers";
 
 /**
  * Task 1 — Bond-toggle no-flash proof, end-to-end.
@@ -55,13 +55,6 @@ const TOKEN: string = (() => {
 })();
 
 const FAKE_ERR = "drop+fake: simulated configure failure";
-
-// Workspace-root evidence dir: 5 levels up from tests/e2e == /mnt/.../ceralive.
-const EVIDENCE_DIR = path.resolve(
-	import.meta.dirname,
-	"../../../../..",
-	".omo/evidence",
-);
 
 function writeEvidence(fileName: string, lines: string[]): void {
 	fs.mkdirSync(EVIDENCE_DIR, { recursive: true });

--- a/apps/frontend/tests/e2e/field-lock.spec.ts
+++ b/apps/frontend/tests/e2e/field-lock.spec.ts
@@ -56,7 +56,7 @@ const TOKEN: string = (() => {
 	return tokens[0];
 })();
 
-// Accumulated human-readable evidence, flushed to .omo/evidence at the end.
+// Accumulated human-readable evidence, flushed to the repo-local test-results dir at the end.
 const evidence: string[] = [];
 function record(line: string): void {
 	evidence.push(line);

--- a/apps/frontend/tests/e2e/helpers/index.ts
+++ b/apps/frontend/tests/e2e/helpers/index.ts
@@ -16,10 +16,13 @@ import { expect, type Page } from '@playwright/test';
  */
 
 /**
- * Absolute path to the workspace evidence directory.
- * helpers/ -> e2e -> tests -> frontend -> apps -> CeraUI -> ceralive (6 up).
+ * Absolute path to the repo-local test-artifact directory (gitignored).
+ * helpers/ -> e2e -> tests -> frontend (3 up) == apps/frontend/test-results.
+ * This is the single source of truth for the evidence dir — specs MUST import it
+ * from here rather than recomputing an external path. Tests never write outside
+ * the repo (the orchestration workspace above the checkout is off-limits).
  */
-export const EVIDENCE_DIR = path.resolve(import.meta.dirname, '../../../../../../.omo/evidence');
+export const EVIDENCE_DIR = path.resolve(import.meta.dirname, '../../../test-results');
 
 /** Resolve an evidence screenshot path by file name. */
 export function evidencePath(fileName: string): string {

--- a/apps/frontend/tests/e2e/relay-notifications.spec.ts
+++ b/apps/frontend/tests/e2e/relay-notifications.spec.ts
@@ -3,11 +3,7 @@ import path from 'node:path';
 
 import { expect, type Page, test } from '@playwright/test';
 
-import { navigateTo } from './helpers/index.js';
-
-// Workstream evidence root: CeraUI/.omo/evidence (where every prior task in this
-// workstream wrote its evidence). e2e -> tests -> frontend -> apps -> CeraUI.
-const EVIDENCE_DIR = path.resolve(import.meta.dirname, '../../../../.omo/evidence');
+import { EVIDENCE_DIR, navigateTo } from './helpers/index.js';
 
 /**
  * Task 21 — Relay catalog + notification toasts, integrated E2E (mock mode).
@@ -43,10 +39,10 @@ const EVIDENCE_DIR = path.resolve(import.meta.dirname, '../../../../.omo/evidenc
  *
  * Conventions (PLAYBOOK.md): no screenshot or visual-snapshot APIs in this
  * functional spec, and no fixed-delay waits — every async wait is a web-first
- * assertion or `expect.poll` against a real changing signal. Evidence is written
- * as ARIA/text proof (the PLAYBOOK-sanctioned form) to `.omo/evidence/
- * task-21-e2e/`; video is captured at the runner level (allowed — it does not go
- * through the guarded `page.screenshot`).
+  * assertion or `expect.poll` against a real changing signal. Evidence is written
+  * as ARIA/text proof (the PLAYBOOK-sanctioned form) to the repo-local
+  * `test-results/task-21-e2e/`; video is captured at the runner level (allowed —
+  * it does not go through the guarded `page.screenshot`).
  *
  * Backend broadcasts reach EVERY authed client, so this file runs `serial` to
  * keep `dev.emit` injections from leaking between its own tests.

--- a/apps/frontend/tests/e2e/relay-validate.spec.ts
+++ b/apps/frontend/tests/e2e/relay-validate.spec.ts
@@ -13,7 +13,7 @@
  * A loopback UDP echo answers the backend's post-connection reachability probe.
  * It replies on a short delay so the in-flight (validating) state is observable
  * via web-first auto-retry — no fixed sleeps (PLAYBOOK.md). Evidence is written
- * to .omo/evidence per the task contract.
+ * to the repo-local test-results dir per the task contract.
  */
 import { createSocket } from 'node:dgram';
 import fs from 'node:fs';

--- a/apps/frontend/tests/e2e/visual/task-1-switch.visual.spec.ts
+++ b/apps/frontend/tests/e2e/visual/task-1-switch.visual.spec.ts
@@ -3,12 +3,10 @@ import path from 'node:path';
 
 import { expect, type Locator, type Page, test } from '@playwright/test';
 
-import { navigateTo, setTheme } from '../helpers/index.js';
+import { EVIDENCE_DIR, navigateTo, setTheme } from '../helpers/index.js';
 
-// Repo-local evidence dir (apps/frontend/tests/e2e/visual -> CeraUI root, 5 up).
-const REPO_EVIDENCE_DIR = path.resolve(import.meta.dirname, '../../../../../.omo/evidence');
 function repoEvidence(name: string): string {
-	return path.join(REPO_EVIDENCE_DIR, name);
+	return path.join(EVIDENCE_DIR, name);
 }
 
 /**

--- a/docs/TOUCHSCREEN.md
+++ b/docs/TOUCHSCREEN.md
@@ -72,14 +72,14 @@ Primary target: **1024×600 landscape** (e.g. a Waveshare 10.1" capacitive
 touchscreen attached to the device). All three destinations — **Live**,
 **Network**, **Settings** — must fit at 1024×600 with **no horizontal
 overflow**, in both default and touch modes. This is verified with Playwright
-(see `.omo/evidence/task-36-default.png` and `task-36-touch.png`).
+(see `test-results/task-36-default.png` and `task-36-touch.png`).
 
 ## Minimum Supported Resolution
 
 | Orientation | Minimum | Verified |
 |---|---|---|
-| Landscape | **800×480** | `.omo/evidence/task-13-800x480.txt` |
-| Portrait | **600×1024** | `.omo/evidence/task-13-portrait.txt` |
+| Landscape | **800×480** | `test-results/task-13-800x480.txt` |
+| Portrait | **600×1024** | `test-results/task-13-portrait.txt` |
 
 **800×480 landscape is the floor.** Below this the chrome and the larger config
 dialogs (notably `ServerDialog`) can no longer be laid out without clipping. At


### PR DESCRIPTION
## What
E2E + backend tests now write their traces and human-readable evidence to a repo-local, gitignored `test-results/` directory instead of `../../../.omo/evidence` (the orchestration workspace that sits *above* the checkout).

## Why
The evidence dir resolved to a path **outside the repo** — the `ceralive/` workspace scratch dir. That path doesn't exist in CI's standalone CeraUI checkout, and a repo's own tests should never depend on its orchestration parent. Several specs also recomputed the path independently with fragile `../../../../..` chains at inconsistent depths.

## How
- `playwright.config.ts` + `tests/e2e/helpers/index.ts`: `EVIDENCE_DIR` → repo-local `test-results/` (single source of truth; Playwright `outputDir` reuses it).
- `bond-toggle-flash`, `relay-notifications`, `task-1-switch.visual`: import `EVIDENCE_DIR` from the helper instead of recomputing an external path.
- `mock-modems-output` backend test → `test-results/`.
- `.gitignore`: add `test-results/` (kept `.omo/`).
- Dropped stale `.omo/evidence` mentions from PLAYBOOK + TOUCHSCREEN docs.

## Verify
- `git grep .omo -- ':!.gitignore'` → zero matches.
- Evidence-writing E2E specs (bond-toggle-flash, field-lock, relay-notifications, relay-validate): pass; artifacts land in `apps/frontend/test-results/`.
- Backend tests: 444/444 pass; mock-modems evidence lands in `apps/backend/test-results/`.
- `git check-ignore` confirms both `test-results/` dirs are ignored.

## Risks
Low. Only artifact/output paths change — no product code, no test assertions touched. Any external tooling that scraped `.omo/evidence` would need to read `test-results/` instead.