### PR TITLE
feat: add-on subsystem, device-stats panel, kiosk→add-on refactor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,12 @@ TypeScript source of truth for the descriptor shape — never duplicate it in `a
 
 `AddonStateSchema` describes per-feature runtime state persisted under the `addons`
 key of `config.json`. Fields: `enabled`, `phase`, `versionMaterialized`,
-`userConfig`, `autoDisabled`.
+`osVersionMaterialized`, `userConfig`, `lastError`, `autoDisabled`.
+`osVersionMaterialized` (T29) records the OS VERSION_ID the staged `.raw` was
+fetched for, so the reconciler can detect an OTA-stale artifact by exact (G1)
+match. The persisted `phase` enum (`ADDON_PHASES`) is
+`idle | installing | active | pending | disabling | error`; `pending` (T29) is
+the reconciler's non-terminal "wanted but not yet materialisable" state.
 
 Key regex constants (defined once in `addons.schema.ts`, imported everywhere):
 - `ADDON_ID_RE` — lowercase alphanumeric + hyphens (stricter than `APT_PACKAGE_NAME_RE`)
@@ -177,6 +182,35 @@ tests), and the SAME crash-loop discriminator drives auto-disable.
 Test coverage: `apps/backend/src/tests/manager.test.ts` — pure mapping, the
 enable/disable pipelines, crash-loop + validation auto-disable, and the G6/E1
 negative paths.
+
+**Post-boot reconciler** (`apps/backend/src/modules/addons/reconciler.ts`) [EXISTS]
+
+`runAddonReconciler()` (T29) reconciles desired state (config.json `addons`)
+against the materialised `/data/extensions/<id>.raw` sysexts after a boot/OTA. It
+is **fire-and-forget and NEVER gates boot or the OS-update healthcheck/rollback** —
+every failure is caught and downgraded to a persisted `pending` phase; the run
+never throws and self-serialises (a concurrent call is a no-op).
+
+- Per enabled add-on: if the staged `.raw` is missing **or** its
+  `osVersionMaterialized` ≠ the live `/etc/os-release` VERSION_ID (G1 exact
+  match — never loosened), re-fetch `artifact.urlTemplate` (substituting
+  `{os_version}` + `{board}`) → sha256 + GPG verify → atomic stage → helper
+  `refresh`.
+- **No compatible artifact** (404 / network / descriptor `compatibleOsVersions`
+  excludes the live OS): set `phase: pending` + `lastError:
+  addon_not_available_for_os_version`. Boot is unaffected.
+- **Live stream**: a disruptive refresh is deferred — set `phase: pending` +
+  `lastError: addon_refresh_deferred_streaming`; retried on the next boot.
+- Triggered from `main.ts` at startup (non-blocking) and re-pokable via SIGUSR1
+  from the `ceralive-addon-reconciler.service` oneshot (deployment/), which is
+  deliberately NOT wired into any rollback/healthcheck target.
+- All effectful surface is injected via `ReconcilerDeps`; default deps are built
+  lazily (dynamic import) so the module never pulls the streaming/config graph or
+  requires `setup.json` at test-import time.
+
+Test coverage: `apps/backend/src/tests/addon-reconciler.test.ts` — re-materialise
+(missing + VERSION_ID mismatch), idempotency, the pending/defer negative paths,
+and the boot-safety (never-throws) + emulated-mode no-op guarantees.
 
 **sysext refresh protocol**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ CeraUI/
 │           ├── modules/system/
 │           │   ├── device-stats.ts        # 5-signal device stats (S1 lock)
 │           │   ├── device-detection.ts    # isRealDevice() — gates all add-on ops
-│           │   ├── kiosk.ts               # Kiosk state machine (template for add-on manager)
+│           │   ├── kiosk.ts               # Kiosk DC-2 state machine; toggle runs the cog-display add-on via the manager
 │           │   └── software-updates.ts    # apt/size parsing; APT_PACKAGE_NAME_RE
 │           └── modules/addons/
 │               └── manager.ts             # Add-on enable/disable state machine (T28)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,20 @@ CeraUI/
 │   │               ├── connection-ux.svelte.ts # Reconnect/reboot/session-expiry UX state
 │   │               └── layout-mode.svelte.ts  # Touch/kiosk layout flag ($persist)
 │   └── backend/      # Bun server — WebSocket RPC via oRPC, serves frontend static
+│       └── src/
+│           ├── helpers/
+│           │   ├── config-loader.ts       # loadJsonConfig + writeFileAtomicSync (E3)
+│           │   └── config-schemas.ts      # runtimeConfigSchema — addons key lives here
+│           └── modules/system/
+│               ├── device-stats.ts        # 5-signal device stats (S1 lock)
+│               ├── device-detection.ts    # isRealDevice() — gates all add-on ops
+│               ├── kiosk.ts               # Kiosk state machine (template for add-on manager)
+│               └── software-updates.ts    # apt/size parsing; APT_PACKAGE_NAME_RE
 ├── packages/
 │   ├── rpc/          # Shared oRPC schemas (workspace:*) — validation constants live here
+│   │   └── src/schemas/
+│   │       ├── addons.schema.ts           # AddonDescriptorSchema + AddonStateSchema (T21)
+│   │       └── system.schema.ts           # KIOSK_UNAVAILABLE_ERROR + system schemas
 │   └── i18n/         # typesafe-i18n, 10 languages (workspace:*)
 ├── scripts/build/    # build-debian-package.sh — produces ceraui .deb
 ├── docs/             # ARCHITECTURE, BUILD_PIPELINE, APT_VERSION_CONTROL, BRANDING, TOUCHSCREEN
@@ -83,6 +95,10 @@ CeraUI/
 | Kiosk RPC + polling loop (backend) | `apps/backend/src/` (kiosk procedures, Task 23) |
 | Kiosk settings dialog (frontend) | `apps/frontend/src/main/dialogs/` (Task 25) |
 | Display-profile store + `?display=` param | `apps/frontend/src/lib/stores/display-profile.svelte.ts` |
+| **Add-on Zod schemas (descriptor + state)** | `packages/rpc/src/schemas/addons.schema.ts` |
+| **Device stats (5-signal broadcast)** | `apps/backend/src/modules/system/device-stats.ts` |
+| **Config atomicity (E3)** | `apps/backend/src/helpers/config-loader.ts` — `writeFileAtomicSync` |
+| **Runtime config schema (addons key)** | `apps/backend/src/helpers/config-schemas.ts` — `runtimeConfigSchema` |
 | Design rules | `.impeccable.md` |
 
 ## COMMANDS
@@ -96,6 +112,74 @@ BUILD_ARCH=amd64 ./scripts/build/build-debian-package.sh   # .deb for AMD64
 bun tsc --noEmit      # type-check backend (run from apps/backend/)
 pnpm --filter frontend run test   # vitest frontend unit tests
 ```
+
+## ADD-ON SUBSYSTEM [EXISTS]
+
+The add-on subsystem lets CeraUI install, enable, and disable optional feature
+sysexts at runtime without a reflash. It is gated on `isRealDevice()` — all
+add-on operations are no-ops in dev/emulated mode.
+
+**Zod schemas** (`packages/rpc/src/schemas/addons.schema.ts`) [EXISTS]
+
+`AddonDescriptorSchema` mirrors the image-baked JSON descriptor format from
+`image-building-pipeline/v2/manifests/schema/addon.schema.json`. It is the single
+TypeScript source of truth for the descriptor shape — never duplicate it in `apps/`.
+
+`AddonStateSchema` describes per-feature runtime state persisted under the `addons`
+key of `config.json`. Fields: `enabled`, `phase`, `versionMaterialized`,
+`userConfig`, `autoDisabled`.
+
+Key regex constants (defined once in `addons.schema.ts`, imported everywhere):
+- `ADDON_ID_RE` — lowercase alphanumeric + hyphens (stricter than `APT_PACKAGE_NAME_RE`)
+- `SEMVER_RE` — `MAJOR.MINOR.PATCH` with optional pre-release/build
+- `SYSEXT_PATH_RE` — `/usr/…` or `/opt/…` only (G2 contract)
+- `ARTIFACT_URL_RE` — HTTPS with mandatory `{os_version}` placeholder
+
+**Config atomicity (E3)** [EXISTS]
+
+All writes to `config.json` go through `writeFileAtomicSync` in
+`apps/backend/src/helpers/config-loader.ts`. The pattern: write to a sibling temp
+file (`.<name>.<pid>.tmp`), `fsync`, then `rename` — so a crash mid-write never
+corrupts the live config. The `addons` key in `runtimeConfigSchema` defaults to
+`{}` when absent, so old configs without the key parse cleanly.
+
+Test coverage: `apps/backend/src/tests/addons-config-state.test.ts` — round-trip,
+crash-mid-write, and missing-key defaulting.
+
+**sysext refresh protocol**
+
+The add-on manager must follow the protocol from
+`image-building-pipeline/v2/docs/addon-sysext-refresh.md`:
+- **Update:** `systemd-sysext refresh` → `systemctl restart <addon>.service`
+- **Disable:** `systemctl stop <addon>.service` → `systemd-sysext refresh`
+
+Never report an add-on "updated" or "disabled" on the strength of the sysext call
+alone. The service restart (on update) or stop (on disable) is what makes the
+transition real.
+
+**isRealDevice() gate**
+
+All add-on operations (install, enable, disable, refresh) MUST call
+`await isRealDevice()` at entry. In dev/emulated mode return
+`{ success: false, error: "addon_unavailable_in_emulated_mode" }` without touching
+`systemd-sysext` or `systemctl`. Read-only status queries are NOT gated.
+
+## DEVICE STATS [EXISTS]
+
+`apps/backend/src/modules/system/device-stats.ts` broadcasts exactly **5 signals**
+on a `device-stats` event every 5 seconds (S1 lock):
+
+| Signal | Description |
+|--------|-------------|
+| `disk` | Used/total bytes on `/data` + media type (SSD/HDD/eMMC/unknown) |
+| `cpuLoad1` | 1-minute load average |
+| `socTemp` | SoC temperature (wired from `sensors.ts` — no second `/sys/class/thermal` read) |
+| `ifaceRxTx` | Per-interface RX/TX byte counters |
+| `raucSlot` | Active RAUC A/B slot |
+
+Adding a sixth field is a deliberate contract change, not a tweak. Every collector
+wraps its read in its own `try/catch` and degrades to `null` on failure — a missing
+`/sys` path or absent `rauc` binary must never crash the sampling loop.
 
 ## DEVICE DETECTION + KIOSK EMULATION SAFETY
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,11 +49,13 @@ CeraUI/
 │           ├── helpers/
 │           │   ├── config-loader.ts       # loadJsonConfig + writeFileAtomicSync (E3)
 │           │   └── config-schemas.ts      # runtimeConfigSchema — addons key lives here
-│           └── modules/system/
-│               ├── device-stats.ts        # 5-signal device stats (S1 lock)
-│               ├── device-detection.ts    # isRealDevice() — gates all add-on ops
-│               ├── kiosk.ts               # Kiosk state machine (template for add-on manager)
-│               └── software-updates.ts    # apt/size parsing; APT_PACKAGE_NAME_RE
+│           ├── modules/system/
+│           │   ├── device-stats.ts        # 5-signal device stats (S1 lock)
+│           │   ├── device-detection.ts    # isRealDevice() — gates all add-on ops
+│           │   ├── kiosk.ts               # Kiosk state machine (template for add-on manager)
+│           │   └── software-updates.ts    # apt/size parsing; APT_PACKAGE_NAME_RE
+│           └── modules/addons/
+│               └── manager.ts             # Add-on enable/disable state machine (T28)
 ├── packages/
 │   ├── rpc/          # Shared oRPC schemas (workspace:*) — validation constants live here
 │   │   └── src/schemas/
@@ -96,6 +98,7 @@ CeraUI/
 | Kiosk settings dialog (frontend) | `apps/frontend/src/main/dialogs/` (Task 25) |
 | Display-profile store + `?display=` param | `apps/frontend/src/lib/stores/display-profile.svelte.ts` |
 | **Add-on Zod schemas (descriptor + state)** | `packages/rpc/src/schemas/addons.schema.ts` |
+| **Add-on manager (enable/disable state machine, T28)** | `apps/backend/src/modules/addons/manager.ts` |
 | **Device stats (5-signal broadcast)** | `apps/backend/src/modules/system/device-stats.ts` |
 | **Config atomicity (E3)** | `apps/backend/src/helpers/config-loader.ts` — `writeFileAtomicSync` |
 | **Runtime config schema (addons key)** | `apps/backend/src/helpers/config-schemas.ts` — `runtimeConfigSchema` |
@@ -146,6 +149,35 @@ corrupts the live config. The `addons` key in `runtimeConfigSchema` defaults to
 Test coverage: `apps/backend/src/tests/addons-config-state.test.ts` — round-trip,
 crash-mid-write, and missing-key defaulting.
 
+**Manager state machine** (`apps/backend/src/modules/addons/manager.ts`) [EXISTS]
+
+The runtime orchestration layer (T28). Mirrors the kiosk state machine: every
+OS/network/persistence primitive is injected through `AddonManagerDeps` (DI for
+tests), and the SAME crash-loop discriminator drives auto-disable.
+
+- **Manager phases** (`AddonManagerPhase`): `disabled → enabling → enabled`,
+  `enabled → disabling → disabled`, plus `failed`, `pending`, `auto_disabled`.
+  `toAddonState`/`phaseFromState` losslessly map these onto the schema-valid
+  `AddonState` triple (`enabled` + `phase` + `autoDisabled`), so `config.json`
+  always parses even though the persisted `phase` enum is coarser.
+- **Enable pipeline** (ordered, each gated/atomic): `isRealDevice()` (G6) →
+  free-space precheck (E1: `/data` free > `sizeInstalled × 2 + 512 MiB`) →
+  download → `/data/tmp/<id>.raw.tmp` → sha256 (+ helper GPG) verify → atomic
+  rename → `/data/extensions/<id>.raw` → `ceralive-addon-helper enable <id>` →
+  unmask + start descriptor units → validation probe (auto-disable on failure).
+- **Disable pipeline**: reverse + idempotent — stop + mask units → helper
+  `disable` → remove artifact → drop config state.
+- **Crash-loop auto-disable**: `pollAddonCrashLoop` reads `NRestarts` per unit;
+  `>= ADDON_CRASH_LOOP_RESTART_THRESHOLD` (3) masks the units and parks the
+  add-on in `auto_disabled` (same rule as kiosk T5).
+- All privileged work is delegated to `ceralive-addon-helper` (G-trust); the
+  manager never mutates the sysext scan dir or systemd directly on the trusted
+  path — it drives the helper and argv-only `systemctl`.
+
+Test coverage: `apps/backend/src/tests/manager.test.ts` — pure mapping, the
+enable/disable pipelines, crash-loop + validation auto-disable, and the G6/E1
+negative paths.
+
 **sysext refresh protocol**
 
 The add-on manager must follow the protocol from
@@ -162,7 +194,9 @@ transition real.
 All add-on operations (install, enable, disable, refresh) MUST call
 `await isRealDevice()` at entry. In dev/emulated mode return
 `{ success: false, error: "addon_unavailable_in_emulated_mode" }` without touching
-`systemd-sysext` or `systemctl`. Read-only status queries are NOT gated.
+`systemd-sysext` or `systemctl`. Read-only status queries are NOT gated. The
+manager's `enableAddon`/`disableAddon`/`pollAddonCrashLoop` all enforce this gate
+as their first step (`ADDON_UNAVAILABLE_ERROR`).
 
 ## DEVICE STATS [EXISTS]
 

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -20,6 +20,7 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 | WebSocket server wiring | `modules/ui/websocket-server.ts` + `rpc/server.ts` |
 | Auth token logic | `modules/ui/auth.ts` + `rpc/middleware/auth.middleware.ts` |
 | Kiosk loopback token (DC-3, single-use, tmpfs) | `modules/ui/kiosk-token.ts` + `rpc/server.ts` |
+| Add-on enable/disable state machine (T28) | `modules/addons/manager.ts` |
 | Mock hardware data | `mocks/providers/` |
 | Shared RPC schema types | `../../../packages/rpc/` (`@ceraui/rpc`) |
 

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -21,6 +21,7 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 | Auth token logic | `modules/ui/auth.ts` + `rpc/middleware/auth.middleware.ts` |
 | Kiosk loopback token (DC-3, single-use, tmpfs) | `modules/ui/kiosk-token.ts` + `rpc/server.ts` |
 | Add-on enable/disable state machine (T28) | `modules/addons/manager.ts` |
+| Post-boot add-on reconciler (T29, non-blocking; never gates rollback) | `modules/addons/reconciler.ts` |
 | Mock hardware data | `mocks/providers/` |
 | Shared RPC schema types | `../../../packages/rpc/` (`@ceraui/rpc`) |
 

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -20,6 +20,7 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 | WebSocket server wiring | `modules/ui/websocket-server.ts` + `rpc/server.ts` |
 | Auth token logic | `modules/ui/auth.ts` + `rpc/middleware/auth.middleware.ts` |
 | Kiosk loopback token (DC-3, single-use, tmpfs) | `modules/ui/kiosk-token.ts` + `rpc/server.ts` |
+| Kiosk DC-2 state machine (toggle runs the `cog-display` add-on via the manager) | `modules/system/kiosk.ts` |
 | Add-on enable/disable state machine (T28) | `modules/addons/manager.ts` |
 | Post-boot add-on reconciler (T29, non-blocking; never gates rollback) | `modules/addons/reconciler.ts` |
 | Mock hardware data | `mocks/providers/` |

--- a/apps/backend/bunfig.toml
+++ b/apps/backend/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./src/tests/test-preload.ts"]

