### PR TITLE
test: route notifications-panel evidence to repo-local test-results

### DIFF
--- a/apps/frontend/tests/e2e/notifications-panel.spec.ts
+++ b/apps/frontend/tests/e2e/notifications-panel.spec.ts
@@ -3,11 +3,7 @@ import path from 'node:path';
 
 import { expect, type Page, test } from '@playwright/test';
 
-import { navigateTo } from './helpers/index.js';
-
-// Workstream evidence root: CeraUI/.omo/evidence. e2e -> tests -> frontend ->
-// apps -> CeraUI.
-const EVIDENCE_DIR = path.resolve(import.meta.dirname, '../../../../.omo/evidence');
+import { EVIDENCE_DIR, navigateTo } from './helpers/index.js';
 
 /**
  * Task 16 — Persistent-notifications panel, integrated E2E (mock backend).


### PR DESCRIPTION
## What
`notifications-panel.spec.ts` now imports `EVIDENCE_DIR` from the e2e helper instead of defining its own `../../../../.omo/evidence` path.

## Why
The repo-local test-artifact decoupling (#93) swept every `.omo` reference, but `notifications-panel.spec.ts` arrived on `main` via #90 — a branch cut before #93 — so its external evidence path was never cleaned. This restores the Rule D invariant that no tracked file (outside `.gitignore`) references `.omo`.

## How
- Replace the local `EVIDENCE_DIR = path.resolve(import.meta.dirname, '../../../../.omo/evidence')` with `import { EVIDENCE_DIR, navigateTo } from './helpers/index.js'`.

## Verify
- `git grep .omo -- ':!.gitignore'` → empty.
- `notifications-panel` e2e: 2 passed, 2 skipped; evidence lands in `apps/frontend/test-results/`.

## Risks
None — single import change in one spec; no product code, no assertions touched.