### PR TITLE
feat: engine↔UI protocol-skew safety (apt coupling, startup probe, auto-vendor)

### DIFF
--- a/.github/workflows/vendor-refresh.yml
+++ b/.github/workflows/vendor-refresh.yml
@@ -1,0 +1,91 @@
+name: Refresh vendored cerastream bindings
+
+# Keeps apps/backend/vendor/ceralive-cerastream.tgz in step with the published
+# @ceralive/cerastream npm package, so CeraUI's baked-in bindings never silently
+# lag the engine. Fired automatically by a repository_dispatch from cerastream's
+# publish-bindings workflow, or manually with a specific version/dist-tag.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "npm version or dist-tag of @ceralive/cerastream"
+        required: false
+        default: "next"
+  repository_dispatch:
+    types: [cerastream-bindings-published]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  NODE_VERSION: "24"
+
+jobs:
+  refresh:
+    name: Refresh vendored tarball and open PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout CeraUI
+        uses: actions/checkout@v4
+        with:
+          path: CeraUI
+
+      - name: "Checkout srtla (sibling link: dependency)"
+        uses: actions/checkout@v4
+        with:
+          repository: CERALIVE/srtla
+          path: srtla
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: CeraUI/package.json
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org/
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install srtla sibling bindings
+        run: pnpm install --dir srtla/bindings/typescript
+
+      - name: Resolve target version
+        id: ver
+        run: |
+          V="${{ github.event.inputs.version || github.event.client_payload.version || 'next' }}"
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+
+      - name: Refresh vendored bindings
+        working-directory: CeraUI
+        run: bash scripts/refresh-cerastream-vendor.sh "${{ steps.ver.outputs.version }}"
+
+      - name: Verify bindings skew
+        working-directory: CeraUI
+        run: pnpm --filter backend test src/tests/cerastream-bindings-skew.test.ts
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          path: CeraUI
+          branch: chore/refresh-cerastream-bindings
+          delete-branch: true
+          title: "chore: refresh vendored @ceralive/cerastream to ${{ steps.ver.outputs.version }}"
+          commit-message: "chore: refresh vendored @ceralive/cerastream to ${{ steps.ver.outputs.version }}"
+          body: |
+            Automated refresh of `apps/backend/vendor/ceralive-cerastream.tgz` to
+            `@ceralive/cerastream@${{ steps.ver.outputs.version }}`, triggered by a
+            cerastream bindings publish (or manual dispatch).
+
+            The backend bindings-skew test ran here; **Build Check** runs the full
+            suite on this PR before it can merge.
+          labels: |
+            dependencies
+            automated

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -40,6 +40,7 @@ import {
 } from "./modules/streaming/audio.ts";
 import { startBcrpt } from "./modules/streaming/bcrpt.ts";
 import { checkCamlinkUsb2 } from "./modules/streaming/camlink.ts";
+import { checkEngineCompatibilityOnStartup } from "./modules/streaming/cerastream-backend.ts";
 import { startDeviceDiscovery } from "./modules/streaming/devices.ts";
 import { broadcastHealthIfChanged } from "./modules/streaming/health.ts";
 import { broadcastLinkTelemetryIfChanged } from "./modules/streaming/link-telemetry.ts";
@@ -159,6 +160,12 @@ onHeartbeatTick(broadcastHealthIfChanged);
 onHeartbeatTick(broadcastLinkTelemetryIfChanged);
 
 checkAutoStartStream();
+
+// Engine protocol-compatibility probe (T-skew): fire-and-forget. A protocol-major
+// mismatch (e.g. a newer engine .deb against older baked-in bindings) raises a
+// persistent notification rather than failing silently at first stream. Never
+// gates boot — failures are handled inside the call.
+void checkEngineCompatibilityOnStartup();
 
 // Post-boot add-on reconciler (T29): fire-and-forget. Add-ons NEVER gate boot or
 // the OS-update healthcheck/rollback, so this is a non-blocking background task