--- a/apps/backend/ceralive-addon-helper
+++ b/apps/backend/ceralive-addon-helper
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+#
+# ceralive-addon-helper — privileged (root) add-on lifecycle helper.
+#
+# CeraUI's backend runs UNPRIVILEGED. Every operation that needs root to
+# activate or tear down a systemd-sysext add-on is funnelled through this one
+# binary, invoked argv-only as `sudo ceralive-addon-helper <subcommand> [id]`
+# (the sudoers drop-in scopes NOPASSWD to exactly this path). This helper — NOT
+# the backend — is the trust boundary: it re-derives the allowlist and
+# re-verifies every signature itself, so a compromised backend can never enable
+# arbitrary code.
+#
+# TRUST MODEL (G-trust — do NOT weaken):
+#   * The set of installable add-ons is EXACTLY the descriptors BAKED read-only
+#     into the image at /usr/share/ceralive/addons/<id>.json. An <id> with no
+#     baked descriptor is refused.
+#   * A descriptor delivered any other way (e.g. dropped into a merged sysext,
+#     which overlays /usr and could shadow the registry path) can NEVER expand
+#     the trusted set: a descriptor only NAMES an id + an expected sha256, while
+#     the AUTHORITY to activate is the detached GPG signature, which must verify
+#     against the image-baked add-on keyring at
+#     /usr/share/ceralive/addon-keyring.gpg. An attacker who can shadow a
+#     descriptor still cannot forge a signature for that keyring.
+#   * Both the sha256 (against the baked descriptor) AND the GPG signature
+#     (against the baked keyring) are re-checked here on every enable, even if
+#     the backend already checked them. Verification is NEVER skipped.
+#
+# Every filesystem location and external tool is overridable via env vars so the
+# security logic is exercised hermetically by the test suite — without root,
+# without a real device, without touching the host. On the device the defaults
+# below are the only values used.
+#
+# shellcheck shell=bash
+# Embedded jq filters use single quotes intentionally: $id/$k/$i/$installed are
+# jq variables, NOT bash — they must NOT be expanded by the shell.
+# shellcheck disable=SC2016
+set -euo pipefail
+
+# --- Injectable locations (device defaults; tests override via env) -----------
+# REGISTRY_DIR is the SOLE source of the allowlist (G-trust). Baked, read-only.
+REGISTRY_DIR="${CERALIVE_ADDON_REGISTRY_DIR:-/usr/share/ceralive/addons}"
+# Image-baked PUBLIC add-on keyring — the root of authenticity. Distinct trust
+# domain from the RAUC OS-signing key.
+KEYRING="${CERALIVE_ADDON_KEYRING:-/usr/share/ceralive/addon-keyring.gpg}"
+# Persistent store the verified .raw is written to / removed from (survives OTA).
+STAGE_DIR="${CERALIVE_ADDON_STAGE_DIR:-/data/extensions}"
+# Directory systemd-sysext scans + `status` enumerates. On the device this is a
+# bind mount of STAGE_DIR (/var/lib/extensions -> /data/extensions); when the
+# two differ the staged .raw is linked here so a refresh can find it.
+EXT_DIR="${CERALIVE_ADDON_EXT_DIR:-/var/lib/extensions}"
+# Where the backend has already downloaded <id>.raw + <id>.raw.sig for re-verify.
+CACHE_DIR="${CERALIVE_ADDON_CACHE_DIR:-/var/cache/ceralive/addons}"
+
+# --- Injectable tools (device defaults; tests point at real tools / stubs) ----
+JQ="${CERALIVE_JQ:-jq}"
+GPGV="${CERALIVE_GPGV:-gpgv}"
+SHA256SUM="${CERALIVE_SHA256SUM:-sha256sum}"
+SYSTEMCTL="${CERALIVE_SYSTEMCTL:-systemctl}"
+SYSEXT="${CERALIVE_SYSEXT:-systemd-sysext}"
+
+# --- Validation patterns (mirror packages/rpc addons.schema.ts) --------------
+# Add-on id: lowercase alphanumeric with internal hyphens. The charset forbids
+# '/' and '.', so it cannot express path traversal (../, absolute paths).
+ADDON_ID_RE='^[a-z0-9][a-z0-9-]*$'
+# Lowercase hex SHA-256 (64 chars).
+SHA256_RE='^[a-f0-9]{64}$'
+# systemd unit name with a mandatory unit-type suffix.
+UNIT_RE='^[A-Za-z0-9@._:-]+\.(service|socket|target|timer|path|mount)$'
+
+fail() {
+	printf 'ceralive-addon-helper: %s\n' "$*" >&2
+	exit 1
+}
+
+need() {
+	command -v "$1" >/dev/null 2>&1 || fail "required tool not found: $1"
+}
+
+usage() {
+	cat >&2 <<'EOF'
+Usage: ceralive-addon-helper <subcommand> [id]
+
+Subcommands:
+  enable <id>   Verify (sha256 + GPG against the baked keyring) and activate the
+                baked add-on <id>: stage its .raw, refresh sysext, unmask/enable/
+                start its units.
+  disable <id>  Reverse enable: stop/disable/mask units, remove the staged .raw,
+                refresh sysext.
+  refresh       Run `systemd-sysext refresh` only.
+  status        Emit JSON describing the baked registry + installed state.
+
+The add-on <id> is resolved ONLY against the image-baked registry; signatures
+are re-verified against the image-baked keyring. Neither can be overridden by a
+descriptor delivered through a merged sysext.
+EOF
+}
+
+validate_id() {
+	[[ "$1" =~ $ADDON_ID_RE ]] || fail "invalid add-on id: $1"
+}
+
+# Resolve <id> to its baked descriptor path, enforcing the G-trust allowlist:
+# the descriptor MUST be a regular file living directly in the baked registry.
+# Symlinks are rejected so a merged sysext cannot redirect the lookup out of the
+# baked tree.
+require_baked_descriptor() {
+	local id="$1" desc="${REGISTRY_DIR}/$1.json"
+	[[ -f "$desc" && ! -L "$desc" ]] || fail "add-on not in baked registry: ${id}"
+	printf '%s' "$desc"
+}
+
+# Re-verify the cached artifact for <id> against the BAKED descriptor + keyring.
+# Refuses on any mismatch. This is the activation authority — a shadowed/injected
+# descriptor cannot pass it without a signature from the baked keyring.
+verify_artifact() {
+	local id="$1" desc="$2" raw sig want_sha got_sha payload desc_id
+	need "$JQ"
+	need "$SHA256SUM"
+	need "$GPGV"
+
+	payload="$("$JQ" -r '.payload.type' "$desc")"
+	[[ "$payload" == "sysext" ]] || fail "unsupported payload type for ${id}: ${payload}"
+
+	desc_id="$("$JQ" -r '.id' "$desc")"
+	[[ "$desc_id" == "$id" ]] || fail "descriptor id mismatch: ${desc_id} != ${id}"
+
+	want_sha="$("$JQ" -r '.artifact.sha256' "$desc")"
+	[[ "$want_sha" =~ $SHA256_RE ]] || fail "descriptor sha256 malformed for ${id}"
+
+	raw="${CACHE_DIR}/${id}.raw"
+	sig="${raw}.sig"
+	[[ -f "$raw" ]] || fail "artifact not present in cache: ${raw}"
+	[[ -f "$sig" ]] || fail "signature not present in cache: ${sig}"
+
+	got_sha="$("$SHA256SUM" "$raw" | cut -d' ' -f1)"
+	[[ "$got_sha" == "$want_sha" ]] \
+		|| fail "sha256 mismatch for ${id}: artifact does not match baked descriptor"
+
+	"$GPGV" --keyring "$KEYRING" "$sig" "$raw" >/dev/null 2>&1 \
+		|| fail "GPG verify failed for ${id}: not signed by the baked add-on keyring"
+}
+
+# Emit the units of one list (unmask|enable|start) and run <verb> on each.
+run_units() {
+	local desc="$1" key="$2" verb="$3" u
+	while IFS= read -r u; do
+		[[ -n "$u" ]] || continue
+		[[ "$u" =~ $UNIT_RE ]] || fail "invalid unit name in descriptor: ${u}"
+		"$SYSTEMCTL" "$verb" "$u"
+	done < <("$JQ" -r --arg k "$key" '.units[$k][]? // empty' "$desc")
+}
+
+# Make the staged .raw discoverable by systemd-sysext. When STAGE_DIR and
+# EXT_DIR are the same directory (the device bind-mount case) the install already
+# placed it in the scan dir; otherwise link it in (bytes stay in STAGE_DIR).
+ensure_discoverable() {
+	local id="$1"
+	mkdir -p "$EXT_DIR"
+	if [[ ! "${EXT_DIR}/${id}.raw" -ef "${STAGE_DIR}/${id}.raw" ]]; then
+		ln -sf "${STAGE_DIR}/${id}.raw" "${EXT_DIR}/${id}.raw"
+	fi
+}
+
+cmd_enable() {
+	local id="$1" desc
+	validate_id "$id"
+	need "$SYSEXT"
+	need "$SYSTEMCTL"
+	desc="$(require_baked_descriptor "$id")"
+	verify_artifact "$id" "$desc"
+
+	mkdir -p "$STAGE_DIR"
+	install -m 0644 "${CACHE_DIR}/${id}.raw" "${STAGE_DIR}/${id}.raw"
+	ensure_discoverable "$id"
+
+	# Filesystem-level merge first, THEN unit lifecycle. The refresh is live-safe
+	# but does not hot-swap running code (T1 protocol) — units are (re)started
+	# below so they pick up the freshly merged binaries.
+	"$SYSEXT" refresh
+	run_units "$desc" unmask unmask
+	run_units "$desc" enable enable
+	run_units "$desc" start start
+
+	"$JQ" -cn --arg id "$id" '{ok: true, id: $id, action: "enable"}'
+}
+
+cmd_disable() {
+	local id="$1" desc
+	validate_id "$id"
+	need "$SYSEXT"
+	need "$SYSTEMCTL"
+	desc="$(require_baked_descriptor "$id")"
+
+	# Stop BEFORE teardown so each service shuts down via its still-present binary
+	# rather than lingering on a deleted inode (T1 sysext restart protocol).
+	run_units "$desc" start stop
+	run_units "$desc" enable disable
+	run_units "$desc" unmask mask
+
+	rm -f "${STAGE_DIR}/${id}.raw" "${EXT_DIR}/${id}.raw"
+	"$SYSEXT" refresh
+
+	"$JQ" -cn --arg id "$id" '{ok: true, id: $id, action: "disable"}'
+}
+
+cmd_refresh() {
+	need "$SYSEXT"
+	need "$JQ"
+	"$SYSEXT" refresh
+	"$JQ" -cn '{ok: true, action: "refresh"}'
+}
+
+# JSON array of ids currently staged in the sysext scan dir.
+status_installed_ids() {
+	local ids=() f id
+	shopt -s nullglob
+	for f in "$EXT_DIR"/*.raw; do
+		id="$(basename "${f%.raw}")"
+		ids+=("$id")
+	done
+	shopt -u nullglob
+	if [[ ${#ids[@]} -eq 0 ]]; then
+		printf '[]'
+		return 0
+	fi
+	printf '%s\n' "${ids[@]}" | "$JQ" -R . | "$JQ" -s .
+}
+
+cmd_status() {
+	need "$JQ"
+	local files=() installed
+	shopt -s nullglob
+	files=("$REGISTRY_DIR"/*.json)
+	shopt -u nullglob
+
+	if [[ ${#files[@]} -eq 0 ]]; then
+		"$JQ" -cn '{ok: true, addons: []}'
+		return 0
+	fi
+
+	installed="$(status_installed_ids)"
+	"$JQ" -c -s --argjson installed "$installed" \
+		'map({
+			id, name, version, category,
+			units: (.units // {}),
+			installed: (.id as $i | $installed | index($i) != null)
+		}) | {ok: true, addons: .}' "${files[@]}"
+}
+
+main() {
+	local sub="${1:-}"
+	case "$sub" in
+		enable)
+			[[ $# -eq 2 ]] || { usage; fail "enable requires exactly one <id>"; }
+			cmd_enable "$2"
+			;;
+		disable)
+			[[ $# -eq 2 ]] || { usage; fail "disable requires exactly one <id>"; }
+			cmd_disable "$2"
+			;;
+		refresh)
+			[[ $# -eq 1 ]] || { usage; fail "refresh takes no arguments"; }
+			cmd_refresh
+			;;
+		status)
+			[[ $# -eq 1 ]] || { usage; fail "status takes no arguments"; }
+			cmd_status
+			;;
+		-h | --help | "")
+			usage
+			exit 0
+			;;
+		*)
+			usage
+			fail "unknown subcommand: ${sub}"
+			;;
+	esac
+}
+
+main "$@"

--- a/apps/backend/ceralive-addon-helper.sudoers
+++ b/apps/backend/ceralive-addon-helper.sudoers
@@ -1,0 +1,16 @@
+# CeraLive add-on helper — narrow privilege escalation for add-on lifecycle.
+#
+# The CeraUI backend runs UNPRIVILEGED (user `ceraui`). Activating or tearing
+# down a systemd-sysext add-on needs root, so the backend shells out to the
+# single privileged helper below — argv-only, no shell — as:
+#
+#     sudo ceralive-addon-helper <enable|disable|refresh|status> [id]
+#
+# This rule grants password-less sudo for EXACTLY that one binary path and
+# nothing else: no wildcards, no arguments grammar, no other commands. The
+# helper itself is the trust boundary — it re-derives the add-on allowlist from
+# the image-baked registry and re-verifies every signature against the baked
+# keyring, so this rule cannot be leveraged to run arbitrary code.
+#
+# Install: /etc/sudoers.d/ceralive-addon-helper, owned root:root, mode 0440.
+ceraui ALL=(root) NOPASSWD: /usr/bin/ceralive-addon-helper

--- a/apps/backend/src/helpers/addon-helper.ts
+++ b/apps/backend/src/helpers/addon-helper.ts
@@ -1,0 +1,134 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * Argv-only wrapper around the privileged `ceralive-addon-helper` root binary
+ * (T27). The backend is UNPRIVILEGED; every add-on lifecycle op is performed by
+ * the helper, invoked here as:
+ *
+ *     sudo ceralive-addon-helper <enable|disable|refresh|status> [id]
+ *
+ * Design rules (deliberate):
+ *  - argv-only (NO shell): the call goes through execFileP, so the sudoers
+ *    NOPASSWD grant is scoped to one binary and add-on ids can never be
+ *    re-interpreted as shell syntax. Satisfies scripts/check-exec-guard.sh.
+ *  - isRealDevice() gates EVERY op (G6). The helper itself runs as root; the
+ *    backend must never invoke it in dev/emulated mode where there is no real
+ *    sysext/systemd to drive. The gate fires BEFORE sudo is ever spawned.
+ *  - The id is re-validated against the same charset the helper enforces, as
+ *    defense in depth — a malformed id is rejected before it reaches argv.
+ *  - The probe surface (isRealDevice + exec) is injected via {@link AddonHelperDeps}
+ *    so the wrapper is unit-testable without spawning sudo (mirrors ssh.ts /
+ *    kiosk.ts). The helper's own security logic is exercised separately by the
+ *    bash-script integration test.
+ */
+
+import { isRealDevice } from "../modules/system/device-detection.ts";
+import { type ExecResult, execFileP } from "./exec.ts";
+
+/** The privileged helper binary (resolved on PATH at /usr/bin on the device). */
+const HELPER_BIN = "ceralive-addon-helper";
+const SUDO = "sudo";
+
+/**
+ * Add-on id charset — mirrors `ADDON_ID_RE` in both the bash helper and
+ * `packages/rpc/src/schemas/addons.schema.ts`. Lowercase alphanumeric with
+ * internal hyphens; the charset forbids `/` and `.`, so it cannot express a
+ * path or a leading-dash flag.
+ */
+const ADDON_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+/**
+ * Returned by every wrapper call when the device gate is closed. The backend
+ * surfaces this to the UI as a calm "unavailable in emulated mode" state rather
+ * than an error (mirrors the kiosk `KIOSK_UNAVAILABLE_ERROR` convention).
+ */
+export const ADDON_UNAVAILABLE_ERROR = "addon_unavailable_in_emulated_mode";
+
+/**
+ * Injectable surface. Defaults talk to the real OS (real device detection +
+ * argv-only sudo exec). Tests inject deterministic stand-ins and spies.
+ */
+export type AddonHelperDeps = {
+	/** Whether we are on a real RK3588 device (G6 gate). */
+	isRealDevice: () => Promise<boolean>;
+	/** Run a binary argv-only (NO shell); rejects on non-zero exit. */
+	exec: (file: string, args: readonly string[]) => Promise<ExecResult>;
+};
+
+const defaultDeps: AddonHelperDeps = {
+	isRealDevice: () => isRealDevice(),
+	exec: (file, args) => execFileP(file, args),
+};
+
+/** Validate + return an add-on id, or throw before it can reach argv. */
+function assertAddonId(id: string): string {
+	if (!ADDON_ID_RE.test(id)) {
+		throw new Error(`invalid add-on id: ${id}`);
+	}
+	return id;
+}
+
+/**
+ * Gate on the real device, then invoke the helper argv-only via sudo. Returns
+ * the helper's stdout (a JSON document the caller may parse). Throws
+ * {@link ADDON_UNAVAILABLE_ERROR} when not on a real device, and rejects (via
+ * execFileP) with the helper's stderr on a non-zero exit.
+ */
+async function invokeHelper(
+	args: string[],
+	deps: AddonHelperDeps,
+): Promise<string> {
+	if (!(await deps.isRealDevice())) {
+		throw new Error(ADDON_UNAVAILABLE_ERROR);
+	}
+	const { stdout } = await deps.exec(SUDO, [HELPER_BIN, ...args]);
+	return stdout;
+}
+
+// All four are `async` so the synchronous assertAddonId() throw surfaces as a
+// rejected promise (callers always await), never an unguarded sync throw.
+
+/** Verify + activate the baked add-on `id` (helper re-checks sig + sha256). */
+export async function addonEnable(
+	id: string,
+	deps: AddonHelperDeps = defaultDeps,
+): Promise<string> {
+	return invokeHelper(["enable", assertAddonId(id)], deps);
+}
+
+/** Tear down the add-on `id`: stop/mask units, remove the staged .raw, refresh. */
+export async function addonDisable(
+	id: string,
+	deps: AddonHelperDeps = defaultDeps,
+): Promise<string> {
+	return invokeHelper(["disable", assertAddonId(id)], deps);
+}
+
+/** Run `systemd-sysext refresh` via the helper. */
+export async function addonRefresh(
+	deps: AddonHelperDeps = defaultDeps,
+): Promise<string> {
+	return invokeHelper(["refresh"], deps);
+}
+
+/** Read the baked registry + installed state as JSON via the helper. */
+export async function addonStatus(
+	deps: AddonHelperDeps = defaultDeps,
+): Promise<string> {
+	return invokeHelper(["status"], deps);
+}

--- a/apps/backend/src/helpers/config-loader.ts
+++ b/apps/backend/src/helpers/config-loader.ts
@@ -24,6 +24,9 @@
  * preserves the original boot-time load order without introducing races.
  */
 
+import fs from "node:fs";
+import path from "node:path";
+
 import type { z } from "zod";
 
 import { logger } from "./logger.ts";
@@ -219,6 +222,40 @@ export async function saveJsonConfigAsync<T>(
 		? JSON.stringify(data, null, "\t")
 		: JSON.stringify(data);
 	await Bun.write(filePath, contents);
+}
+
+/**
+ * Atomically write a string to disk: write to a sibling temp file, fsync it to
+ * durable storage, then rename over the target. The rename is atomic on POSIX,
+ * so a crash mid-write leaves the original file intact — readers never observe a
+ * truncated config.json (E3 guardrail). Synchronous because config save callers
+ * (setBitrate/setAutostart) depend on the write completing before they return.
+ */
+export function writeFileAtomicSync(filePath: string, contents: string): void {
+	const dir = path.dirname(filePath);
+	const tmpPath = path.join(
+		dir,
+		`.${path.basename(filePath)}.${process.pid}.tmp`,
+	);
+
+	const fd = fs.openSync(tmpPath, "w");
+	try {
+		fs.writeFileSync(fd, contents);
+		fs.fsyncSync(fd);
+	} finally {
+		fs.closeSync(fd);
+	}
+
+	try {
+		fs.renameSync(tmpPath, filePath);
+	} catch (err) {
+		try {
+			fs.unlinkSync(tmpPath);
+		} catch {
+			// Temp already gone; nothing to clean up.
+		}
+		throw err;
+	}
 }
 
 /**

--- a/apps/backend/src/helpers/config-schemas.ts
+++ b/apps/backend/src/helpers/config-schemas.ts
@@ -21,6 +21,7 @@
  */
 
 import {
+	AddonConfigSchema,
 	type DetectionMethod,
 	detectionMethodSchema,
 	isNamespacedRelayId,
@@ -142,6 +143,10 @@ export const runtimeConfigSchema = z.object({
 	kiosk_touch: z.boolean().optional(),
 	kiosk_motion: z.boolean().optional(),
 	kiosk_performance: kioskPerformanceSchema.optional(),
+
+	// Per-add-on runtime state (id -> AddonState): device-local metadata only,
+	// never the sysext `.raw` payload bytes.
+	addons: AddonConfigSchema.optional(),
 });
 
 export type RuntimeConfig = z.infer<typeof runtimeConfigSchema>;
@@ -159,6 +164,7 @@ export const RUNTIME_CONFIG_DEFAULTS: Partial<RuntimeConfig> = {
 	kiosk_touch: true,
 	kiosk_motion: true,
 	kiosk_performance: "balanced",
+	addons: {},
 };
 
 export const DEFAULT_RELAY_PROVIDER_ID = "ceralive";

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -44,6 +44,7 @@ import {
 	checkAutoStartStream,
 	srtlaSendExec,
 } from "./modules/streaming/streamloop.ts";
+import { initDeviceStats } from "./modules/system/device-stats.ts";
 import { initRevisions } from "./modules/system/revisions.ts";
 import { initHardwareMonitoring } from "./modules/system/sensors.ts";
 import { periodicCheckForSoftwareUpdates } from "./modules/system/software-updates.ts";
@@ -83,6 +84,7 @@ initPipelines();
 void initRevisions();
 // WebSocket server is now integrated with HTTP server via Bun.serve()
 initHardwareMonitoring();
+initDeviceStats();
 await initRTMPIngestStats();
 initSRTIngest();
 void getSshStatus();

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -20,6 +20,7 @@ import killall from "./helpers/killall.ts";
 import { logger } from "./helpers/logger.ts";
 import { isDevelopment } from "./mocks/mock-config.ts";
 import { initMockService } from "./mocks/mock-service.ts";
+import { runAddonReconciler } from "./modules/addons/reconciler.ts";
 import { loadConfig } from "./modules/config.ts";
 import { initRTMPIngestStats } from "./modules/ingest/rtmp.ts";
 import { initSRTIngest } from "./modules/ingest/srt.ts";
@@ -145,3 +146,13 @@ startHeartbeat();
 onHeartbeatTick(broadcastHealthIfChanged);
 
 checkAutoStartStream();
+
+// Post-boot add-on reconciler (T29): fire-and-forget. Add-ons NEVER gate boot or
+// the OS-update healthcheck/rollback, so this is a non-blocking background task
+// whose failures are swallowed inside runAddonReconciler(). The
+// ceralive-addon-reconciler.service oneshot re-triggers a pass via SIGUSR1; the
+// run self-serialises, so the boot fire and the signal can both fire harmlessly.
+void runAddonReconciler();
+process.on("SIGUSR1", function reconcileAddons() {
+	void runAddonReconciler();
+});

--- a/apps/backend/src/modules/addons/manager.ts
+++ b/apps/backend/src/modules/addons/manager.ts
@@ -1,0 +1,672 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * Add-on manager — the runtime state machine that materialises, enables and
+ * disables optional sysext add-ons on the device (T28). It is the orchestration
+ * layer over three lower trust tiers:
+ *
+ *   - the privileged `ceralive-addon-helper` root binary (T27, via
+ *     helpers/addon-helper.ts) — the ONLY component that mutates the sysext
+ *     scan dir / drives systemd units / re-verifies sig + sha256 (G-trust);
+ *   - the per-add-on runtime state persisted under config.json's `addons` key
+ *     (T23 setAddonState/removeAddonState, atomic E3 writes);
+ *   - the descriptor + state Zod schemas (T22, @ceraui/rpc/schemas).
+ *
+ * It mirrors the kiosk state machine (modules/system/kiosk.ts) deliberately:
+ *   - every OS-touching primitive is injected through {@link AddonManagerDeps}
+ *     so the whole machine is unit-testable without a board, sudo, or network;
+ *   - the SAME crash-loop discriminator (NRestarts >= threshold → mask +
+ *     auto-disable) keeps a crash-looping add-on from wedging the device;
+ *   - EVERY mutating op gates on `isRealDevice()` FIRST (G6) and returns
+ *     {@link ADDON_UNAVAILABLE_ERROR} in dev/emulated mode, never touching
+ *     systemd/sysext/the network.
+ *
+ * The manager tracks a richer lifecycle than the persisted `AddonState.phase`
+ * enum exposes; {@link toAddonState}/{@link phaseFromState} losslessly map the
+ * manager's {@link AddonManagerPhase} onto a schema-valid `AddonState` so the
+ * config file always parses (the persisted phase + `enabled` + `autoDisabled`
+ * triple encodes the manager phase).
+ */
+
+import { mkdir, rename, rm } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import type {
+	AddonDescriptor,
+	AddonPhase,
+	AddonState,
+} from "@ceraui/rpc/schemas";
+
+import {
+	ADDON_UNAVAILABLE_ERROR,
+	addonDisable,
+	addonEnable,
+} from "../../helpers/addon-helper.ts";
+import { type ExecResult, execFileP } from "../../helpers/exec.ts";
+import { logger } from "../../helpers/logger.ts";
+import { getAddons, removeAddonState, setAddonState } from "../config.ts";
+import { isRealDevice } from "../system/device-detection.ts";
+import { broadcastMsg } from "../ui/websocket-server.ts";
+
+// Re-export the helper's emulated-mode error so callers resolve the single
+// source from the manager surface (mirrors kiosk re-exporting isRealDevice).
+export { ADDON_UNAVAILABLE_ERROR };
+
+/** Returned when `/data` cannot fit the materialised add-on plus headroom. */
+export const ADDON_INSUFFICIENT_SPACE_ERROR = "addon_insufficient_space";
+/** A step in the enable pipeline threw — the add-on is parked in `failed`. */
+export const ADDON_ENABLE_FAILED_ERROR = "addon_enable_failed";
+/** A step in the disable pipeline threw. */
+export const ADDON_DISABLE_FAILED_ERROR = "addon_disable_failed";
+/** The post-enable validation probe failed — the add-on was auto-disabled. */
+export const ADDON_VALIDATION_FAILED_ERROR = "addon_validation_failed";
+/** lastError reason persisted when a crash-loop triggers the auto-disable. */
+export const ADDON_CRASH_LOOP_REASON = "addon_crash_loop";
+
+/** Broadcast channel for per-add-on state pushes. */
+export const ADDON_EVENT = "addons";
+
+/** The /data filesystem add-ons are staged on. */
+const DATA_MOUNT = "/data";
+/** Atomic download landing zone (renamed into the scan dir on verify). */
+const DATA_TMP_DIR = "/data/tmp";
+/** systemd-sysext scan dir — where a materialised `.raw` is activated from. */
+const DATA_EXT_DIR = "/data/extensions";
+
+/** 512 MiB of slack kept free on /data beyond the materialised payload (E1). */
+export const ADDON_FREE_SPACE_HEADROOM_BYTES = 512 * 1024 * 1024;
+
+/**
+ * NRestarts at/above which a failing unit is treated as a crash-loop and the
+ * add-on is masked + auto-disabled. Matches the kiosk threshold (3).
+ */
+export const ADDON_CRASH_LOOP_RESTART_THRESHOLD = 3;
+
+/** Fallback validation-probe timeout when the descriptor omits `validate.timeout`. */
+const DEFAULT_VALIDATE_TIMEOUT_MS = 10_000;
+
+/** Descriptor `units` sub-shape (unmask/enable/start lists), all optional. */
+type AddonUnits = NonNullable<AddonDescriptor["units"]>;
+
+/**
+ * Manager-level lifecycle phase. Richer than the persisted `AddonState.phase`
+ * enum: it distinguishes the user-intent + in-flight transitions the UI shows.
+ *
+ *   disabled  ── enable ──▶ enabling ──▶ enabled
+ *   enabled   ── disable ─▶ disabling ─▶ disabled
+ *   enabling/enabled ── failure ─▶ failed | auto_disabled
+ *   pending   = enable intended, not yet materialised (restored from config)
+ */
+export type AddonManagerPhase =
+	| "disabled"
+	| "pending"
+	| "enabling"
+	| "enabled"
+	| "disabling"
+	| "failed"
+	| "auto_disabled";
+
+export const ADDON_MANAGER_PHASES: readonly AddonManagerPhase[] = [
+	"disabled",
+	"pending",
+	"enabling",
+	"enabled",
+	"disabling",
+	"failed",
+	"auto_disabled",
+];
+
+/** Outcome of an enable/disable op (mirrors the RPC setter `{success,...}` shape). */
+export type AddonOpResult =
+	| { success: true; phase: AddonManagerPhase }
+	| { success: false; error: string };
+
+// ─── pure phase encoding (manager phase ⇄ schema-valid AddonState) ───────────
+
+type PhaseEncoding = {
+	enabled: boolean;
+	phase: AddonPhase;
+	autoDisabled: boolean;
+};
+
+/**
+ * The lossless encoding of each manager phase onto the persisted triple. Chosen
+ * so {@link phaseFromState} is an exact inverse — no two manager phases collide.
+ */
+const PHASE_ENCODING: Record<AddonManagerPhase, PhaseEncoding> = {
+	disabled: { enabled: false, phase: "idle", autoDisabled: false },
+	pending: { enabled: true, phase: "idle", autoDisabled: false },
+	enabling: { enabled: true, phase: "installing", autoDisabled: false },
+	enabled: { enabled: true, phase: "active", autoDisabled: false },
+	disabling: { enabled: false, phase: "disabling", autoDisabled: false },
+	failed: { enabled: true, phase: "error", autoDisabled: false },
+	auto_disabled: { enabled: false, phase: "error", autoDisabled: true },
+};
+
+/** Project a manager phase (+ optional metadata) onto a schema-valid AddonState. */
+export function toAddonState(
+	phase: AddonManagerPhase,
+	extra: {
+		versionMaterialized?: string;
+		userConfig?: Record<string, unknown>;
+		lastError?: string;
+	} = {},
+): AddonState {
+	const enc = PHASE_ENCODING[phase];
+	const state: AddonState = {
+		enabled: enc.enabled,
+		phase: enc.phase,
+		autoDisabled: enc.autoDisabled,
+	};
+	// exactOptionalPropertyTypes: only attach optionals when actually present.
+	if (extra.versionMaterialized !== undefined) {
+		state.versionMaterialized = extra.versionMaterialized;
+	}
+	if (extra.userConfig !== undefined) state.userConfig = extra.userConfig;
+	if (extra.lastError !== undefined) state.lastError = extra.lastError;
+	return state;
+}
+
+// Inverse of toAddonState. `default` (not an explicit idle case) keeps this total
+// as the persisted AddonPhase enum grows (e.g. the reconciler's `pending`, T29):
+// an enabled add-on in any idle/pending-like phase → `pending`, disabled → `disabled`.
+export function phaseFromState(state: AddonState): AddonManagerPhase {
+	if (state.autoDisabled) return "auto_disabled";
+	switch (state.phase) {
+		case "active":
+			return "enabled";
+		case "installing":
+			return "enabling";
+		case "disabling":
+			return "disabling";
+		case "error":
+			return "failed";
+		default:
+			return state.enabled ? "pending" : "disabled";
+	}
+}
+
+// ─── pure helpers (free-space, crash-loop, paths, url, df) ───────────────────
+
+/** Bytes that must be free on /data to enable: payload ×2 + 512 MiB headroom. */
+export function requiredFreeBytes(sizeInstalled: number): number {
+	return sizeInstalled * 2 + ADDON_FREE_SPACE_HEADROOM_BYTES;
+}
+
+/** E1 precheck: is there room for the materialised add-on plus headroom? */
+export function hasSufficientSpace(
+	freeBytes: number,
+	sizeInstalled: number,
+): boolean {
+	return freeBytes > requiredFreeBytes(sizeInstalled);
+}
+
+/** A failing unit with this many restarts is a crash-loop (→ auto-disable). */
+export function isAddonCrashLoop(nRestarts: number): boolean {
+	return nRestarts >= ADDON_CRASH_LOOP_RESTART_THRESHOLD;
+}
+
+/** Atomic download target for an add-on id (renamed into the scan dir on verify). */
+export function tmpArtifactPath(id: string): string {
+	return `${DATA_TMP_DIR}/${id}.raw.tmp`;
+}
+
+/** Materialised sysext payload path for an add-on id. */
+export function extArtifactPath(id: string): string {
+	return `${DATA_EXT_DIR}/${id}.raw`;
+}
+
+/** Substitute the OS VERSION_ID into the descriptor's `{os_version}` template. */
+export function resolveArtifactUrl(
+	urlTemplate: string,
+	osVersion: string,
+): string {
+	return urlTemplate.replace(/\{os_version\}/g, osVersion);
+}
+
+/** Parse the available-bytes column from `df -B1 --output=avail <mount>`. */
+export function parseDfAvail(stdout: string): number | null {
+	const lines = stdout.trim().split("\n");
+	const data = lines[lines.length - 1];
+	if (data === undefined) return null;
+	const avail = Number.parseInt(data.trim().split(/\s+/)[0] ?? "", 10);
+	return Number.isFinite(avail) ? avail : null;
+}
+
+/** All distinct unit names referenced by a descriptor (unmask ∪ enable ∪ start). */
+function allUnits(units: AddonUnits | undefined): string[] {
+	if (!units) return [];
+	return [
+		...new Set([
+			...(units.unmask ?? []),
+			...(units.start ?? []),
+			...(units.enable ?? []),
+		]),
+	];
+}
+
+// ─── injectable I/O surface ──────────────────────────────────────────────────
+
+/**
+ * Every OS/network/persistence primitive the state machine touches. Defaults
+ * talk to the real device (sudo helper, argv-only systemctl, df, fetch, atomic
+ * fs ops, config writes). Tests inject deterministic spies. Mirrors `KioskDeps`.
+ */
+export type AddonManagerDeps = {
+	/** G6 gate — true only on a real RK3588 board. */
+	isRealDevice: () => Promise<boolean>;
+	/** Free bytes on /data (E1 precheck input). */
+	getDataFreeBytes: () => Promise<number>;
+	/** OS VERSION_ID substituted into the artifact url template. */
+	getOsVersion: () => Promise<string>;
+	/** Download `url` → `destTmp` (an atomic temp under /data/tmp). */
+	download: (url: string, destTmp: string) => Promise<void>;
+	/** sha256 (+ GPG via the helper) verify the staged temp; reject on mismatch. */
+	verify: (descriptor: AddonDescriptor, tmpPath: string) => Promise<void>;
+	/** Atomic rename `tmpPath` → `destPath` in the sysext scan dir. */
+	stage: (tmpPath: string, destPath: string) => Promise<void>;
+	/** Privileged `ceralive-addon-helper enable <id>` (re-verifies + refreshes). */
+	helperEnable: (id: string) => Promise<void>;
+	/** Privileged `ceralive-addon-helper disable <id>`. */
+	helperDisable: (id: string) => Promise<void>;
+	/** argv-only `systemctl <args>` for unit unmask/start/stop/mask. */
+	systemctl: (args: string[]) => Promise<ExecResult>;
+	/** NRestarts for a unit — the crash-loop discriminator. */
+	getNRestarts: (unit: string) => Promise<number>;
+	/** Run `descriptor.validate.cmd`; resolve true on exit 0, false otherwise. */
+	runValidate: (cmd: string, timeoutMs: number) => Promise<boolean>;
+	/** Remove a staged/temp artifact (best-effort). */
+	removeArtifact: (path: string) => Promise<void>;
+	/** Current persisted state for an add-on id (to preserve userConfig/version). */
+	getState: (id: string) => AddonState | undefined;
+	/** Persist add-on state to config.json (T23, atomic E3 write). */
+	setState: (id: string, state: AddonState) => void;
+	/** Drop an add-on's persisted state (T23). */
+	removeState: (id: string) => void;
+	/** Push the add-on's state to connected clients. */
+	broadcast: (id: string, state: AddonState) => void;
+};
+
+/** Parse `NRestarts=<n>` out of `systemctl show <unit>`; 0 when unavailable. */
+async function probeNRestarts(unit: string): Promise<number> {
+	try {
+		const { stdout } = await execFileP("systemctl", [
+			"show",
+			unit,
+			"--property=NRestarts",
+		]);
+		const match = stdout.match(/NRestarts=(\d+)/);
+		return match?.[1] ? Number.parseInt(match[1], 10) : 0;
+	} catch {
+		return 0;
+	}
+}
+
+/** Read available bytes on /data via `df -B1 --output=avail`. */
+async function probeDataFreeBytes(): Promise<number> {
+	const { stdout } = await execFileP("df", [
+		"-B1",
+		"--output=avail",
+		DATA_MOUNT,
+	]);
+	const avail = parseDfAvail(stdout);
+	if (avail === null) throw new Error("failed to parse df avail for /data");
+	return avail;
+}
+
+/** Read VERSION_ID from /etc/os-release for the artifact url substitution. */
+async function probeOsVersion(): Promise<string> {
+	const text = await Bun.file("/etc/os-release").text();
+	const match = text.match(/^VERSION_ID="?([^"\n]+)"?/m);
+	if (!match?.[1]) throw new Error("VERSION_ID not found in /etc/os-release");
+	return match[1];
+}
+
+/** Fetch `url` to a temp path (parent created), rejecting on a non-2xx status. */
+async function downloadArtifact(url: string, destTmp: string): Promise<void> {
+	await mkdir(dirname(destTmp), { recursive: true });
+	const res = await fetch(url);
+	if (!res.ok) {
+		throw new Error(`download failed: HTTP ${res.status} for ${url}`);
+	}
+	await Bun.write(destTmp, res);
+}
+
+/**
+ * Local sha256 fast-fail pre-check. The privileged helper (step 6) is the
+ * AUTHORITATIVE GPG + sha256 trust anchor; this cheap unprivileged hash rejects
+ * a corrupted download before a sudo round-trip and an atomic rename.
+ */
+async function verifyArtifact(
+	descriptor: AddonDescriptor,
+	tmpPath: string,
+): Promise<void> {
+	const bytes = await Bun.file(tmpPath).bytes();
+	const digest = new Bun.CryptoHasher("sha256").update(bytes).digest("hex");
+	if (digest !== descriptor.artifact.sha256) {
+		throw new Error(
+			`sha256 mismatch for ${descriptor.id}: expected ${descriptor.artifact.sha256}, got ${digest}`,
+		);
+	}
+}
+
+/** Atomic rename into the scan dir (parent created). */
+async function stageArtifact(tmpPath: string, destPath: string): Promise<void> {
+	await mkdir(dirname(destPath), { recursive: true });
+	await rename(tmpPath, destPath);
+}
+
+/**
+ * Run the descriptor's validation command with a hard timeout. The command
+ * string comes from the GPG-signed descriptor (G-trust root), so running it via
+ * the device shell is sound; a hung probe is killed on the timeout → false.
+ */
+async function runValidateCmd(
+	cmd: string,
+	timeoutMs: number,
+): Promise<boolean> {
+	try {
+		const proc = Bun.spawn(["sh", "-c", cmd], {
+			stdin: "ignore",
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+		const timer = setTimeout(() => {
+			try {
+				proc.kill();
+			} catch {}
+		}, timeoutMs);
+		const code = await proc.exited;
+		clearTimeout(timer);
+		return code === 0;
+	} catch {
+		return false;
+	}
+}
+
+const defaultAddonManagerDeps: AddonManagerDeps = {
+	isRealDevice: () => isRealDevice(),
+	getDataFreeBytes: probeDataFreeBytes,
+	getOsVersion: probeOsVersion,
+	download: downloadArtifact,
+	verify: verifyArtifact,
+	stage: stageArtifact,
+	helperEnable: async (id) => {
+		await addonEnable(id);
+	},
+	helperDisable: async (id) => {
+		await addonDisable(id);
+	},
+	systemctl: (args) => execFileP("systemctl", args),
+	getNRestarts: probeNRestarts,
+	runValidate: runValidateCmd,
+	removeArtifact: async (path) => {
+		await rm(path, { force: true });
+	},
+	getState: (id) => getAddons()[id],
+	setState: (id, state) => setAddonState(id, state),
+	removeState: (id) => removeAddonState(id),
+	broadcast: (id, state) => broadcastMsg(ADDON_EVENT, { [id]: state }),
+};
+
+let activeDeps: AddonManagerDeps = defaultAddonManagerDeps;
+
+/** Override the injectable surface (DI for tests + the crash-loop poller). */
+export function setAddonManagerDeps(deps: Partial<AddonManagerDeps>): void {
+	activeDeps = { ...defaultAddonManagerDeps, ...deps };
+}
+
+/** Restore the real-device primitives. */
+export function resetAddonManagerDeps(): void {
+	activeDeps = defaultAddonManagerDeps;
+}
+
+// ─── live state map ──────────────────────────────────────────────────────────
+
+const livePhases = new Map<string, AddonManagerPhase>();
+
+/** Current in-memory manager phase for an add-on (`disabled` when unknown). */
+export function getAddonPhase(id: string): AddonManagerPhase {
+	return livePhases.get(id) ?? "disabled";
+}
+
+/**
+ * Commit a phase transition: persist a schema-valid AddonState (preserving the
+ * add-on's userConfig + materialised version across transitions), update the
+ * live map, and broadcast. `lastError` is set only when supplied — so it clears
+ * on every successful transition.
+ */
+function transition(
+	id: string,
+	phase: AddonManagerPhase,
+	deps: AddonManagerDeps,
+	extra: { versionMaterialized?: string; lastError?: string } = {},
+): AddonState {
+	const prev = deps.getState(id);
+	const meta: {
+		versionMaterialized?: string;
+		userConfig?: Record<string, unknown>;
+		lastError?: string;
+	} = {};
+	const version = extra.versionMaterialized ?? prev?.versionMaterialized;
+	if (version !== undefined) meta.versionMaterialized = version;
+	if (prev?.userConfig !== undefined) meta.userConfig = prev.userConfig;
+	if (extra.lastError !== undefined) meta.lastError = extra.lastError;
+
+	const state = toAddonState(phase, meta);
+	livePhases.set(id, phase);
+	deps.setState(id, state);
+	deps.broadcast(id, state);
+	return state;
+}
+
+// ─── lifecycle ops ───────────────────────────────────────────────────────────
+
+/** Unmask then start the descriptor's units (step 7 of the enable pipeline). */
+async function startUnits(
+	units: AddonUnits | undefined,
+	deps: AddonManagerDeps,
+): Promise<void> {
+	for (const unit of units?.unmask ?? []) {
+		await deps.systemctl(["unmask", unit]);
+	}
+	for (const unit of units?.start ?? []) {
+		await deps.systemctl(["start", unit]);
+	}
+}
+
+/**
+ * Safety stop for a materialised-but-unhealthy add-on (crash-loop or a failed
+ * validation probe). Mask every unit so it cannot restart, then park the add-on
+ * in `auto_disabled` with the reason — mirrors the kiosk auto-disable rule.
+ */
+async function autoDisableAddon(
+	descriptor: AddonDescriptor,
+	deps: AddonManagerDeps,
+	reason: string,
+): Promise<void> {
+	for (const unit of allUnits(descriptor.units)) {
+		try {
+			await deps.systemctl(["mask", unit]);
+		} catch (err) {
+			logger.error(
+				`addon ${descriptor.id}: failed to mask ${unit} on auto-disable: ${err}`,
+			);
+		}
+	}
+	transition(descriptor.id, "auto_disabled", deps, { lastError: reason });
+}
+
+/**
+ * Enable an add-on. Ordered pipeline, each step gated/atomic:
+ *   1. isRealDevice() (G6)               5. atomic rename → scan dir
+ *   2. free-space precheck (E1)          6. helper enable (privileged)
+ *   3. download → /data/tmp temp         7. unmask + start descriptor units
+ *   4. sha256 (+ helper GPG) verify      8. validation probe → auto-disable
+ *
+ * Any failure between steps 3–7 parks the add-on in `failed`; a failed
+ * validation probe (step 8) auto-disables it. Both persist via setState.
+ */
+export async function enableAddon(
+	descriptor: AddonDescriptor,
+	deps: AddonManagerDeps = activeDeps,
+): Promise<AddonOpResult> {
+	const id = descriptor.id;
+
+	// 1. G6 — never drive the host OS in dev/emulated mode.
+	if (!(await deps.isRealDevice())) {
+		return { success: false, error: ADDON_UNAVAILABLE_ERROR };
+	}
+
+	// 2. E1 — free-space precheck BEFORE any download or state mutation.
+	const freeBytes = await deps.getDataFreeBytes();
+	if (!hasSufficientSpace(freeBytes, descriptor.artifact.sizeInstalled)) {
+		return { success: false, error: ADDON_INSUFFICIENT_SPACE_ERROR };
+	}
+
+	transition(id, "enabling", deps);
+	const tmpPath = tmpArtifactPath(id);
+	try {
+		// 3. download artifact → atomic temp under /data/tmp.
+		const osVersion = await deps.getOsVersion();
+		const url = resolveArtifactUrl(descriptor.artifact.urlTemplate, osVersion);
+		await deps.download(url, tmpPath);
+
+		// 4. verify (local sha256 fast-fail; helper is the authoritative gate).
+		await deps.verify(descriptor, tmpPath);
+
+		// 5. atomic rename into the sysext scan dir.
+		await deps.stage(tmpPath, extArtifactPath(id));
+
+		// 6. privileged activation — re-verifies sig + sha256, refreshes sysext.
+		await deps.helperEnable(id);
+
+		// 7. unmask + start the descriptor's units (idempotent).
+		await startUnits(descriptor.units, deps);
+
+		// 8. validation probe — auto-disable a materialised-but-unhealthy add-on.
+		if (descriptor.validate) {
+			const timeoutMs = descriptor.validate.timeout
+				? descriptor.validate.timeout * 1000
+				: DEFAULT_VALIDATE_TIMEOUT_MS;
+			const healthy = await deps.runValidate(
+				descriptor.validate.cmd,
+				timeoutMs,
+			);
+			if (!healthy) {
+				await autoDisableAddon(descriptor, deps, ADDON_VALIDATION_FAILED_ERROR);
+				return { success: false, error: ADDON_VALIDATION_FAILED_ERROR };
+			}
+		}
+
+		transition(id, "enabled", deps, {
+			versionMaterialized: descriptor.version,
+		});
+		return { success: true, phase: "enabled" };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		logger.error(`addon ${id}: enable failed: ${message}`);
+		transition(id, "failed", deps, { lastError: message });
+		// Best-effort: drop the partial temp so a retry starts clean.
+		await deps.removeArtifact(tmpPath).catch(() => {});
+		return { success: false, error: ADDON_ENABLE_FAILED_ERROR };
+	}
+}
+
+/**
+ * Disable an add-on — the exact reverse of enable, idempotent: stop + mask the
+ * descriptor units, privileged helper teardown, remove the staged artifact,
+ * then drop the device-local state. Re-running on an already-disabled add-on is
+ * a harmless no-op (every step is idempotent).
+ */
+export async function disableAddon(
+	descriptor: AddonDescriptor,
+	deps: AddonManagerDeps = activeDeps,
+): Promise<AddonOpResult> {
+	const id = descriptor.id;
+
+	// G6 gate.
+	if (!(await deps.isRealDevice())) {
+		return { success: false, error: ADDON_UNAVAILABLE_ERROR };
+	}
+
+	transition(id, "disabling", deps);
+	try {
+		// stop + mask every descriptor unit (no-ops if already down).
+		for (const unit of allUnits(descriptor.units)) {
+			await deps.systemctl(["stop", unit]);
+			await deps.systemctl(["mask", unit]);
+		}
+		// privileged teardown: helper stops/masks/disables, removes .raw, refresh.
+		await deps.helperDisable(id);
+		// remove the staged artifact (idempotent best-effort).
+		await deps.removeArtifact(extArtifactPath(id));
+
+		// drop device-local state and announce the disabled add-on.
+		livePhases.set(id, "disabled");
+		deps.broadcast(id, toAddonState("disabled"));
+		deps.removeState(id);
+		return { success: true, phase: "disabled" };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		logger.error(`addon ${id}: disable failed: ${message}`);
+		transition(id, "failed", deps, { lastError: message });
+		return { success: false, error: ADDON_DISABLE_FAILED_ERROR };
+	}
+}
+
+/**
+ * One crash-loop observation for an enabled add-on: read NRestarts across its
+ * `start` units and, if any unit hit the threshold, mask + auto-disable. Gated
+ * on isRealDevice() (G6) and a no-op unless the add-on is currently `enabled`.
+ * Returns the resolved manager phase.
+ */
+export async function pollAddonCrashLoop(
+	descriptor: AddonDescriptor,
+	deps: AddonManagerDeps = activeDeps,
+): Promise<AddonManagerPhase> {
+	const id = descriptor.id;
+
+	// G6 — never probe systemd off-device.
+	if (!(await deps.isRealDevice())) return getAddonPhase(id);
+	// Only a running add-on can crash-loop.
+	if (getAddonPhase(id) !== "enabled") return getAddonPhase(id);
+
+	let maxRestarts = 0;
+	for (const unit of descriptor.units?.start ?? []) {
+		maxRestarts = Math.max(maxRestarts, await deps.getNRestarts(unit));
+	}
+
+	if (isAddonCrashLoop(maxRestarts)) {
+		await autoDisableAddon(descriptor, deps, ADDON_CRASH_LOOP_REASON);
+		return "auto_disabled";
+	}
+	return getAddonPhase(id);
+}
+
+/**
+ * Restore live phases from persisted config on backend startup — seeds the live
+ * map so the UI renders instantly without re-probing every add-on. Never drives
+ * the OS; an unhealthy add-on is reconciled lazily by {@link pollAddonCrashLoop}.
+ */
+export function initAddonManager(): void {
+	livePhases.clear();
+	for (const [id, state] of Object.entries(getAddons())) {
+		livePhases.set(id, phaseFromState(state));
+	}
+}

--- a/apps/backend/src/modules/addons/reconciler.ts
+++ b/apps/backend/src/modules/addons/reconciler.ts
@@ -1,0 +1,398 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * Post-boot add-on reconciler (T29).
+ *
+ * After an OTA the device may carry a NEW OS VERSION_ID while /data (and the
+ * add-on desired-state under config.json's `addons` key, T23) survives across
+ * the A/B switch. A sysext built for the previous os_version will not merge on
+ * the new OS, so any enabled add-on whose staged `/data/extensions/<id>.raw` is
+ * missing or was fetched for a different VERSION_ID must be re-materialised.
+ *
+ * HARD CONTRACT — add-ons NEVER gate boot or the OS-update healthcheck/rollback.
+ * This runs as a fire-and-forget background task off the CeraUI startup path;
+ * every failure is caught and downgraded to a persisted `pending` phase. The
+ * reconciler can fail completely and the device still boots and still rolls back
+ * a bad OS update on its own schedule.
+ *
+ * The whole effectful surface (device gate, streaming state, OS version, baked
+ * descriptor, fetch/verify/stage, helper refresh, state persistence) is injected
+ * via {@link ReconcilerDeps} — mirroring addon-helper.ts / device-detection.ts —
+ * so the decision logic is unit-tested without a board, a network, or sudo. The
+ * default deps are assembled lazily (dynamic import) so importing this module in
+ * a test never pulls the streaming/config graph or requires setup.json.
+ */
+
+import fs from "node:fs";
+
+import {
+	type AddonConfig,
+	type AddonDescriptor,
+	AddonDescriptorSchema,
+	type AddonPhase,
+	type AddonState,
+} from "@ceraui/rpc/schemas";
+
+import { addonRefresh } from "../../helpers/addon-helper.ts";
+import { execFileP } from "../../helpers/exec.ts";
+import { logger } from "../../helpers/logger.ts";
+import { isRealDevice } from "../system/device-detection.ts";
+
+/** Persisted on `lastError` when no compatible artifact exists for the live OS. */
+export const ADDON_NOT_AVAILABLE_FOR_OS_VERSION =
+	"addon_not_available_for_os_version";
+/** Persisted on `lastError` when a refresh is deferred because a stream is live. */
+export const ADDON_REFRESH_DEFERRED_STREAMING =
+	"addon_refresh_deferred_streaming";
+/** Persisted on `lastError` when the baked descriptor for an id is unreadable. */
+export const ADDON_DESCRIPTOR_UNAVAILABLE = "addon_descriptor_unavailable";
+
+// Device-default filesystem locations (mirror ceralive-addon-helper, T27).
+const OS_RELEASE_PATH = "/etc/os-release";
+const REGISTRY_DIR = "/usr/share/ceralive/addons";
+const STAGE_DIR = "/data/extensions";
+const CACHE_DIR = "/var/cache/ceralive/addons";
+const KEYRING = "/usr/share/ceralive/addon-keyring.gpg";
+
+const FETCH_TIMEOUT_MS = 60_000;
+const MAX_SIG_BYTES = 64 * 1024;
+
+/** Fetch + verify + stage one add-on artifact for a given OS version / board. */
+export type MaterialiseArgs = {
+	descriptor: AddonDescriptor;
+	osVersion: string;
+	board: string;
+};
+
+/**
+ * Injectable surface. Defaults talk to the real OS; tests inject deterministic
+ * stand-ins and spies.
+ */
+export type ReconcilerDeps = {
+	/** RK3588-board gate (G6); reconciliation is a no-op in dev/emulated mode. */
+	isRealDevice: () => Promise<boolean>;
+	/** Live-stream guard — a disruptive refresh is deferred while true. */
+	getIsStreaming: () => boolean;
+	/** The live OS VERSION_ID (from /etc/os-release). */
+	getOsVersionId: () => Promise<string>;
+	/** Board token substituted into the artifact url's `{board}` placeholder. */
+	getBoard: () => string;
+	/** Desired add-on state (config.json `addons`, T23). */
+	getAddons: () => AddonConfig;
+	/** Read + validate the image-baked descriptor for an id. */
+	readDescriptor: (id: string) => Promise<AddonDescriptor>;
+	/** Whether the staged `/data/extensions/<id>.raw` exists. */
+	rawExists: (id: string) => Promise<boolean>;
+	/** Fetch, verify (sha256 + GPG), and atomically stage the artifact. */
+	fetchAndStage: (args: MaterialiseArgs) => Promise<void>;
+	/** Run `systemd-sysext refresh` via the privileged helper. */
+	refresh: () => Promise<void>;
+	/** Persist an add-on's runtime state. */
+	setState: (id: string, state: AddonState) => void;
+	log: (msg: string) => void;
+};
+
+type StatePatch = {
+	phase: AddonPhase;
+	// null = clear; undefined = keep prev; string = set.
+	lastError?: string | null;
+	osVersionMaterialized?: string;
+	versionMaterialized?: string;
+};
+
+/**
+ * Build the next AddonState from the previous one + a patch. Written field-by-
+ * field (rather than spread) because `exactOptionalPropertyTypes` forbids
+ * assigning `undefined` to clear an optional — an absent key is the only way to
+ * clear `lastError`.
+ */
+function buildState(prev: AddonState, patch: StatePatch): AddonState {
+	const next: AddonState = {
+		enabled: prev.enabled,
+		phase: patch.phase,
+		autoDisabled: prev.autoDisabled,
+	};
+	if (prev.userConfig !== undefined) next.userConfig = prev.userConfig;
+
+	const versionMaterialized =
+		patch.versionMaterialized ?? prev.versionMaterialized;
+	if (versionMaterialized !== undefined)
+		next.versionMaterialized = versionMaterialized;
+
+	const osVersionMaterialized =
+		patch.osVersionMaterialized ?? prev.osVersionMaterialized;
+	if (osVersionMaterialized !== undefined)
+		next.osVersionMaterialized = osVersionMaterialized;
+
+	if (patch.lastError === null) {
+		// cleared — omit the key
+	} else if (patch.lastError !== undefined) {
+		next.lastError = patch.lastError;
+	} else if (prev.lastError !== undefined) {
+		next.lastError = prev.lastError;
+	}
+	return next;
+}
+
+async function reconcileOne(
+	id: string,
+	prev: AddonState,
+	osVersion: string,
+	board: string,
+	deps: ReconcilerDeps,
+): Promise<void> {
+	let descriptor: AddonDescriptor;
+	try {
+		descriptor = await deps.readDescriptor(id);
+	} catch (err) {
+		deps.log(`addon reconciler: ${id} descriptor unavailable: ${String(err)}`);
+		deps.setState(
+			id,
+			buildState(prev, {
+				phase: "error",
+				lastError: ADDON_DESCRIPTOR_UNAVAILABLE,
+			}),
+		);
+		return;
+	}
+
+	// G1 — exact OS VERSION_ID match. A descriptor that declares its compatible
+	// versions and does not list the live one has no artifact to fetch: pending.
+	if (
+		descriptor.compatibleOsVersions &&
+		!descriptor.compatibleOsVersions.includes(osVersion)
+	) {
+		deps.setState(
+			id,
+			buildState(prev, {
+				phase: "pending",
+				lastError: ADDON_NOT_AVAILABLE_FOR_OS_VERSION,
+			}),
+		);
+		return;
+	}
+
+	// Already materialised for the live VERSION_ID (exact match) → nothing to do.
+	const rawPresent = await deps.rawExists(id);
+	if (rawPresent && prev.osVersionMaterialized === osVersion) {
+		if (prev.phase !== "active" || prev.lastError !== undefined) {
+			deps.setState(id, buildState(prev, { phase: "active", lastError: null }));
+		}
+		return;
+	}
+
+	// (Re)materialisation is needed and is disruptive (a sysext refresh re-merges
+	// /usr). Defer while a stream is live; retry on the next boot.
+	if (deps.getIsStreaming()) {
+		deps.log(`addon reconciler: ${id} deferred (stream live); retry next boot`);
+		deps.setState(
+			id,
+			buildState(prev, {
+				phase: "pending",
+				lastError: ADDON_REFRESH_DEFERRED_STREAMING,
+			}),
+		);
+		return;
+	}
+
+	try {
+		await deps.fetchAndStage({ descriptor, osVersion, board });
+		await deps.refresh();
+	} catch (err) {
+		// 404 / network / verification failure: no usable artifact for this OS.
+		// Set pending and move on — never block.
+		deps.log(
+			`addon reconciler: ${id} not available for os ${osVersion}: ${String(err)}`,
+		);
+		deps.setState(
+			id,
+			buildState(prev, {
+				phase: "pending",
+				lastError: ADDON_NOT_AVAILABLE_FOR_OS_VERSION,
+			}),
+		);
+		return;
+	}
+
+	deps.setState(
+		id,
+		buildState(prev, {
+			phase: "active",
+			lastError: null,
+			osVersionMaterialized: osVersion,
+			versionMaterialized: descriptor.version,
+		}),
+	);
+	deps.log(`addon reconciler: ${id} materialised for os ${osVersion}`);
+}
+
+let inFlight = false;
+
+/**
+ * Reconcile every enabled add-on against the live OS VERSION_ID. Idempotent,
+ * never throws, and self-serialises (a second concurrent call is a no-op) so the
+ * boot hook and the oneshot SIGUSR1 trigger can both fire harmlessly.
+ */
+export async function runAddonReconciler(deps?: ReconcilerDeps): Promise<void> {
+	if (inFlight) return;
+	inFlight = true;
+	try {
+		const d = deps ?? (await buildDefaultDeps());
+
+		if (!(await d.isRealDevice())) {
+			d.log("addon reconciler: skipped (emulated / not a real device)");
+			return;
+		}
+
+		let osVersion: string;
+		try {
+			osVersion = await d.getOsVersionId();
+		} catch (err) {
+			d.log(
+				`addon reconciler: cannot read OS VERSION_ID, skipping: ${String(err)}`,
+			);
+			return;
+		}
+
+		const board = d.getBoard();
+		for (const [id, state] of Object.entries(d.getAddons())) {
+			// Only desired (enabled) add-ons; respect a system auto-disable.
+			if (!state.enabled || state.autoDisabled) continue;
+			try {
+				await reconcileOne(id, state, osVersion, board, d);
+			} catch (err) {
+				// One add-on must never abort the loop or escape to the boot path.
+				d.log(`addon reconciler: ${id} unexpected error: ${String(err)}`);
+			}
+		}
+	} catch (err) {
+		// Whole-run failure is swallowed: add-ons NEVER gate boot / OTA rollback.
+		logger.error(`addon reconciler aborted (non-fatal): ${String(err)}`);
+	} finally {
+		inFlight = false;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Default (real-device) dependency implementations.
+// ---------------------------------------------------------------------------
+
+async function buildDefaultDeps(): Promise<ReconcilerDeps> {
+	// Dynamic import keeps the heavy streaming/config graph (and setup.json's
+	// required top-level load) out of the module's static import set, so tests
+	// that inject their own deps never trigger it.
+	const [streaming, config, setupMod] = await Promise.all([
+		import("../streaming/streaming.ts"),
+		import("../config.ts"),
+		import("../setup.ts"),
+	]);
+
+	return {
+		isRealDevice: () => isRealDevice(),
+		getIsStreaming: () => streaming.getIsStreaming(),
+		getOsVersionId: readOsVersionId,
+		getBoard: () => setupMod.setup.hw,
+		getAddons: () => config.getAddons(),
+		readDescriptor: readBakedDescriptor,
+		rawExists: (id) => Bun.file(`${STAGE_DIR}/${id}.raw`).exists(),
+		fetchAndStage: fetchAndStageArtifact,
+		refresh: async () => {
+			await addonRefresh();
+		},
+		setState: (id, state) => config.setAddonState(id, state),
+		log: (msg) => logger.info(msg),
+	};
+}
+
+async function readOsVersionId(): Promise<string> {
+	const txt = await Bun.file(OS_RELEASE_PATH).text();
+	const m = txt.match(/^VERSION_ID=(.*)$/m);
+	if (!m) throw new Error("VERSION_ID missing from /etc/os-release");
+	return m[1].trim().replace(/^"(.*)"$/, "$1");
+}
+
+async function readBakedDescriptor(id: string): Promise<AddonDescriptor> {
+	const raw = await Bun.file(`${REGISTRY_DIR}/${id}.json`).json();
+	return AddonDescriptorSchema.parse(raw);
+}
+
+// `{os_version}` / `{board}` are bare tokens (OS_VERSION_RE / hw enum), so
+// encodeURIComponent is effectively identity here — kept as defence in depth.
+function substitutePlaceholders(
+	template: string,
+	osVersion: string,
+	board: string,
+): string {
+	return template
+		.replace(/\{os_version\}/g, encodeURIComponent(osVersion))
+		.replace(/\{board\}/g, encodeURIComponent(board));
+}
+
+async function fetchCapped(url: string, maxBytes: number): Promise<Uint8Array> {
+	const res = await fetch(url, {
+		signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+	});
+	if (!res.ok) throw new Error(`fetch ${url} failed: HTTP ${res.status}`);
+	const buf = new Uint8Array(await res.arrayBuffer());
+	if (buf.byteLength > maxBytes) {
+		throw new Error(
+			`artifact exceeds declared sizeDownload (${buf.byteLength} > ${maxBytes})`,
+		);
+	}
+	return buf;
+}
+
+async function fetchAndStageArtifact(args: MaterialiseArgs): Promise<void> {
+	const { descriptor, osVersion, board } = args;
+	const id = descriptor.id;
+	const rawUrl = substitutePlaceholders(
+		descriptor.artifact.urlTemplate,
+		osVersion,
+		board,
+	);
+	const sigUrl = substitutePlaceholders(
+		descriptor.artifact.gpgSigRef,
+		osVersion,
+		board,
+	);
+
+	const rawBytes = await fetchCapped(rawUrl, descriptor.artifact.sizeDownload);
+	const digest = new Bun.CryptoHasher("sha256").update(rawBytes).digest("hex");
+	if (digest !== descriptor.artifact.sha256) {
+		throw new Error(`sha256 mismatch for ${id}`);
+	}
+	const sigBytes = await fetchCapped(sigUrl, MAX_SIG_BYTES);
+
+	await fs.promises.mkdir(CACHE_DIR, { recursive: true });
+	const cacheRaw = `${CACHE_DIR}/${id}.raw`;
+	const cacheSig = `${cacheRaw}.sig`;
+	await Bun.write(cacheRaw, rawBytes);
+	await Bun.write(cacheSig, sigBytes);
+
+	// Detached-signature check against the image-baked add-on keyring (argv-only;
+	// rejects on non-zero exit). The privileged helper re-verifies on refresh.
+	await execFileP("gpgv", ["--keyring", KEYRING, cacheSig, cacheRaw]);
+
+	// Atomic publish into the persistent sysext store: temp + rename in-dir so a
+	// crash never leaves a half-written .raw for systemd-sysext to merge (E3).
+	await fs.promises.mkdir(STAGE_DIR, { recursive: true });
+	const stageRaw = `${STAGE_DIR}/${id}.raw`;
+	const stageTmp = `${STAGE_DIR}/.${id}.raw.${process.pid}.tmp`;
+	await Bun.write(stageTmp, rawBytes);
+	await fs.promises.rename(stageTmp, stageRaw);
+}

--- a/apps/backend/src/modules/config.ts
+++ b/apps/backend/src/modules/config.ts
@@ -17,7 +17,12 @@
 
 import fs from "node:fs";
 
-import { loadJsonConfig } from "../helpers/config-loader.ts";
+import type { AddonConfig, AddonState } from "@ceraui/rpc/schemas";
+
+import {
+	loadJsonConfig,
+	writeFileAtomicSync,
+} from "../helpers/config-loader.ts";
 import {
 	RUNTIME_CONFIG_DEFAULTS,
 	type RuntimeConfig,
@@ -75,10 +80,26 @@ export function saveConfig() {
 		ssh_pass_hash: getSshPasswordHash(),
 	};
 	// Must stay sync: sync callers (setBitrate/setAutostart) depend on the write
-	// finishing before return, and Bun.write() is async-only.
-	fs.writeFileSync(CONFIG_FILE, JSON.stringify(dataToSave));
+	// finishing before return. Atomic (temp+fsync+rename) so a crash mid-write
+	// can't corrupt config.json — add-on state lives here too (E3).
+	writeFileAtomicSync(CONFIG_FILE, JSON.stringify(dataToSave));
 }
 
 export function getConfig(): RuntimeConfig {
 	return config;
+}
+
+export function getAddons(): AddonConfig {
+	return config.addons ?? {};
+}
+
+export function setAddonState(id: string, state: AddonState): void {
+	config.addons = { ...getAddons(), [id]: state };
+	saveConfig();
+}
+
+export function removeAddonState(id: string): void {
+	const { [id]: _removed, ...rest } = getAddons();
+	config.addons = rest;
+	saveConfig();
 }

--- a/apps/backend/src/modules/system/apt-package-name.ts
+++ b/apps/backend/src/modules/system/apt-package-name.ts
@@ -1,0 +1,7 @@
+// Debian package-name charset (letters, digits, and `. + : ~ -`); rejects
+// whitespace and shell metacharacters in poisoned/malformed apt output.
+// Kept in its own side-effect-free module so the add-on descriptor schema in
+// @ceraui/rpc can reuse the exact same pattern without importing the
+// software-updates module graph (which loads config/network/streaming at
+// import time). Single source of truth — never copy this charset (G5).
+export const APT_PACKAGE_NAME_RE = /^[A-Za-z0-9.+:~-]+$/;

--- a/apps/backend/src/modules/system/device-stats.ts
+++ b/apps/backend/src/modules/system/device-stats.ts
@@ -1,0 +1,387 @@
+/*
+    CeraUI - web UI for the CERALIVE project
+    Copyright (C) 2024-2025 CeraLive project
+
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * Device stats — exactly FIVE signals, broadcast on a 5s `device-stats` event.
+ *
+ * S1 lock: this module emits ONLY {disk, cpuLoad1, socTemp, ifaceRxTx, raucSlot}.
+ * No per-core freq, GPU util, mem pressure, modem signal, swap, etc. Adding a
+ * sixth field is a deliberate contract change, not a tweak.
+ *
+ * Design: every collector is a pure parse function over injected I/O
+ * (`DeviceStatsDeps`), so the whole payload is unit-testable with no real
+ * hardware. `collectDeviceStats` wraps each signal in its own try/catch and
+ * degrades to `null` on any failure — a missing /sys path or an absent `rauc`
+ * binary must never crash the sampling loop.
+ *
+ * socTemp is WIRED from sensors.ts (already broadcasting "SoC temperature" at
+ * 1s) via `getSocTempRaw` — we do NOT read /sys/class/thermal a second time.
+ */
+
+import { execFileP } from "../../helpers/exec.ts";
+import { logger } from "../../helpers/logger.ts";
+import { ACTIVE_TO } from "../../helpers/shared.ts";
+import { getms } from "../../helpers/time.ts";
+import { DEVICE_STATS_EVENT } from "../../rpc/events.ts";
+import { broadcastMsg } from "../ui/websocket-server.ts";
+import { getSensors } from "./sensors.ts";
+
+/** Broadcast cadence for the `device-stats` event. */
+export const DEVICE_STATS_INTERVAL_MS = 5000;
+
+/** Key under which sensors.ts publishes the SoC temperature string. */
+const SOC_TEMP_SENSOR_KEY = "SoC temperature";
+
+/** Filesystem whose usage we report. */
+const DATA_MOUNT = "/data";
+
+export type DiskType = "SSD" | "HDD" | "eMMC" | "unknown";
+
+export type DiskStat = {
+	/** Bytes used on the /data filesystem. */
+	used: number;
+	/** Total bytes on the /data filesystem. */
+	total: number;
+	/** Backing media classification. */
+	type: DiskType;
+};
+
+export type IfaceRxTxStat = {
+	/** Active interface name (e.g. "eth0"). */
+	iface: string;
+	/** Receive rate in bytes/second over the last sampling interval. */
+	rxBytesPerSec: number;
+	/** Transmit rate in bytes/second over the last sampling interval. */
+	txBytesPerSec: number;
+};
+
+/**
+ * The complete device-stats payload. Keys are FROZEN by S1 — exactly five.
+ * Every field is independently nullable: an unavailable source reports `null`
+ * (or `"unavailable"` for raucSlot) rather than failing the whole tick.
+ */
+export type DeviceStatsPayload = {
+	disk: DiskStat | null;
+	cpuLoad1: number | null;
+	socTemp: number | null;
+	ifaceRxTx: IfaceRxTxStat | null;
+	raucSlot: string;
+};
+
+/** Injected I/O surface — replaced wholesale in tests. */
+export type DeviceStatsDeps = {
+	/** Read a file as text (Bun.file().text() in production). */
+	readText: (path: string) => Promise<string>;
+	/** argv-only exec (execFileP in production — NO shell). */
+	execFile: (
+		file: string,
+		args: readonly string[],
+	) => Promise<{ stdout: string; stderr: string }>;
+	/** Wire to sensors.ts SoC temperature — NOT a second thermal read. */
+	getSocTempRaw: () => string | undefined;
+	/** Monotonic-enough clock (ms) for the rx/tx rate delta. */
+	now: () => number;
+};
+
+/** Cross-tick state: previous /proc/net/dev snapshot for the rate delta. */
+export type DeviceStatsState = {
+	prevNetDev?: { time: number; ifaces: Map<string, NetDevCounters> };
+};
+
+export function createDeviceStatsState(): DeviceStatsState {
+	return {};
+}
+
+// ─── pure parsers (exported for tests) ──────────────────────────────────────
+
+/** Parse `/proc/loadavg` → the 1-minute load average. */
+export function parseLoadAvg(text: string): number | null {
+	const first = text.trim().split(/\s+/)[0];
+	if (first === undefined) return null;
+	const n = Number.parseFloat(first);
+	return Number.isFinite(n) ? n : null;
+}
+
+/** Parse sensors.ts "45.1 °C" → 45.1. Returns null when absent/unparseable. */
+export function parseSocTemp(raw: string | undefined): number | null {
+	if (raw === undefined) return null;
+	const n = Number.parseFloat(raw);
+	return Number.isFinite(n) ? n : null;
+}
+
+export type DfParsed = { used: number; total: number; source: string };
+
+/**
+ * Parse `df -B1 --output=used,size,source <mount>`:
+ *
+ *         Used         Size Source
+ *   1234567890  10000000000 /dev/mmcblk0p2
+ */
+export function parseDfOutput(stdout: string): DfParsed | null {
+	const lines = stdout.trim().split("\n");
+	const data = lines[lines.length - 1];
+	if (data === undefined) return null;
+	const cols = data.trim().split(/\s+/);
+	if (cols.length < 3) return null;
+	const used = Number.parseInt(cols[0] ?? "", 10);
+	const total = Number.parseInt(cols[1] ?? "", 10);
+	const source = cols[2] ?? "";
+	if (!Number.isFinite(used) || !Number.isFinite(total)) return null;
+	return { used, total, source };
+}
+
+/**
+ * Reduce a partition source (`/dev/mmcblk0p2`, `/dev/sda1`, `/dev/nvme0n1p3`)
+ * to its parent block device name (`mmcblk0`, `sda`, `nvme0n1`) — the name
+ * under /sys/block. Returns null for anything that is not a /dev/ node.
+ */
+export function blockDeviceFromSource(source: string): string | null {
+	const dev = source.replace(/^\/dev\//, "");
+	if (dev === source) return null; // not a /dev/ path (tmpfs, overlay, …)
+	let m = dev.match(/^(nvme\d+n\d+)(p\d+)?$/);
+	if (m?.[1]) return m[1];
+	m = dev.match(/^(mmcblk\d+)(p\d+)?$/);
+	if (m?.[1]) return m[1];
+	m = dev.match(/^(sd[a-z]+)\d*$/);
+	if (m?.[1]) return m[1];
+	return dev;
+}
+
+/**
+ * Classify backing media from the block device name + its
+ * `queue/rotational` flag ("0" non-rotational, "1" spinning).
+ */
+export function classifyDiskType(
+	blockDev: string | null,
+	rotational: string | null,
+): DiskType {
+	if (blockDev === null) return "unknown";
+	if (blockDev.startsWith("mmcblk")) return "eMMC";
+	if (blockDev.startsWith("nvme")) return "SSD";
+	if (rotational === null) return "unknown";
+	const r = rotational.trim();
+	if (r === "1") return "HDD";
+	if (r === "0") return "SSD";
+	return "unknown";
+}
+
+export type NetDevCounters = { rx: number; tx: number };
+
+/**
+ * Parse `/proc/net/dev` into per-interface rx/tx byte counters. Skips the two
+ * header lines and the loopback interface.
+ */
+export function parseProcNetDev(text: string): Map<string, NetDevCounters> {
+	const out = new Map<string, NetDevCounters>();
+	for (const line of text.split("\n")) {
+		const idx = line.indexOf(":");
+		if (idx < 0) continue; // header / blank lines have no "iface:"
+		const name = line.slice(0, idx).trim();
+		if (name === "" || name === "lo") continue;
+		const fields = line
+			.slice(idx + 1)
+			.trim()
+			.split(/\s+/);
+		// /proc/net/dev column layout: rx bytes is field 0, tx bytes is field 8.
+		const rx = Number.parseInt(fields[0] ?? "", 10);
+		const tx = Number.parseInt(fields[8] ?? "", 10);
+		if (!Number.isFinite(rx) || !Number.isFinite(tx)) continue;
+		out.set(name, { rx, tx });
+	}
+	return out;
+}
+
+/**
+ * Compute the rx/tx rate for the single most-active interface from two
+ * /proc/net/dev snapshots. "Active" = the interface with the largest total
+ * byte counter in the current snapshot (excluding lo, already filtered out).
+ * Returns null when there is no positive elapsed time or no interface.
+ */
+export function computeIfaceRates(
+	prev: Map<string, NetDevCounters>,
+	cur: Map<string, NetDevCounters>,
+	dtSec: number,
+): IfaceRxTxStat | null {
+	if (dtSec <= 0) return null;
+
+	let bestIface: string | null = null;
+	let bestTotal = -1;
+	for (const [name, c] of cur) {
+		const total = c.rx + c.tx;
+		if (total > bestTotal) {
+			bestTotal = total;
+			bestIface = name;
+		}
+	}
+	if (bestIface === null) return null;
+
+	const curC = cur.get(bestIface);
+	const prevC = prev.get(bestIface);
+	if (!curC) return null;
+	// New interface with no baseline → 0 rate this tick (not a crash).
+	const rxDelta = prevC ? curC.rx - prevC.rx : 0;
+	const txDelta = prevC ? curC.tx - prevC.tx : 0;
+	return {
+		iface: bestIface,
+		// Counter resets (negative delta) clamp to 0.
+		rxBytesPerSec: Math.max(0, Math.round(rxDelta / dtSec)),
+		txBytesPerSec: Math.max(0, Math.round(txDelta / dtSec)),
+	};
+}
+
+/**
+ * Parse `rauc status --output-format=json` → the booted slot identifier.
+ * Falls back to `boot_primary`. Returns null when neither is present.
+ */
+export function parseRaucSlot(stdout: string): string | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(stdout);
+	} catch {
+		return null;
+	}
+	if (parsed === null || typeof parsed !== "object") return null;
+	const obj = parsed as Record<string, unknown>;
+	if (typeof obj.booted === "string" && obj.booted !== "") return obj.booted;
+	if (typeof obj.boot_primary === "string" && obj.boot_primary !== "") {
+		return obj.boot_primary;
+	}
+	return null;
+}
+
+// ─── per-signal collectors (each degrades to null/"unavailable") ─────────────
+
+async function collectDisk(deps: DeviceStatsDeps): Promise<DiskStat | null> {
+	try {
+		const { stdout } = await deps.execFile("df", [
+			"-B1",
+			"--output=used,size,source",
+			DATA_MOUNT,
+		]);
+		const df = parseDfOutput(stdout);
+		if (!df) return null;
+
+		const blockDev = blockDeviceFromSource(df.source);
+		let rotational: string | null = null;
+		if (blockDev) {
+			try {
+				rotational = await deps.readText(
+					`/sys/block/${blockDev}/queue/rotational`,
+				);
+			} catch {
+				rotational = null;
+			}
+		}
+		return {
+			used: df.used,
+			total: df.total,
+			type: classifyDiskType(blockDev, rotational),
+		};
+	} catch {
+		return null;
+	}
+}
+
+async function collectCpuLoad1(deps: DeviceStatsDeps): Promise<number | null> {
+	try {
+		return parseLoadAvg(await deps.readText("/proc/loadavg"));
+	} catch {
+		return null;
+	}
+}
+
+async function collectIfaceRxTx(
+	deps: DeviceStatsDeps,
+	state: DeviceStatsState,
+): Promise<IfaceRxTxStat | null> {
+	try {
+		const now = deps.now();
+		const ifaces = parseProcNetDev(await deps.readText("/proc/net/dev"));
+		const prev = state.prevNetDev;
+		state.prevNetDev = { time: now, ifaces };
+		if (!prev) return null; // first sample establishes the baseline only
+		return computeIfaceRates(prev.ifaces, ifaces, (now - prev.time) / 1000);
+	} catch {
+		return null;
+	}
+}
+
+async function collectRaucSlot(deps: DeviceStatsDeps): Promise<string> {
+	try {
+		const { stdout } = await deps.execFile("rauc", [
+			"status",
+			"--output-format=json",
+		]);
+		return parseRaucSlot(stdout) ?? "unavailable";
+	} catch {
+		// rauc not installed / non-zero exit → graceful "unavailable".
+		return "unavailable";
+	}
+}
+
+/**
+ * Collect all five signals. Each is isolated: one failing source yields a null
+ * (or "unavailable") field, never a thrown tick. socTemp is read from the
+ * injected sensors value — there is no second /sys/class/thermal read here.
+ */
+export async function collectDeviceStats(
+	deps: DeviceStatsDeps,
+	state: DeviceStatsState,
+): Promise<DeviceStatsPayload> {
+	const [disk, cpuLoad1, ifaceRxTx, raucSlot] = await Promise.all([
+		collectDisk(deps),
+		collectCpuLoad1(deps),
+		collectIfaceRxTx(deps, state),
+		collectRaucSlot(deps),
+	]);
+	const socTemp = parseSocTemp(deps.getSocTempRaw());
+	return { disk, cpuLoad1, socTemp, ifaceRxTx, raucSlot };
+}
+
+// ─── production wiring ───────────────────────────────────────────────────────
+
+export const defaultDeviceStatsDeps: DeviceStatsDeps = {
+	readText: (path) => Bun.file(path).text(),
+	execFile: (file, args) => execFileP(file, args),
+	getSocTempRaw: () => getSensors()[SOC_TEMP_SENSOR_KEY],
+	now: () => Date.now(),
+};
+
+const deviceStatsState = createDeviceStatsState();
+
+/**
+ * Start the 5s `device-stats` broadcast loop. Mirrors the sensors/netif
+ * pattern: an immediate first tick (after the baseline rx/tx sample lands)
+ * then a fixed interval. Coalescing (5s window) lives in rpc/coalesce.ts.
+ */
+export function initDeviceStats(): void {
+	const tick = async () => {
+		try {
+			const payload = await collectDeviceStats(
+				defaultDeviceStatsDeps,
+				deviceStatsState,
+			);
+			broadcastMsg(DEVICE_STATS_EVENT, payload, getms() - ACTIVE_TO);
+		} catch (err) {
+			logger.error(`device-stats tick failed: ${err}`);
+		}
+	};
+
+	void tick();
+	setInterval(tick, DEVICE_STATS_INTERVAL_MS);
+}

--- a/apps/backend/src/modules/system/kiosk.ts
+++ b/apps/backend/src/modules/system/kiosk.ts
@@ -16,9 +16,12 @@
 */
 
 /* Kiosk toggle state machine (DC-2 — docs/KIOSK_STATE_MACHINE.md) */
+import { readFileSync } from "node:fs";
 import { rm } from "node:fs/promises";
 
 import {
+	type AddonDescriptor,
+	AddonDescriptorSchema,
 	KIOSK_CRASH_LOOP_RESTART_THRESHOLD,
 	KIOSK_POLL_INTERVAL_MS,
 	type KioskConfigureInput,
@@ -28,6 +31,11 @@ import {
 
 import { type ExecResult, execFileP } from "../../helpers/exec.ts";
 import { logger } from "../../helpers/logger.ts";
+import {
+	type AddonOpResult,
+	disableAddon as managerDisableAddon,
+	enableAddon as managerEnableAddon,
+} from "../addons/manager.ts";
 import { getConfig, saveConfig } from "../config.ts";
 import { broadcastMsg } from "../ui/websocket-server.ts";
 
@@ -40,9 +48,22 @@ export {
 	isRealDevice,
 } from "./device-detection.ts";
 
-// The systemd unit CeraUI drives. Cage is NEVER started by any other path — the
-// backend only ever toggles this unit (DC-1: the image owns the chassis).
+// The systemd unit the DC-2 failure-observation poll loop watches for live
+// state. Its lifecycle is driven by the cog-display add-on (DC-1: the image owns
+// the chassis); the backend never starts cage by any other path.
 const KIOSK_SERVICE = "kiosk.service";
+
+// The on-device display engine ships as the managed `cog-display` add-on; the
+// add-on manager owns its sysext lifecycle. The DC-2 state machine wraps that
+// with the 5-state poll loop, crash-loop auto-disable, display/touch/motion/
+// performance profiles, and OSK.
+const COG_DISPLAY_ADDON_ID = "cog-display";
+
+// Image-baked descriptor (T37) defining the display engine's units + signed
+// sysext artifact. Read + schema-validated at toggle time; only reached on a
+// real device, since the kiosk RPC handlers gate on isRealDevice() first (G6).
+const COG_DISPLAY_DESCRIPTOR_PATH =
+	"/usr/share/ceralive/addons/cog-display.json";
 
 // tmpfs marker written by the unit's OnFailure handler when cage exits because
 // no DRM output was found. Distinguishes display-unplug from a crash-loop.
@@ -77,7 +98,36 @@ export type KioskDeps = {
 	oskSignal: (signal: OskSignal) => Promise<void>;
 	/** Emit the current kiosk status to all clients. */
 	broadcast: (status: KioskStatus) => void;
+	/** Read + schema-validate the baked cog-display descriptor; null if absent. */
+	loadCogDescriptor: () => AddonDescriptor | null;
+	/** Enable the cog-display add-on via the add-on manager (T28). */
+	enableAddon: (descriptor: AddonDescriptor) => Promise<AddonOpResult>;
+	/** Disable the cog-display add-on via the add-on manager (T28). */
+	disableAddon: (descriptor: AddonDescriptor) => Promise<AddonOpResult>;
 };
+
+// Synchronous (not Bun.file().text()) so the manager enable/disable call is
+// issued in the same tick as the persisted-state commit — the RPC handler fires
+// kioskStart/kioskStop fire-and-forget. Returns null instead of throwing so a
+// missing/malformed descriptor degrades the toggle rather than crashing it.
+function loadCogDescriptorFromDisk(): AddonDescriptor | null {
+	try {
+		const raw = JSON.parse(readFileSync(COG_DISPLAY_DESCRIPTOR_PATH, "utf8"));
+		const descriptor = AddonDescriptorSchema.parse(raw);
+		if (descriptor.id !== COG_DISPLAY_ADDON_ID) {
+			logger.error(
+				`kiosk: descriptor id mismatch: expected ${COG_DISPLAY_ADDON_ID}, got ${descriptor.id}`,
+			);
+			return null;
+		}
+		return descriptor;
+	} catch (err) {
+		logger.error(
+			`kiosk: failed to load ${COG_DISPLAY_DESCRIPTOR_PATH}: ${err}`,
+		);
+		return null;
+	}
+}
 
 /** Resolve whether the kiosk unit is active, swallowing the non-zero exit. */
 async function probeIsActive(): Promise<boolean> {
@@ -133,6 +183,9 @@ const defaultKioskDeps: KioskDeps = {
 		await execFileP("pkill", ["--signal", signal, "-x", KIOSK_OSK_PROCESS]);
 	},
 	broadcast: (status) => broadcastMsg("kiosk", status),
+	loadCogDescriptor: loadCogDescriptorFromDisk,
+	enableAddon: (descriptor) => managerEnableAddon(descriptor),
+	disableAddon: (descriptor) => managerDisableAddon(descriptor),
 };
 
 let activeDeps: KioskDeps = defaultKioskDeps;
@@ -297,9 +350,10 @@ export function stopKioskPolling(): void {
 
 /**
  * T1 — toggle-on. Synchronously (before the first await) persist
- * `kiosk_enabled = true` and snap to `enabled-stopped`, then unmask + enable
- * --now the unit and begin polling. The synchronous prelude lets RPC handlers
- * read the committed state immediately without blocking on systemd.
+ * `kiosk_enabled = true` and snap to `enabled-stopped`, then enable the
+ * cog-display add-on (manager owns the sysext + unit lifecycle) and begin
+ * polling. The synchronous prelude lets RPC handlers read the committed state
+ * immediately without blocking on the add-on materialisation.
  */
 export async function kioskStart(
 	deps: KioskDeps = activeDeps,
@@ -307,11 +361,14 @@ export async function kioskStart(
 	getConfig().kiosk_enabled = true;
 	applyState("enabled-stopped", deps);
 
-	try {
-		await deps.systemctl(["unmask", KIOSK_SERVICE]);
-		await deps.systemctl(["enable", "--now", KIOSK_SERVICE]);
-	} catch (err) {
-		logger.error(`kiosk: failed to enable --now ${KIOSK_SERVICE}: ${err}`);
+	const descriptor = deps.loadCogDescriptor();
+	if (descriptor) {
+		const result = await deps.enableAddon(descriptor);
+		if (!result.success) {
+			logger.error(`kiosk: cog-display enable failed: ${result.error}`);
+		}
+	} else {
+		logger.error("kiosk: cog-display descriptor unavailable; cannot enable");
 	}
 
 	startKioskPolling(deps);
@@ -319,9 +376,10 @@ export async function kioskStart(
 }
 
 /**
- * T3 — toggle-off. Synchronously persist the toggle off + `disabled`, then
- * stop + disable + mask the unit, delete the display-failure marker, and stop
- * polling. Valid from `enabled-running` and from `failed-no-display`.
+ * T3 — toggle-off. Synchronously persist the toggle off + `disabled` and stop
+ * polling, then disable the cog-display add-on (manager stops + masks the units
+ * and tears down the sysext) and delete the display-failure marker. Valid from
+ * `enabled-running` and from `failed-no-display`.
  */
 export async function kioskStop(
 	deps: KioskDeps = activeDeps,
@@ -330,12 +388,14 @@ export async function kioskStop(
 	applyState("disabled", deps);
 	stopKioskPolling();
 
-	try {
-		await deps.systemctl(["stop", KIOSK_SERVICE]);
-		await deps.systemctl(["disable", KIOSK_SERVICE]);
-		await deps.systemctl(["mask", KIOSK_SERVICE]);
-	} catch (err) {
-		logger.error(`kiosk: failed to stop ${KIOSK_SERVICE}: ${err}`);
+	const descriptor = deps.loadCogDescriptor();
+	if (descriptor) {
+		const result = await deps.disableAddon(descriptor);
+		if (!result.success) {
+			logger.error(`kiosk: cog-display disable failed: ${result.error}`);
+		}
+	} else {
+		logger.error("kiosk: cog-display descriptor unavailable; cannot disable");
 	}
 	try {
 		await deps.removeNoDisplayMarker();

--- a/apps/backend/src/modules/system/software-updates.ts
+++ b/apps/backend/src/modules/system/software-updates.ts
@@ -16,18 +16,18 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-/* Software updates */
 import { execPNR } from "../../helpers/exec.ts";
 import { invariant } from "../../helpers/invariant.ts";
 import { logger } from "../../helpers/logger.ts";
 import { run } from "../../helpers/run.ts";
 import { getms, oneHour, oneMinute } from "../../helpers/time.ts";
-
 import { queueUpdateGw } from "../network/gateways.ts";
 import { setup } from "../setup.ts";
 import { getIsStreaming } from "../streaming/streaming.ts";
 import { notificationBroadcast } from "../ui/notifications.ts";
 import { broadcastMsg } from "../ui/websocket-server.ts";
+/* Software updates */
+import { APT_PACKAGE_NAME_RE } from "./apt-package-name.ts";
 
 let availableUpdates:
 	| {
@@ -91,10 +91,6 @@ const ceralivePackageList = [
 ];
 // Reboot instead of just restarting CeraUI if we've updated packages matching this list
 const rebootPackageList = ["l4t", "ceralive-linux-", "ceralive-network-config"];
-
-// Debian package-name charset (letters, digits, and `. + : ~ -`); rejects
-// whitespace and shell metacharacters in poisoned/malformed apt output.
-const APT_PACKAGE_NAME_RE = /^[A-Za-z0-9.+:~-]+$/;
 
 export function parseHeldBackPackages(packages: string): string[] {
 	const names = packages

--- a/apps/backend/src/rpc/coalesce.ts
+++ b/apps/backend/src/rpc/coalesce.ts
@@ -32,10 +32,11 @@ export type CoalesceState = Map<string, CoalesceEntry>;
  * Per-type coalescing windows for the LOCAL profile, in milliseconds.
  *
  * Each window equals the type's broadcast interval (see the emitters):
- * - netif    5000ms (`network-interfaces.ts`)
- * - sensors  1000ms (`sensors.ts`)
- * - gateways 2000ms (`gateways.ts`)
- * - modems  30000ms (`modem-update-loop.ts`)
+ * - netif        5000ms (`network-interfaces.ts`)
+ * - sensors      1000ms (`sensors.ts`)
+ * - gateways     2000ms (`gateways.ts`)
+ * - modems      30000ms (`modem-update-loop.ts`)
+ * - device-stats 5000ms (`device-stats.ts`)
  *
  * Types not listed here are never coalesced (window resolves to 0).
  */
@@ -44,6 +45,7 @@ export const COALESCE_WINDOW_MS: Record<string, number> = {
 	sensors: 1000,
 	gateways: 2000,
 	modems: 30000,
+	"device-stats": 5000,
 };
 
 /**

--- a/apps/backend/src/rpc/events.ts
+++ b/apps/backend/src/rpc/events.ts
@@ -13,6 +13,10 @@ import type { AppWebSocket } from "./types.ts";
 type EventHandler<T = unknown> = (data: T) => void;
 type UnsubscribeFn = () => void;
 
+// Source-of-truth event name for the 5-signal device-stats broadcast (S1 lock).
+// 5s coalescing window registered in coalesce.ts; emitter in device-stats.ts.
+export const DEVICE_STATS_EVENT = "device-stats" as const;
+
 /**
  * Simple event emitter for internal broadcasts
  */

--- a/apps/backend/src/rpc/events.ts
+++ b/apps/backend/src/rpc/events.ts
@@ -17,6 +17,11 @@ type UnsubscribeFn = () => void;
 // 5s coalescing window registered in coalesce.ts; emitter in device-stats.ts.
 export const DEVICE_STATS_EVENT = "device-stats" as const;
 
+// Per-add-on state broadcast channel. The manager is the single source of truth
+// (it owns the `broadcastMsg(ADDON_EVENT, …)` push); re-exported here so the RPC
+// layer resolves the channel name from the events surface like every other event.
+export { ADDON_EVENT } from "../modules/addons/manager.ts";
+
 /**
  * Simple event emitter for internal broadcasts
  */

--- a/apps/backend/src/rpc/procedures/__tests__/addons.procedure.test.ts
+++ b/apps/backend/src/rpc/procedures/__tests__/addons.procedure.test.ts
@@ -1,0 +1,377 @@
+/*
+ * Task 30 — add-on RPC procedures (rpc/procedures/addons.procedure.ts).
+ *
+ * The read-only handlers (`list`, `getStatus`) merge the image-baked descriptors
+ * with the manager's live phase + persisted state and are NOT gated; the three
+ * mutating handlers gate on isRealDevice() (G6) and drive the device only
+ * through the manager. The descriptor disk read is injected via the procedure's
+ * `AddonProcedureDeps`; the enable/disable pipeline is exercised against a real
+ * manager wired to a spy `AddonManagerDeps` (mirrors tests/manager.test.ts), so
+ * the suite never needs a board, sudo, or network.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { AddonDescriptor, AddonState } from "@ceraui/rpc/schemas";
+import { call } from "@orpc/server";
+
+import {
+	type AddonManagerDeps,
+	getAddonPhase,
+	initAddonManager,
+	resetAddonManagerDeps,
+	setAddonManagerDeps,
+} from "../../../modules/addons/manager.ts";
+import { ADDON_EVENT } from "../../events.ts";
+import type { AppWebSocket, RPCContext } from "../../types.ts";
+import {
+	ADDON_NOT_FOUND_ERROR,
+	configureAddonProcedure,
+	getAddonStatusProcedure,
+	installAddonProcedure,
+	listAddonsProcedure,
+	resetAddonProcedureDeps,
+	setAddonProcedureDeps,
+	uninstallAddonProcedure,
+} from "../addons.procedure.ts";
+
+const ADDON_UNAVAILABLE = "addon_unavailable_in_emulated_mode";
+const UNIT = "debug-toolset.service";
+
+function makeDescriptor(over: Partial<AddonDescriptor> = {}): AddonDescriptor {
+	return {
+		id: "debug-toolset",
+		name: "Debug Toolset",
+		version: "1.2.3",
+		category: "debug",
+		payload: { type: "sysext" },
+		sysextLevel: "1",
+		versionId: "12",
+		artifact: {
+			urlTemplate:
+				"https://apt.ceralive.tv/addons/debug-toolset/{os_version}/debug-toolset.raw",
+			sha256: "a".repeat(64),
+			gpgSigRef:
+				"https://apt.ceralive.tv/addons/debug-toolset/{os_version}/debug-toolset.raw.sig",
+			sizeDownload: 1024,
+			sizeInstalled: 4096,
+		},
+		provides: ["/usr/bin/debug-toolset"],
+		units: { unmask: [UNIT], enable: [UNIT], start: [UNIT] },
+		validate: { cmd: "test -x /usr/bin/debug-toolset" },
+		...over,
+	};
+}
+
+type ManagerHarness = {
+	deps: AddonManagerDeps;
+	store: Map<string, AddonState>;
+	broadcasts: Array<{ id: string; state: AddonState }>;
+	helperEnable: string[];
+	helperDisable: string[];
+	removeState: string[];
+};
+
+function makeManagerHarness(): ManagerHarness {
+	const store = new Map<string, AddonState>();
+	const broadcasts: Array<{ id: string; state: AddonState }> = [];
+	const helperEnable: string[] = [];
+	const helperDisable: string[] = [];
+	const removeState: string[] = [];
+
+	const deps: AddonManagerDeps = {
+		isRealDevice: () => Promise.resolve(true),
+		getDataFreeBytes: () => Promise.resolve(100 * 1024 * 1024 * 1024),
+		getOsVersion: () => Promise.resolve("12"),
+		download: () => Promise.resolve(),
+		verify: () => Promise.resolve(),
+		stage: () => Promise.resolve(),
+		helperEnable: (id) => {
+			helperEnable.push(id);
+			return Promise.resolve();
+		},
+		helperDisable: (id) => {
+			helperDisable.push(id);
+			return Promise.resolve();
+		},
+		systemctl: () => Promise.resolve({ stdout: "", stderr: "" }),
+		getNRestarts: () => Promise.resolve(0),
+		runValidate: () => Promise.resolve(true),
+		removeArtifact: () => Promise.resolve(),
+		getState: (id) => store.get(id),
+		setState: (id, state) => {
+			store.set(id, state);
+		},
+		removeState: (id) => {
+			store.delete(id);
+			removeState.push(id);
+		},
+		broadcast: (id, state) => {
+			broadcasts.push({ id, state });
+		},
+	};
+
+	return { deps, store, broadcasts, helperEnable, helperDisable, removeState };
+}
+
+function makeContext(authenticated = true): RPCContext {
+	const ws = {
+		send: () => {},
+		data: { isAuthenticated: authenticated, lastActive: Date.now() },
+	} as unknown as AppWebSocket;
+	return {
+		ws,
+		isAuthenticated: () => authenticated,
+		authenticate: () => {},
+		deauthenticate: () => {},
+		markActive: () => {},
+		getLastActive: () => 0,
+		setSenderId: () => {},
+		getSenderId: () => undefined,
+		clearSenderId: () => {},
+	};
+}
+
+beforeEach(() => {
+	resetAddonManagerDeps();
+	resetAddonProcedureDeps();
+	initAddonManager();
+});
+
+afterEach(() => {
+	resetAddonManagerDeps();
+	resetAddonProcedureDeps();
+});
+
+describe("addons.list (read-only, not gated)", () => {
+	test("returns each descriptor merged with its persisted state + live phase", async () => {
+		const descriptor = makeDescriptor();
+		const state: AddonState = {
+			enabled: true,
+			phase: "active",
+			autoDisabled: false,
+			versionMaterialized: "1.2.3",
+		};
+		setAddonProcedureDeps({
+			readDescriptors: () => Promise.resolve([descriptor]),
+			getAddonState: () => state,
+			getAddonPhase: () => "enabled",
+		});
+
+		const result = await call(listAddonsProcedure, undefined, {
+			context: makeContext(),
+		});
+
+		expect(result.addons).toHaveLength(1);
+		expect(result.addons[0]?.descriptor.id).toBe("debug-toolset");
+		expect(result.addons[0]?.state).toEqual(state);
+		expect(result.addons[0]?.managerPhase).toBe("enabled");
+	});
+
+	test("still returns data in emulated mode (NOT gated)", async () => {
+		const descriptor = makeDescriptor();
+		setAddonProcedureDeps({
+			readDescriptors: () => Promise.resolve([descriptor]),
+			isRealDevice: () => Promise.resolve(false),
+		});
+
+		const result = await call(listAddonsProcedure, undefined, {
+			context: makeContext(),
+		});
+
+		expect(result.addons).toHaveLength(1);
+		expect(result.addons[0]?.descriptor.id).toBe("debug-toolset");
+	});
+});
+
+describe("addons.getStatus (read-only, not gated)", () => {
+	test("surfaces the descriptor's disk-size impact + live state", async () => {
+		const descriptor = makeDescriptor();
+		setAddonProcedureDeps({
+			readDescriptors: () => Promise.resolve([descriptor]),
+		});
+
+		const result = await call(
+			getAddonStatusProcedure,
+			{ id: "debug-toolset" },
+			{ context: makeContext() },
+		);
+
+		expect(result?.descriptor.artifact.sizeInstalled).toBe(4096);
+		expect(result?.descriptor.artifact.sizeDownload).toBe(1024);
+		expect(result?.managerPhase).toBe("disabled");
+	});
+
+	test("resolves null for an unknown id", async () => {
+		setAddonProcedureDeps({ readDescriptors: () => Promise.resolve([]) });
+
+		const result = await call(
+			getAddonStatusProcedure,
+			{ id: "nope" },
+			{ context: makeContext() },
+		);
+
+		expect(result).toBeNull();
+	});
+});
+
+describe("addons.install (gated on isRealDevice, drives the manager)", () => {
+	test("transitions the add-on to enabled and emits addons broadcasts", async () => {
+		const h = makeManagerHarness();
+		setAddonManagerDeps(h.deps);
+		const descriptor = makeDescriptor();
+		setAddonProcedureDeps({
+			isRealDevice: () => Promise.resolve(true),
+			readDescriptors: () => Promise.resolve([descriptor]),
+		});
+
+		const result = await call(
+			installAddonProcedure,
+			{ id: "debug-toolset" },
+			{ context: makeContext() },
+		);
+
+		expect(result).toEqual({ success: true, phase: "enabled" });
+		expect(getAddonPhase("debug-toolset")).toBe("enabled");
+		expect(h.helperEnable).toEqual(["debug-toolset"]);
+		// The `addons` channel is the manager broadcast surface (single source).
+		expect(ADDON_EVENT).toBe("addons");
+		expect(h.broadcasts.map((b) => b.state.phase)).toEqual([
+			"installing",
+			"active",
+		]);
+		expect(h.broadcasts.at(-1)?.state.enabled).toBe(true);
+	});
+
+	test("returns addon_unavailable in emulated mode and never touches the manager", async () => {
+		const h = makeManagerHarness();
+		setAddonManagerDeps(h.deps);
+		const descriptor = makeDescriptor();
+		setAddonProcedureDeps({
+			isRealDevice: () => Promise.resolve(false),
+			readDescriptors: () => Promise.resolve([descriptor]),
+		});
+
+		const result = await call(
+			installAddonProcedure,
+			{ id: "debug-toolset" },
+			{ context: makeContext() },
+		);
+
+		expect(result).toEqual({ success: false, error: ADDON_UNAVAILABLE });
+		expect(h.helperEnable).toHaveLength(0);
+		expect(h.broadcasts).toHaveLength(0);
+		expect(getAddonPhase("debug-toolset")).toBe("disabled");
+	});
+
+	test("returns addon_not_found for an id with no descriptor", async () => {
+		setAddonProcedureDeps({
+			isRealDevice: () => Promise.resolve(true),
+			readDescriptors: () => Promise.resolve([]),
+		});
+
+		const result = await call(
+			installAddonProcedure,
+			{ id: "ghost-addon" },
+			{ context: makeContext() },
+		);
+
+		expect(result).toEqual({ success: false, error: ADDON_NOT_FOUND_ERROR });
+	});
+});
+
+describe("addons.uninstall (gated on isRealDevice, reverses install)", () => {
+	test("disables the add-on and tears down its persisted state", async () => {
+		const h = makeManagerHarness();
+		setAddonManagerDeps(h.deps);
+		const descriptor = makeDescriptor();
+		setAddonProcedureDeps({
+			isRealDevice: () => Promise.resolve(true),
+			readDescriptors: () => Promise.resolve([descriptor]),
+		});
+
+		await call(
+			installAddonProcedure,
+			{ id: "debug-toolset" },
+			{ context: makeContext() },
+		);
+		expect(getAddonPhase("debug-toolset")).toBe("enabled");
+
+		const result = await call(
+			uninstallAddonProcedure,
+			{ id: "debug-toolset" },
+			{ context: makeContext() },
+		);
+
+		expect(result).toEqual({ success: true, phase: "disabled" });
+		expect(getAddonPhase("debug-toolset")).toBe("disabled");
+		expect(h.helperDisable).toEqual(["debug-toolset"]);
+		expect(h.removeState).toContain("debug-toolset");
+	});
+
+	test("returns addon_unavailable in emulated mode", async () => {
+		const h = makeManagerHarness();
+		setAddonManagerDeps(h.deps);
+		const descriptor = makeDescriptor();
+		setAddonProcedureDeps({
+			isRealDevice: () => Promise.resolve(false),
+			readDescriptors: () => Promise.resolve([descriptor]),
+		});
+
+		const result = await call(
+			uninstallAddonProcedure,
+			{ id: "debug-toolset" },
+			{ context: makeContext() },
+		);
+
+		expect(result).toEqual({ success: false, error: ADDON_UNAVAILABLE });
+		expect(h.helperDisable).toHaveLength(0);
+	});
+});
+
+describe("addons.configure (gated on isRealDevice)", () => {
+	test("persists userConfig onto the existing state", async () => {
+		const existing: AddonState = {
+			enabled: true,
+			phase: "active",
+			autoDisabled: false,
+		};
+		const saved: Array<{ id: string; state: AddonState }> = [];
+		setAddonProcedureDeps({
+			isRealDevice: () => Promise.resolve(true),
+			getAddonState: () => existing,
+			setAddonState: (id, state) => {
+				saved.push({ id, state });
+			},
+		});
+
+		const result = await call(
+			configureAddonProcedure,
+			{ id: "debug-toolset", fields: { verbose: true } },
+			{ context: makeContext() },
+		);
+
+		expect(result).toEqual({ success: true, applied: { verbose: true } });
+		expect(saved[0]?.state.userConfig).toEqual({ verbose: true });
+		expect(saved[0]?.state.enabled).toBe(true);
+	});
+
+	test("returns addon_unavailable in emulated mode", async () => {
+		setAddonProcedureDeps({ isRealDevice: () => Promise.resolve(false) });
+
+		const result = await call(
+			configureAddonProcedure,
+			{ id: "debug-toolset", fields: { verbose: true } },
+			{ context: makeContext() },
+		);
+
+		expect(result).toEqual({ success: false, error: ADDON_UNAVAILABLE });
+	});
+});
+
+describe("addons procedures reject an unauthenticated caller", () => {
+	test("list rejects without auth", async () => {
+		await expect(
+			call(listAddonsProcedure, undefined, { context: makeContext(false) }),
+		).rejects.toThrow();
+	});
+});

--- a/apps/backend/src/rpc/procedures/addons.procedure.ts
+++ b/apps/backend/src/rpc/procedures/addons.procedure.ts
@@ -1,0 +1,240 @@
+/**
+ * Add-on Procedures
+ *
+ * The RPC surface over the add-on manager state machine (T28,
+ * modules/addons/manager.ts). Read-only queries (`listAddons`,
+ * `getAddonStatus`) merge the image-baked descriptors with the manager's live
+ * phase + persisted state and are NOT gated. The three mutating handlers
+ * (`installAddon`, `uninstallAddon`, `configureAddon`) gate on `isRealDevice()`
+ * (G6) and drive the device only through the manager — never the privileged
+ * helper directly.
+ *
+ * Every OS/disk-touching primitive is injected through {@link AddonProcedureDeps}
+ * so the suite runs without a board (mirrors the manager's `AddonManagerDeps`).
+ */
+
+import { readdir } from "node:fs/promises";
+
+import {
+	type AddonDescriptor,
+	AddonDescriptorSchema,
+	type AddonState,
+	AddonStateSchema,
+} from "@ceraui/rpc/schemas";
+import { os } from "@orpc/server";
+import { z } from "zod";
+
+import { logger } from "../../helpers/logger.ts";
+import {
+	ADDON_MANAGER_PHASES,
+	ADDON_UNAVAILABLE_ERROR,
+	type AddonManagerPhase,
+	type AddonOpResult,
+	disableAddon,
+	enableAddon,
+	getAddonPhase,
+	toAddonState,
+} from "../../modules/addons/manager.ts";
+import { getAddons, setAddonState } from "../../modules/config.ts";
+import { isRealDevice } from "../../modules/system/kiosk.ts";
+import { authMiddleware } from "../middleware/auth.middleware.ts";
+import type { RPCContext } from "../types.ts";
+
+const baseProcedure = os.$context<RPCContext>();
+const authedProcedure = baseProcedure.use(authMiddleware);
+
+/** Returned when an id has no matching image-baked descriptor on disk. */
+export const ADDON_NOT_FOUND_ERROR = "addon_not_found";
+
+/** Image-baked, read-only descriptor drop directory (one `<id>.json` per add-on). */
+const ADDON_DESCRIPTOR_DIR = "/usr/share/ceralive/addons";
+
+// Reuse the descriptor's own id pattern (G5: never re-declare the regex).
+const addonIdSchema = AddonDescriptorSchema.shape.id;
+const userConfigSchema = z.record(z.string(), z.unknown());
+
+const addonManagerPhaseSchema = z.enum(
+	ADDON_MANAGER_PHASES as unknown as [
+		AddonManagerPhase,
+		...AddonManagerPhase[],
+	],
+);
+
+const addonListItemSchema = z.object({
+	descriptor: AddonDescriptorSchema,
+	state: AddonStateSchema,
+	managerPhase: addonManagerPhaseSchema,
+});
+
+const addonOpResultSchema = z.union([
+	z.object({ success: z.literal(true), phase: addonManagerPhaseSchema }),
+	z.object({ success: z.literal(false), error: z.string() }),
+]);
+
+const configureResultSchema = z.union([
+	z.object({ success: z.literal(true), applied: userConfigSchema }),
+	z.object({ success: z.literal(false), error: z.string() }),
+]);
+
+/**
+ * The injectable surface. Defaults read the image-baked descriptors off disk,
+ * gate on the real device-detector, and delegate state ops to the manager +
+ * config. Tests inject deterministic spies via {@link setAddonProcedureDeps}.
+ */
+export type AddonProcedureDeps = {
+	readDescriptors: () => Promise<AddonDescriptor[]>;
+	isRealDevice: () => Promise<boolean>;
+	getAddonPhase: (id: string) => AddonManagerPhase;
+	getAddonState: (id: string) => AddonState | undefined;
+	enableAddon: (descriptor: AddonDescriptor) => Promise<AddonOpResult>;
+	disableAddon: (descriptor: AddonDescriptor) => Promise<AddonOpResult>;
+	setAddonState: (id: string, state: AddonState) => void;
+};
+
+async function readBakedDescriptors(): Promise<AddonDescriptor[]> {
+	let entries: string[];
+	try {
+		entries = await readdir(ADDON_DESCRIPTOR_DIR);
+	} catch {
+		return [];
+	}
+	const descriptors: AddonDescriptor[] = [];
+	for (const entry of entries) {
+		if (!entry.endsWith(".json")) continue;
+		try {
+			const raw = await Bun.file(`${ADDON_DESCRIPTOR_DIR}/${entry}`).json();
+			descriptors.push(AddonDescriptorSchema.parse(raw));
+		} catch (err) {
+			logger.error(`addon descriptor ${entry} failed to parse: ${err}`);
+		}
+	}
+	return descriptors;
+}
+
+const defaultAddonProcedureDeps: AddonProcedureDeps = {
+	readDescriptors: readBakedDescriptors,
+	isRealDevice: () => isRealDevice(),
+	getAddonPhase: (id) => getAddonPhase(id),
+	getAddonState: (id) => getAddons()[id],
+	enableAddon: (descriptor) => enableAddon(descriptor),
+	disableAddon: (descriptor) => disableAddon(descriptor),
+	setAddonState: (id, state) => setAddonState(id, state),
+};
+
+let activeDeps: AddonProcedureDeps = defaultAddonProcedureDeps;
+
+/** Override the injectable surface (DI for tests). */
+export function setAddonProcedureDeps(deps: Partial<AddonProcedureDeps>): void {
+	activeDeps = { ...defaultAddonProcedureDeps, ...deps };
+}
+
+/** Restore the real-device primitives. */
+export function resetAddonProcedureDeps(): void {
+	activeDeps = defaultAddonProcedureDeps;
+}
+
+/** Merge a descriptor with its persisted state + live manager phase. */
+function buildItem(
+	descriptor: AddonDescriptor,
+	deps: AddonProcedureDeps,
+): z.infer<typeof addonListItemSchema> {
+	const managerPhase = deps.getAddonPhase(descriptor.id);
+	const state = deps.getAddonState(descriptor.id) ?? toAddonState(managerPhase);
+	return { descriptor, state, managerPhase };
+}
+
+async function findDescriptor(
+	id: string,
+	deps: AddonProcedureDeps,
+): Promise<AddonDescriptor | undefined> {
+	return (await deps.readDescriptors()).find((d) => d.id === id);
+}
+
+/**
+ * List every image-baked add-on merged with its live state. Read-only — NOT
+ * gated on isRealDevice() so the UI renders the catalogue in emulated mode too.
+ */
+export const listAddonsProcedure = authedProcedure
+	.output(z.object({ addons: z.array(addonListItemSchema) }))
+	.handler(async () => {
+		const deps = activeDeps;
+		const descriptors = await deps.readDescriptors();
+		return { addons: descriptors.map((d) => buildItem(d, deps)) };
+	});
+
+/**
+ * Materialise + enable an add-on through the manager. Gated on isRealDevice()
+ * (G6); an optional `userConfig` is pre-seeded so the manager preserves it.
+ */
+export const installAddonProcedure = authedProcedure
+	.input(
+		z.object({ id: addonIdSchema, userConfig: userConfigSchema.optional() }),
+	)
+	.output(addonOpResultSchema)
+	.handler(async ({ input }) => {
+		const deps = activeDeps;
+		if (!(await deps.isRealDevice())) {
+			return { success: false, error: ADDON_UNAVAILABLE_ERROR };
+		}
+		const descriptor = await findDescriptor(input.id, deps);
+		if (!descriptor) {
+			return { success: false, error: ADDON_NOT_FOUND_ERROR };
+		}
+		if (input.userConfig !== undefined) {
+			const base = deps.getAddonState(input.id) ?? toAddonState("disabled");
+			deps.setAddonState(input.id, { ...base, userConfig: input.userConfig });
+		}
+		return deps.enableAddon(descriptor);
+	});
+
+/**
+ * Disable + remove an add-on through the manager. Gated on isRealDevice() (G6).
+ */
+export const uninstallAddonProcedure = authedProcedure
+	.input(z.object({ id: addonIdSchema }))
+	.output(addonOpResultSchema)
+	.handler(async ({ input }) => {
+		const deps = activeDeps;
+		if (!(await deps.isRealDevice())) {
+			return { success: false, error: ADDON_UNAVAILABLE_ERROR };
+		}
+		const descriptor = await findDescriptor(input.id, deps);
+		if (!descriptor) {
+			return { success: false, error: ADDON_NOT_FOUND_ERROR };
+		}
+		return deps.disableAddon(descriptor);
+	});
+
+/**
+ * Persist an add-on's userConfig without touching its materialised payload.
+ * Gated on isRealDevice() (G6); the add-on must already have persisted state.
+ */
+export const configureAddonProcedure = authedProcedure
+	.input(z.object({ id: addonIdSchema, fields: userConfigSchema }))
+	.output(configureResultSchema)
+	.handler(async ({ input }) => {
+		const deps = activeDeps;
+		if (!(await deps.isRealDevice())) {
+			return { success: false, error: ADDON_UNAVAILABLE_ERROR };
+		}
+		const state = deps.getAddonState(input.id);
+		if (!state) {
+			return { success: false, error: ADDON_NOT_FOUND_ERROR };
+		}
+		deps.setAddonState(input.id, { ...state, userConfig: input.fields });
+		return { success: true, applied: input.fields };
+	});
+
+/**
+ * Single add-on snapshot: descriptor (carries the disk-size impact) + live
+ * state. Read-only — NOT gated. Resolves null for an unknown id.
+ */
+export const getAddonStatusProcedure = authedProcedure
+	.input(z.object({ id: addonIdSchema }))
+	.output(addonListItemSchema.nullable())
+	.handler(async ({ input }) => {
+		const deps = activeDeps;
+		const descriptor = await findDescriptor(input.id, deps);
+		if (!descriptor) return null;
+		return buildItem(descriptor, deps);
+	});

--- a/apps/backend/src/rpc/procedures/index.ts
+++ b/apps/backend/src/rpc/procedures/index.ts
@@ -1,6 +1,7 @@
 /**
  * Export all procedures
  */
+export * from "./addons.procedure.ts";
 export * from "./auth.procedure.ts";
 export * from "./modems.procedure.ts";
 export * from "./network.procedure.ts";

--- a/apps/backend/src/rpc/router.ts
+++ b/apps/backend/src/rpc/router.ts
@@ -5,6 +5,13 @@
 import { os } from "@orpc/server";
 
 import {
+	configureAddonProcedure,
+	getAddonStatusProcedure,
+	installAddonProcedure,
+	listAddonsProcedure,
+	uninstallAddonProcedure,
+} from "./procedures/addons.procedure.ts";
+import {
 	loginProcedure,
 	logoutProcedure,
 	setPasswordProcedure,
@@ -161,6 +168,14 @@ const stableRoutes = {
 	pairing: os.router({
 		generateClaimCode: generateClaimCodeProcedure,
 		completePairing: completePairingProcedure,
+	}),
+
+	addons: os.router({
+		list: listAddonsProcedure,
+		install: installAddonProcedure,
+		uninstall: uninstallAddonProcedure,
+		configure: configureAddonProcedure,
+		getStatus: getAddonStatusProcedure,
 	}),
 };
 

--- a/apps/backend/src/tests/addon-helper-script.test.ts
+++ b/apps/backend/src/tests/addon-helper-script.test.ts
@@ -1,0 +1,336 @@
+/*
+ * End-to-end security tests for the privileged `ceralive-addon-helper` bash
+ * script (T27). These drive the REAL script in a hermetic temp sandbox — real
+ * jq / gpg / gpgv / sha256sum, stubbed systemctl + systemd-sysext — without root
+ * and without touching the host.
+ *
+ * The properties under test are the G-trust invariants:
+ *  - enable/disable/status/refresh work for a baked, validly-signed add-on;
+ *  - an id with no baked descriptor is refused (allowlist source = baked only);
+ *  - a tampered .raw is refused (sha256 re-verify against the baked descriptor);
+ *  - a sysext-INJECTED descriptor cannot bypass the keyring root-of-trust: even
+ *    with a matching sha256, an artifact signed by a NON-baked key fails gpgv;
+ *  - a malformed / traversal id is refused before any filesystem access.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const HELPER = join(import.meta.dir, "..", "..", "ceralive-addon-helper");
+
+// The script needs these real tools; skip the suite cleanly where unavailable
+// (e.g. a minimal CI image) rather than reporting a false failure.
+const HAVE_TOOLS = ["bash", "jq", "gpg", "gpgv", "sha256sum"].every(
+	(t) => Bun.which(t) !== null,
+);
+
+let ROOT = "";
+let LEGIT_HOME = "";
+let ATTACKER_HOME = "";
+let KEYRING = "";
+
+function sh(
+	cmd: string[],
+	opts: { env?: Record<string, string> } = {},
+): { code: number; stdout: string; stderr: string } {
+	const proc = Bun.spawnSync(cmd, {
+		env: opts.env ? { ...process.env, ...opts.env } : process.env,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	return {
+		code: proc.exitCode,
+		stdout: proc.stdout.toString(),
+		stderr: proc.stderr.toString(),
+	};
+}
+
+function gpgGenKey(home: string, name: string): void {
+	mkdirSync(home, { recursive: true });
+	chmodSync(home, 0o700);
+	const params = join(home, "params");
+	writeFileSync(
+		params,
+		`%no-protection\nKey-Type: RSA\nKey-Length: 2048\nKey-Usage: sign\nName-Real: ${name}\nExpire-Date: 0\n%commit\n`,
+	);
+	const r = sh(["gpg", "--homedir", home, "--batch", "--gen-key", params]);
+	if (r.code !== 0) throw new Error(`gpg gen-key failed: ${r.stderr}`);
+}
+
+function gpgExportPub(home: string, out: string): void {
+	const proc = Bun.spawnSync(["gpg", "--homedir", home, "--export"], {
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	if (proc.exitCode !== 0) {
+		throw new Error(`gpg export failed: ${proc.stderr.toString()}`);
+	}
+	writeFileSync(out, proc.stdout);
+}
+
+function gpgSign(home: string, raw: string, sig: string): void {
+	const r = sh([
+		"gpg",
+		"--homedir",
+		home,
+		"--batch",
+		"--yes",
+		"--detach-sign",
+		"--output",
+		sig,
+		raw,
+	]);
+	if (r.code !== 0) throw new Error(`gpg sign failed: ${r.stderr}`);
+}
+
+function sha256(file: string): string {
+	const proc = Bun.spawnSync(["sha256sum", file], { stdout: "pipe" });
+	return proc.stdout.toString().split(/\s+/)[0] ?? "";
+}
+
+type Descriptor = {
+	id: string;
+	sha256: string;
+	units?: { unmask?: string[]; enable?: string[]; start?: string[] };
+};
+
+function writeDescriptor(path: string, d: Descriptor): void {
+	const doc = {
+		id: d.id,
+		name: `Add-on ${d.id}`,
+		version: "1.0.0",
+		category: "debug",
+		payload: { type: "sysext" },
+		sysextLevel: "1",
+		versionId: "12",
+		artifact: {
+			urlTemplate: `https://apt.ceralive.tv/addons/${d.id}/{os_version}/${d.id}.raw`,
+			sha256: d.sha256,
+			gpgSigRef: `https://apt.ceralive.tv/addons/${d.id}/{os_version}/${d.id}.raw.sig`,
+			sizeDownload: 1024,
+			sizeInstalled: 4096,
+		},
+		provides: [`/usr/bin/${d.id}`],
+		units: d.units ?? {},
+	};
+	writeFileSync(path, JSON.stringify(doc, null, 2));
+}
+
+type Sandbox = {
+	dir: string;
+	env: Record<string, string>;
+	registry: string;
+	cache: string;
+	ext: string;
+	callsLog: string;
+};
+
+/** A fresh, fully wired sandbox with one baked, validly-signed `debug-toolset`. */
+function mkSandbox(): Sandbox {
+	const dir = mkdtempSync(join(ROOT, "sb-"));
+	const registry = join(dir, "registry");
+	const cache = join(dir, "cache");
+	const ext = join(dir, "extensions");
+	const bin = join(dir, "bin");
+	for (const d of [registry, cache, ext, bin])
+		mkdirSync(d, { recursive: true });
+
+	const callsLog = join(dir, "calls.log");
+	for (const [name, tag] of [
+		["systemctl", "systemctl"],
+		["systemd-sysext", "sysext"],
+	]) {
+		const stub = join(bin, name);
+		writeFileSync(
+			stub,
+			`#!/usr/bin/env bash\nprintf '${tag} %s\\n' "$*" >> ${JSON.stringify(callsLog)}\nexit 0\n`,
+		);
+		chmodSync(stub, 0o755);
+	}
+
+	// A baked, validly-signed add-on with units to exercise the lifecycle.
+	const raw = join(cache, "debug-toolset.raw");
+	writeFileSync(raw, "SYSEXT-RAW-debug-toolset-v1");
+	gpgSign(LEGIT_HOME, raw, `${raw}.sig`);
+	writeDescriptor(join(registry, "debug-toolset.json"), {
+		id: "debug-toolset",
+		sha256: sha256(raw),
+		units: {
+			unmask: ["debug-toolset.service"],
+			enable: ["debug-toolset.service"],
+			start: ["debug-toolset.service"],
+		},
+	});
+
+	const env: Record<string, string> = {
+		CERALIVE_ADDON_REGISTRY_DIR: registry,
+		CERALIVE_ADDON_KEYRING: KEYRING,
+		CERALIVE_ADDON_STAGE_DIR: ext,
+		CERALIVE_ADDON_EXT_DIR: ext,
+		CERALIVE_ADDON_CACHE_DIR: cache,
+		CERALIVE_SYSTEMCTL: join(bin, "systemctl"),
+		CERALIVE_SYSEXT: join(bin, "systemd-sysext"),
+	};
+	return { dir, env, registry, cache, ext, callsLog };
+}
+
+function helper(
+	sb: Sandbox,
+	args: string[],
+): { code: number; stdout: string; stderr: string } {
+	return sh([HELPER, ...args], { env: sb.env });
+}
+
+beforeAll(() => {
+	if (!HAVE_TOOLS) return;
+	ROOT = mkdtempSync(join(tmpdir(), "addon-helper-"));
+	LEGIT_HOME = join(ROOT, "gnupg-legit");
+	ATTACKER_HOME = join(ROOT, "gnupg-attacker");
+	KEYRING = join(ROOT, "addon-keyring.gpg");
+	gpgGenKey(LEGIT_HOME, "CeraLive Add-on Signing (test)");
+	gpgGenKey(ATTACKER_HOME, "Attacker (test)");
+	// The baked keyring holds ONLY the legitimate public key.
+	gpgExportPub(LEGIT_HOME, KEYRING);
+});
+
+afterAll(() => {
+	if (ROOT) rmSync(ROOT, { recursive: true, force: true });
+});
+
+describe.skipIf(!HAVE_TOOLS)("ceralive-addon-helper — happy path", () => {
+	it("enable verifies + activates a baked, validly-signed add-on", async () => {
+		const sb = mkSandbox();
+		const r = helper(sb, ["enable", "debug-toolset"]);
+
+		expect(r.code).toBe(0);
+		const out = JSON.parse(r.stdout) as { ok: boolean; action: string };
+		expect(out.ok).toBe(true);
+		expect(out.action).toBe("enable");
+
+		// Staged into the sysext scan dir.
+		expect(existsSync(join(sb.ext, "debug-toolset.raw"))).toBe(true);
+
+		// Filesystem merge, THEN unit lifecycle (unmask -> enable -> start).
+		const log = await Bun.file(sb.callsLog).text();
+		expect(log).toContain("sysext refresh");
+		expect(log).toContain("systemctl unmask debug-toolset.service");
+		expect(log).toContain("systemctl enable debug-toolset.service");
+		expect(log).toContain("systemctl start debug-toolset.service");
+	});
+
+	it("status emits JSON with the baked registry + installed flag", async () => {
+		const sb = mkSandbox();
+
+		// Before enable: present in registry, not installed.
+		const before = JSON.parse(helper(sb, ["status"]).stdout) as {
+			ok: boolean;
+			addons: Array<{ id: string; installed: boolean; units: unknown }>;
+		};
+		expect(before.ok).toBe(true);
+		const a0 = before.addons.find((a) => a.id === "debug-toolset");
+		expect(a0?.installed).toBe(false);
+
+		// After enable: installed flips true, units surfaced from the descriptor.
+		expect(helper(sb, ["enable", "debug-toolset"]).code).toBe(0);
+		const after = JSON.parse(helper(sb, ["status"]).stdout) as {
+			addons: Array<{
+				id: string;
+				installed: boolean;
+				units: { start?: string[] };
+			}>;
+		};
+		const a1 = after.addons.find((a) => a.id === "debug-toolset");
+		expect(a1?.installed).toBe(true);
+		expect(a1?.units.start).toEqual(["debug-toolset.service"]);
+	});
+
+	it("disable reverses enable: stop/disable/mask, removes .raw, refresh", async () => {
+		const sb = mkSandbox();
+		expect(helper(sb, ["enable", "debug-toolset"]).code).toBe(0);
+
+		const r = helper(sb, ["disable", "debug-toolset"]);
+		expect(r.code).toBe(0);
+		expect((JSON.parse(r.stdout) as { action: string }).action).toBe("disable");
+
+		expect(existsSync(join(sb.ext, "debug-toolset.raw"))).toBe(false);
+		const log = await Bun.file(sb.callsLog).text();
+		expect(log).toContain("systemctl stop debug-toolset.service");
+		expect(log).toContain("systemctl disable debug-toolset.service");
+		expect(log).toContain("systemctl mask debug-toolset.service");
+	});
+
+	it("refresh runs systemd-sysext refresh only", async () => {
+		const sb = mkSandbox();
+		const r = helper(sb, ["refresh"]);
+		expect(r.code).toBe(0);
+		expect((JSON.parse(r.stdout) as { action: string }).action).toBe("refresh");
+		expect((await Bun.file(sb.callsLog).text()).trim()).toBe("sysext refresh");
+	});
+});
+
+describe.skipIf(!HAVE_TOOLS)("ceralive-addon-helper — G-trust refusals", () => {
+	it("refuses an id with no baked descriptor (allowlist = baked registry only)", () => {
+		const sb = mkSandbox();
+		const r = helper(sb, ["enable", "ghost-addon"]);
+		expect(r.code).not.toBe(0);
+		expect(r.stderr).toMatch(/not in baked registry/);
+		// Nothing was staged.
+		expect(existsSync(join(sb.ext, "ghost-addon.raw"))).toBe(false);
+	});
+
+	it("refuses a tampered artifact (sha256 no longer matches the baked descriptor)", () => {
+		const sb = mkSandbox();
+		// Tamper AFTER signing + hashing: the descriptor's sha256 is now stale.
+		writeFileSync(join(sb.cache, "debug-toolset.raw"), "TAMPERED-PAYLOAD");
+
+		const r = helper(sb, ["enable", "debug-toolset"]);
+		expect(r.code).not.toBe(0);
+		expect(r.stderr).toMatch(/sha256 mismatch/);
+		expect(existsSync(join(sb.ext, "debug-toolset.raw"))).toBe(false);
+	});
+
+	it("refuses a sysext-injected descriptor: a non-baked key cannot pass gpgv", () => {
+		const sb = mkSandbox();
+		// Simulate an attacker who shadows a descriptor into the registry (as a
+		// merged sysext overlaying /usr could) AND supplies a matching-sha256
+		// artifact — but signs it with a key NOT in the baked keyring.
+		const evilRaw = join(sb.cache, "evil-addon.raw");
+		writeFileSync(evilRaw, "EVIL-PAYLOAD");
+		gpgSign(ATTACKER_HOME, evilRaw, `${evilRaw}.sig`);
+		writeDescriptor(join(sb.registry, "evil-addon.json"), {
+			id: "evil-addon",
+			sha256: sha256(evilRaw), // sha256 deliberately CORRECT — isolates gpg gate
+		});
+
+		const r = helper(sb, ["enable", "evil-addon"]);
+		expect(r.code).not.toBe(0);
+		expect(r.stderr).toMatch(/GPG verify failed/);
+		expect(existsSync(join(sb.ext, "evil-addon.raw"))).toBe(false);
+	});
+
+	it("refuses when the cached artifact is missing", () => {
+		const sb = mkSandbox();
+		rmSync(join(sb.cache, "debug-toolset.raw"));
+		const r = helper(sb, ["enable", "debug-toolset"]);
+		expect(r.code).not.toBe(0);
+		expect(r.stderr).toMatch(/artifact not present/);
+	});
+
+	it("rejects a traversal / malformed id before any filesystem access", () => {
+		const sb = mkSandbox();
+		for (const bad of ["../../etc/passwd", "Debug", "a/b", "-rf"]) {
+			const r = helper(sb, ["enable", bad]);
+			expect(r.code).not.toBe(0);
+			expect(r.stderr).toMatch(/invalid add-on id/);
+		}
+	});
+});

--- a/apps/backend/src/tests/addon-helper.test.ts
+++ b/apps/backend/src/tests/addon-helper.test.ts
@@ -1,0 +1,127 @@
+/*
+ * Unit tests for the TypeScript wrapper around the privileged
+ * `ceralive-addon-helper` binary (T27, src/helpers/addon-helper.ts).
+ *
+ * These cover the WRAPPER's contract — argv-only construction, the isRealDevice
+ * gate (G6), and id validation — via injected deps, without ever spawning sudo.
+ * The helper's OWN security logic (allowlist + sig/sha256 verification) is
+ * exercised end-to-end against the real bash script in addon-helper-script.test.ts.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import {
+	ADDON_UNAVAILABLE_ERROR,
+	type AddonHelperDeps,
+	addonDisable,
+	addonEnable,
+	addonRefresh,
+	addonStatus,
+} from "../helpers/addon-helper.ts";
+
+type Call = { file: string; args: readonly string[] };
+
+/** Build deps with a recording exec spy; defaults to a real device + ok exit. */
+function spyDeps(over: Partial<AddonHelperDeps> = {}): {
+	deps: AddonHelperDeps;
+	calls: Call[];
+} {
+	const calls: Call[] = [];
+	const deps: AddonHelperDeps = {
+		isRealDevice: () => Promise.resolve(true),
+		exec: (file, args) => {
+			calls.push({ file, args });
+			return Promise.resolve({ stdout: '{"ok":true}', stderr: "" });
+		},
+		...over,
+	};
+	return { deps, calls };
+}
+
+describe("addon-helper wrapper — argv-only invocation", () => {
+	it("enable spawns `sudo ceralive-addon-helper enable <id>` argv-only and returns stdout", async () => {
+		const { deps, calls } = spyDeps();
+
+		const out = await addonEnable("debug-toolset", deps);
+
+		expect(out).toBe('{"ok":true}');
+		expect(calls).toHaveLength(1);
+		const call = calls[0];
+		// argv-only: (file, args) — no shell, no command string.
+		expect(call?.file).toBe("sudo");
+		expect(call?.args).toEqual([
+			"ceralive-addon-helper",
+			"enable",
+			"debug-toolset",
+		]);
+	});
+
+	it("disable, refresh, status build the expected argv", async () => {
+		const { deps, calls } = spyDeps();
+
+		await addonDisable("debug-toolset", deps);
+		await addonRefresh(deps);
+		await addonStatus(deps);
+
+		expect(calls.map((c) => c.args)).toEqual([
+			["ceralive-addon-helper", "disable", "debug-toolset"],
+			["ceralive-addon-helper", "refresh"],
+			["ceralive-addon-helper", "status"],
+		]);
+		// Every op goes through sudo, never a raw helper exec.
+		expect(calls.every((c) => c.file === "sudo")).toBe(true);
+	});
+});
+
+describe("addon-helper wrapper — isRealDevice gate (G6)", () => {
+	it("refuses every op in emulated mode and never spawns sudo", async () => {
+		let spawned = false;
+		const { deps } = spyDeps({
+			isRealDevice: () => Promise.resolve(false),
+			exec: () => {
+				spawned = true;
+				return Promise.resolve({ stdout: "", stderr: "" });
+			},
+		});
+
+		await expect(addonEnable("debug-toolset", deps)).rejects.toThrow(
+			ADDON_UNAVAILABLE_ERROR,
+		);
+		await expect(addonDisable("debug-toolset", deps)).rejects.toThrow(
+			ADDON_UNAVAILABLE_ERROR,
+		);
+		await expect(addonRefresh(deps)).rejects.toThrow(ADDON_UNAVAILABLE_ERROR);
+		await expect(addonStatus(deps)).rejects.toThrow(ADDON_UNAVAILABLE_ERROR);
+
+		expect(spawned).toBe(false);
+	});
+});
+
+describe("addon-helper wrapper — id validation (defense in depth)", () => {
+	it("rejects a malformed / traversal id before the gate or any exec", async () => {
+		let touched = false;
+		const { deps } = spyDeps({
+			isRealDevice: () => {
+				touched = true;
+				return Promise.resolve(true);
+			},
+			exec: () => {
+				touched = true;
+				return Promise.resolve({ stdout: "", stderr: "" });
+			},
+		});
+
+		for (const bad of ["../../etc/passwd", "-rf", "Debug", "a/b", "a.b", ""]) {
+			await expect(addonEnable(bad, deps)).rejects.toThrow(/invalid add-on id/);
+		}
+		// id validation runs first — neither the gate nor exec was reached.
+		expect(touched).toBe(false);
+	});
+
+	it("accepts a well-formed lowercase-hyphen id", async () => {
+		const { deps, calls } = spyDeps();
+		await addonEnable("debug-toolset", deps);
+		await addonDisable("net-tools-2", deps);
+		expect(calls).toHaveLength(2);
+	});
+});

--- a/apps/backend/src/tests/addon-reconciler.test.ts
+++ b/apps/backend/src/tests/addon-reconciler.test.ts
@@ -1,0 +1,271 @@
+/*
+ * Post-boot add-on reconciler tests (T29).
+ *
+ * The reconciler's whole effectful surface is injected via ReconcilerDeps, so
+ * these exercise the decision logic — re-materialise vs pending vs defer vs
+ * no-op — without a board, a network, or sudo. The two hard guarantees under
+ * test: add-ons NEVER gate boot (every failure becomes a persisted `pending`,
+ * the run never throws) and a live stream is never disrupted by a refresh.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import type { AddonDescriptor, AddonState } from "@ceraui/rpc/schemas";
+
+import {
+	ADDON_NOT_AVAILABLE_FOR_OS_VERSION,
+	ADDON_REFRESH_DEFERRED_STREAMING,
+	type ReconcilerDeps,
+	runAddonReconciler,
+} from "../modules/addons/reconciler.ts";
+
+// sha256 of the upstream debug-toolset fixture (matches addons.schema.test.ts).
+const FIXTURE_SHA =
+	"d0009ed268df5fd0ec12904201c64be392f56671a4d61acec7355188536bb5e9";
+
+function descriptor(over: Partial<AddonDescriptor> = {}): AddonDescriptor {
+	return {
+		id: "debug-toolset",
+		name: "Debug Toolset",
+		version: "1.0.0",
+		category: "debug",
+		payload: { type: "sysext" },
+		sysextLevel: "1",
+		versionId: "12",
+		artifact: {
+			urlTemplate:
+				"https://apt.ceralive.tv/addons/debug-toolset/{os_version}/debug-toolset.raw",
+			sha256: FIXTURE_SHA,
+			gpgSigRef:
+				"https://apt.ceralive.tv/addons/debug-toolset/{os_version}/debug-toolset.raw.asc",
+			sizeDownload: 4194304,
+			sizeInstalled: 12582912,
+		},
+		provides: ["/usr/bin/htop"],
+		...over,
+	};
+}
+
+function enabledState(over: Partial<AddonState> = {}): AddonState {
+	return { enabled: true, phase: "active", autoDisabled: false, ...over };
+}
+
+type Recorded = { id: string; state: AddonState };
+
+function makeDeps(over: Partial<ReconcilerDeps> = {}): {
+	deps: ReconcilerDeps;
+	states: Recorded[];
+	calls: { fetch: number; refresh: number };
+} {
+	const states: Recorded[] = [];
+	const calls = { fetch: 0, refresh: 0 };
+	const deps: ReconcilerDeps = {
+		isRealDevice: () => Promise.resolve(true),
+		getIsStreaming: () => false,
+		getOsVersionId: () => Promise.resolve("12"),
+		getBoard: () => "rk3588",
+		getAddons: () => ({
+			"debug-toolset": enabledState({ osVersionMaterialized: "12" }),
+		}),
+		readDescriptor: () => Promise.resolve(descriptor()),
+		rawExists: () => Promise.resolve(true),
+		fetchAndStage: () => {
+			calls.fetch++;
+			return Promise.resolve();
+		},
+		refresh: () => {
+			calls.refresh++;
+			return Promise.resolve();
+		},
+		setState: (id, state) => {
+			states.push({ id, state });
+		},
+		log: () => {},
+		...over,
+	};
+	return { deps, states, calls };
+}
+
+const last = (states: Recorded[]): AddonState | undefined =>
+	states[states.length - 1]?.state;
+
+describe("addon reconciler — re-materialisation", () => {
+	it("re-materialises an enabled add-on when the staged .raw is missing", async () => {
+		const { deps, states, calls } = makeDeps({
+			rawExists: () => Promise.resolve(false),
+			getAddons: () => ({
+				"debug-toolset": enabledState({
+					phase: "active",
+					osVersionMaterialized: "12",
+				}),
+			}),
+		});
+
+		await runAddonReconciler(deps);
+
+		expect(calls.fetch).toBe(1);
+		expect(calls.refresh).toBe(1);
+		const s = last(states);
+		expect(s?.phase).toBe("active");
+		expect(s?.osVersionMaterialized).toBe("12");
+		expect(s?.versionMaterialized).toBe("1.0.0");
+		expect(s?.lastError).toBeUndefined();
+	});
+
+	it("re-materialises when the staged .raw was built for a different VERSION_ID (G1 exact match)", async () => {
+		const { deps, states, calls } = makeDeps({
+			getOsVersionId: () => Promise.resolve("13"),
+			rawExists: () => Promise.resolve(true),
+			getAddons: () => ({
+				"debug-toolset": enabledState({
+					phase: "active",
+					osVersionMaterialized: "12",
+				}),
+			}),
+		});
+
+		await runAddonReconciler(deps);
+
+		expect(calls.fetch).toBe(1);
+		expect(last(states)?.osVersionMaterialized).toBe("13");
+	});
+
+	it("is idempotent: an already-materialised add-on triggers no fetch, refresh, or write", async () => {
+		const { deps, states, calls } = makeDeps({
+			rawExists: () => Promise.resolve(true),
+			getAddons: () => ({
+				"debug-toolset": enabledState({
+					phase: "active",
+					osVersionMaterialized: "12",
+				}),
+			}),
+		});
+
+		await runAddonReconciler(deps);
+
+		expect(calls.fetch).toBe(0);
+		expect(calls.refresh).toBe(0);
+		expect(states).toHaveLength(0);
+	});
+});
+
+describe("addon reconciler — pending (no compatible artifact; never blocks)", () => {
+	it("sets pending (not error) when the artifact 404s, never refreshing", async () => {
+		const { deps, states, calls } = makeDeps({
+			rawExists: () => Promise.resolve(false),
+			fetchAndStage: () => {
+				calls.fetch++;
+				return Promise.reject(new Error("fetch failed: HTTP 404"));
+			},
+		});
+
+		await runAddonReconciler(deps);
+
+		expect(calls.fetch).toBe(1);
+		expect(calls.refresh).toBe(0);
+		const s = last(states);
+		expect(s?.phase).toBe("pending");
+		expect(s?.lastError).toBe(ADDON_NOT_AVAILABLE_FOR_OS_VERSION);
+		// Desired state is preserved — the add-on stays enabled, retried next boot.
+		expect(s?.enabled).toBe(true);
+	});
+
+	it("sets pending without fetching when the descriptor lists no compatible OS version", async () => {
+		const { deps, states, calls } = makeDeps({
+			rawExists: () => Promise.resolve(false),
+			readDescriptor: () =>
+				Promise.resolve(descriptor({ compatibleOsVersions: ["13"] })),
+		});
+
+		await runAddonReconciler(deps);
+
+		expect(calls.fetch).toBe(0);
+		expect(calls.refresh).toBe(0);
+		expect(last(states)?.phase).toBe("pending");
+		expect(last(states)?.lastError).toBe(ADDON_NOT_AVAILABLE_FOR_OS_VERSION);
+	});
+
+	it("never throws when an injected dependency itself blows up (boot stays unaffected)", async () => {
+		const { deps } = makeDeps({
+			getAddons: () => {
+				throw new Error("config exploded");
+			},
+		});
+
+		// Resolves (does not reject) — a throw here would fail the await.
+		const result = await runAddonReconciler(deps);
+		expect(result).toBeUndefined();
+	});
+});
+
+describe("addon reconciler — live-stream defer + device gate", () => {
+	it("defers (pending) without fetching or refreshing while a stream is live", async () => {
+		const { deps, states, calls } = makeDeps({
+			getIsStreaming: () => true,
+			rawExists: () => Promise.resolve(false),
+		});
+
+		await runAddonReconciler(deps);
+
+		expect(calls.fetch).toBe(0);
+		expect(calls.refresh).toBe(0);
+		const s = last(states);
+		expect(s?.phase).toBe("pending");
+		expect(s?.lastError).toBe(ADDON_REFRESH_DEFERRED_STREAMING);
+	});
+
+	it("does not disrupt a live stream for an already-materialised add-on", async () => {
+		const { deps, states, calls } = makeDeps({
+			getIsStreaming: () => true,
+			rawExists: () => Promise.resolve(true),
+			getAddons: () => ({
+				"debug-toolset": enabledState({
+					phase: "active",
+					osVersionMaterialized: "12",
+				}),
+			}),
+		});
+
+		await runAddonReconciler(deps);
+
+		expect(calls.fetch).toBe(0);
+		expect(calls.refresh).toBe(0);
+		expect(states).toHaveLength(0);
+	});
+
+	it("is a no-op in emulated mode (never reads OS version or writes state)", async () => {
+		let osRead = false;
+		const { deps, states, calls } = makeDeps({
+			isRealDevice: () => Promise.resolve(false),
+			rawExists: () => Promise.resolve(false),
+			getOsVersionId: () => {
+				osRead = true;
+				return Promise.resolve("12");
+			},
+		});
+
+		await runAddonReconciler(deps);
+
+		expect(osRead).toBe(false);
+		expect(states).toHaveLength(0);
+		expect(calls.fetch).toBe(0);
+	});
+
+	it("skips disabled and auto-disabled add-ons", async () => {
+		const { deps, states, calls } = makeDeps({
+			rawExists: () => Promise.resolve(false),
+			getAddons: () => ({
+				disabled: enabledState({ enabled: false, osVersionMaterialized: "12" }),
+				"auto-off": enabledState({
+					autoDisabled: true,
+					osVersionMaterialized: "12",
+				}),
+			}),
+		});
+
+		await runAddonReconciler(deps);
+
+		expect(calls.fetch).toBe(0);
+		expect(states).toHaveLength(0);
+	});
+});

--- a/apps/backend/src/tests/addons-config-state.test.ts
+++ b/apps/backend/src/tests/addons-config-state.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { AddonState } from "@ceraui/rpc/schemas";
+
+import {
+	loadJsonConfig,
+	writeFileAtomicSync,
+} from "../helpers/config-loader.ts";
+import {
+	RUNTIME_CONFIG_DEFAULTS,
+	runtimeConfigSchema,
+} from "../helpers/config-schemas.ts";
+
+const sampleState: AddonState = {
+	enabled: true,
+	phase: "active",
+	versionMaterialized: "1.2.3",
+	userConfig: { theme: "dark" },
+	autoDisabled: false,
+};
+
+describe("config.json add-on state", () => {
+	let tempDir: string;
+	let configPath: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "addons-config-"));
+		configPath = path.join(tempDir, "config.json");
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("defaults addons to {} when the key is absent", async () => {
+		fs.writeFileSync(configPath, JSON.stringify({ max_br: 6000 }));
+
+		const result = await loadJsonConfig(
+			configPath,
+			runtimeConfigSchema,
+			RUNTIME_CONFIG_DEFAULTS,
+		);
+
+		expect(result.data.addons).toEqual({});
+		expect(result.defaultedFields).toContain("addons");
+	});
+
+	it("round-trips an add-on state through an atomic write", async () => {
+		const persisted = { max_br: 5000, addons: { hdmi: sampleState } };
+		writeFileAtomicSync(configPath, JSON.stringify(persisted));
+
+		const result = await loadJsonConfig(
+			configPath,
+			runtimeConfigSchema,
+			RUNTIME_CONFIG_DEFAULTS,
+		);
+
+		expect(result.data.addons).toEqual({ hdmi: sampleState });
+		// No temp artifact may survive a successful write.
+		expect(fs.readdirSync(tempDir)).toEqual(["config.json"]);
+	});
+
+	it("leaves the original config intact when a write is interrupted before rename", () => {
+		const original = { max_br: 5000, addons: { hdmi: sampleState } };
+		writeFileAtomicSync(configPath, JSON.stringify(original));
+
+		// Simulate a crash mid-write: the new bytes land in the sibling temp file
+		// and fsync, but the process dies before the atomic rename runs.
+		const tmpPath = path.join(tempDir, `.config.json.${process.pid}.tmp`);
+		const fd = fs.openSync(tmpPath, "w");
+		fs.writeFileSync(fd, '{"max_br":9999,"addons":{"hdmi":{"enab');
+		fs.fsyncSync(fd);
+		fs.closeSync(fd);
+
+		// The target was never the write destination, so it still parses cleanly.
+		const onDisk = JSON.parse(fs.readFileSync(configPath, "utf8"));
+		expect(onDisk).toEqual(original);
+		expect(runtimeConfigSchema.safeParse(onDisk).success).toBe(true);
+	});
+});

--- a/apps/backend/src/tests/cog-addon-qa.test.ts
+++ b/apps/backend/src/tests/cog-addon-qa.test.ts
@@ -23,7 +23,7 @@
  * across the repo boundary — a CeraUI test stays self-contained.
  */
 
-import { describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
 
 import {
 	type AddonDescriptor,
@@ -31,16 +31,34 @@ import {
 	type AddonState,
 } from "@ceraui/rpc/schemas";
 
-import {
-	ADDON_UNAVAILABLE_ERROR,
-	type AddonManagerDeps,
-	disableAddon,
-	enableAddon,
-} from "../modules/addons/manager.ts";
+import type { AddonManagerDeps } from "../modules/addons/manager.ts";
 import {
 	type ReconcilerDeps,
 	runAddonReconciler,
 } from "../modules/addons/reconciler.ts";
+
+// manager.ts → config.ts → setup.ts, whose top-level `await loadJsonConfigSync`
+// throws when setup.json is absent — so a STATIC manager import would crash this
+// file at load on any host without setup.json. Stub the one setup.json reader and
+// load the manager dynamically AFTER (config.ts reads setup.hw only lazily). The
+// stub is torn down in afterAll so it never leaks to another test file.
+mock.module("../modules/setup.ts", () => ({ setup: { hw: "rk3588" } }));
+
+let enableAddon: typeof import("../modules/addons/manager.ts").enableAddon;
+let disableAddon: typeof import("../modules/addons/manager.ts").disableAddon;
+let ADDON_UNAVAILABLE_ERROR: string;
+
+beforeAll(async () => {
+	const mgr = await import("../modules/addons/manager.ts");
+	enableAddon = mgr.enableAddon;
+	disableAddon = mgr.disableAddon;
+	ADDON_UNAVAILABLE_ERROR = mgr.ADDON_UNAVAILABLE_ERROR;
+});
+
+afterAll(() => {
+	// Drop the setup.ts stub so the real module is restored for other files.
+	mock.restore();
+});
 
 // ─── fixtures ────────────────────────────────────────────────────────────────
 

--- a/apps/backend/src/tests/cog-addon-qa.test.ts
+++ b/apps/backend/src/tests/cog-addon-qa.test.ts
@@ -23,7 +23,7 @@
  * across the repo boundary — a CeraUI test stays self-contained.
  */
 
-import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
 import {
 	type AddonDescriptor,
@@ -31,34 +31,20 @@ import {
 	type AddonState,
 } from "@ceraui/rpc/schemas";
 
-import type { AddonManagerDeps } from "../modules/addons/manager.ts";
+import {
+	ADDON_UNAVAILABLE_ERROR,
+	type AddonManagerDeps,
+	disableAddon,
+	enableAddon,
+} from "../modules/addons/manager.ts";
 import {
 	type ReconcilerDeps,
 	runAddonReconciler,
 } from "../modules/addons/reconciler.ts";
 
-// manager.ts → config.ts → setup.ts, whose top-level `await loadJsonConfigSync`
-// throws when setup.json is absent — so a STATIC manager import would crash this
-// file at load on any host without setup.json. Stub the one setup.json reader and
-// load the manager dynamically AFTER (config.ts reads setup.hw only lazily). The
-// stub is torn down in afterAll so it never leaks to another test file.
-mock.module("../modules/setup.ts", () => ({ setup: { hw: "rk3588" } }));
-
-let enableAddon: typeof import("../modules/addons/manager.ts").enableAddon;
-let disableAddon: typeof import("../modules/addons/manager.ts").disableAddon;
-let ADDON_UNAVAILABLE_ERROR: string;
-
-beforeAll(async () => {
-	const mgr = await import("../modules/addons/manager.ts");
-	enableAddon = mgr.enableAddon;
-	disableAddon = mgr.disableAddon;
-	ADDON_UNAVAILABLE_ERROR = mgr.ADDON_UNAVAILABLE_ERROR;
-});
-
-afterAll(() => {
-	// Drop the setup.ts stub so the real module is restored for other files.
-	mock.restore();
-});
+// The manager's config→setup.ts chain throws if setup.json is absent; resilience
+// is handled globally by the test preload (bunfig.toml → src/tests/test-preload.ts)
+// which stubs setup.ts with required=false, so a static manager import is safe.
 
 // ─── fixtures ────────────────────────────────────────────────────────────────
 

--- a/apps/backend/src/tests/cog-addon-qa.test.ts
+++ b/apps/backend/src/tests/cog-addon-qa.test.ts
@@ -1,0 +1,294 @@
+/*
+ * T39 — Cog display add-on software QA (emulated dry-run).
+ *
+ * The on-device render of Cog (WPE WebKit on Mali-G610 EGL/GBM) is
+ * HARDWARE-GATED — it cannot be proven without a physical RK3588 (Task 1 spike:
+ * NO-GO). The ready-to-run on-hardware checklist lives at
+ * image-building-pipeline/v2/docs/cog-display-hw-checklist.md.
+ *
+ * Everything provable WITHOUT hardware is asserted here, against the real
+ * manager/reconciler code with every effectful primitive injected:
+ *
+ *   1. emulated-mode reconciler dry-run — with cog-display enabled in config the
+ *      reconciler skips gracefully (no descriptor read, no fetch, no state write,
+ *      never throws) when isRealDevice() is false;
+ *   2. G6 enable gate — enableAddon(cog-display) returns
+ *      `addon_unavailable_in_emulated_mode` and touches no OS primitive;
+ *   3. G6 disable gate — the symmetric guard on disableAddon;
+ *   4. wire-path proof — the cog-display descriptor shape the manager consumes
+ *      parses cleanly under the CeraUI AddonDescriptorSchema source of truth.
+ *
+ * Rule D: the descriptor fixture is inlined here (a faithful mirror of
+ * image-building-pipeline/v2/manifests/addons/cog-display.json), never read
+ * across the repo boundary — a CeraUI test stays self-contained.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import {
+	type AddonDescriptor,
+	AddonDescriptorSchema,
+	type AddonState,
+} from "@ceraui/rpc/schemas";
+
+import {
+	ADDON_UNAVAILABLE_ERROR,
+	type AddonManagerDeps,
+	disableAddon,
+	enableAddon,
+} from "../modules/addons/manager.ts";
+import {
+	type ReconcilerDeps,
+	runAddonReconciler,
+} from "../modules/addons/reconciler.ts";
+
+// ─── fixtures ────────────────────────────────────────────────────────────────
+
+/**
+ * The cog-display descriptor as the CeraUI runtime consumes it — the subset of
+ * image-building-pipeline/v2/manifests/addons/cog-display.json that the strict
+ * AddonDescriptorSchema currently accepts. The image-baked descriptor ALSO
+ * carries `conditions` + `boardVariants` (T37); those extra keys are a documented
+ * follow-up for the runtime schema (see the wire-path test below) and are NOT
+ * required for the emulated-mode gates this suite proves.
+ */
+function cogDescriptor(over: Partial<AddonDescriptor> = {}): AddonDescriptor {
+	return {
+		id: "cog-display",
+		name: "Cog Display Engine",
+		version: "0.16.1",
+		category: "display",
+		icon: "monitor",
+		payload: { type: "sysext" },
+		sysextLevel: "1",
+		versionId: "12",
+		compatibleOsVersions: ["12"],
+		artifact: {
+			urlTemplate:
+				"https://apt.ceralive.tv/addons/cog-display/{os_version}/cog-display-{board}-{os_version}.raw",
+			sha256:
+				"0000000000000000000000000000000000000000000000000000000000000000",
+			gpgSigRef:
+				"https://apt.ceralive.tv/addons/cog-display/{os_version}/cog-display-{board}-{os_version}.raw.sig",
+			sizeDownload: 57671680,
+			sizeInstalled: 125829120,
+		},
+		provides: [
+			"/usr/bin/cog",
+			"/usr/bin/cage",
+			"/usr/lib/systemd/system/cog.service",
+			"/usr/lib/systemd/system/cage.service",
+		],
+		deps: [],
+		conflicts: [],
+		units: {
+			unmask: ["cage.service", "cog.service"],
+			enable: ["cage.service", "cog.service"],
+			start: ["cage.service", "cog.service"],
+		},
+		validate: { cmd: "/usr/bin/cog --version", timeout: 10 },
+		...over,
+	};
+}
+
+/** cog-display, enabled in config — the desired state the reconciler reconciles. */
+function cogEnabledState(over: Partial<AddonState> = {}): AddonState {
+	return {
+		enabled: true,
+		phase: "active",
+		autoDisabled: false,
+		osVersionMaterialized: "12",
+		...over,
+	};
+}
+
+// ─── 1. reconciler dry-run — emulated mode skips gracefully ──────────────────
+
+describe("T39 cog-display — reconciler emulated-mode dry-run", () => {
+	function makeReconcilerDeps(over: Partial<ReconcilerDeps> = {}): {
+		deps: ReconcilerDeps;
+		probes: {
+			osRead: boolean;
+			descriptorRead: boolean;
+			fetch: number;
+			refresh: number;
+			writes: number;
+		};
+	} {
+		const probes = {
+			osRead: false,
+			descriptorRead: false,
+			fetch: 0,
+			refresh: 0,
+			writes: 0,
+		};
+		const deps: ReconcilerDeps = {
+			// G6 — emulated: the whole run is a no-op.
+			isRealDevice: () => Promise.resolve(false),
+			getIsStreaming: () => false,
+			getOsVersionId: () => {
+				probes.osRead = true;
+				return Promise.resolve("12");
+			},
+			getBoard: () => "rock-5b-plus",
+			getAddons: () => ({ "cog-display": cogEnabledState() }),
+			readDescriptor: () => {
+				probes.descriptorRead = true;
+				return Promise.resolve(cogDescriptor());
+			},
+			rawExists: () => Promise.resolve(false),
+			fetchAndStage: () => {
+				probes.fetch++;
+				return Promise.resolve();
+			},
+			refresh: () => {
+				probes.refresh++;
+				return Promise.resolve();
+			},
+			setState: () => {
+				probes.writes++;
+			},
+			log: () => {},
+			...over,
+		};
+		return { deps, probes };
+	}
+
+	it("skips without reading the OS version, fetching, refreshing, or writing state", async () => {
+		const { deps, probes } = makeReconcilerDeps();
+
+		const result = await runAddonReconciler(deps);
+
+		// Returns (never throws) and short-circuits before any effectful step.
+		expect(result).toBeUndefined();
+		expect(probes.osRead).toBe(false);
+		expect(probes.descriptorRead).toBe(false);
+		expect(probes.fetch).toBe(0);
+		expect(probes.refresh).toBe(0);
+		expect(probes.writes).toBe(0);
+	});
+
+	it("would materialise cog-display on a real device (positive control)", async () => {
+		// Same desired state, but isRealDevice() true and the staged .raw missing:
+		// the reconciler now fetches + refreshes — proving the emulated skip above
+		// is the device gate, not a dead code path.
+		const { deps, probes } = makeReconcilerDeps({
+			isRealDevice: () => Promise.resolve(true),
+			rawExists: () => Promise.resolve(false),
+		});
+
+		await runAddonReconciler(deps);
+
+		expect(probes.osRead).toBe(true);
+		expect(probes.fetch).toBe(1);
+		expect(probes.refresh).toBe(1);
+		expect(probes.writes).toBeGreaterThan(0);
+	});
+});
+
+// ─── 2 + 3. manager enable/disable — G6 emulated-mode gate ───────────────────
+
+describe("T39 cog-display — manager G6 emulated-mode gate", () => {
+	function gatedDeps(): {
+		deps: AddonManagerDeps;
+		touched: { os: boolean; net: boolean; systemctl: boolean };
+	} {
+		const touched = { os: false, net: false, systemctl: false };
+		const unreached = (label: keyof typeof touched) => {
+			touched[label] = true;
+		};
+		const deps: AddonManagerDeps = {
+			// G6 — emulated mode. Every other primitive flips a "touched" flag so
+			// the test proves the gate returns BEFORE any OS/network side effect.
+			isRealDevice: () => Promise.resolve(false),
+			getDataFreeBytes: () => {
+				unreached("os");
+				return Promise.resolve(Number.MAX_SAFE_INTEGER);
+			},
+			getOsVersion: () => {
+				unreached("os");
+				return Promise.resolve("12");
+			},
+			download: () => {
+				unreached("net");
+				return Promise.resolve();
+			},
+			verify: () => Promise.resolve(),
+			stage: () => Promise.resolve(),
+			helperEnable: () => Promise.resolve(),
+			helperDisable: () => Promise.resolve(),
+			systemctl: () => {
+				unreached("systemctl");
+				return Promise.resolve({ stdout: "", stderr: "" });
+			},
+			getNRestarts: () => Promise.resolve(0),
+			runValidate: () => Promise.resolve(true),
+			removeArtifact: () => Promise.resolve(),
+			getState: () => undefined,
+			setState: () => {},
+			removeState: () => {},
+			broadcast: () => {},
+		};
+		return { deps, touched };
+	}
+
+	it("enableAddon(cog-display) returns addon_unavailable_in_emulated_mode (G6)", async () => {
+		const { deps, touched } = gatedDeps();
+
+		const result = await enableAddon(cogDescriptor(), deps);
+
+		expect(result).toEqual({
+			success: false,
+			error: ADDON_UNAVAILABLE_ERROR,
+		});
+		expect(ADDON_UNAVAILABLE_ERROR).toBe("addon_unavailable_in_emulated_mode");
+		// No OS/network/systemctl primitive was reached.
+		expect(touched).toEqual({ os: false, net: false, systemctl: false });
+	});
+
+	it("disableAddon(cog-display) is gated the same way (symmetry)", async () => {
+		const { deps, touched } = gatedDeps();
+
+		const result = await disableAddon(cogDescriptor(), deps);
+
+		expect(result).toEqual({
+			success: false,
+			error: ADDON_UNAVAILABLE_ERROR,
+		});
+		expect(touched.systemctl).toBe(false);
+	});
+});
+
+// ─── 4. wire-path proof — descriptor validates against the CeraUI schema ─────
+
+describe("T39 cog-display — descriptor wire-path", () => {
+	it("the runtime descriptor shape parses under AddonDescriptorSchema", () => {
+		const parsed = AddonDescriptorSchema.safeParse(cogDescriptor());
+		expect(parsed.success).toBe(true);
+	});
+
+	it("documents the strict-schema gap: conditions/boardVariants are not yet mirrored (T37 follow-up)", () => {
+		// The image-baked cog-display.json ALSO carries `conditions` and
+		// `boardVariants`. The CeraUI AddonDescriptorSchema is .strict() and does
+		// not yet model them, so a descriptor carrying those extra keys is
+		// REJECTED today. This is the documented T37 follow-up (mirror the
+		// optional fields + extend ADDON_PHASES). Locking it with a test makes the
+		// gap visible and turns the eventual schema extension into a deliberate,
+		// test-driven change rather than a silent drift.
+		const withExtraKeys = {
+			...cogDescriptor(),
+			conditions: {
+				requires_display: true,
+				requires_gpu_userspace: true,
+				min_os_version: "12",
+				boardAllowlist: ["rock-5b-plus", "orange-pi-5-plus"],
+			},
+			boardVariants: {
+				"rock-5b-plus": cogDescriptor().artifact,
+				"orange-pi-5-plus": cogDescriptor().artifact,
+			},
+		};
+		const parsed = AddonDescriptorSchema.safeParse(withExtraKeys);
+		expect(parsed.success).toBe(false);
+	});
+});

--- a/apps/backend/src/tests/device-stats.test.ts
+++ b/apps/backend/src/tests/device-stats.test.ts
@@ -1,0 +1,278 @@
+/*
+ * T32 — device-stats backend collectors (exactly FIVE signals).
+ *
+ * Proves the S1 lock (payload keys == {disk, cpuLoad1, socTemp, ifaceRxTx,
+ * raucSlot}), that socTemp is WIRED from sensors.ts (no second
+ * /sys/class/thermal read), and that every source degrades gracefully to
+ * null / "unavailable" without crashing the tick.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+	blockDeviceFromSource,
+	classifyDiskType,
+	collectDeviceStats,
+	computeIfaceRates,
+	createDeviceStatsState,
+	type DeviceStatsDeps,
+	type DeviceStatsState,
+	parseDfOutput,
+	parseLoadAvg,
+	parseProcNetDev,
+	parseRaucSlot,
+	parseSocTemp,
+} from "../modules/system/device-stats.ts";
+
+// ─── deps stub ───────────────────────────────────────────────────────────────
+
+type StubOpts = {
+	files?: Record<string, string>;
+	exec?: Record<string, { stdout: string; stderr?: string } | "throw">;
+	socTemp?: string | undefined;
+	now?: number;
+};
+
+function makeDeps(opts: StubOpts = {}): {
+	deps: DeviceStatsDeps;
+	readPaths: string[];
+	execCalls: Array<{ file: string; args: readonly string[] }>;
+} {
+	const readPaths: string[] = [];
+	const execCalls: Array<{ file: string; args: readonly string[] }> = [];
+	const deps: DeviceStatsDeps = {
+		readText: async (path) => {
+			readPaths.push(path);
+			const v = opts.files?.[path];
+			if (v === undefined) throw new Error(`ENOENT: ${path}`);
+			return v;
+		},
+		execFile: async (file, args) => {
+			execCalls.push({ file, args });
+			const entry = opts.exec?.[file];
+			if (entry === undefined || entry === "throw") {
+				throw new Error(`exec failed: ${file}`);
+			}
+			return { stdout: entry.stdout, stderr: entry.stderr ?? "" };
+		},
+		getSocTempRaw: () => opts.socTemp,
+		now: () => opts.now ?? 1000,
+	};
+	return { deps, readPaths, execCalls };
+}
+
+const DF_OK =
+	"        Used         Size Source\n   536870912  10737418240 /dev/mmcblk0p2\n";
+const RAUC_OK = JSON.stringify({
+	booted: "rootfs.0",
+	boot_primary: "rootfs.0",
+});
+const NETDEV = (rx: number, tx: number) =>
+	`Inter-|   Receive                                                |  Transmit\n` +
+	` face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets\n` +
+	`    lo: 1000 10 0 0 0 0 0 0 1000 10 0 0 0 0 0 0\n` +
+	`  eth0: ${rx} 100 0 0 0 0 0 0 ${tx} 100 0 0 0 0 0 0\n`;
+
+// ─── pure parsers ─────────────────────────────────────────────────────────────
+
+describe("device-stats pure parsers", () => {
+	test("parseLoadAvg: first field of /proc/loadavg", () => {
+		expect(parseLoadAvg("0.52 0.48 0.40 1/234 5678\n")).toBe(0.52);
+		expect(parseLoadAvg("garbage")).toBeNull();
+	});
+
+	test("parseSocTemp: '45.1 °C' → 45.1; undefined → null", () => {
+		expect(parseSocTemp("45.1 °C")).toBe(45.1);
+		expect(parseSocTemp(undefined)).toBeNull();
+		expect(parseSocTemp("n/a")).toBeNull();
+	});
+
+	test("parseDfOutput: used/size/source from -B1 output", () => {
+		expect(parseDfOutput(DF_OK)).toEqual({
+			used: 536870912,
+			total: 10737418240,
+			source: "/dev/mmcblk0p2",
+		});
+		expect(parseDfOutput("Used Size Source\n")).toBeNull();
+	});
+
+	test("blockDeviceFromSource: partition → parent block device", () => {
+		expect(blockDeviceFromSource("/dev/mmcblk0p2")).toBe("mmcblk0");
+		expect(blockDeviceFromSource("/dev/sda1")).toBe("sda");
+		expect(blockDeviceFromSource("/dev/nvme0n1p3")).toBe("nvme0n1");
+		expect(blockDeviceFromSource("tmpfs")).toBeNull();
+	});
+
+	test("classifyDiskType: media class from name + rotational flag", () => {
+		expect(classifyDiskType("mmcblk0", "0")).toBe("eMMC");
+		expect(classifyDiskType("nvme0n1", null)).toBe("SSD");
+		expect(classifyDiskType("sda", "1")).toBe("HDD");
+		expect(classifyDiskType("sda", "0")).toBe("SSD");
+		expect(classifyDiskType("sda", null)).toBe("unknown");
+		expect(classifyDiskType(null, "0")).toBe("unknown");
+	});
+
+	test("parseProcNetDev: per-iface rx/tx, skips lo + headers", () => {
+		const m = parseProcNetDev(NETDEV(2000, 3000));
+		expect(m.has("lo")).toBe(false);
+		expect(m.get("eth0")).toEqual({ rx: 2000, tx: 3000 });
+	});
+
+	test("computeIfaceRates: bytes/sec delta on the most-active iface", () => {
+		const prev = parseProcNetDev(NETDEV(1000, 1000));
+		const cur = parseProcNetDev(NETDEV(3000, 5000));
+		expect(computeIfaceRates(prev, cur, 2)).toEqual({
+			iface: "eth0",
+			rxBytesPerSec: 1000,
+			txBytesPerSec: 2000,
+		});
+	});
+
+	test("computeIfaceRates: counter reset clamps to 0; dt<=0 → null", () => {
+		const prev = parseProcNetDev(NETDEV(9000, 9000));
+		const cur = parseProcNetDev(NETDEV(10, 10));
+		expect(computeIfaceRates(prev, cur, 2)).toEqual({
+			iface: "eth0",
+			rxBytesPerSec: 0,
+			txBytesPerSec: 0,
+		});
+		expect(computeIfaceRates(prev, cur, 0)).toBeNull();
+	});
+
+	test("parseRaucSlot: booted slot; invalid JSON → null", () => {
+		expect(parseRaucSlot(RAUC_OK)).toBe("rootfs.0");
+		expect(parseRaucSlot('{"boot_primary":"rootfs.1"}')).toBe("rootfs.1");
+		expect(parseRaucSlot("not json")).toBeNull();
+		expect(parseRaucSlot("{}")).toBeNull();
+	});
+});
+
+// ─── S1 lock + happy path ─────────────────────────────────────────────────────
+
+describe("collectDeviceStats — S1 lock (exactly five keys)", () => {
+	test("payload keys are EXACTLY {disk, cpuLoad1, socTemp, ifaceRxTx, raucSlot}", async () => {
+		const mk = (rx: number, tx: number, now: number) =>
+			makeDeps({
+				files: {
+					"/proc/loadavg": "1.25 0.9 0.7 1/100 42\n",
+					"/proc/net/dev": NETDEV(rx, tx),
+					"/sys/block/mmcblk0/queue/rotational": "0\n",
+				},
+				exec: { df: { stdout: DF_OK }, rauc: { stdout: RAUC_OK } },
+				socTemp: "48.3 °C",
+				now,
+			}).deps;
+		const state = createDeviceStatsState();
+		await collectDeviceStats(mk(5000, 6000, 1000), state); // baseline sample
+		const payload = await collectDeviceStats(mk(7000, 9000, 3000), state);
+
+		expect(Object.keys(payload).sort()).toEqual(
+			["cpuLoad1", "disk", "ifaceRxTx", "raucSlot", "socTemp"].sort(),
+		);
+		expect(payload.disk).toEqual({
+			used: 536870912,
+			total: 10737418240,
+			type: "eMMC",
+		});
+		expect(payload.cpuLoad1).toBe(1.25);
+		expect(payload.socTemp).toBe(48.3);
+		expect(payload.ifaceRxTx?.iface).toBe("eth0");
+		expect(payload.raucSlot).toBe("rootfs.0");
+	});
+
+	test("socTemp is WIRED from sensors.ts — no /sys/class/thermal read", async () => {
+		const { deps, readPaths } = makeDeps({
+			files: {
+				"/proc/loadavg": "0.1 0.1 0.1 1/1 1\n",
+				"/proc/net/dev": NETDEV(1, 1),
+				"/sys/block/mmcblk0/queue/rotational": "0\n",
+			},
+			exec: { df: { stdout: DF_OK }, rauc: { stdout: RAUC_OK } },
+			socTemp: "42.0 °C",
+		});
+		const payload = await collectDeviceStats(deps, createDeviceStatsState());
+
+		expect(payload.socTemp).toBe(42.0);
+		// The collector must NEVER touch the thermal sysfs — sensors.ts owns it.
+		expect(readPaths.some((p) => p.includes("/sys/class/thermal"))).toBe(false);
+	});
+
+	test("first tick establishes the rx/tx baseline (ifaceRxTx null), second yields a rate", async () => {
+		const state: DeviceStatsState = createDeviceStatsState();
+		const mk = (rx: number, tx: number, now: number) =>
+			makeDeps({
+				files: {
+					"/proc/loadavg": "0.1 0 0 1/1 1\n",
+					"/proc/net/dev": NETDEV(rx, tx),
+					"/sys/block/mmcblk0/queue/rotational": "0\n",
+				},
+				exec: { df: { stdout: DF_OK }, rauc: { stdout: RAUC_OK } },
+				socTemp: "40 °C",
+				now,
+			}).deps;
+
+		const first = await collectDeviceStats(mk(1000, 1000, 1000), state);
+		expect(first.ifaceRxTx).toBeNull();
+		const second = await collectDeviceStats(mk(3000, 7000, 3000), state);
+		expect(second.ifaceRxTx).toEqual({
+			iface: "eth0",
+			rxBytesPerSec: 1000,
+			txBytesPerSec: 3000,
+		});
+	});
+});
+
+// ─── negative: graceful degradation ────────────────────────────────────────────
+
+describe("collectDeviceStats — graceful degradation (no crash)", () => {
+	test("all sources unavailable → nulls + 'unavailable', keys intact, no throw", async () => {
+		// Nothing stubbed: every readText/execFile rejects, sensors empty.
+		const { deps } = makeDeps({ socTemp: undefined });
+		let payload!: Awaited<ReturnType<typeof collectDeviceStats>>;
+		await expect(
+			(async () => {
+				payload = await collectDeviceStats(deps, createDeviceStatsState());
+			})(),
+		).resolves.toBeUndefined();
+
+		expect(Object.keys(payload).sort()).toEqual(
+			["cpuLoad1", "disk", "ifaceRxTx", "raucSlot", "socTemp"].sort(),
+		);
+		expect(payload.disk).toBeNull();
+		expect(payload.cpuLoad1).toBeNull();
+		expect(payload.socTemp).toBeNull();
+		expect(payload.ifaceRxTx).toBeNull();
+		expect(payload.raucSlot).toBe("unavailable");
+	});
+
+	test("rauc binary absent → raucSlot 'unavailable', other signals still collected", async () => {
+		const { deps } = makeDeps({
+			files: {
+				"/proc/loadavg": "0.7 0.5 0.3 1/1 1\n",
+				"/proc/net/dev": NETDEV(1, 1),
+				"/sys/block/mmcblk0/queue/rotational": "0\n",
+			},
+			exec: { df: { stdout: DF_OK }, rauc: "throw" },
+			socTemp: "50 °C",
+		});
+		const payload = await collectDeviceStats(deps, createDeviceStatsState());
+		expect(payload.raucSlot).toBe("unavailable");
+		expect(payload.cpuLoad1).toBe(0.7);
+		expect(payload.disk?.type).toBe("eMMC");
+	});
+
+	test("missing /sys rotational path → disk still reported, type 'unknown'", async () => {
+		const { deps } = makeDeps({
+			files: { "/proc/loadavg": "0.1 0 0 1/1 1\n" },
+			// df returns an SSD-candidate device but rotational sysfs is absent.
+			exec: {
+				df: {
+					stdout: "        Used         Size Source\n   100  200 /dev/sda1\n",
+				},
+				rauc: { stdout: RAUC_OK },
+			},
+			socTemp: undefined,
+		});
+		const payload = await collectDeviceStats(deps, createDeviceStatsState());
+		expect(payload.disk).toEqual({ used: 100, total: 200, type: "unknown" });
+	});
+});

--- a/apps/backend/src/tests/kiosk-rpc.test.ts
+++ b/apps/backend/src/tests/kiosk-rpc.test.ts
@@ -5,14 +5,19 @@
  * state classifier (all five states), the crash-loop auto-disable rule, every
  * one of the six transitions, and the four authenticated RPC procedures.
  *
- * All systemd interaction is injected through the `KioskDeps` surface (mirrors
- * the `SshStatusDeps` pattern in modules/system/ssh.ts) so the suite never
- * shells out to a real `systemctl`. The injected `systemctl` spy records the
- * exact argv the state machine issued; the injected `broadcast` spy is the
- * oracle for client-facing state events.
+ * All OS interaction is injected through the `KioskDeps` surface (mirrors the
+ * `SshStatusDeps` pattern in modules/system/ssh.ts) so the suite never shells
+ * out to a real `systemctl`. The poll loop + auto-disable drive `kiosk.service`
+ * via the injected `systemctl` spy; toggle-on/off route through the injected
+ * `enableAddon`/`disableAddon` spies (the cog-display add-on manager); the
+ * injected `broadcast` spy is the oracle for client-facing state events.
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { KIOSK_UNAVAILABLE_ERROR, type KioskStatus } from "@ceraui/rpc/schemas";
+import {
+	type AddonDescriptor,
+	KIOSK_UNAVAILABLE_ERROR,
+	type KioskStatus,
+} from "@ceraui/rpc/schemas";
 import { call } from "@orpc/server";
 
 import { getConfig } from "../modules/config.ts";
@@ -51,8 +56,39 @@ type KioskHarness = {
 	deps: KioskDeps;
 	systemctlCalls: string[][];
 	broadcasts: KioskStatus[];
+	enableAddonCalls: AddonDescriptor[];
+	disableAddonCalls: AddonDescriptor[];
 	markerRemoved: () => number;
 	signals: KioskSignals;
+};
+
+// A schema-valid stand-in for the image-baked cog-display descriptor (T37). The
+// kiosk module loads this (injected) and hands it to the add-on manager.
+const COG_DESCRIPTOR: AddonDescriptor = {
+	id: "cog-display",
+	name: "Cog Display Engine",
+	version: "0.16.1",
+	category: "display",
+	payload: { type: "sysext" },
+	sysextLevel: "1",
+	versionId: "12",
+	compatibleOsVersions: ["12"],
+	artifact: {
+		urlTemplate:
+			"https://apt.ceralive.tv/addons/cog-display/{os_version}/cog-display.raw",
+		sha256: "a".repeat(64),
+		gpgSigRef:
+			"https://apt.ceralive.tv/addons/cog-display/{os_version}/cog-display.raw.sig",
+		sizeDownload: 57671680,
+		sizeInstalled: 125829120,
+	},
+	provides: ["/usr/bin/cog", "/usr/bin/cage"],
+	units: {
+		unmask: ["kiosk.service"],
+		enable: ["kiosk.service"],
+		start: ["kiosk.service"],
+	},
+	validate: { cmd: "/usr/bin/cog --version", timeout: 10 },
 };
 
 function makeHarness(initial: Partial<KioskSignals> = {}): KioskHarness {
@@ -65,6 +101,8 @@ function makeHarness(initial: Partial<KioskSignals> = {}): KioskHarness {
 	};
 	const systemctlCalls: string[][] = [];
 	const broadcasts: KioskStatus[] = [];
+	const enableAddonCalls: AddonDescriptor[] = [];
+	const disableAddonCalls: AddonDescriptor[] = [];
 	let markerRemovedCount = 0;
 
 	const deps: KioskDeps = {
@@ -80,8 +118,18 @@ function makeHarness(initial: Partial<KioskSignals> = {}): KioskHarness {
 			markerRemovedCount++;
 			signals.marker = false;
 		},
+		oskSignal: async () => {},
 		broadcast: (status) => {
 			broadcasts.push(status);
+		},
+		loadCogDescriptor: () => COG_DESCRIPTOR,
+		enableAddon: async (descriptor) => {
+			enableAddonCalls.push(descriptor);
+			return { success: true, phase: "enabled" };
+		},
+		disableAddon: async (descriptor) => {
+			disableAddonCalls.push(descriptor);
+			return { success: true, phase: "disabled" };
 		},
 	};
 
@@ -89,6 +137,8 @@ function makeHarness(initial: Partial<KioskSignals> = {}): KioskHarness {
 		deps,
 		systemctlCalls,
 		broadcasts,
+		enableAddonCalls,
+		disableAddonCalls,
 		markerRemoved: () => markerRemovedCount,
 		signals,
 	};
@@ -222,7 +272,7 @@ describe("isCrashLoop — auto-disable classification", () => {
 });
 
 describe("kioskStart (T1: toggle-on)", () => {
-	test("persists the toggle, snaps to enabled-stopped, unmasks + enable --now", async () => {
+	test("persists the toggle, snaps to enabled-stopped, enables the cog-display add-on", async () => {
 		const h = makeHarness();
 		setKioskDeps(h.deps);
 
@@ -232,12 +282,8 @@ describe("kioskStart (T1: toggle-on)", () => {
 		expect(status.state).toBe("enabled-stopped");
 		expect(getKioskLiveState()).toBe("enabled-stopped");
 		expect(getConfig().kiosk_last_state).toBe("enabled-stopped");
-		expect(h.systemctlCalls).toContainEqual(["unmask", "kiosk.service"]);
-		expect(h.systemctlCalls).toContainEqual([
-			"enable",
-			"--now",
-			"kiosk.service",
-		]);
+		expect(h.enableAddonCalls).toContainEqual(COG_DESCRIPTOR);
+		expect(h.disableAddonCalls).toHaveLength(0);
 		expect(lastBroadcast(h)?.state).toBe("enabled-stopped");
 
 		stopKioskPolling();
@@ -263,28 +309,25 @@ describe("pollKioskOnce (T2: start resolves OK)", () => {
 });
 
 describe("kioskStop (T3: toggle-off)", () => {
-	test("from enabled-running: stop + disable + mask, remove marker, persist disabled", async () => {
+	test("from enabled-running: disables the cog-display add-on, removes marker, persists disabled", async () => {
 		const h = makeHarness({ isActive: true });
 		getConfig().kiosk_enabled = true;
 		setKioskDeps(h.deps);
 		await pollKioskOnce(h.deps);
 		expect(getKioskLiveState()).toBe("enabled-running");
 
-		h.systemctlCalls.length = 0;
 		h.broadcasts.length = 0;
 		const status = await kioskStop(h.deps);
 
 		expect(getConfig().kiosk_enabled).toBe(false);
 		expect(status.state).toBe("disabled");
 		expect(getKioskLiveState()).toBe("disabled");
-		expect(h.systemctlCalls).toContainEqual(["stop", "kiosk.service"]);
-		expect(h.systemctlCalls).toContainEqual(["disable", "kiosk.service"]);
-		expect(h.systemctlCalls).toContainEqual(["mask", "kiosk.service"]);
+		expect(h.disableAddonCalls).toContainEqual(COG_DESCRIPTOR);
 		expect(h.markerRemoved()).toBeGreaterThanOrEqual(1);
 		expect(lastBroadcast(h)?.state).toBe("disabled");
 	});
 
-	test("from failed-no-display: toggle-off returns to disabled", async () => {
+	test("from failed-no-display: toggle-off disables the add-on and returns to disabled", async () => {
 		const h = makeHarness({ isFailed: true, marker: true, nRestarts: 0 });
 		getConfig().kiosk_enabled = true;
 		setKioskDeps(h.deps);
@@ -293,6 +336,7 @@ describe("kioskStop (T3: toggle-off)", () => {
 		const status = await kioskStop(h.deps);
 		expect(status.state).toBe("disabled");
 		expect(getConfig().kiosk_enabled).toBe(false);
+		expect(h.disableAddonCalls).toContainEqual(COG_DESCRIPTOR);
 	});
 });
 
@@ -453,9 +497,10 @@ describe("system.kiosk* RPC procedures", () => {
  * T13 — the four action handlers gate on isRealDevice(). On a dev/CI/emulated
  * host the user-reported bug was that toggling kiosk pushed the developer's own
  * machine into host kiosk mode. The gate must short-circuit BEFORE any kiosk
- * module function runs, so systemd is never touched. The harness spies the whole
- * KioskDeps surface (systemctl + oskSignal + broadcast); a gated handler must
- * leave every spy untouched and the persisted config unchanged.
+ * module function runs, so systemd and the add-on manager are never touched. The
+ * harness spies the whole KioskDeps surface (systemctl + oskSignal + broadcast +
+ * enableAddon/disableAddon); a gated handler must leave every spy untouched and
+ * the persisted config unchanged.
  */
 describe("kiosk RPC isRealDevice() gate (T13)", () => {
 	type GateHarness = {
@@ -463,12 +508,16 @@ describe("kiosk RPC isRealDevice() gate (T13)", () => {
 		systemctlCalls: string[][];
 		broadcasts: KioskStatus[];
 		oskSignals: OskSignal[];
+		enableAddonCalls: AddonDescriptor[];
+		disableAddonCalls: AddonDescriptor[];
 	};
 
 	function makeGateHarness(): GateHarness {
 		const systemctlCalls: string[][] = [];
 		const broadcasts: KioskStatus[] = [];
 		const oskSignals: OskSignal[] = [];
+		const enableAddonCalls: AddonDescriptor[] = [];
+		const disableAddonCalls: AddonDescriptor[] = [];
 		const deps: KioskDeps = {
 			systemctl: async (args) => {
 				systemctlCalls.push(args);
@@ -485,8 +534,24 @@ describe("kiosk RPC isRealDevice() gate (T13)", () => {
 			broadcast: (status) => {
 				broadcasts.push(status);
 			},
+			loadCogDescriptor: () => COG_DESCRIPTOR,
+			enableAddon: async (descriptor) => {
+				enableAddonCalls.push(descriptor);
+				return { success: true, phase: "enabled" };
+			},
+			disableAddon: async (descriptor) => {
+				disableAddonCalls.push(descriptor);
+				return { success: true, phase: "disabled" };
+			},
 		};
-		return { deps, systemctlCalls, broadcasts, oskSignals };
+		return {
+			deps,
+			systemctlCalls,
+			broadcasts,
+			oskSignals,
+			enableAddonCalls,
+			disableAddonCalls,
+		};
 	}
 
 	let savedDeviceType: string | undefined;
@@ -503,7 +568,7 @@ describe("kiosk RPC isRealDevice() gate (T13)", () => {
 			process.env.CERALIVE_DEVICE_TYPE = "emulated";
 		});
 
-		test("kioskStart: unavailable, never unmasks the unit, leaves toggle off", async () => {
+		test("kioskStart: unavailable, never enables the add-on, leaves toggle off", async () => {
 			const h = makeGateHarness();
 			setKioskDeps(h.deps);
 
@@ -515,10 +580,11 @@ describe("kiosk RPC isRealDevice() gate (T13)", () => {
 			expect(result.error).toBe(KIOSK_UNAVAILABLE_ERROR);
 			expect(result.applied).toBeUndefined();
 			expect(h.systemctlCalls).toHaveLength(0);
+			expect(h.enableAddonCalls).toHaveLength(0);
 			expect(getConfig().kiosk_enabled).toBe(false);
 		});
 
-		test("kioskStop: unavailable, never stops/masks the unit", async () => {
+		test("kioskStop: unavailable, never disables the add-on", async () => {
 			const h = makeGateHarness();
 			setKioskDeps(h.deps);
 
@@ -530,6 +596,7 @@ describe("kiosk RPC isRealDevice() gate (T13)", () => {
 			expect(result.error).toBe(KIOSK_UNAVAILABLE_ERROR);
 			expect(result.applied).toBeUndefined();
 			expect(h.systemctlCalls).toHaveLength(0);
+			expect(h.disableAddonCalls).toHaveLength(0);
 		});
 
 		test("kioskConfigure: unavailable, never persists or broadcasts", async () => {
@@ -570,7 +637,7 @@ describe("kiosk RPC isRealDevice() gate (T13)", () => {
 			process.env.CERALIVE_DEVICE_TYPE = "real";
 		});
 
-		test("kioskStart commits the toggle and drives the unit", async () => {
+		test("kioskStart commits the toggle and enables the cog-display add-on", async () => {
 			const h = makeGateHarness();
 			setKioskDeps(h.deps);
 
@@ -583,7 +650,7 @@ describe("kiosk RPC isRealDevice() gate (T13)", () => {
 			expect(result.applied?.enabled).toBe(true);
 			expect(result.applied?.state).toBe("enabled-stopped");
 			expect(getConfig().kiosk_enabled).toBe(true);
-			expect(h.systemctlCalls).toContainEqual(["unmask", "kiosk.service"]);
+			expect(h.enableAddonCalls).toContainEqual(COG_DESCRIPTOR);
 
 			stopKioskPolling();
 		});

--- a/apps/backend/src/tests/manager.test.ts
+++ b/apps/backend/src/tests/manager.test.ts
@@ -1,0 +1,521 @@
+/*
+ * Task 28 — add-on manager state machine (modules/addons/manager.ts).
+ *
+ * Covers the orchestration the manager owns, with every OS/network/persistence
+ * primitive injected through `AddonManagerDeps` (mirrors the kiosk-rpc suite):
+ *
+ *   - the pure layer: phase ⇄ AddonState mapping (always schema-valid), the E1
+ *     free-space formula, the crash-loop discriminator, url/df parsing;
+ *   - the enable pipeline: ordered steps + phase transitions → enabled;
+ *   - the disable pipeline: reverse + idempotent;
+ *   - crash-loop auto-disable (NRestarts >= 3 → mask + auto_disabled);
+ *   - the validation-probe auto-disable;
+ *   - the negative paths: G6 emulated-mode gate + E1 insufficient space.
+ *
+ * No real sudo / systemctl / network / disk is touched, and the injected
+ * setState/removeState spies keep config.json out of the test entirely.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	type AddonDescriptor,
+	type AddonPhase,
+	type AddonState,
+	AddonStateSchema,
+} from "@ceraui/rpc/schemas";
+
+import {
+	ADDON_CRASH_LOOP_RESTART_THRESHOLD,
+	ADDON_ENABLE_FAILED_ERROR,
+	ADDON_FREE_SPACE_HEADROOM_BYTES,
+	ADDON_INSUFFICIENT_SPACE_ERROR,
+	ADDON_MANAGER_PHASES,
+	ADDON_UNAVAILABLE_ERROR,
+	ADDON_VALIDATION_FAILED_ERROR,
+	type AddonManagerDeps,
+	type AddonManagerPhase,
+	disableAddon,
+	enableAddon,
+	extArtifactPath,
+	getAddonPhase,
+	hasSufficientSpace,
+	initAddonManager,
+	isAddonCrashLoop,
+	parseDfAvail,
+	phaseFromState,
+	pollAddonCrashLoop,
+	requiredFreeBytes,
+	resetAddonManagerDeps,
+	resolveArtifactUrl,
+	tmpArtifactPath,
+	toAddonState,
+} from "../modules/addons/manager.ts";
+
+// ─── fixtures ────────────────────────────────────────────────────────────────
+
+const UNIT = "debug-toolset.service";
+
+/** A fully-formed, schema-valid descriptor (overridable per test). */
+function makeDescriptor(over: Partial<AddonDescriptor> = {}): AddonDescriptor {
+	return {
+		id: "debug-toolset",
+		name: "Debug Toolset",
+		version: "1.2.3",
+		category: "debug",
+		payload: { type: "sysext" },
+		sysextLevel: "1",
+		versionId: "12",
+		artifact: {
+			urlTemplate:
+				"https://apt.ceralive.tv/addons/debug-toolset/{os_version}/debug-toolset.raw",
+			sha256: "a".repeat(64),
+			gpgSigRef:
+				"https://apt.ceralive.tv/addons/debug-toolset/{os_version}/debug-toolset.raw.sig",
+			sizeDownload: 1024,
+			sizeInstalled: 4096,
+		},
+		provides: ["/usr/bin/debug-toolset"],
+		units: { unmask: [UNIT], enable: [UNIT], start: [UNIT] },
+		validate: { cmd: "test -x /usr/bin/debug-toolset" },
+		...over,
+	};
+}
+
+type Signals = {
+	isRealDevice: boolean;
+	freeBytes: number;
+	nRestarts: number;
+	validateOk: boolean;
+};
+
+type Recorded = {
+	setState: Array<{
+		id: string;
+		persistedPhase: AddonPhase;
+		mgr: AddonManagerPhase;
+	}>;
+	broadcast: Array<{ id: string; state: AddonState }>;
+	systemctl: string[][];
+	download: Array<{ url: string; dest: string }>;
+	verify: string[];
+	stage: Array<{ tmp: string; dest: string }>;
+	helperEnable: string[];
+	helperDisable: string[];
+	removeArtifact: string[];
+	removeState: string[];
+	runValidate: string[];
+	/** Chronological op log for ordering assertions. */
+	order: string[];
+};
+
+type Harness = {
+	deps: AddonManagerDeps;
+	signals: Signals;
+	store: Map<string, AddonState>;
+	rec: Recorded;
+};
+
+/** A spying dep surface: real-device + plenty of space + healthy probe by default. */
+function makeHarness(
+	signalsOver: Partial<Signals> = {},
+	over: Partial<AddonManagerDeps> = {},
+): Harness {
+	const signals: Signals = {
+		isRealDevice: true,
+		freeBytes: 100 * 1024 * 1024 * 1024, // 100 GiB — never the limiting factor
+		nRestarts: 0,
+		validateOk: true,
+		...signalsOver,
+	};
+	const store = new Map<string, AddonState>();
+	const rec: Recorded = {
+		setState: [],
+		broadcast: [],
+		systemctl: [],
+		download: [],
+		verify: [],
+		stage: [],
+		helperEnable: [],
+		helperDisable: [],
+		removeArtifact: [],
+		removeState: [],
+		runValidate: [],
+		order: [],
+	};
+
+	const deps: AddonManagerDeps = {
+		isRealDevice: () => Promise.resolve(signals.isRealDevice),
+		getDataFreeBytes: () => Promise.resolve(signals.freeBytes),
+		getOsVersion: () => Promise.resolve("12"),
+		download: (url, dest) => {
+			rec.download.push({ url, dest });
+			rec.order.push("download");
+			return Promise.resolve();
+		},
+		verify: (_d, tmp) => {
+			rec.verify.push(tmp);
+			rec.order.push("verify");
+			return Promise.resolve();
+		},
+		stage: (tmp, dest) => {
+			rec.stage.push({ tmp, dest });
+			rec.order.push("stage");
+			return Promise.resolve();
+		},
+		helperEnable: (id) => {
+			rec.helperEnable.push(id);
+			rec.order.push("helperEnable");
+			return Promise.resolve();
+		},
+		helperDisable: (id) => {
+			rec.helperDisable.push(id);
+			rec.order.push("helperDisable");
+			return Promise.resolve();
+		},
+		systemctl: (args) => {
+			rec.systemctl.push(args);
+			rec.order.push(`systemctl:${args.join(" ")}`);
+			return Promise.resolve({ stdout: "", stderr: "" });
+		},
+		getNRestarts: () => Promise.resolve(signals.nRestarts),
+		runValidate: (cmd) => {
+			rec.runValidate.push(cmd);
+			rec.order.push("validate");
+			return Promise.resolve(signals.validateOk);
+		},
+		removeArtifact: (path) => {
+			rec.removeArtifact.push(path);
+			return Promise.resolve();
+		},
+		getState: (id) => store.get(id),
+		setState: (id, state) => {
+			store.set(id, state);
+			rec.setState.push({
+				id,
+				persistedPhase: state.phase,
+				mgr: phaseFromState(state),
+			});
+		},
+		removeState: (id) => {
+			store.delete(id);
+			rec.removeState.push(id);
+		},
+		broadcast: (id, state) => {
+			rec.broadcast.push({ id, state });
+		},
+		...over,
+	};
+
+	return { deps, signals, store, rec };
+}
+
+beforeEach(() => {
+	resetAddonManagerDeps();
+	// Clears the module-level live-phase map (config is empty in tests).
+	initAddonManager();
+});
+
+afterEach(() => {
+	resetAddonManagerDeps();
+});
+
+// ─── pure layer ──────────────────────────────────────────────────────────────
+
+describe("phase ⇄ AddonState mapping", () => {
+	test("every manager phase encodes a schema-valid AddonState", () => {
+		for (const phase of ADDON_MANAGER_PHASES) {
+			const state = toAddonState(phase);
+			expect(AddonStateSchema.safeParse(state).success).toBe(true);
+		}
+	});
+
+	test("phaseFromState is the exact inverse of toAddonState", () => {
+		for (const phase of ADDON_MANAGER_PHASES) {
+			expect(phaseFromState(toAddonState(phase))).toBe(phase);
+		}
+	});
+
+	test("optional metadata is attached only when supplied", () => {
+		const bare = toAddonState("enabled");
+		expect(bare).toEqual({
+			enabled: true,
+			phase: "active",
+			autoDisabled: false,
+		});
+
+		const rich = toAddonState("enabled", {
+			versionMaterialized: "1.2.3",
+			userConfig: { theme: "dark" },
+		});
+		expect(rich.versionMaterialized).toBe("1.2.3");
+		expect(rich.userConfig).toEqual({ theme: "dark" });
+		expect(rich.lastError).toBeUndefined();
+	});
+});
+
+describe("free-space precheck (E1)", () => {
+	test("requiredFreeBytes = sizeInstalled × 2 + 512 MiB headroom", () => {
+		expect(requiredFreeBytes(4096)).toBe(
+			4096 * 2 + ADDON_FREE_SPACE_HEADROOM_BYTES,
+		);
+		expect(ADDON_FREE_SPACE_HEADROOM_BYTES).toBe(512 * 1024 * 1024);
+	});
+
+	test("hasSufficientSpace is strict (must exceed the requirement)", () => {
+		const need = requiredFreeBytes(4096);
+		expect(hasSufficientSpace(need + 1, 4096)).toBe(true);
+		expect(hasSufficientSpace(need, 4096)).toBe(false);
+		expect(hasSufficientSpace(need - 1, 4096)).toBe(false);
+	});
+});
+
+describe("crash-loop discriminator", () => {
+	test("true at/above the threshold, false below", () => {
+		expect(ADDON_CRASH_LOOP_RESTART_THRESHOLD).toBe(3);
+		expect(isAddonCrashLoop(2)).toBe(false);
+		expect(isAddonCrashLoop(3)).toBe(true);
+		expect(isAddonCrashLoop(9)).toBe(true);
+	});
+});
+
+describe("url + df parsing", () => {
+	test("resolveArtifactUrl substitutes every {os_version}", () => {
+		expect(
+			resolveArtifactUrl("https://x/{os_version}/a/{os_version}.raw", "12"),
+		).toBe("https://x/12/a/12.raw");
+	});
+
+	test("parseDfAvail reads the avail column of df -B1 --output=avail", () => {
+		expect(parseDfAvail("Avail\n  10737418240\n")).toBe(10737418240);
+		expect(parseDfAvail("garbage")).toBeNull();
+	});
+});
+
+// ─── enable pipeline ─────────────────────────────────────────────────────────
+
+describe("enableAddon — happy path", () => {
+	test("runs the pipeline in order and transitions enabling → enabled", async () => {
+		const h = makeHarness();
+		const d = makeDescriptor();
+
+		const result = await enableAddon(d, h.deps);
+
+		expect(result).toEqual({ success: true, phase: "enabled" });
+		expect(getAddonPhase(d.id)).toBe("enabled");
+
+		// Phase transitions persisted in order: installing (enabling) → active (enabled).
+		expect(h.rec.setState.map((s) => s.mgr)).toEqual(["enabling", "enabled"]);
+		expect(h.rec.setState.map((s) => s.persistedPhase)).toEqual([
+			"installing",
+			"active",
+		]);
+		// Final persisted state records the materialised version.
+		expect(h.store.get(d.id)?.versionMaterialized).toBe("1.2.3");
+		expect(h.store.get(d.id)?.enabled).toBe(true);
+
+		// Pipeline targets the atomic temp + scan-dir paths.
+		expect(h.rec.download[0]?.dest).toBe(tmpArtifactPath(d.id));
+		expect(h.rec.download[0]?.url).toBe(
+			"https://apt.ceralive.tv/addons/debug-toolset/12/debug-toolset.raw",
+		);
+		expect(h.rec.stage[0]).toEqual({
+			tmp: tmpArtifactPath(d.id),
+			dest: extArtifactPath(d.id),
+		});
+		expect(h.rec.helperEnable).toEqual([d.id]);
+
+		// Strict ordering: download → verify → stage → helper enable → unmask →
+		// start → validate.
+		const o = h.rec.order;
+		const idx = (tag: string) => o.indexOf(tag);
+		expect(idx("download")).toBeLessThan(idx("verify"));
+		expect(idx("verify")).toBeLessThan(idx("stage"));
+		expect(idx("stage")).toBeLessThan(idx("helperEnable"));
+		expect(idx("helperEnable")).toBeLessThan(idx(`systemctl:unmask ${UNIT}`));
+		expect(idx(`systemctl:unmask ${UNIT}`)).toBeLessThan(
+			idx(`systemctl:start ${UNIT}`),
+		);
+		expect(idx(`systemctl:start ${UNIT}`)).toBeLessThan(idx("validate"));
+	});
+
+	test("an enable-step failure parks the add-on in failed and cleans the temp", async () => {
+		const h = makeHarness(
+			{},
+			{
+				helperEnable: () => Promise.reject(new Error("sudo denied")),
+			},
+		);
+		const d = makeDescriptor();
+
+		const result = await enableAddon(d, h.deps);
+
+		expect(result).toEqual({
+			success: false,
+			error: ADDON_ENABLE_FAILED_ERROR,
+		});
+		expect(getAddonPhase(d.id)).toBe("failed");
+		expect(h.store.get(d.id)?.phase).toBe("error");
+		expect(h.store.get(d.id)?.lastError).toContain("sudo denied");
+		// The partial download was removed.
+		expect(h.rec.removeArtifact).toContain(tmpArtifactPath(d.id));
+	});
+});
+
+describe("enableAddon — validation probe auto-disable", () => {
+	test("a failing probe masks units and parks the add-on in auto_disabled", async () => {
+		const h = makeHarness({ validateOk: false });
+		const d = makeDescriptor();
+
+		const result = await enableAddon(d, h.deps);
+
+		expect(result).toEqual({
+			success: false,
+			error: ADDON_VALIDATION_FAILED_ERROR,
+		});
+		expect(getAddonPhase(d.id)).toBe("auto_disabled");
+		expect(h.store.get(d.id)?.autoDisabled).toBe(true);
+		expect(h.rec.systemctl).toContainEqual(["mask", UNIT]);
+	});
+});
+
+// ─── disable pipeline ────────────────────────────────────────────────────────
+
+describe("disableAddon — reverse + idempotent", () => {
+	test("stops + masks units, tears down via helper, removes artifact + state", async () => {
+		const h = makeHarness();
+		const d = makeDescriptor();
+		await enableAddon(d, h.deps);
+
+		// Isolate the disable systemctl traffic from the enable run.
+		h.rec.systemctl.length = 0;
+		const result = await disableAddon(d, h.deps);
+
+		expect(result).toEqual({ success: true, phase: "disabled" });
+		expect(getAddonPhase(d.id)).toBe("disabled");
+		expect(h.rec.systemctl).toContainEqual(["stop", UNIT]);
+		expect(h.rec.systemctl).toContainEqual(["mask", UNIT]);
+		expect(h.rec.helperDisable).toEqual([d.id]);
+		expect(h.rec.removeArtifact).toContain(extArtifactPath(d.id));
+		expect(h.rec.removeState).toContain(d.id);
+		// Device-local state was dropped.
+		expect(h.store.has(d.id)).toBe(false);
+	});
+
+	test("a second disable on an already-disabled add-on is a harmless no-op", async () => {
+		const h = makeHarness();
+		const d = makeDescriptor();
+		await enableAddon(d, h.deps);
+
+		expect((await disableAddon(d, h.deps)).success).toBe(true);
+		expect((await disableAddon(d, h.deps)).success).toBe(true);
+		expect(getAddonPhase(d.id)).toBe("disabled");
+	});
+});
+
+// ─── crash-loop auto-disable ─────────────────────────────────────────────────
+
+describe("pollAddonCrashLoop — NRestarts >= 3 auto-disable", () => {
+	test("a crash-looping unit is masked and the add-on goes auto_disabled", async () => {
+		const h = makeHarness();
+		const d = makeDescriptor();
+		await enableAddon(d, h.deps);
+		expect(getAddonPhase(d.id)).toBe("enabled");
+
+		h.signals.nRestarts = ADDON_CRASH_LOOP_RESTART_THRESHOLD;
+		h.rec.systemctl.length = 0;
+		const phase = await pollAddonCrashLoop(d, h.deps);
+
+		expect(phase).toBe("auto_disabled");
+		expect(getAddonPhase(d.id)).toBe("auto_disabled");
+		expect(h.store.get(d.id)?.autoDisabled).toBe(true);
+		expect(h.store.get(d.id)?.lastError).toBe("addon_crash_loop");
+		expect(h.rec.systemctl).toContainEqual(["mask", UNIT]);
+	});
+
+	test("below the threshold the add-on stays enabled and nothing is masked", async () => {
+		const h = makeHarness();
+		const d = makeDescriptor();
+		await enableAddon(d, h.deps);
+
+		h.signals.nRestarts = ADDON_CRASH_LOOP_RESTART_THRESHOLD - 1;
+		h.rec.systemctl.length = 0;
+		const phase = await pollAddonCrashLoop(d, h.deps);
+
+		expect(phase).toBe("enabled");
+		expect(getAddonPhase(d.id)).toBe("enabled");
+		expect(h.rec.systemctl).not.toContainEqual(["mask", UNIT]);
+	});
+
+	test("a non-enabled add-on is never crash-loop-disabled", async () => {
+		const h = makeHarness({ nRestarts: 9 });
+		const d = makeDescriptor();
+		// Never enabled — phase is the default `disabled`.
+		const phase = await pollAddonCrashLoop(d, h.deps);
+		expect(phase).toBe("disabled");
+		expect(h.rec.systemctl).toHaveLength(0);
+	});
+});
+
+// ─── negative paths (G6 emulated gate + E1 insufficient space) ───────────────
+
+describe("enableAddon — negative: G6 emulated-mode gate", () => {
+	test("emulated mode returns addon_unavailable and touches nothing", async () => {
+		const h = makeHarness({ isRealDevice: false });
+		const d = makeDescriptor();
+
+		const result = await enableAddon(d, h.deps);
+
+		expect(result).toEqual({ success: false, error: ADDON_UNAVAILABLE_ERROR });
+		// No download, no transition, no systemd — the gate fires first.
+		expect(h.rec.download).toHaveLength(0);
+		expect(h.rec.setState).toHaveLength(0);
+		expect(h.rec.systemctl).toHaveLength(0);
+		expect(getAddonPhase(d.id)).toBe("disabled");
+	});
+});
+
+describe("disableAddon — negative: G6 emulated-mode gate", () => {
+	test("emulated mode returns addon_unavailable and never tears down", async () => {
+		const h = makeHarness({ isRealDevice: false });
+		const d = makeDescriptor();
+
+		const result = await disableAddon(d, h.deps);
+
+		expect(result).toEqual({ success: false, error: ADDON_UNAVAILABLE_ERROR });
+		expect(h.rec.systemctl).toHaveLength(0);
+		expect(h.rec.helperDisable).toHaveLength(0);
+		expect(h.rec.setState).toHaveLength(0);
+	});
+});
+
+describe("pollAddonCrashLoop — negative: G6 emulated-mode gate", () => {
+	test("emulated mode never probes NRestarts or masks", async () => {
+		const h = makeHarness({ isRealDevice: false, nRestarts: 9 });
+		const d = makeDescriptor();
+
+		const phase = await pollAddonCrashLoop(d, h.deps);
+
+		expect(phase).toBe("disabled");
+		expect(h.rec.systemctl).toHaveLength(0);
+	});
+});
+
+describe("enableAddon — negative: E1 insufficient space", () => {
+	test("too little free /data returns addon_insufficient_space before any work", async () => {
+		const d = makeDescriptor();
+		// One byte short of the requirement.
+		const need = requiredFreeBytes(d.artifact.sizeInstalled);
+		const h = makeHarness({ freeBytes: need });
+
+		const result = await enableAddon(d, h.deps);
+
+		expect(result).toEqual({
+			success: false,
+			error: ADDON_INSUFFICIENT_SPACE_ERROR,
+		});
+		// Precheck fires before the first transition or download.
+		expect(h.rec.setState).toHaveLength(0);
+		expect(h.rec.download).toHaveLength(0);
+		expect(getAddonPhase(d.id)).toBe("disabled");
+	});
+});

--- a/apps/backend/src/tests/test-preload.ts
+++ b/apps/backend/src/tests/test-preload.ts
@@ -1,0 +1,14 @@
+import { mock } from "bun:test";
+import { loadJsonConfigSync } from "../helpers/config-loader.ts";
+import {
+	SETUP_CONFIG_DEFAULTS,
+	setupConfigSchema,
+} from "../helpers/config-schemas.ts";
+
+const setup = await loadJsonConfigSync(
+	"setup.json",
+	setupConfigSchema,
+	SETUP_CONFIG_DEFAULTS,
+	false,
+);
+mock.module("../modules/setup.ts", () => ({ setup }));

--- a/apps/frontend/src/lib/rpc/client.ts
+++ b/apps/frontend/src/lib/rpc/client.ts
@@ -5,6 +5,8 @@
  * Uses the AppContract from @ceraui/rpc for end-to-end type safety.
  */
 import type {
+	AddonDescriptor,
+	AddonState,
 	AutostartOutput,
 	BitrateInput,
 	BitrateOutput,
@@ -426,6 +428,27 @@ function createRPCProxy<T extends object>(
 // Singleton client instance
 export const rpcClient = new RPCClient();
 
+// Mirrors the backend AddonManagerPhase union (modules/addons/manager.ts). No
+// shared schema source exists for it, so it is kept in lockstep by hand.
+export type AddonManagerPhase =
+	| "disabled"
+	| "pending"
+	| "enabling"
+	| "enabled"
+	| "disabling"
+	| "failed"
+	| "auto_disabled";
+
+export interface AddonListItem {
+	descriptor: AddonDescriptor;
+	state: AddonState;
+	managerPhase: AddonManagerPhase;
+}
+
+export type AddonOpResult =
+	| { success: true; phase: AddonManagerPhase }
+	| { success: false; error: string };
+
 /**
  * Type-safe RPC interface definition
  * Maps contract structure to callable async functions
@@ -517,6 +540,15 @@ export interface TypedRPC {
 		completePairing: (
 			input: CompletePairingInput,
 		) => Promise<CompletePairingOutput>;
+	};
+	addons: {
+		list: () => Promise<{ addons: AddonListItem[] }>;
+		install: (input: {
+			id: string;
+			userConfig?: Record<string, unknown>;
+		}) => Promise<AddonOpResult>;
+		uninstall: (input: { id: string }) => Promise<AddonOpResult>;
+		getStatus: (input: { id: string }) => Promise<AddonListItem | null>;
 	};
 	// Dev-only: registered on the backend ONLY when NODE_ENV !== "production".
 	// Absent in production builds — guard usage with the optional chain.

--- a/apps/frontend/src/lib/rpc/subscriptions.svelte.ts
+++ b/apps/frontend/src/lib/rpc/subscriptions.svelte.ts
@@ -7,6 +7,7 @@
 
 import type {
 	ConfigMessage,
+	DeviceStats,
 	KioskStatus,
 	ModemList,
 	NetifEntry,
@@ -79,6 +80,7 @@ let wifiState = $state<WifiStatus | undefined>(undefined);
 let modemsState = $state<ModemList | undefined>(undefined);
 
 // System state
+let deviceStatsState = $state<DeviceStats | undefined>(undefined);
 let sensorsState = $state<SensorsStatus | undefined>(undefined);
 let revisionsState = $state<Revisions | undefined>(undefined);
 let pipelinesState = $state<PipelinesMessage | undefined>(undefined);
@@ -153,6 +155,10 @@ export function getModems() {
 
 export function getSensors() {
 	return sensorsState;
+}
+
+export function getDeviceStats() {
+	return deviceStatsState;
 }
 
 export function getRevisions() {
@@ -362,6 +368,10 @@ function handleMessage(type: string, data: unknown, seq?: number): void {
 
 		case "sensors":
 			sensorsState = data as SensorsStatus;
+			break;
+
+		case "device-stats":
+			deviceStatsState = data as DeviceStats;
 			break;
 
 		case "revisions":
@@ -584,6 +594,7 @@ export function resetState(): void {
 	wifiState = undefined;
 	modemsState = undefined;
 	sensorsState = undefined;
+	deviceStatsState = undefined;
 	revisionsState = undefined;
 	pipelinesState = undefined;
 	audioCodecsState = undefined;

--- a/apps/frontend/src/lib/rpc/subscriptions.svelte.ts
+++ b/apps/frontend/src/lib/rpc/subscriptions.svelte.ts
@@ -6,6 +6,7 @@
  */
 
 import type {
+	AddonState,
 	ConfigMessage,
 	DeviceStats,
 	KioskStatus,
@@ -100,6 +101,11 @@ let notificationsState = $state<NotificationsMessage | undefined>(undefined);
 // failed unit.
 let kioskState = $state<KioskStatus | undefined>(undefined);
 
+// Live per-add-on runtime state, keyed by id. The `addons` broadcast carries a
+// PARTIAL map of only the changed add-ons, so it is merged per id, never replaced
+// wholesale. Descriptors come from rpc.addons.list(); this tracks state only.
+let addonsState = $state<Record<string, AddonState>>({});
+
 // Connection state
 let connectionState = $state<ConnectionState>("disconnected");
 let isConnectedState = $state<boolean>(false);
@@ -183,6 +189,10 @@ export function getNotifications() {
 
 export function getKiosk() {
 	return kioskState;
+}
+
+export function getAddons() {
+	return addonsState;
 }
 
 export function getConnectionState() {
@@ -425,6 +435,17 @@ function handleMessage(type: string, data: unknown, seq?: number): void {
 			}
 			break;
 
+		case "addons":
+			// Partial map of changed add-ons: merge per id so an untouched add-on's
+			// state is preserved (mirrors the modem per-id merge above).
+			if (data && typeof data === "object") {
+				addonsState = {
+					...addonsState,
+					...(data as Record<string, AddonState>),
+				};
+			}
+			break;
+
 		case "health":
 			// Tri-state stream-liveness rollup (Task 13). Read-only: feeds the HUD
 			// indicator + raises a transition toast; never drives restart logic.
@@ -601,6 +622,7 @@ export function resetState(): void {
 	relaysState = undefined;
 	notificationsState = undefined;
 	kioskState = undefined;
+	addonsState = {};
 	connectionReadyState = false;
 
 	if (lockExpiryTick !== undefined) {

--- a/apps/frontend/src/main/SettingsView.svelte
+++ b/apps/frontend/src/main/SettingsView.svelte
@@ -11,6 +11,7 @@
 <script lang="ts">
 import { LL } from '@ceraui/i18n/svelte';
 import {
+	Blocks,
 	ChevronRight,
 	Cloud,
 	Info,
@@ -42,6 +43,7 @@ import LogsDialog from './dialogs/LogsDialog.svelte';
 import PairingDialog from './dialogs/PairingDialog.svelte';
 import PasswordDialog from './dialogs/PasswordDialog.svelte';
 import PowerDialog from './dialogs/PowerDialog.svelte';
+import AddonsSection from './settings/AddonsSection.svelte';
 import DeviceStatsSection from './settings/DeviceStatsSection.svelte';
 import OnDeviceDisplaySection from './settings/OnDeviceDisplaySection.svelte';
 import SshDialog from './dialogs/SshDialog.svelte';
@@ -147,7 +149,15 @@ const groups = $derived<Group[]>([
 	{
 		id: 'software',
 		label: t.groups.software(),
-		entries: [{ key: 'updates', title: t.updates(), desc: t.updatesDesc(), icon: RefreshCw }],
+		entries: [
+			{ key: 'updates', title: t.updates(), desc: t.updatesDesc(), icon: RefreshCw },
+			{
+				key: 'addons',
+				title: 'Add-ons',
+				desc: 'Install and manage optional device features',
+				icon: Blocks,
+			},
+		],
 	},
 	{
 		id: 'display',
@@ -174,6 +184,7 @@ let updatesOpen = $state(false);
 let powerOpen = $state(false);
 let versionsOpen = $state(false);
 let displayOpen = $state(false);
+let addonsOpen = $state(false);
 
 // Fallback placeholder dialog for any not-yet-wired entries.
 let open = $state(false);
@@ -207,6 +218,9 @@ function openEntry(entry: Entry) {
 			return;
 		case 'onDeviceDisplay':
 			displayOpen = true;
+			return;
+		case 'addons':
+			addonsOpen = true;
 			return;
 		default:
 			active = entry;
@@ -367,3 +381,4 @@ const ActiveIcon = $derived(active?.icon);
 <PowerDialog bind:open={powerOpen} />
 <VersionsDialog bind:open={versionsOpen} />
 <OnDeviceDisplaySection bind:open={displayOpen} />
+<AddonsSection bind:open={addonsOpen} />

--- a/apps/frontend/src/main/SettingsView.svelte
+++ b/apps/frontend/src/main/SettingsView.svelte
@@ -42,6 +42,7 @@ import LogsDialog from './dialogs/LogsDialog.svelte';
 import PairingDialog from './dialogs/PairingDialog.svelte';
 import PasswordDialog from './dialogs/PasswordDialog.svelte';
 import PowerDialog from './dialogs/PowerDialog.svelte';
+import DeviceStatsSection from './settings/DeviceStatsSection.svelte';
 import OnDeviceDisplaySection from './settings/OnDeviceDisplaySection.svelte';
 import SshDialog from './dialogs/SshDialog.svelte';
 import UpdatesDialog from './dialogs/UpdatesDialog.svelte';
@@ -226,6 +227,9 @@ const ActiveIcon = $derived(active?.icon);
 
 		<!-- Grouped settings index -->
 		<div class="space-y-7">
+			<!-- Live device telemetry first: status at a glance, no dialog to open. -->
+			<DeviceStatsSection />
+
 			<!-- Mobile-only: desktop hosts language + theme in the header toolbar instead. -->
 			{#if !isDesktop.current}
 				<section class="space-y-2.5" data-testid="settings-appearance">

--- a/apps/frontend/src/main/settings/AddonsSection.svelte
+++ b/apps/frontend/src/main/settings/AddonsSection.svelte
@@ -1,0 +1,274 @@
+<!--
+  AddonsSection.svelte — the Add-ons settings surface (T31).
+
+  A generic, descriptor-driven catalogue of optional device add-ons. Each add-on
+  renders the SAME card (no per-add-on bespoke UI): name, a derived meta line, a
+  pessimistic enable toggle, a 7-state status badge, install progress, and the
+  disk-size impact. Descriptors are loaded once from rpc.addons.list(); live state
+  tracks the backend `addons` broadcast (getAddons) so install progress and a
+  crash-loop auto-disable reflect without a refresh.
+
+  The toggle is pessimistic (AsyncSwitch): it drives install/uninstall and only
+  settles once the RPC resolves, reverting on error. In emulated mode the backend
+  rejects mutating ops, so the toggle reverts and a calm banner appears (mirrors
+  the kiosk unavailable pattern) instead of an error toast.
+-->
+<script lang="ts">
+import type { AddonDescriptor, AddonState } from '@ceraui/rpc/schemas';
+import { Blocks, HardDrive, LoaderCircle, Package } from '@lucide/svelte';
+import { onMount } from 'svelte';
+import { toast } from 'svelte-sonner';
+
+import AsyncSwitch from '$lib/components/custom/async-switch.svelte';
+import AppDialog from '$lib/components/dialogs/AppDialog.svelte';
+import { type AddonManagerPhase, rpc } from '$lib/rpc/client';
+import { getAddons } from '$lib/rpc/subscriptions.svelte';
+import { cn } from '$lib/utils';
+
+interface Props {
+	open?: boolean;
+}
+
+let { open = $bindable(false) }: Props = $props();
+
+// The backend returns this from a mutating op attempted off a real board. It has
+// no @ceraui/rpc/schemas export (unlike KIOSK_UNAVAILABLE_ERROR), so it is named
+// here to drive the calm banner instead of an error toast.
+const ADDON_UNAVAILABLE_ERROR = 'addon_unavailable_in_emulated_mode';
+
+const DEFAULT_STATE: AddonState = { enabled: false, phase: 'idle', autoDisabled: false };
+
+// Descriptors are static (image-baked); runtime state is live. Holding them apart
+// lets the broadcast overlay state without ever touching the descriptor list.
+let descriptors = $state<AddonDescriptor[]>([]);
+let seedStates = $state<Record<string, AddonState>>({});
+let loaded = $state(false);
+let unavailable = $state(false);
+
+// Lossless mirror of the backend phaseFromState (manager.ts): the persisted
+// (autoDisabled + phase + enabled) triple encodes all 7 manager phases.
+function phaseFromState(state: AddonState): AddonManagerPhase {
+	if (state.autoDisabled) return 'auto_disabled';
+	switch (state.phase) {
+		case 'active':
+			return 'enabled';
+		case 'installing':
+			return 'enabling';
+		case 'disabling':
+			return 'disabling';
+		case 'error':
+			return 'failed';
+		default:
+			return state.enabled ? 'pending' : 'disabled';
+	}
+}
+
+const cards = $derived.by(() => {
+	const live = getAddons();
+	return descriptors.map((descriptor) => {
+		const state = live[descriptor.id] ?? seedStates[descriptor.id] ?? DEFAULT_STATE;
+		return { descriptor, state, phase: phaseFromState(state) };
+	});
+});
+
+onMount(async () => {
+	try {
+		const result = await rpc.addons.list();
+		descriptors = result.addons.map((a) => a.descriptor);
+		seedStates = Object.fromEntries(result.addons.map((a) => [a.descriptor.id, a.state]));
+	} catch (error) {
+		console.error('Failed to load add-ons:', error);
+	} finally {
+		loaded = true;
+	}
+});
+
+function humanBytes(n: number): string {
+	const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+	let value = n;
+	let i = 0;
+	while (value >= 1000 && i < units.length - 1) {
+		value /= 1000;
+		i++;
+	}
+	return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+function errorMessage(error: unknown): string | undefined {
+	if (error instanceof Error && error.message) return error.message;
+	if (typeof error === 'string' && error) return error;
+	return undefined;
+}
+
+const ERROR_COPY: Record<string, string> = {
+	addon_insufficient_space: 'Not enough free space on the device to install this add-on.',
+	addon_enable_failed: "The add-on couldn't be installed. Check the device logs for details.",
+	addon_disable_failed: "The add-on couldn't be removed. Check the device logs for details.",
+	addon_validation_failed: 'The add-on started but failed its health check, so it was disabled.',
+	addon_crash_loop: 'The add-on kept restarting, so it was disabled to protect the device.',
+	addon_not_found: 'This add-on is no longer available on the device.',
+};
+
+function humanError(code: string | undefined): string | undefined {
+	if (!code) return undefined;
+	return ERROR_COPY[code] ?? code;
+}
+
+const PHASE_META = {
+	disabled: { label: 'Disabled', badge: 'bg-status-neutral/12 text-status-neutral', busy: false },
+	pending: { label: 'Update pending', badge: 'bg-status-info/12 text-status-info', busy: false },
+	enabling: { label: 'Installing', badge: 'bg-primary/12 text-primary', busy: true },
+	enabled: { label: 'Enabled', badge: 'bg-status-success/15 text-status-success', busy: false },
+	disabling: { label: 'Removing', badge: 'bg-status-neutral/12 text-status-neutral', busy: true },
+	failed: { label: 'Failed', badge: 'bg-status-error/12 text-status-error', busy: false },
+	auto_disabled: {
+		label: 'Auto-disabled',
+		badge: 'bg-status-warning/15 text-status-warning',
+		busy: false,
+	},
+} as const satisfies Record<AddonManagerPhase, { label: string; badge: string; busy: boolean }>;
+
+function metaLine(descriptor: AddonDescriptor): string {
+	const category = descriptor.category.charAt(0).toUpperCase() + descriptor.category.slice(1);
+	return `${category} \u00b7 v${descriptor.version}`;
+}
+
+async function handleToggle(id: string, next: boolean) {
+	let result: Awaited<ReturnType<typeof rpc.addons.install>>;
+	try {
+		result = next ? await rpc.addons.install({ id }) : await rpc.addons.uninstall({ id });
+	} catch (error) {
+		toast.error(errorMessage(error) ?? 'Add-on action failed.');
+		throw error;
+	}
+	if (!result.success) {
+		if (result.error === ADDON_UNAVAILABLE_ERROR) {
+			unavailable = true;
+			// Reject so AsyncSwitch reverts to the prior value without a toast.
+			throw new Error(ADDON_UNAVAILABLE_ERROR);
+		}
+		toast.error(humanError(result.error) ?? 'Add-on action failed.');
+		throw new Error(result.error);
+	}
+	unavailable = false;
+}
+</script>
+
+<AppDialog
+	bind:open
+	description="Install and manage optional device features."
+	hideFooter
+	icon={Blocks}
+	title="Add-ons"
+>
+	<div class="space-y-4" data-testid="addons-section">
+		{#if unavailable}
+			<div
+				class="border-border bg-muted/40 text-muted-foreground rounded-lg border px-4 py-3 text-sm"
+				data-testid="addons-unavailable"
+				role="status"
+			>
+				Add-ons can't be changed in this preview. Connect to a CeraLive device to install or
+				remove them.
+			</div>
+		{/if}
+
+		{#if loaded && cards.length === 0}
+			<!-- Empty state: descriptors only exist on a device image that bakes them in. -->
+			<div
+				class="border-border/70 bg-muted/30 flex flex-col items-center gap-3 rounded-xl border border-dashed px-6 py-10 text-center"
+				data-testid="addons-empty"
+			>
+				<span class="bg-secondary text-muted-foreground grid size-11 place-items-center rounded-xl">
+					<Package class="size-5" />
+				</span>
+				<div class="space-y-1">
+					<p class="text-sm font-semibold">No add-ons available</p>
+					<p class="text-muted-foreground mx-auto max-w-xs text-xs leading-relaxed">
+						Optional features appear here when your device image includes them.
+					</p>
+				</div>
+			</div>
+		{/if}
+
+		{#each cards as card (card.descriptor.id)}
+			{@const meta = PHASE_META[card.phase]}
+			<div
+				class="bg-card space-y-3 rounded-xl border p-4"
+				data-addon-id={card.descriptor.id}
+				data-addon-phase={card.phase}
+				data-testid={`addon-card-${card.descriptor.id}`}
+			>
+				<div class="flex items-start gap-3">
+					<div class="min-w-0 flex-1 space-y-0.5">
+						<p class="truncate text-sm font-semibold">{card.descriptor.name}</p>
+						<p class="text-muted-foreground truncate text-xs">{metaLine(card.descriptor)}</p>
+					</div>
+					<AsyncSwitch
+						aria-label={`Enable ${card.descriptor.name}`}
+						checked={card.state.enabled}
+						data-testid={`addon-switch-${card.descriptor.id}`}
+						disabled={!loaded || meta.busy}
+						onCheckedChange={(next) => handleToggle(card.descriptor.id, next)}
+					/>
+				</div>
+
+				<div class="flex items-center justify-between gap-3">
+					<span
+						class={cn(
+							'inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium',
+							meta.badge,
+						)}
+						data-testid={`addon-badge-${card.descriptor.id}`}
+					>
+						{#if meta.busy}
+							<LoaderCircle class="size-3 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+						{:else}
+							<span class="size-1.5 rounded-full bg-current"></span>
+						{/if}
+						{meta.label}
+					</span>
+					<span class="text-muted-foreground inline-flex shrink-0 items-center gap-1.5 text-xs">
+						<HardDrive class="size-3.5" aria-hidden="true" />
+						<span class="tabular-nums">{humanBytes(card.descriptor.artifact.sizeInstalled)}</span>
+					</span>
+				</div>
+
+				{#if card.phase === 'enabling'}
+					<div
+						class="bg-primary/10 h-1.5 w-full overflow-hidden rounded-full"
+						role="progressbar"
+						aria-label="Installing add-on"
+					>
+						<div class="bg-primary h-full w-1/3 animate-pulse rounded-full motion-reduce:animate-none"></div>
+					</div>
+				{/if}
+
+				{#if card.phase === 'pending'}
+					<p
+						class="text-status-info/90 bg-status-info/8 rounded-md px-3 py-2 text-xs leading-relaxed"
+						data-testid={`addon-pending-${card.descriptor.id}`}
+					>
+						Waiting for a compatible update. This add-on stays selected and finishes installing
+						after the next system update.
+					</p>
+				{:else if card.phase === 'auto_disabled'}
+					<p
+						class="text-status-warning bg-status-warning/8 rounded-md px-3 py-2 text-xs leading-relaxed"
+						data-testid={`addon-autodisabled-${card.descriptor.id}`}
+					>
+						Auto-disabled to protect the device.{#if humanError(card.state.lastError)}
+							{' '}{humanError(card.state.lastError)}{/if}
+					</p>
+				{:else if card.phase === 'failed' && humanError(card.state.lastError)}
+					<p
+						class="text-status-error bg-status-error/8 rounded-md px-3 py-2 text-xs leading-relaxed"
+						data-testid={`addon-error-${card.descriptor.id}`}
+					>
+						{humanError(card.state.lastError)}
+					</p>
+				{/if}
+			</div>
+		{/each}
+	</div>
+</AppDialog>

--- a/apps/frontend/src/main/settings/DeviceStatsSection.svelte
+++ b/apps/frontend/src/main/settings/DeviceStatsSection.svelte
@@ -1,0 +1,135 @@
+<!--
+  DeviceStatsSection.svelte — the five-signal device telemetry panel (T33).
+
+  Surfaces exactly the five signals of the backend `device-stats` broadcast
+  (T32): disk, CPU load, SoC temperature, network rate, and boot slot. socTemp
+  is taken straight from the device-stats event — never a second sensors
+  subscription. Every signal degrades to a calm "—" placeholder when its source
+  reports null / "unavailable", so a dead source never blanks or NaNs the panel.
+-->
+<script lang="ts">
+import { LL } from '@ceraui/i18n/svelte';
+import type { Component } from 'svelte';
+import { ArrowDownUp, CircuitBoard, Cpu, HardDrive, Thermometer } from '@lucide/svelte';
+
+import { getDeviceStats } from '$lib/rpc/subscriptions.svelte';
+
+const t = $derived($LL.settings.deviceStats);
+
+// Sentinel the backend emits for the boot slot when `rauc` is absent.
+const RAUC_UNAVAILABLE = 'unavailable';
+
+// Humanize a byte count to a decimal-SI string ("58.2 GB"). Sub-KB stays whole.
+function humanBytes(n: number): string {
+	const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+	let value = n;
+	let i = 0;
+	while (value >= 1000 && i < units.length - 1) {
+		value /= 1000;
+		i++;
+	}
+	return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+// Humanize a byte/second rate to a decimal-SI string ("2.1 MB/s").
+function humanRate(n: number): string {
+	const units = ['B/s', 'KB/s', 'MB/s', 'GB/s'];
+	let value = n;
+	let i = 0;
+	while (value >= 1000 && i < units.length - 1) {
+		value /= 1000;
+		i++;
+	}
+	return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+const stats = $derived(getDeviceStats());
+
+interface Row {
+	key: string;
+	icon: Component;
+	label: string;
+	sub?: string;
+	// `null` ⇒ source unavailable ⇒ render the placeholder, never blank/NaN.
+	value: string | null;
+}
+
+const rows = $derived.by<Row[]>(() => {
+	const s = stats;
+	const disk = s?.disk ?? null;
+	const net = s?.ifaceRxTx ?? null;
+	const slot = s?.raucSlot;
+
+	return [
+		{
+			key: 'disk',
+			icon: HardDrive,
+			label: t.disk(),
+			sub: disk && disk.type !== 'unknown' ? disk.type : undefined,
+			value: disk ? `${humanBytes(disk.used)} / ${humanBytes(disk.total)}` : null,
+		},
+		{
+			key: 'cpuLoad',
+			icon: Cpu,
+			label: t.cpuLoad(),
+			value: s && s.cpuLoad1 != null ? s.cpuLoad1.toFixed(2) : null,
+		},
+		{
+			key: 'socTemp',
+			icon: Thermometer,
+			label: t.socTemp(),
+			value: s && s.socTemp != null ? `${s.socTemp.toFixed(1)} \u00b0C` : null,
+		},
+		{
+			key: 'network',
+			icon: ArrowDownUp,
+			label: t.network(),
+			sub: net?.iface,
+			value: net ? `\u2191 ${humanRate(net.txBytesPerSec)}  \u2193 ${humanRate(net.rxBytesPerSec)}` : null,
+		},
+		{
+			key: 'bootSlot',
+			icon: CircuitBoard,
+			label: t.bootSlot(),
+			value: slot && slot !== RAUC_UNAVAILABLE ? slot : null,
+		},
+	];
+});
+</script>
+
+<section class="space-y-2.5" data-testid="device-stats">
+	<h2 class="text-muted-foreground px-1 text-sm font-medium">{t.title()}</h2>
+	<div class="divide-border bg-card divide-y overflow-hidden rounded-xl border">
+		{#each rows as row (row.key)}
+			{@const RowIcon = row.icon}
+			<div class="flex w-full items-center gap-4 px-4 py-3.5" data-testid={`device-stat-${row.key}`}>
+				<span class="bg-secondary text-foreground grid size-9 shrink-0 place-items-center rounded-lg">
+					<RowIcon class="size-[18px]" />
+				</span>
+				<span class="min-w-0 flex-1">
+					<span class="block truncate text-sm font-semibold">{row.label}</span>
+					{#if row.sub}
+						<span class="text-muted-foreground block truncate text-xs">{row.sub}</span>
+					{/if}
+				</span>
+				{#if row.value === null}
+					<span
+						class="text-muted-foreground/60 shrink-0 font-mono text-sm"
+						data-testid={`device-stat-${row.key}-value`}
+						title={t.unavailable()}
+						aria-label={t.unavailable()}
+					>
+						&mdash;
+					</span>
+				{:else}
+					<span
+						class="text-foreground shrink-0 font-mono text-sm tabular-nums"
+						data-testid={`device-stat-${row.key}-value`}
+					>
+						{row.value}
+					</span>
+				{/if}
+			</div>
+		{/each}
+	</div>
+</section>

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./apps/backend/src/tests/test-preload.ts"]

--- a/deployment/ceralive-addon-reconciler.service
+++ b/deployment/ceralive-addon-reconciler.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=CeraLive post-boot add-on reconciler (desired-state; non-blocking)
+Documentation=https://github.com/CERALIVE/CeraUI
+# Run after the main service so the backend (which owns the reconcile logic) is
+# up to receive the trigger. Add-ons NEVER gate boot or the OS-update
+# healthcheck/rollback, so this unit is deliberately NOT a dependency of any
+# rollback/healthcheck target and never blocks the boot transaction.
+After=ceralive.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# The reconcile pass lives inside the running ceralive backend; poke it with
+# SIGUSR1 (handled in main.ts). The leading '-' tolerates a non-running backend
+# so this oneshot can never fail the boot transaction — the backend also fires
+# one reconcile pass on its own startup.
+ExecStart=-/usr/bin/systemctl kill --signal=SIGUSR1 ceralive.service
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/KIOSK_STATE_MACHINE.md
+++ b/docs/KIOSK_STATE_MACHINE.md
@@ -54,11 +54,14 @@ Six transitions. Each entry lists the trigger, the systemd actions the backend t
 
 **Backend actions:**
 1. Write `kiosk_enabled = true` to persisted config.
-2. `systemctl unmask kiosk.service`
-3. `systemctl enable kiosk.service`
-4. `systemctl start kiosk.service`
+2. Enable the `cog-display` add-on through the add-on manager (`enableAddon`). The
+   manager owns the sysext lifecycle (materialise → verify → stage → helper →
+   unmask + start the descriptor's units → validate). The display engine units
+   (incl. `kiosk.service`) are unmasked and started by that pipeline.
 
-The backend transitions to `enabled-stopped` synchronously after issuing the start command, then polls (see Failure-Observation Channel) to confirm the service reached `active (running)`.
+The backend transitions to `enabled-stopped` synchronously after committing the
+toggle (before the add-on enable resolves), then polls `kiosk.service` (see
+Failure-Observation Channel) to confirm the service reached `active (running)`.
 
 ---
 
@@ -77,11 +80,11 @@ The backend transitions to `enabled-stopped` synchronously after issuing the sta
 **To:** `enabled-stopped` (transient) then `disabled`
 
 **Backend actions:**
-1. `systemctl stop kiosk.service`
-2. `systemctl disable kiosk.service`
-3. `systemctl mask kiosk.service`
-4. Write `kiosk_enabled = false` to persisted config.
-5. Delete the display-failure marker file if present (`/run/kiosk-no-display`).
+1. Write `kiosk_enabled = false` to persisted config and stop polling.
+2. Disable the `cog-display` add-on through the add-on manager (`disableAddon`).
+   The manager stops + masks the descriptor's units (incl. `kiosk.service`) and
+   tears down the staged sysext.
+3. Delete the display-failure marker file if present (`/run/kiosk-no-display`).
 
 ---
 

--- a/packages/i18n/src/ar/index.ts
+++ b/packages/i18n/src/ar/index.ts
@@ -216,6 +216,16 @@ const ar = {
 		signingIn: "جاري تسجيل الدخول...",
 	},
 	settings: {
+		deviceStats: {
+			title: "إحصاءات الجهاز",
+			description: "قياس مباشر لأجهزة هذا الجهاز.",
+			disk: "القرص",
+			cpuLoad: "حمل المعالج",
+			socTemp: "حرارة المعالج",
+			network: "الشبكة",
+			bootSlot: "فتحة الإقلاع",
+			unavailable: "غير متاح",
+		},
 		onDeviceDisplay: {
 			title: "On-Device Display",
 			description: "Manage the on-device kiosk display, profile, and input.",

--- a/packages/i18n/src/de/index.ts
+++ b/packages/i18n/src/de/index.ts
@@ -377,6 +377,16 @@ const de = {
 		signingIn: "Anmeldung läuft...",
 	},
 	settings: {
+		deviceStats: {
+			title: "Gerätestatistik",
+			description: "Live-Hardware-Telemetrie dieses Geräts.",
+			disk: "Datenträger",
+			cpuLoad: "CPU-Last",
+			socTemp: "SoC-Temp.",
+			network: "Netzwerk",
+			bootSlot: "Boot-Slot",
+			unavailable: "Nicht verfügbar",
+		},
 		onDeviceDisplay: {
 			title: "On-Device Display",
 			description: "Manage the on-device kiosk display, profile, and input.",

--- a/packages/i18n/src/en/index.ts
+++ b/packages/i18n/src/en/index.ts
@@ -421,6 +421,16 @@ const en = {
 			autostartDesc: "Start streaming automatically when the device boots",
 			autostartError: "Couldn't change autostart. Please try again.",
 		},
+		deviceStats: {
+			title: "Device Stats",
+			description: "Live hardware telemetry from this device.",
+			disk: "Disk",
+			cpuLoad: "CPU Load",
+			socTemp: "SoC Temp",
+			network: "Network",
+			bootSlot: "Boot Slot",
+			unavailable: "Unavailable",
+		},
 		onDeviceDisplay: {
 			title: "On-Device Display",
 			description: "Manage the on-device kiosk display, profile, and input.",

--- a/packages/i18n/src/es/index.ts
+++ b/packages/i18n/src/es/index.ts
@@ -386,6 +386,16 @@ const es = {
 		selectLanguage: "Seleccionar Idioma",
 	},
 	settings: {
+		deviceStats: {
+			title: "Estado del dispositivo",
+			description: "Telemetría de hardware en vivo de este dispositivo.",
+			disk: "Disco",
+			cpuLoad: "Carga de CPU",
+			socTemp: "Temp. SoC",
+			network: "Red",
+			bootSlot: "Ranura de arranque",
+			unavailable: "No disponible",
+		},
 		onDeviceDisplay: {
 			title: "On-Device Display",
 			description: "Manage the on-device kiosk display, profile, and input.",

--- a/packages/i18n/src/fr/index.ts
+++ b/packages/i18n/src/fr/index.ts
@@ -232,6 +232,16 @@ const fr = {
 		signingIn: "Connexion en cours...",
 	},
 	settings: {
+		deviceStats: {
+			title: "État de l'appareil",
+			description: "Télémétrie matérielle en direct de cet appareil.",
+			disk: "Disque",
+			cpuLoad: "Charge CPU",
+			socTemp: "Temp. SoC",
+			network: "Réseau",
+			bootSlot: "Slot de démarrage",
+			unavailable: "Indisponible",
+		},
 		onDeviceDisplay: {
 			title: "On-Device Display",
 			description: "Manage the on-device kiosk display, profile, and input.",

--- a/packages/i18n/src/hi/index.ts
+++ b/packages/i18n/src/hi/index.ts
@@ -78,6 +78,16 @@ const hi = {
 		signingIn: "साइन इन हो रहे हैं...",
 	},
 	settings: {
+		deviceStats: {
+			title: "डिवाइस आँकड़े",
+			description: "इस डिवाइस से लाइव हार्डवेयर टेलीमेट्री।",
+			disk: "डिस्क",
+			cpuLoad: "CPU लोड",
+			socTemp: "SoC तापमान",
+			network: "नेटवर्क",
+			bootSlot: "बूट स्लॉट",
+			unavailable: "अनुपलब्ध",
+		},
 		onDeviceDisplay: {
 			title: "On-Device Display",
 			description: "Manage the on-device kiosk display, profile, and input.",

--- a/packages/i18n/src/ja/index.ts
+++ b/packages/i18n/src/ja/index.ts
@@ -79,6 +79,16 @@ const ja = {
 		signingIn: "サインイン中...",
 	},
 	settings: {
+		deviceStats: {
+			title: "デバイス統計",
+			description: "このデバイスのライブハードウェアテレメトリ。",
+			disk: "ディスク",
+			cpuLoad: "CPU 負荷",
+			socTemp: "SoC 温度",
+			network: "ネットワーク",
+			bootSlot: "ブートスロット",
+			unavailable: "利用不可",
+		},
 		onDeviceDisplay: {
 			title: "On-Device Display",
 			description: "Manage the on-device kiosk display, profile, and input.",

--- a/packages/i18n/src/ko/index.ts
+++ b/packages/i18n/src/ko/index.ts
@@ -78,6 +78,16 @@ const ko = {
 		signingIn: "로그인 중...",
 	},
 	settings: {
+		deviceStats: {
+			title: "장치 통계",
+			description: "이 장치의 실시간 하드웨어 텔레메트리.",
+			disk: "디스크",
+			cpuLoad: "CPU 부하",
+			socTemp: "SoC 온도",
+			network: "네트워크",
+			bootSlot: "부트 슬롯",
+			unavailable: "사용 불가",
+		},
 		onDeviceDisplay: {
 			title: "On-Device Display",
 			description: "Manage the on-device kiosk display, profile, and input.",

--- a/packages/i18n/src/pt-BR/index.ts
+++ b/packages/i18n/src/pt-BR/index.ts
@@ -231,6 +231,16 @@ const ptBR = {
 		signingIn: "Fazendo login...",
 	},
 	settings: {
+		deviceStats: {
+			title: "Status do dispositivo",
+			description: "Telemetria de hardware ao vivo deste dispositivo.",
+			disk: "Disco",
+			cpuLoad: "Carga da CPU",
+			socTemp: "Temp. SoC",
+			network: "Rede",
+			bootSlot: "Slot de inicialização",
+			unavailable: "Indisponível",
+		},
 		onDeviceDisplay: {
 			title: "On-Device Display",
 			description: "Manage the on-device kiosk display, profile, and input.",

--- a/packages/i18n/src/zh/index.ts
+++ b/packages/i18n/src/zh/index.ts
@@ -77,6 +77,16 @@ const zh = {
 		signingIn: "登录中...",
 	},
 	settings: {
+		deviceStats: {
+			title: "设备统计",
+			description: "本设备的实时硬件遥测。",
+			disk: "磁盘",
+			cpuLoad: "CPU 负载",
+			socTemp: "SoC 温度",
+			network: "网络",
+			bootSlot: "启动分区",
+			unavailable: "不可用",
+		},
 		onDeviceDisplay: {
 			title: "On-Device Display",
 			description: "Manage the on-device kiosk display, profile, and input.",

--- a/packages/rpc/src/schemas/addons.schema.test.ts
+++ b/packages/rpc/src/schemas/addons.schema.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Add-on descriptor + state schema tests (T22).
+ *
+ * The descriptor fixture mirrors image-building-pipeline's debug-toolset.json.
+ * It is inlined (not imported) because that file lives in a sibling repo and a
+ * schema test must never read above the CeraUI checkout root (Rule D).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+// APT_PACKAGE_NAME_RE is imported (never copied) to prove the add-on schema
+// reuses the one canonical Debian package-name pattern (G5). It lives in a
+// side-effect-free backend module so this rpc test can import it without
+// loading the software-updates module graph. Test-only relative import — the
+// @ceraui/rpc *source* must never import the backend.
+import { APT_PACKAGE_NAME_RE } from '../../../../apps/backend/src/modules/system/apt-package-name';
+import { AddonConfigSchema, AddonDescriptorSchema, AddonStateSchema } from './addons.schema';
+
+const validDebugToolset = {
+	id: 'debug-toolset',
+	name: 'Debug Toolset',
+	version: '1.0.0',
+	category: 'debug',
+	icon: 'wrench',
+	payload: { type: 'sysext' },
+	sysextLevel: '1',
+	versionId: '12',
+	compatibleOsVersions: ['12'],
+	artifact: {
+		urlTemplate: 'https://apt.ceralive.tv/addons/debug-toolset/{os_version}/debug-toolset.raw',
+		sha256: 'd0009ed268df5fd0ec12904201c64be392f56671a4d61acec7355188536bb5e9',
+		gpgSigRef: 'https://apt.ceralive.tv/addons/debug-toolset/{os_version}/debug-toolset.raw.asc',
+		sizeDownload: 4194304,
+		sizeInstalled: 12582912,
+	},
+	provides: ['/usr/bin/htop', '/usr/bin/strace', '/usr/bin/tcpdump', '/usr/bin/iperf3'],
+	deps: [],
+	conflicts: [],
+	units: { unmask: [], enable: [], start: [] },
+	validate: { cmd: '/usr/bin/strace -V', timeout: 10 },
+};
+
+describe('AddonDescriptorSchema', () => {
+	test('valid debug-toolset descriptor parses successfully', () => {
+		const parsed = AddonDescriptorSchema.parse(validDebugToolset);
+		expect(parsed.id).toBe('debug-toolset');
+		expect(parsed.sysextLevel).toBe('1');
+		expect(parsed.versionId).toBe('12');
+		expect(parsed.provides).toHaveLength(4);
+	});
+
+	test('G2 — a /etc path in provides[] is rejected with a provides field path', () => {
+		const bad = { ...validDebugToolset, provides: ['/usr/bin/htop', '/etc/foo'] };
+		const result = AddonDescriptorSchema.safeParse(bad);
+		expect(result.success).toBe(false);
+		if (result.success) throw new Error('expected /etc path to be rejected');
+		const paths = result.error.issues.map((i) => i.path.join('.'));
+		expect(paths).toContain('provides.1');
+	});
+
+	test('missing sysextLevel is rejected with a sysextLevel field path', () => {
+		const { sysextLevel: _omitted, ...withoutLevel } = validDebugToolset;
+		const result = AddonDescriptorSchema.safeParse(withoutLevel);
+		expect(result.success).toBe(false);
+		if (result.success) throw new Error('expected missing sysextLevel to be rejected');
+		const paths = result.error.issues.map((i) => i.path.join('.'));
+		expect(paths).toContain('sysextLevel');
+	});
+});
+
+describe('AddonStateSchema / AddonConfigSchema', () => {
+	test('a well-formed runtime state parses', () => {
+		const state = AddonStateSchema.parse({ enabled: true, phase: 'active', autoDisabled: false });
+		expect(state.phase).toBe('active');
+	});
+
+	test('an invalid phase enum value is rejected with a phase field path', () => {
+		const result = AddonStateSchema.safeParse({
+			enabled: true,
+			phase: 'running',
+			autoDisabled: false,
+		});
+		expect(result.success).toBe(false);
+		if (result.success) throw new Error('expected invalid phase to be rejected');
+		const paths = result.error.issues.map((i) => i.path.join('.'));
+		expect(paths).toContain('phase');
+	});
+
+	test('AddonConfigSchema maps add-on id -> state', () => {
+		const cfg = AddonConfigSchema.parse({
+			'debug-toolset': { enabled: false, phase: 'idle', autoDisabled: false },
+		});
+		expect(cfg['debug-toolset']?.phase).toBe('idle');
+	});
+});
+
+describe('G5 — package-name pattern is reused, not copied', () => {
+	test('APT_PACKAGE_NAME_RE is the canonical imported regex', () => {
+		expect(APT_PACKAGE_NAME_RE).toBeInstanceOf(RegExp);
+		expect(APT_PACKAGE_NAME_RE.source).toBe('^[A-Za-z0-9.+:~-]+$');
+	});
+
+	test('addons.schema.ts does not redefine the Debian package-name charset', () => {
+		const source = readFileSync(new URL('./addons.schema.ts', import.meta.url), 'utf8');
+		expect(source).not.toContain('A-Za-z0-9.+:~-');
+	});
+});

--- a/packages/rpc/src/schemas/addons.schema.ts
+++ b/packages/rpc/src/schemas/addons.schema.ts
@@ -1,0 +1,124 @@
+/**
+ * Add-on descriptor + runtime-state Zod schemas (single source of truth).
+ *
+ * `AddonDescriptorSchema` mirrors `image-building-pipeline/v2/manifests/schema/
+ * addon.schema.json` (T21). That JSON Schema validates the image-baked, read-only
+ * descriptors; this Zod schema validates the same shape inside CeraUI at runtime.
+ * Field literals (patterns, enums, the G1 sysext identity constants) are mirrored
+ * here so Zod is the single TypeScript source — never duplicate the descriptor
+ * shape elsewhere in `apps/`.
+ *
+ * `AddonStateSchema` / `AddonConfigSchema` describe per-feature *runtime* state
+ * persisted under the `addons` key of `config.json` — they have no JSON Schema
+ * counterpart because they are device-local, not baked into the image.
+ */
+import { z } from 'zod';
+
+// Reject arrays whose JSON Schema source declares `uniqueItems: true`.
+const isUnique = <T>(items: readonly T[]): boolean => new Set(items).size === items.length;
+const uniqueArray = <T extends z.ZodTypeAny>(item: T) =>
+	z.array(item).refine(isUnique, { message: 'items must be unique' });
+
+// Add-on id and the deps[]/conflicts[] references to other add-on ids:
+// lowercase alphanumeric with internal hyphens. NOT a Debian package name —
+// distinct, stricter charset than APT_PACKAGE_NAME_RE on purpose.
+const ADDON_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+// Semver MAJOR.MINOR.PATCH with optional -prerelease / +build.
+const SEMVER_RE =
+	/^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+// G2 — a systemd-sysext overlays ONLY /usr and /opt; paths elsewhere are lost at
+// merge time, so the descriptor rejects them up front.
+const SYSEXT_PATH_RE = /^\/(usr|opt)\/.+$/;
+// Bare OS VERSION_ID token substituted into artifact.urlTemplate's {os_version}.
+const OS_VERSION_RE = /^[0-9A-Za-z][0-9A-Za-z.-]*$/;
+// HTTPS artifact URL that MUST carry the literal {os_version} placeholder.
+const ARTIFACT_URL_RE = /^https:\/\/[^\s]*\{os_version\}[^\s]*$/;
+// Lowercase hex SHA-256 (64 chars).
+const SHA256_RE = /^[a-f0-9]{64}$/;
+// systemd unit name with a mandatory unit-type suffix.
+const SYSTEMD_UNIT_RE = /^[A-Za-z0-9@._:-]+\.(service|socket|target|timer|path|mount)$/;
+
+export const ADDON_CATEGORIES = ['debug', 'display', 'media', 'network', 'other'] as const;
+export const addonCategorySchema = z.enum(ADDON_CATEGORIES);
+export type AddonCategory = z.infer<typeof addonCategorySchema>;
+
+const addonIdSchema = z.string().regex(ADDON_ID_RE);
+
+// Only the sysext payload backend is implemented; appfs is reserved (rejected).
+export const addonPayloadSchema = z
+	.object({
+		type: z.literal('sysext'),
+	})
+	.strict();
+
+export const addonArtifactSchema = z
+	.object({
+		urlTemplate: z.string().regex(ARTIFACT_URL_RE),
+		sha256: z.string().regex(SHA256_RE),
+		gpgSigRef: z.string().min(1),
+		sizeDownload: z.number().int().min(1),
+		sizeInstalled: z.number().int().min(1),
+	})
+	.strict();
+
+export const addonUnitsSchema = z
+	.object({
+		unmask: uniqueArray(z.string().regex(SYSTEMD_UNIT_RE)).optional(),
+		enable: uniqueArray(z.string().regex(SYSTEMD_UNIT_RE)).optional(),
+		start: uniqueArray(z.string().regex(SYSTEMD_UNIT_RE)).optional(),
+	})
+	.strict();
+
+export const addonValidateSchema = z
+	.object({
+		cmd: z.string().min(1),
+		timeout: z.number().int().min(1).optional(),
+	})
+	.strict();
+
+export const AddonDescriptorSchema = z
+	.object({
+		id: addonIdSchema,
+		name: z.string().min(1),
+		version: z.string().regex(SEMVER_RE),
+		category: addonCategorySchema,
+		icon: z.string().min(1).optional(),
+		payload: addonPayloadSchema,
+		// G1 — sysext merge identity the kernel keys on. Both are fixed literals;
+		// any other value is un-mergeable on the device.
+		sysextLevel: z.literal('1'),
+		versionId: z.literal('12'),
+		compatibleOsVersions: uniqueArray(z.string().regex(OS_VERSION_RE)).min(1).optional(),
+		artifact: addonArtifactSchema,
+		provides: uniqueArray(z.string().regex(SYSEXT_PATH_RE)).min(1),
+		deps: uniqueArray(addonIdSchema).optional(),
+		conflicts: uniqueArray(addonIdSchema).optional(),
+		units: addonUnitsSchema.optional(),
+		configSchemaRef: z.string().min(1).optional(),
+		validate: addonValidateSchema.optional(),
+	})
+	.strict();
+export type AddonDescriptor = z.infer<typeof AddonDescriptorSchema>;
+
+// Lifecycle phase of one add-on as the manager materialises/enables/disables it.
+export const ADDON_PHASES = ['idle', 'installing', 'active', 'disabling', 'error'] as const;
+export const addonPhaseSchema = z.enum(ADDON_PHASES);
+export type AddonPhase = z.infer<typeof addonPhaseSchema>;
+
+// Per-feature runtime state persisted under config.json's `addons` key. No JSON
+// Schema counterpart — this is device-local state, not an image-baked descriptor.
+export const AddonStateSchema = z
+	.object({
+		enabled: z.boolean(),
+		phase: addonPhaseSchema,
+		versionMaterialized: z.string().optional(),
+		userConfig: z.record(z.string(), z.unknown()).optional(),
+		lastError: z.string().optional(),
+		autoDisabled: z.boolean(),
+	})
+	.strict();
+export type AddonState = z.infer<typeof AddonStateSchema>;
+
+// The whole `addons` map in config.json: add-on id -> its runtime state.
+export const AddonConfigSchema = z.record(z.string(), AddonStateSchema);
+export type AddonConfig = z.infer<typeof AddonConfigSchema>;

--- a/packages/rpc/src/schemas/addons.schema.ts
+++ b/packages/rpc/src/schemas/addons.schema.ts
@@ -101,7 +101,18 @@ export const AddonDescriptorSchema = z
 export type AddonDescriptor = z.infer<typeof AddonDescriptorSchema>;
 
 // Lifecycle phase of one add-on as the manager materialises/enables/disables it.
-export const ADDON_PHASES = ['idle', 'installing', 'active', 'disabling', 'error'] as const;
+// `pending` is the post-boot reconciler's non-terminal "wanted but not yet
+// materialisable" state (T29): no compatible artifact for the current OS
+// VERSION_ID, or a refresh deferred because a stream is live. It is desired-state
+// preserving (`enabled` stays true) and retried on the next boot — never an error.
+export const ADDON_PHASES = [
+	'idle',
+	'installing',
+	'active',
+	'pending',
+	'disabling',
+	'error',
+] as const;
 export const addonPhaseSchema = z.enum(ADDON_PHASES);
 export type AddonPhase = z.infer<typeof addonPhaseSchema>;
 
@@ -112,6 +123,10 @@ export const AddonStateSchema = z
 		enabled: z.boolean(),
 		phase: addonPhaseSchema,
 		versionMaterialized: z.string().optional(),
+		// OS VERSION_ID the staged .raw was fetched for. The reconciler (T29)
+		// compares it to the live /etc/os-release VERSION_ID to detect an
+		// OTA-stale artifact (G1 exact match) and re-fetch for the new os_version.
+		osVersionMaterialized: z.string().optional(),
 		userConfig: z.record(z.string(), z.unknown()).optional(),
 		lastError: z.string().optional(),
 		autoDisabled: z.boolean(),

--- a/packages/rpc/src/schemas/index.ts
+++ b/packages/rpc/src/schemas/index.ts
@@ -1,6 +1,7 @@
 /**
  * Export all Zod schemas
  */
+export * from './addons.schema';
 export * from './auth.schema';
 export * from './broadcast.schema';
 export * from './cloud-provider.schema';

--- a/packages/rpc/src/schemas/system.schema.ts
+++ b/packages/rpc/src/schemas/system.schema.ts
@@ -201,3 +201,38 @@ export const kioskOskInputSchema = z.object({
 	visible: z.boolean(),
 });
 export type KioskOskInput = z.infer<typeof kioskOskInputSchema>;
+
+// =============================================================================
+// Device stats broadcast (T32 — `device-stats` event)
+// =============================================================================
+//
+// S1 lock: exactly these five signals, mirroring the backend emitter
+// (`apps/backend/src/modules/system/device-stats.ts`). Adding a sixth is a
+// deliberate contract change. Every field is independently nullable (raucSlot
+// degrades to the string "unavailable") so one dead source never blanks the
+// whole panel.
+export const diskTypeSchema = z.enum(['SSD', 'HDD', 'eMMC', 'unknown']);
+export type DiskType = z.infer<typeof diskTypeSchema>;
+
+export const diskStatSchema = z.object({
+	used: z.number(),
+	total: z.number(),
+	type: diskTypeSchema,
+});
+export type DiskStat = z.infer<typeof diskStatSchema>;
+
+export const ifaceRxTxStatSchema = z.object({
+	iface: z.string(),
+	rxBytesPerSec: z.number(),
+	txBytesPerSec: z.number(),
+});
+export type IfaceRxTxStat = z.infer<typeof ifaceRxTxStatSchema>;
+
+export const deviceStatsSchema = z.object({
+	disk: diskStatSchema.nullable(),
+	cpuLoad1: z.number().nullable(),
+	socTemp: z.number().nullable(),
+	ifaceRxTx: ifaceRxTxStatSchema.nullable(),
+	raucSlot: z.string(),
+});
+export type DeviceStats = z.infer<typeof deviceStatsSchema>;

--- a/scripts/build/build-debian-package.sh
+++ b/scripts/build/build-debian-package.sh
@@ -51,8 +51,10 @@ log_step "Preparing package structure"
 
 # Create directory structure
 mkdir -p "$TEMP_DIR/usr/local/bin"
+mkdir -p "$TEMP_DIR/usr/bin"
 mkdir -p "$TEMP_DIR/etc/systemd/system"
 mkdir -p "$TEMP_DIR/etc/udev/rules.d"
+mkdir -p "$TEMP_DIR/etc/sudoers.d"
 mkdir -p "$TEMP_DIR/var/www/ceralive"
 mkdir -p "$TEMP_DIR/etc/ceralive"
 
@@ -68,10 +70,18 @@ cp dist/config.json "$TEMP_DIR/etc/ceralive/"
 cp dist/override-belaui.sh "$TEMP_DIR/usr/local/bin/"
 cp dist/reset-to-default.sh "$TEMP_DIR/usr/local/bin/"
 
+# Privileged add-on lifecycle helper (T27) + its narrow sudoers drop-in, copied
+# straight from the repo (a plain script, not a bun-build artifact).
+cp apps/backend/ceralive-addon-helper "$TEMP_DIR/usr/bin/ceralive-addon-helper"
+cp apps/backend/ceralive-addon-helper.sudoers "$TEMP_DIR/etc/sudoers.d/ceralive-addon-helper"
+
 # Make binaries executable
 chmod +x "$TEMP_DIR/usr/local/bin/ceralive"
 chmod +x "$TEMP_DIR/usr/local/bin/override-belaui.sh"
 chmod +x "$TEMP_DIR/usr/local/bin/reset-to-default.sh"
+chmod 0755 "$TEMP_DIR/usr/bin/ceralive-addon-helper"
+# sudo REFUSES a drop-in that is group/world-writable — ship it 0440.
+chmod 0440 "$TEMP_DIR/etc/sudoers.d/ceralive-addon-helper"
 
 # Create post-install script
 log_step "Creating maintenance scripts"
@@ -95,6 +105,17 @@ fi
 # Set permissions
 chown -R ceralive:ceralive /var/www/ceralive
 chown ceralive:ceralive /etc/ceralive/config.json
+
+# The add-on helper runs as root via sudo; sudo IGNORES a drop-in unless it is
+# owned by root and not group/world-writable. Enforce both on install.
+if [ -f /etc/sudoers.d/ceralive-addon-helper ]; then
+    chown root:root /etc/sudoers.d/ceralive-addon-helper
+    chmod 0440 /etc/sudoers.d/ceralive-addon-helper
+fi
+if [ -f /usr/bin/ceralive-addon-helper ]; then
+    chown root:root /usr/bin/ceralive-addon-helper
+    chmod 0755 /usr/bin/ceralive-addon-helper
+fi
 
 echo "✅ CeraLive device software configured successfully!"
 echo ""

--- a/scripts/build/build-debian-package.sh
+++ b/scripts/build/build-debian-package.sh
@@ -63,6 +63,8 @@ log_step "Copying files to package structure"
 cp dist/ceralive "$TEMP_DIR/usr/local/bin/ceralive"
 cp dist/ceralive.service "$TEMP_DIR/etc/systemd/system/"
 cp dist/ceralive.socket "$TEMP_DIR/etc/systemd/system/"
+# Post-boot add-on reconciler oneshot (T29). Non-blocking; never gates rollback.
+cp dist/ceralive-addon-reconciler.service "$TEMP_DIR/etc/systemd/system/"
 cp dist/98-ceralive-audio.rules "$TEMP_DIR/etc/udev/rules.d/"
 cp dist/99-ceralive-check-usb-devices.rules "$TEMP_DIR/etc/udev/rules.d/"
 cp -r dist/public/* "$TEMP_DIR/var/www/ceralive/"
@@ -93,6 +95,10 @@ echo "🚀 Configuring CeraLive after installation..."
 
 # Reload systemd daemon
 systemctl daemon-reload
+
+# Enable the post-boot add-on reconciler oneshot (T29). It is non-blocking and
+# deliberately decoupled from the OS-update healthcheck/rollback chain.
+systemctl enable ceralive-addon-reconciler.service 2>/dev/null || true
 
 # Reload udev rules
 udevadm control --reload


### PR DESCRIPTION
## What
Three major additions to CeraUI as part of the build-paradigm-overhaul plan:

**Add-on subsystem (runtime feature management)**
- `packages/rpc/src/schemas/addons.schema.ts` — Zod descriptor + state schemas (single source of truth)
- `apps/backend/src/modules/config.ts` — add-on state in config.json (atomic writes, E3)
- `apps/backend/ceralive-addon-helper` — privileged root helper: allowlist from baked descriptors only, GPG+sha256 re-verify, narrow sudoers (G-trust)
- `apps/backend/src/modules/addons/manager.ts` — state machine: disabled→enabling→enabled, crash-loop auto-disable, G6 isRealDevice gate, free-space precheck (E1)
- `apps/backend/src/modules/addons/reconciler.ts` — post-boot OTA reconciler: re-materialises enabled add-ons after VERSION_ID change, pending state, never gates rollback
- `apps/backend/src/rpc/procedures/addons.procedure.ts` — RPC: list/install/uninstall/configure/getStatus; read-only ungated, mutators G6-gated
- `apps/frontend/src/main/settings/AddonsSection.svelte` — generic add-on cards: 7 states, live progress, disk-size impact, pending/error banners

**Device-stats panel (5 locked signals)**
- `apps/backend/src/modules/system/device-stats.ts` — collectors: /data disk usage+type, CPU 1-min load, SoC temp (reuses sensors.ts), iface TX/RX rate, RAUC active slot
- `apps/frontend/src/main/settings/DeviceStatsSection.svelte` — live panel, graceful unavailable states

**Kiosk → add-on framework refactor**
- `apps/backend/src/modules/system/kiosk.ts` — kioskStart/Stop now route through enableAddon/disableAddon (cog-display descriptor); DC-2 state machine fully preserved (5 states, crash-loop, profiles, OSK)

**Test infrastructure**
- `apps/backend/src/tests/test-preload.ts` + `bunfig.toml` — global setup.json stub; test suite goes from 31 failures → 570 pass / 0 fail

## Why
Enables runtime feature management (install/uninstall add-ons without reflashing), surfaces device telemetry, and routes the kiosk through the unified add-on lifecycle.

## How to verify
```bash
cd CeraUI
bun test apps/backend          # 570 pass / 0 fail
bun tsc --noEmit               # clean
biome check apps/backend       # clean
```

## Risks
- Add-on ops are gated on `isRealDevice()` — all mutating ops are no-ops in dev/emulated mode
- `ceralive-addon-helper` requires a narrow sudoers entry baked into the device image
- Kiosk DC-2 semantics preserved; existing `kioskStatus` RPC surface unchanged
- Pre-existing 13 biome warnings in unrelated modem/streaming files (not introduced here)