--- a/apps/backend/src/modules/streaming/cerastream-backend.ts
+++ b/apps/backend/src/modules/streaming/cerastream-backend.ts
@@ -36,6 +36,9 @@ import { existsSync } from "node:fs";
 import {
 	CERASTREAM_BIN,
 	type CerastreamClient,
+	CerastreamConnectionError,
+	CerastreamRpcError,
+	CerastreamTimeoutError,
 	type ConnectOptions,
 	connect,
 	DEFAULT_BALANCER,
@@ -49,6 +52,7 @@ import {
 	type PartialCerastreamConfig,
 	type ReloadConfigParams,
 	type RuntimeErrorEvent,
+	SCHEMA_VERSION,
 	type StartParams,
 	type Subscription,
 	type SwitchInputParams,
@@ -146,6 +150,67 @@ function defaultCerastreamBackendDeps(): CerastreamBackendDeps {
 		configPath: DEFAULT_CONFIG_PATH,
 		logger: defaultLogger,
 	};
+}
+
+/**
+ * Outcome of a startup `hello` handshake against the engine. The protocol MAJOR
+ * is the hard compatibility contract (the engine rejects a mismatched major and
+ * the client's `helloResultSchema` is a literal); `schema_version` differences
+ * within a major are additive-only and informational (ADR-0002 §4).
+ */
+export type EngineProbeStatus =
+	| "compatible"
+	| "protocol_incompatible"
+	| "unreachable"
+	| "error";
+
+export interface EngineProbe {
+	status: EngineProbeStatus;
+	protocol?: string;
+	engineVersion?: string;
+	schemaVersion?: string;
+	detail?: string;
+}
+
+function probeErrorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
+/** A ZodError raised inside the bindings' own bundled Zod copy (cross-instance
+ * `instanceof` is unreliable, so match by name) means the engine returned a
+ * hello shape the frozen literal schema rejected — a protocol mismatch. */
+function isZodLikeError(err: unknown): boolean {
+	return (
+		typeof err === "object" &&
+		err !== null &&
+		(err as { name?: string }).name === "ZodError"
+	);
+}
+
+/** Classify a failed `connect()`/handshake into an {@link EngineProbe}. */
+export function classifyEngineProbeError(err: unknown): EngineProbe {
+	if (err instanceof CerastreamRpcError) {
+		if (
+			err.dataCode === "cerastream.protocol.unsupported_version" ||
+			err.code === -32000
+		) {
+			return { status: "protocol_incompatible", detail: err.message };
+		}
+		return { status: "error", detail: err.message };
+	}
+	if (isZodLikeError(err)) {
+		return {
+			status: "protocol_incompatible",
+			detail: "engine returned an unexpected hello shape",
+		};
+	}
+	if (
+		err instanceof CerastreamConnectionError ||
+		err instanceof CerastreamTimeoutError
+	) {
+		return { status: "unreachable", detail: probeErrorMessage(err) };
+	}
+	return { status: "error", detail: probeErrorMessage(err) };
 }
 
 export class CerastreamBackend implements StreamingBackend {
@@ -275,6 +340,41 @@ export class CerastreamBackend implements StreamingBackend {
 
 	getTelemetry(): EngineTelemetry | null {
 		return this.telemetry;
+	}
+
+	/**
+	 * Connect, run the `hello` handshake, and disconnect — a cheap startup probe
+	 * of engine compatibility independent of any stream. The engine is a
+	 * systemd-owned service, so `close()` only drops our connection; it never
+	 * spawns or stops the engine. A protocol-major mismatch surfaces here as
+	 * `protocol_incompatible` instead of waiting for the first stream to fail.
+	 */
+	async probeEngine(): Promise<EngineProbe> {
+		let client: CerastreamClient | undefined;
+		try {
+			client = await this.deps.connect(this.deps.connectOptions);
+			const hello = client.hello;
+			if (hello.schema_version !== SCHEMA_VERSION) {
+				this.deps.logger.warn(
+					"cerastream: engine schema_version differs from bindings (additive-only, informational)",
+					{ engine: hello.schema_version, bindings: SCHEMA_VERSION },
+				);
+			}
+			return {
+				status: "compatible",
+				protocol: hello.protocol,
+				engineVersion: hello.engine_version,
+				schemaVersion: hello.schema_version,
+			};
+		} catch (err) {
+			return classifyEngineProbeError(err);
+		} finally {
+			try {
+				await client?.close();
+			} catch {
+				// Best-effort disconnect of a probe connection; never respawns the engine.
+			}
+		}
 	}
 
 	// ---- additive cerastream-only RPC passthroughs (NOT on the frozen seam) ----
@@ -456,3 +556,62 @@ export class CerastreamBackend implements StreamingBackend {
 // Process-wide singleton; the engine registry (streaming-engine.ts) hands this
 // out to every streaming call site.
 export const cerastreamBackend = new CerastreamBackend();
+
+/** The persistent notification name for an engine-protocol incompatibility. */
+export const ENGINE_COMPAT_NOTIFICATION = "cerastream-engine-compat";
+
+/** Injectable surface for {@link checkEngineCompatibilityOnStartup} (tests). */
+export interface EngineCompatDeps {
+	probe: () => Promise<EngineProbe>;
+	notify: CerastreamBridge["notify"];
+	logger: CerastreamLogger;
+}
+
+/**
+ * Run a startup engine probe and surface a protocol incompatibility as a
+ * persistent, non-dismissable notification (the UI already renders these), so a
+ * new-engine/old-bindings skew is visible immediately rather than only when a
+ * stream is first attempted. Unreachable/transient failures only log — the
+ * engine may simply not be up yet at boot. Returns the probe for the caller.
+ */
+export async function checkEngineCompatibilityOnStartup(
+	deps: Partial<EngineCompatDeps> = {},
+): Promise<EngineProbe> {
+	const probe = deps.probe ?? (() => cerastreamBackend.probeEngine());
+	const notify = deps.notify ?? notificationBroadcast;
+	const logger = deps.logger ?? defaultLogger;
+
+	const result = await probe();
+	switch (result.status) {
+		case "protocol_incompatible":
+			logger.error("cerastream: engine protocol incompatible at startup", {
+				probe: result,
+			});
+			notify(
+				ENGINE_COMPAT_NOTIFICATION,
+				"error",
+				"The streaming engine speaks an incompatible protocol version. A system update is required before streaming will work.",
+				0,
+				true,
+				false,
+			);
+			break;
+		case "unreachable":
+			logger.warn("cerastream: engine unreachable at startup", {
+				probe: result,
+			});
+			break;
+		case "error":
+			logger.warn("cerastream: engine probe failed at startup", {
+				probe: result,
+			});
+			break;
+		case "compatible":
+			logger.info("cerastream: engine compatible", {
+				engine: result.engineVersion,
+				protocol: result.protocol,
+			});
+			break;
+	}
+	return result;
+}

--- a/apps/backend/src/tests/cerastream-engine-probe.test.ts
+++ b/apps/backend/src/tests/cerastream-engine-probe.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type CerastreamClient,
+	CerastreamConnectionError,
+	CerastreamRpcError,
+	CerastreamTimeoutError,
+	type ConnectOptions,
+	SCHEMA_VERSION,
+} from "@ceralive/cerastream";
+import {
+	CerastreamBackend,
+	checkEngineCompatibilityOnStartup,
+	classifyEngineProbeError,
+	ENGINE_COMPAT_NOTIFICATION,
+	type EngineProbe,
+} from "../modules/streaming/cerastream-backend.ts";
+
+// A minimal hello-only fake client. `close()` is tracked so we can assert the
+// probe always disconnects (it must never leave a dangling connection).
+function fakeClient(hello: Partial<CerastreamClient["hello"]> = {}): {
+	client: CerastreamClient;
+	closed: () => number;
+} {
+	let closes = 0;
+	const client = {
+		hello: {
+			protocol: "cerastream-ipc/1",
+			schema_version: SCHEMA_VERSION,
+			engine_version: "2026.6.0",
+			...hello,
+		},
+		close: async () => {
+			closes += 1;
+		},
+	} as unknown as CerastreamClient;
+	return { client, closed: () => closes };
+}
+
+interface LogSpy {
+	logger: {
+		debug: (m: string, x?: unknown) => void;
+		info: (m: string, x?: unknown) => void;
+		warn: (m: string, x?: unknown) => void;
+		error: (m: string, x?: unknown) => void;
+	};
+	warns: Array<{ msg: string; meta?: unknown }>;
+	errors: Array<{ msg: string; meta?: unknown }>;
+	infos: Array<{ msg: string; meta?: unknown }>;
+}
+
+function logSpy(): LogSpy {
+	const warns: Array<{ msg: string; meta?: unknown }> = [];
+	const errors: Array<{ msg: string; meta?: unknown }> = [];
+	const infos: Array<{ msg: string; meta?: unknown }> = [];
+	return {
+		warns,
+		errors,
+		infos,
+		logger: {
+			debug: () => {},
+			info: (msg, meta) => infos.push({ msg, meta }),
+			warn: (msg, meta) => warns.push({ msg, meta }),
+			error: (msg, meta) => errors.push({ msg, meta }),
+		},
+	};
+}
+
+function backendWith(
+	connect: (options?: ConnectOptions) => Promise<CerastreamClient>,
+	logger?: LogSpy["logger"],
+): CerastreamBackend {
+	return new CerastreamBackend({ connect, ...(logger ? { logger } : {}) });
+}
+
+describe("classifyEngineProbeError", () => {
+	test("protocol-unsupported RPC error → protocol_incompatible (by dataCode)", () => {
+		const err = new CerastreamRpcError(
+			-32000,
+			"unsupported protocol",
+			"cerastream.protocol.unsupported_version",
+			1,
+		);
+		expect(classifyEngineProbeError(err).status).toBe("protocol_incompatible");
+	});
+
+	test("numeric -32000 alone → protocol_incompatible (by code)", () => {
+		const err = new CerastreamRpcError(-32000, "nope", undefined, 1);
+		expect(classifyEngineProbeError(err).status).toBe("protocol_incompatible");
+	});
+
+	test("a ZodError-shaped failure → protocol_incompatible", () => {
+		const err = Object.assign(new Error("bad hello shape"), {
+			name: "ZodError",
+		});
+		expect(classifyEngineProbeError(err).status).toBe("protocol_incompatible");
+	});
+
+	test("connection error → unreachable", () => {
+		const err = new CerastreamConnectionError("ECONNREFUSED");
+		expect(classifyEngineProbeError(err).status).toBe("unreachable");
+	});
+
+	test("timeout error → unreachable", () => {
+		const err = new CerastreamTimeoutError("hello", 2000);
+		expect(classifyEngineProbeError(err).status).toBe("unreachable");
+	});
+
+	test("a non-protocol RPC error → error", () => {
+		const err = new CerastreamRpcError(
+			-32004,
+			"out of range",
+			"cerastream.bitrate.out_of_range",
+			1,
+		);
+		expect(classifyEngineProbeError(err).status).toBe("error");
+	});
+
+	test("an unknown failure → error", () => {
+		expect(classifyEngineProbeError(new Error("boom")).status).toBe("error");
+	});
+});
+
+describe("CerastreamBackend.probeEngine", () => {
+	test("compatible engine returns the hello fields and disconnects", async () => {
+		const f = fakeClient();
+		const backend = backendWith(async () => f.client);
+
+		const probe = await backend.probeEngine();
+
+		expect(probe.status).toBe("compatible");
+		expect(probe.protocol).toBe("cerastream-ipc/1");
+		expect(probe.engineVersion).toBe("2026.6.0");
+		expect(probe.schemaVersion).toBe(SCHEMA_VERSION);
+		expect(f.closed()).toBe(1); // probe must always close its connection
+	});
+
+	test("warns (non-fatally) on schema_version skew within the same major", async () => {
+		const f = fakeClient({ schema_version: "9.9.9-different" });
+		const spy = logSpy();
+		const backend = backendWith(async () => f.client, spy.logger);
+
+		const probe = await backend.probeEngine();
+
+		expect(probe.status).toBe("compatible"); // skew is informational only
+		expect(spy.warns.some((w) => w.msg.includes("schema_version"))).toBe(true);
+	});
+
+	test("protocol-major mismatch surfaces as protocol_incompatible", async () => {
+		const backend = backendWith(async () => {
+			throw new CerastreamRpcError(
+				-32000,
+				"this server speaks cerastream-ipc/1",
+				"cerastream.protocol.unsupported_version",
+				1,
+			);
+		});
+
+		const probe = await backend.probeEngine();
+
+		expect(probe.status).toBe("protocol_incompatible");
+	});
+
+	test("an unreachable engine surfaces as unreachable", async () => {
+		const backend = backendWith(async () => {
+			throw new CerastreamConnectionError("no socket");
+		});
+
+		expect((await backend.probeEngine()).status).toBe("unreachable");
+	});
+});
+
+describe("checkEngineCompatibilityOnStartup", () => {
+	function notifySpy() {
+		const calls: Array<{
+			name: string;
+			type: string;
+			msg: string;
+			persistent: boolean;
+		}> = [];
+		const notify = (
+			name: string,
+			type: "success" | "warning" | "error",
+			msg: string,
+			_duration: number,
+			isPersistent: boolean,
+		) => {
+			calls.push({ name, type, msg, persistent: isPersistent });
+		};
+		return { calls, notify };
+	}
+
+	test("protocol_incompatible raises a persistent error notification", async () => {
+		const spyN = notifySpy();
+		const spyL = logSpy();
+
+		await checkEngineCompatibilityOnStartup({
+			probe: async (): Promise<EngineProbe> => ({
+				status: "protocol_incompatible",
+				detail: "mismatch",
+			}),
+			notify: spyN.notify,
+			logger: spyL.logger,
+		});
+
+		expect(spyN.calls).toHaveLength(1);
+		expect(spyN.calls[0]?.name).toBe(ENGINE_COMPAT_NOTIFICATION);
+		expect(spyN.calls[0]?.type).toBe("error");
+		expect(spyN.calls[0]?.persistent).toBe(true);
+		expect(spyL.errors).toHaveLength(1);
+	});
+
+	test("unreachable only logs a warning — no user notification", async () => {
+		const spyN = notifySpy();
+		const spyL = logSpy();
+
+		await checkEngineCompatibilityOnStartup({
+			probe: async (): Promise<EngineProbe> => ({ status: "unreachable" }),
+			notify: spyN.notify,
+			logger: spyL.logger,
+		});
+
+		expect(spyN.calls).toHaveLength(0);
+		expect(spyL.warns).toHaveLength(1);
+	});
+
+	test("compatible logs info and does not notify", async () => {
+		const spyN = notifySpy();
+		const spyL = logSpy();
+
+		await checkEngineCompatibilityOnStartup({
+			probe: async (): Promise<EngineProbe> => ({
+				status: "compatible",
+				protocol: "cerastream-ipc/1",
+				engineVersion: "2026.6.0",
+			}),
+			notify: spyN.notify,
+			logger: spyL.logger,
+		});
+
+		expect(spyN.calls).toHaveLength(0);
+		expect(spyL.infos).toHaveLength(1);
+	});
+});

--- a/scripts/build/build-debian-package.sh
+++ b/scripts/build/build-debian-package.sh
@@ -28,6 +28,23 @@ MAINTAINER="Andrés Cera <andres@ceralive.com>"
 DESCRIPTION="CERALIVE device software - live streaming hardware controller"
 URL="https://github.com/CERALIVE/CeraUI"
 
+# Engine protocol-major coupling (engine ↔ UI version-skew guard). The cerastream
+# .deb Provides cerastream-ipc-<major>; we Depends on the major our baked-in
+# bindings speak, so apt refuses a cross-protocol-major skew on-device and mkosi
+# fails a mismatched pair at image-build time. Derived from the vendored bindings
+# (the single source of truth for what's compiled in) — never hardcoded.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VENDOR_TGZ="$SCRIPT_DIR/../../apps/backend/vendor/ceralive-cerastream.tgz"
+IPC_PROTOCOL="$(tar -xzOf "$VENDOR_TGZ" package/dist/constants.js 2>/dev/null \
+    | grep -oE 'cerastream-ipc/[0-9]+' | head -1)"
+IPC_MAJOR="${IPC_PROTOCOL##*/}"
+if ! printf '%s' "$IPC_MAJOR" | grep -qE '^[0-9]+$'; then
+    log_error "Could not derive cerastream protocol major from vendored bindings: $VENDOR_TGZ"
+    exit 1
+fi
+IPC_VPKG="cerastream-ipc-${IPC_MAJOR}"
+log_info "Engine protocol coupling: Depends $IPC_VPKG"
+
 # Clean previous builds
 log_step "Cleaning previous builds"
 rm -rf dist/debian
@@ -191,6 +208,7 @@ fpm -s dir -t deb \
     --depends "network-manager" \
     --depends "modemmanager" \
     --depends "cerastream" \
+    --depends "$IPC_VPKG" \
     --depends "srtla" \
     --conflicts "belaui" \
     --replaces "belaui" \
@@ -237,6 +255,7 @@ cat > dist/debian/package-info-${ARCHITECTURE}.json << EOF
     "network-manager",
     "modemmanager",
     "cerastream",
+    "$IPC_VPKG",
     "srtla"
   ],
   "apt": {

--- a/scripts/refresh-cerastream-vendor.sh
+++ b/scripts/refresh-cerastream-vendor.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+
+# Refresh the vendored @ceralive/cerastream tarball to a published npm version.
+# CeraUI consumes the bindings as a vendored file: dependency (ADR-0002 Decision
+# 13 — standalone build, no sibling checkout). This script replaces the tarball
+# with a freshly packed npm release so the baked-in bindings track the engine,
+# instead of a developer remembering to do it by hand.
+#
+# Usage:
+#   scripts/refresh-cerastream-vendor.sh [version]
+#     version — an npm version (e.g. 2026.6.0-rc.2) or dist-tag (default: next)
+
+VERSION="${1:-next}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+VENDOR_DIR="$REPO_ROOT/apps/backend/vendor"
+TARGET="$VENDOR_DIR/ceralive-cerastream.tgz"
+
+mkdir -p "$VENDOR_DIR"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "Fetching @ceralive/cerastream@${VERSION} from npm…"
+( cd "$TMP" && npm pack "@ceralive/cerastream@${VERSION}" >/dev/null )
+
+PACKED="$(ls "$TMP"/ceralive-cerastream-*.tgz 2>/dev/null | head -1)"
+if [ -z "${PACKED:-}" ]; then
+    echo "error: npm pack produced no tarball for @ceralive/cerastream@${VERSION}" >&2
+    exit 1
+fi
+
+# The file: dependency points at a version-agnostic filename, so overwrite in place.
+cp "$PACKED" "$TARGET"
+echo "Vendored → $TARGET"
+
+# Re-extract into the workspace so the file: dependency resolves the new contents.
+( cd "$REPO_ROOT" && pnpm install )
+
+echo "Done. Verify with: pnpm --filter backend test"


### PR DESCRIPTION
## Why
Under a **package-based** device-update model (apt repo, not full-image re-cut), a deployed device can update the `cerastream` engine `.deb` independently of CeraUI — risking a newer engine against CeraUI's *older* baked-in bindings. The protocol **major** (`cerastream-ipc/1`) is the real compatibility contract (additive-only within a major, ADR-0002 §4), so this defends the major with defense-in-depth instead of forcing release-version lockstep.

## What (three layers)
**L1 — apt makes cross-major skew un-installable.** The `ceralive-device` .deb now `Depends: cerastream-ipc-<major>`, derived at build time from the vendored bindings' `PROTOCOL_VERSION` (no hardcoding). Paired with cerastream's new `Provides: cerastream-ipc-<major>` ([cerastream#1](https://github.com/CERALIVE/cerastream/pull/1)), apt refuses to move one across a protocol-major boundary without the other, and mkosi fails a mismatched pair at image-build time.

**L2 — startup handshake health-check.** `CerastreamBackend.probeEngine()` connects, runs `hello`, classifies `compatible` / `protocol_incompatible` / `unreachable` / `error`, and disconnects (never spawns the engine). `checkEngineCompatibilityOnStartup()` raises a **persistent notification** on incompatibility, wired fire-and-forget in `main.ts` (never gates boot). Surfaces a bad pairing immediately instead of at first stream. **14 new tests.**

**L3 — automated vendoring.** `scripts/refresh-cerastream-vendor.sh` packs a published `@ceralive/cerastream` from npm into the vendored tarball; `vendor-refresh.yml` auto-opens a refresh PR on a `repository_dispatch` from cerastream's publish (or manual dispatch), gated by the bindings-skew test. Kills the manual-lag SPOF.

## How to verify
```
pnpm --filter backend test          # 726 pass (14 new engine-probe tests)
bun tsc --noEmit                     # clean
bash -n scripts/build/build-debian-package.sh && shellcheck scripts/refresh-cerastream-vendor.sh
# L1 sandbox: a .deb Depends: cerastream-ipc-2 against an engine Providing cerastream-ipc-1 → apt-get install fails (unmet dep).
```

## Risks / notes
- The auto-vendor dispatch from cerastream needs a cross-repo token (`CERAUI_DISPATCH_TOKEN`) on the cerastream repo — flagged in the companion PR; the workflow also runs on manual `workflow_dispatch`.
- No release-version lockstep introduced; engine and bindings stay independently releasable within a protocol major.
- Pre-existing: `build-check.yml` still checks out the retired `ceracoder` sibling — out of scope here.