### PR TITLE
feat(remote): bidirectional control channel + PASETO verify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ BUILD_SYSTEM_IMPROVEMENTS.md
 # Test artifacts (Playwright traces + E2E evidence) — never tracked
 test-results/
 
+# Playwright visual baseline snapshots — mobile viewport variants (not part of tracked baselines)
+*-mobile-linux.png
+
 # Agent orchestration state (local only)
 .omo/
 *.tsbuildinfo

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -25,6 +25,15 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 | Stream lifecycle (spawn supervision, start/stop, autostart, exec paths) | `modules/streaming/streamloop/` (barrel: `modules/streaming/streamloop.ts`) |
 | WebSocket server wiring | `modules/ui/websocket-server.ts` + `rpc/server.ts` |
 | Auth token logic | `modules/ui/auth.ts` + `rpc/middleware/auth.middleware.ts` |
+| PASETO device-token verification (relay-config + device-control, ADR-0006) | `modules/pairing/device-token.ts` — `verifyDeviceControlToken`, `resolveControlChannelEndpoint` |
+| PASETO v4.public crypto primitives (PAE, Ed25519 sign/verify, key import) | `modules/pairing/paseto-v4.ts` |
+| Control-channel hub endpoint pinning (rejects `custom_provider`, spec §10) | `modules/remote/control-endpoint.ts` |
+| **Device identity init (`initIdentity`, `canDialControlChannel`)** | `modules/identity/index.ts` — resolves `device_id` + `paired` at boot; gates the control channel |
+| **Remote-control channel (second outbound WS, independent of BCRPT relay)** | `modules/remote-control/channel.ts` — `initControlChannel`, `sendFrame`, `isConnected`; exponential backoff + keepalive |
+| **Inbound command routing (PASETO-authed, role-checked, RPC dispatch)** | `modules/remote-control/command-router.ts` — `routeCommand`; NEVER_REMOTE guard, owner-only, streaming dispatch |
+| **Outbound status relay (broadcast → gateway fan-out)** | `modules/remote-control/status-relay.ts` — `relayStatusToGateway`, `RELAYABLE_TYPES` (7 types), per-type seq |
+| **self_fencing watchdog (commit-confirm + auto-revert)** | `modules/remote-control/self-fencing.ts` — `handleSelfFencingOp`, `handleSelfFencingConfirm`; 30 s watchdog |
+| **Wire-envelope Zod schema + contract test** | `modules/remote-control/protocol.ts` — `FrameSchema`, `CommandSchema`, `StatusSchema`, `COMMAND_REGISTRY`, `NEVER_REMOTE` |
 | Kiosk loopback token (DC-3, single-use, tmpfs) | `modules/ui/kiosk-token.ts` + `rpc/server.ts` |
 | SIM PIN secrets store (opt-in "remember PIN", chmod-600 tmpfs) | `modules/modems/sim-secrets.ts` |
 | Boot SIM PIN auto-unlock hook (bounded, single attempt) | `modules/modems/sim-autounlock.ts` |
@@ -196,6 +205,42 @@ structural contract over the production singleton + the cerastream behavioural
 contract, error-mapping, status-bridge, passthroughs, engine-crash, and engine
 selection.
 
+## REMOTE CONTROL PLANE [EXISTS]
+
+The remote control plane (v2.0) adds a **second, independent outbound WebSocket** from the device to the cloud platform hub. It does NOT multiplex onto the existing BCRPT relay socket (`modules/remote/remote.ts`) and does NOT touch the proto-v16 relay protocol.
+
+### Architecture
+
+```
+modules/identity/index.ts          # initIdentity() — resolves device_id + paired at boot
+modules/remote/control-endpoint.ts # resolveControlChannelEndpoint() — reads CERALIVE_CONTROL_HUB_URL (build-time pin)
+modules/pairing/paseto-v4.ts       # Ed25519 sign/verify primitives (node:crypto, synchronous)
+modules/pairing/device-token.ts    # verifyDeviceControlToken — purpose gate BEFORE claim-shape validation
+modules/remote-control/
+├── protocol.ts          # Zod envelope schemas (FrameSchema, CommandSchema, StatusSchema, NEVER_REMOTE)
+├── channel.ts           # initControlChannel — second outbound WS; exponential backoff; WS-level keepalive ping
+├── command-router.ts    # routeCommand — NEVER_REMOTE → unknown → role → self_fencing → streaming dispatch
+├── status-relay.ts      # relayStatusToGateway — wired into broadcastMsg; 7 relayable types; per-type seq
+└── self-fencing.ts      # handleSelfFencingOp / handleSelfFencingConfirm — 30 s watchdog; revertible + non-revertible
+```
+
+### Key invariants
+
+- **Gate = `canDialControlChannel()`** (`paired && deviceId !== undefined`). An unpaired device or one whose `device_id` is missing never dials the hub.
+- **`CERALIVE_CONTROL_HUB_URL`** is the build-time-pinned hub URL. It is NOT operator-configurable and is NOT derived from `custom_provider` or `remote_provider`.
+- **Two token audiences** (`purpose: "device-control"` vs `purpose: "relay-config"`). The purpose check runs BEFORE claim-schema validation — a validly-signed relay-config token is rejected by purpose, not by signature failure.
+- **`RELAYABLE_TYPES`** = `[status, config, sensors, netif, modems, device-stats, notifications]`. No auth/token/secret-bearing type is ever in this set. The no-secrets contract test enforces this.
+- **`self_fencing: true`** is a TOP-LEVEL frame flag, NOT inside payload. Revertible ops emit two result frames (apply + commit/revert). Non-revertible ops do NOT execute until an explicit `self_fencing.confirm` arrives.
+- The control channel grants ZERO local UI-client authority — it never calls `addAuthedSocket` and has no import of `modules/remote/remote.ts`.
+
+### Boot wiring order (main.ts)
+
+```
+initIdentity()        # resolves device_id + paired
+initControlChannel()  # gates on canDialControlChannel(); dials hub if paired
+initPipelines()       # streaming engine init (unaffected)
+```
+
 ## ANTI-PATTERNS
 
 - Don't import from `@ceralive/srtla` — that package is retired from CeraUI. Use `@ceralive/srtla-send` (the `srtla-send-rs` binding, registry dep). Check `../../../srtla-send-rs/AGENTS.md` before touching call sites.
@@ -209,3 +254,5 @@ selection.
 - Don't wire `@ceralive/cerastream` as a sibling `link:` or vendored `.tgz` — it
   is a public-npm registry dep by design; bump the pinned version in
   `package.json` to track the engine.
+- Don't multiplex the control channel onto the BCRPT relay socket — the two channels are independent by design (different token audiences, different endpoints, different authority models).
+- Don't add secret-bearing event types to `RELAYABLE_TYPES` — the no-secrets contract test will catch it.

--- a/apps/backend/src/helpers/config-schemas.ts
+++ b/apps/backend/src/helpers/config-schemas.ts
@@ -155,6 +155,9 @@ export const runtimeConfigSchema = z.object({
 
 	// Remote/cloud settings
 	remote_key: z.string().optional(),
+	// Platform Device.id (UUID) from the device-control token claim (spec §9/§10),
+	// persisted at pairing time. initIdentity() only reads it — never mints one.
+	device_id: z.uuid().optional(),
 	remote_provider: providerSelectionSchema.optional(),
 	custom_provider: customProviderSchema.optional(),
 	// Device-pairing claim-code seed. Persistent crypto-random secret that seeds

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -29,6 +29,7 @@ import { isDevelopment } from "./mocks/mock-config.ts";
 import { initMockService } from "./mocks/mock-service.ts";
 import { runAddonReconciler } from "./modules/addons/reconciler.ts";
 import { getConfig, loadConfig } from "./modules/config.ts";
+import { initIdentity } from "./modules/identity/index.ts";
 import { initRTMPIngestStats } from "./modules/ingest/rtmp.ts";
 import { initSRTIngest } from "./modules/ingest/srt.ts";
 import { initModemUpdateLoop } from "./modules/modems/modem-update-loop.ts";
@@ -40,6 +41,7 @@ import {
 	updateNetif,
 } from "./modules/network/network-interfaces.ts";
 import { initRemote } from "./modules/remote/remote.ts";
+import { initControlChannel } from "./modules/remote-control/channel.ts";
 import { setup } from "./modules/setup.ts";
 import {
 	startAudioDeviceWatcher,
@@ -111,6 +113,15 @@ await loadConfig();
 logger.info(bootTimer.phase("🔧", "config"));
 
 initRemote();
+// Resolve device_id + paired state before anything that gates the control
+// channel (spec §9: it MUST NOT dial until identity is resolved). Fail-soft —
+// never blocks boot.
+await initIdentity();
+// Second, independent outbound control channel (spec §9): dials the pinned
+// device-gateway hub once identity is resolved + paired. Distinct from the BCRPT
+// relay socket above — its own endpoint, token audience, and lifecycle. Fail-soft,
+// never blocks boot.
+await initControlChannel();
 await initPipelines();
 
 // Migrate persisted config vs the offered set: a `pipeline` the current hardware

--- a/apps/backend/src/modules/identity/index.ts
+++ b/apps/backend/src/modules/identity/index.ts
@@ -1,0 +1,106 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Device identity — the explicit init-time boot step (remote-relay-support spec
+ * §9). initIdentity() loads `device_id` + `remote_key` from runtime config,
+ * derives the paired state, and parks the result in module state so the control
+ * channel can gate on it via getIdentity()/canDialControlChannel().
+ *
+ * Fail-soft, like the capabilities fallback ladder (MINIMAL_SAFE_CAPABILITIES):
+ * a missing or unreadable identity NEVER throws and NEVER blocks boot — it
+ * resolves to the unpaired floor and the device surfaces re-pairing locally.
+ *
+ * Per spec §9 the control channel MUST NOT dial until identity is resolved —
+ * i.e. paired AND a `device_id` is available — so the hub can route a known
+ * device. canDialControlChannel() encodes exactly that gate.
+ */
+
+import type { RuntimeConfig } from "../../helpers/config-schemas.ts";
+import { logger } from "../../helpers/logger.ts";
+import { getConfig } from "../config.ts";
+
+export interface DeviceIdentity {
+	deviceId: string | undefined;
+	paired: boolean;
+}
+
+export const UNPAIRED_IDENTITY: DeviceIdentity = {
+	deviceId: undefined,
+	paired: false,
+};
+
+export interface IdentityLogger {
+	info: (message: string, meta?: unknown) => void;
+	warn: (message: string, meta?: unknown) => void;
+}
+
+export interface IdentityServiceDeps {
+	readConfig: () => Pick<RuntimeConfig, "device_id" | "remote_key">;
+	logger: IdentityLogger;
+}
+
+function defaultDeps(): IdentityServiceDeps {
+	return {
+		readConfig: () => getConfig(),
+		logger,
+	};
+}
+
+let currentIdentity: DeviceIdentity = UNPAIRED_IDENTITY;
+
+export function getIdentity(): DeviceIdentity {
+	return currentIdentity;
+}
+
+export function canDialControlChannel(): boolean {
+	return currentIdentity.paired && currentIdentity.deviceId !== undefined;
+}
+
+export async function initIdentity(
+	overrides: Partial<IdentityServiceDeps> = {},
+): Promise<DeviceIdentity> {
+	const deps: IdentityServiceDeps = { ...defaultDeps(), ...overrides };
+
+	try {
+		const config = deps.readConfig();
+		const paired = config.remote_key !== undefined;
+		const deviceId = paired ? config.device_id : undefined;
+
+		currentIdentity = { deviceId, paired };
+
+		if (!paired) {
+			deps.logger.info("identity: device unpaired; control channel disabled");
+		} else if (deviceId === undefined) {
+			deps.logger.warn(
+				"identity: paired but device_id missing; control channel stays closed until identity resolves",
+			);
+		} else {
+			deps.logger.info("identity: device paired; control channel gate open");
+		}
+
+		return currentIdentity;
+	} catch (err) {
+		// Fail-soft (spec §9): an unreadable/unexpected config must never block
+		// boot. Fall back to the unpaired floor; re-pairing is surfaced locally.
+		deps.logger.warn(
+			`identity: resolution failed, falling back to unpaired: ${err}`,
+		);
+		currentIdentity = UNPAIRED_IDENTITY;
+		return currentIdentity;
+	}
+}

--- a/apps/backend/src/modules/pairing/device-token.ts
+++ b/apps/backend/src/modules/pairing/device-token.ts
@@ -16,30 +16,40 @@
 */
 
 /**
- * Device token — verification contract + stub issuer (ADR-0006).
+ * Device token — PASETO v4.public verification (ADR-0006).
  *
  * ADR-0006 selects PASETO v4.public (Ed25519) for the device token, verified
- * on-device against a public key provisioned at image-build time. That ADR is
- * still `proposed` and the Ed25519 key is not yet provisioned, so this module
- * is intentionally a STUB: it carries the real claim shape and the real
- * `v4.public.` header, validates `iat`/`exp` with the ADR's ±30s skew band, but
- * performs NO Ed25519 signing or verification yet.
+ * on-device against a public key provisioned at image-build time. The crypto
+ * primitives (PAE, Ed25519 sign/verify, key import) live in {@link ./paseto-v4.ts}
+ * and are locked against the official PASETO `v4.public` test vectors; THIS
+ * module is the claim-policy layer on top of them.
  *
- * Verification is GATED on the `PASETO_PUBLIC_KEY` env var (the provisioned
- * public key, ADR-0006 D2). There is NO hardcoded/baked key anywhere here — the
- * env var's PRESENCE selects the path:
- *   - key absent  → MVP opaque-token path: claim shape + window validated,
- *                   signature NOT checked, a clear warning is logged.
- *   - key present → the real Ed25519 verifier is invoked. That path is still
- *                   blocked (see {@link verifyWithProvisionedKey}); it refuses
- *                   the token rather than ever accept it unverified.
- * When the ADR is accepted and the key is provisioned, the real Ed25519 verify
- * slots into {@link verifyWithProvisionedKey} without changing callers.
+ * Two distinct tokens share those primitives but are NEVER interchangeable
+ * (ADR-0006 two-audience rule):
+ *   - relay-config token  → {@link verifyStubDeviceToken} (BCRPT relay,
+ *     `modules/remote/remote.ts`). Claims: {@link DeviceTokenClaims}.
+ *   - device-control token → {@link verifyDeviceControlToken} (the new control
+ *     channel). Claims: {@link DeviceControlTokenClaims}; `purpose` MUST equal
+ *     `"device-control"`, checked before any claim is trusted, so a relay-config
+ *     token cannot authenticate the control channel.
  *
- * Edge E-1: the `sub_status` claim reflects subscription standing AT ISSUANCE,
- * not live billing state. This module enforces only the `iat`/`exp` window;
- * real-time enforcement of a lapse is therefore bounded by `exp` plus a re-pair.
- * Mid-token revocation is out of scope (no refresh/revocation path this cycle).
+ * Verification is GATED on the `PASETO_PUBLIC_KEY` env var (ADR-0006 D2). There
+ * is NO hardcoded/baked key anywhere here — the env var's PRESENCE selects the
+ * path:
+ *   - key present → REAL Ed25519 v4.public verification. An unsigned or forged
+ *     token is rejected; there is NO fallback to the unsigned path when the key
+ *     is set. An unusable key (not 32 base64 bytes) refuses every token.
+ *   - key absent  → MVP opaque-token path: claim shape + `iat`/`exp` window
+ *     validated, signature NOT checked, a clear warn-once is logged. This keeps
+ *     the current key-less device fleet working until the Ed25519 key is
+ *     provisioned at image build.
+ *
+ * Clock skew: `iat`/`exp` are validated with the ADR-0006 ±30s band.
+ *
+ * Edge E-1: the `sub_status` claim (relay-config) reflects subscription standing
+ * AT ISSUANCE, not live billing state. Real-time enforcement of a lapse is
+ * bounded by `exp` plus a re-pair. Mid-token revocation is out of scope (no
+ * refresh/revocation path this cycle).
  */
 
 import type {
@@ -47,8 +57,10 @@ import type {
 	SubscriptionStatus,
 } from "@ceraui/rpc/schemas";
 import { deviceTokenClaimsSchema } from "@ceraui/rpc/schemas";
+import { z } from "zod";
 
 import { logger } from "../../helpers/logger.ts";
+import { importEd25519PublicKey, verifyV4Public } from "./paseto-v4.ts";
 
 /** PASETO v4.public header (ADR-0006). The stub keeps it so the shape is real. */
 export const DEVICE_TOKEN_HEADER = "v4.public.";
@@ -146,27 +158,57 @@ function decodeStubClaims(
 }
 
 /**
- * Real Ed25519 verification seam — GATED / NOT YET IMPLEMENTED.
- *
- * TODO(high-priority-debt): Real Ed25519 verification blocked on ADR-0006
- * sign-off (D1) + Ed25519 key provisioning (D2). When unblocked: use paseto-ts
- * to verify against the image-build-provisioned public key with ±30s skew.
- *
- * A provisioned `PASETO_PUBLIC_KEY` signals the operator expects REAL
- * verification. Because that verifier does not exist yet, this MUST NOT fall
- * back to the unsigned path and silently accept the token — it refuses
- * (returns `null`) and logs at error level. The real implementation will
- * consume `token` / `publicKey` / `now` to run the Ed25519 check.
+ * Run the REAL PASETO v4.public Ed25519 check and return the verified payload
+ * JSON string, or `null` on any failure. An unusable key (not 32 base64 bytes)
+ * makes {@link importEd25519PublicKey} throw — that is logged once-per-call at
+ * error level and treated as "reject", never as "accept unverified".
+ */
+function verifyRealPayload(token: string, publicKeyB64: string): string | null {
+	try {
+		const key = importEd25519PublicKey(publicKeyB64);
+		const verified = verifyV4Public(token, key);
+		return verified ? verified.payload : null;
+	} catch (err) {
+		logger.error(
+			`${DEVICE_TOKEN_PUBLIC_KEY_ENV} is not a usable base64 Ed25519 public key (refusing the token): ${
+				err instanceof Error ? err.message : String(err)
+			}`,
+		);
+		return null;
+	}
+}
+
+/**
+ * REAL Ed25519 verification for the relay-config token (ADR-0006). Verifies the
+ * `v4.public` signature against the provisioned public key, validates the claim
+ * shape, and enforces the `iat`/`exp` ±30s window. Returns the validated claims,
+ * or `null` on any failure — it NEVER falls back to the unsigned path when a key
+ * is provisioned.
  */
 function verifyWithProvisionedKey(
-	_token: string,
-	_publicKey: string,
-	_now: number,
+	token: string,
+	publicKey: string,
+	now: number,
 ): DeviceTokenClaims | null {
-	logger.error(
-		`${DEVICE_TOKEN_PUBLIC_KEY_ENV} is set but PASETO v4.public Ed25519 verification is not implemented yet (ADR-0006 pending D1 sign-off + D2 key provisioning); refusing the token instead of accepting it unverified`,
-	);
-	return null;
+	const payloadJson = verifyRealPayload(token, publicKey);
+	if (payloadJson === null) return null;
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(payloadJson);
+	} catch {
+		return null;
+	}
+
+	const result = deviceTokenClaimsSchema.safeParse(parsed);
+	if (!result.success) return null;
+	const claims = result.data;
+
+	const nowSeconds = Math.floor(now / 1000);
+	if (nowSeconds + DEVICE_TOKEN_SKEW_SECONDS < claims.iat) return null;
+	if (nowSeconds - DEVICE_TOKEN_SKEW_SECONDS > claims.exp) return null;
+
+	return claims;
 }
 
 // Warn-once latch: emit the "running without signature verification" notice at
@@ -174,15 +216,14 @@ function verifyWithProvisionedKey(
 let warnedUnverified = false;
 
 /**
- * Verify a device token (ADR-0006), gated on key provisioning. This is the seam
- * the real Ed25519 verifier slots into.
+ * Verify a relay-config device token (ADR-0006), gated on key provisioning.
  *
  * 1. basic format check (`v4.public.` header);
- * 2/3. if `PASETO_PUBLIC_KEY` is set, invoke the real verifier — see
- *      {@link verifyWithProvisionedKey} for the `TODO(high-priority-debt)`. That
- *      path (5) NEVER silently accepts: it refuses until real verify lands;
- * 4. if no key is provisioned, run the MVP opaque-token path (claim shape +
- *    window validated, signature NOT checked) with a clear log warning.
+ * 2. if `PASETO_PUBLIC_KEY` is set, run REAL Ed25519 verification
+ *    ({@link verifyWithProvisionedKey}); a forged/unsigned/expired token is
+ *    rejected and there is NO fallback to the unsigned path;
+ * 3. if no key is provisioned, run the MVP opaque-token path (claim shape +
+ *    window validated, signature NOT checked) with a clear warn-once.
  *
  * Returns the validated claims, or `null` on any failure.
  */
@@ -193,14 +234,13 @@ export function verifyStubDeviceToken(
 	// (1) Basic format gate: must carry the real PASETO v4.public header.
 	if (!token.startsWith(DEVICE_TOKEN_HEADER)) return null;
 
-	// (2)/(3) A provisioned public key means real verification is expected.
-	// (5) Never silently accept while the real verifier is gated — refuse.
+	// (2) A provisioned public key means real verification is mandatory.
 	const publicKey = process.env[DEVICE_TOKEN_PUBLIC_KEY_ENV]?.trim();
 	if (publicKey) {
 		return verifyWithProvisionedKey(token, publicKey, now);
 	}
 
-	// (4) No provisioned key → MVP opaque-token path, with a clear warning.
+	// (3) No provisioned key → MVP opaque-token path, with a clear warning.
 	if (!warnedUnverified) {
 		warnedUnverified = true;
 		logger.warn(
@@ -214,3 +254,166 @@ export function verifyStubDeviceToken(
 export const stubDeviceTokenVerifier: DeviceTokenVerifier = {
 	verify: verifyStubDeviceToken,
 };
+
+// =============================================================================
+// Device-control channel token (ADR-0006 v2.0 addendum, spec §10)
+// =============================================================================
+
+/**
+ * The `purpose` value a token MUST carry to authenticate the device-control
+ * channel. A relay-config token (or any other audience) is rejected (ADR-0006
+ * two-audience rule, spec §10).
+ */
+export const DEVICE_CONTROL_PURPOSE = "device-control";
+
+/** Control-channel roles (spec §12). v2.0 issues `owner` only. */
+const deviceControlRoleSchema = z.enum(["owner", "copilot", "viewer"]);
+
+/**
+ * Canonical device-control token claims (spec §10). DISTINCT from the
+ * relay-config {@link DeviceTokenClaims}: snake_case `tenant_id`, plus `role`,
+ * `purpose`, `jti`, and the optional `aud`. Each repo defines its own validator
+ * (spec §10 alignment note); this is the device-side validator.
+ */
+export const deviceControlTokenClaimsSchema = z.object({
+	device_id: z.string().min(1),
+	tenant_id: z.string().min(1),
+	serial: z.string().min(1),
+	role: deviceControlRoleSchema,
+	purpose: z.literal(DEVICE_CONTROL_PURPOSE),
+	jti: z.string().min(1),
+	iat: z.number().int().nonnegative(),
+	exp: z.number().int().nonnegative(),
+	aud: z.string().min(1).optional(),
+});
+export type DeviceControlTokenClaims = z.infer<
+	typeof deviceControlTokenClaimsSchema
+>;
+
+export interface MintStubDeviceControlTokenParams {
+	deviceId: string;
+	tenantId: string;
+	serial: string;
+	role?: z.infer<typeof deviceControlRoleSchema>;
+	jti: string;
+	aud?: string;
+	/** Issued-at instant, epoch ms (defaults to now). */
+	now?: number;
+	/** Token lifetime in seconds (defaults to the spec §10 15-minute TTL). */
+	ttlSeconds?: number;
+}
+
+/** Control-channel TTL: 15 minutes (spec §10 short TTL + refresh). */
+export const DEVICE_CONTROL_TOKEN_TTL_SECONDS = 15 * 60;
+
+/**
+ * Mint an UNSIGNED device-control token (dev/test only). Mirrors
+ * {@link mintStubDeviceToken}: it carries the real claim shape behind the real
+ * `v4.public.` header but is NOT signed. Production tokens are signed by the
+ * platform; tests sign with {@link signV4Public} from `./paseto-v4.ts`.
+ */
+export function mintStubDeviceControlToken(
+	params: MintStubDeviceControlTokenParams,
+): string {
+	const nowSeconds = Math.floor((params.now ?? Date.now()) / 1000);
+	const ttl = params.ttlSeconds ?? DEVICE_CONTROL_TOKEN_TTL_SECONDS;
+	const claims: DeviceControlTokenClaims = {
+		device_id: params.deviceId,
+		tenant_id: params.tenantId,
+		serial: params.serial,
+		role: params.role ?? "owner",
+		purpose: DEVICE_CONTROL_PURPOSE,
+		jti: params.jti,
+		iat: nowSeconds,
+		exp: nowSeconds + ttl,
+		...(params.aud !== undefined ? { aud: params.aud } : {}),
+	};
+	return `${DEVICE_TOKEN_HEADER}${base64UrlEncode(JSON.stringify(claims))}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Read the `v4.public.<body>` payload as a JSON string WITHOUT verifying. */
+function decodeUnsignedPayload(token: string): string | null {
+	const parts = token.split(".");
+	const body = parts[2];
+	if (parts[0] !== "v4" || parts[1] !== "public" || body === undefined) {
+		return null;
+	}
+	try {
+		return base64UrlDecode(body);
+	} catch {
+		return null;
+	}
+}
+
+// Warn-once latch for the control-channel unsigned dev path (separate from the
+// relay-config latch so each surfaces its own notice exactly once per process).
+let warnedControlUnverified = false;
+
+/**
+ * Verify a DEVICE-CONTROL token (spec §10), gated on key provisioning.
+ *
+ * 1. format gate (`v4.public.` header);
+ * 2. key present → REAL Ed25519 verification; key absent → MVP unsigned dev
+ *    path with a warn-once (the key-less fleet still resolves identity locally);
+ * 3. PURPOSE GATE: reject unless `purpose === "device-control"` BEFORE any other
+ *    claim is trusted — a relay-config token cannot cross audiences;
+ * 4. validate the full control claim shape;
+ * 5. enforce the `iat`/`exp` ±30s window.
+ *
+ * Returns the validated claims, or `null` on any failure.
+ */
+export function verifyDeviceControlToken(
+	token: string,
+	now: number = Date.now(),
+): DeviceControlTokenClaims | null {
+	// (1) Basic format gate.
+	if (!token.startsWith(DEVICE_TOKEN_HEADER)) return null;
+
+	// (2) Key presence selects real verification vs the MVP unsigned dev path.
+	const publicKey = process.env[DEVICE_TOKEN_PUBLIC_KEY_ENV]?.trim();
+	let payloadJson: string | null;
+	if (publicKey) {
+		payloadJson = verifyRealPayload(token, publicKey);
+	} else {
+		if (!warnedControlUnverified) {
+			warnedControlUnverified = true;
+			logger.warn(
+				`${DEVICE_TOKEN_PUBLIC_KEY_ENV} is not set: accepting device-control tokens WITHOUT signature verification (MVP unsigned path, ADR-0006). Provision an Ed25519 public key to enable real verification.`,
+			);
+		}
+		payloadJson = decodeUnsignedPayload(token);
+	}
+	if (payloadJson === null) return null;
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(payloadJson);
+	} catch {
+		return null;
+	}
+
+	// (3) PURPOSE GATE (ADR-0006 two-audience rule): a relay-config token MUST
+	// NOT authenticate the control channel, even with a valid signature.
+	if (!isRecord(parsed) || parsed.purpose !== DEVICE_CONTROL_PURPOSE) {
+		logger.warn(
+			'device-control token rejected: purpose is not "device-control"',
+		);
+		return null;
+	}
+
+	// (4) Validate the full control claim shape.
+	const result = deviceControlTokenClaimsSchema.safeParse(parsed);
+	if (!result.success) return null;
+	const claims = result.data;
+
+	// (5) Enforce the ±30s expiry window.
+	const nowSeconds = Math.floor(now / 1000);
+	if (nowSeconds + DEVICE_TOKEN_SKEW_SECONDS < claims.iat) return null;
+	if (nowSeconds - DEVICE_TOKEN_SKEW_SECONDS > claims.exp) return null;
+
+	return claims;
+}

--- a/apps/backend/src/modules/pairing/paseto-v4.ts
+++ b/apps/backend/src/modules/pairing/paseto-v4.ts
@@ -1,0 +1,238 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * PASETO v4.public primitives (Ed25519), ADR-0006.
+ *
+ * Pure transport-format layer: PAE (pre-authentication encoding), base64url, and
+ * the Ed25519 sign/verify mechanics. It knows nothing about device-token claims —
+ * that policy lives in {@link ./device-token.ts}. Keeping the crypto here means
+ * the PAE construction exists in exactly ONE place and is locked against the
+ * official PASETO `v4.public` test vectors (see `tests/device-token.test.ts`).
+ *
+ * Why `node:crypto` (not Bun's WebCrypto): Bun's `node:crypto` Ed25519
+ * sign/verify is SYNCHRONOUS, so the device-token verifier keeps its existing
+ * synchronous contract (`DeviceTokenVerifier.verify`). WebCrypto's `subtle.verify`
+ * is async and would force every caller — including the remote channel's
+ * `on("open")` handler — to become async. There is no Bun-native Ed25519
+ * `KeyObject` API, and this is signature verification, not random generation, so
+ * the `randomBase64`-over-`crypto.randomBytes` convention does not apply here.
+ *
+ * The platform is the only signer in production (it holds `PASETO_SIGNING_KEY`);
+ * {@link signV4Public} exists for tests and tooling — the device never signs.
+ */
+
+import {
+	createPublicKey,
+	type KeyObject,
+	sign as nodeSign,
+	verify as nodeVerify,
+} from "node:crypto";
+
+/** PASETO v4.public header. */
+const V4_PUBLIC_HEADER = "v4.public.";
+/** Ed25519 signature length (bytes). */
+const ED25519_SIGNATURE_BYTES = 64;
+/** Raw Ed25519 public key length (bytes). */
+const ED25519_PUBLIC_KEY_BYTES = 32;
+
+/**
+ * Fixed ASN.1 SubjectPublicKeyInfo prefix for an Ed25519 public key. Prepending
+ * it to the 32 raw key bytes yields a 44-byte SPKI DER that `createPublicKey`
+ * accepts — the standard way to import a raw Ed25519 key via `node:crypto`.
+ */
+const ED25519_SPKI_PREFIX = Uint8Array.from([
+	0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+]);
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+/**
+ * Little-endian 64-bit length encoding with the most-significant bit cleared,
+ * per the PASETO PAE specification.
+ */
+function le64(n: number): Uint8Array {
+	const out = new Uint8Array(8);
+	let value = BigInt(n);
+	for (let i = 0; i < 8; i++) {
+		if (i === 7) value &= 0x7fn; // clear the top bit of the final byte (spec)
+		out[i] = Number(value & 0xffn);
+		value >>= 8n;
+	}
+	return out;
+}
+
+function concatBytes(chunks: Uint8Array[]): Uint8Array {
+	const total = chunks.reduce((sum, c) => sum + c.length, 0);
+	const out = new Uint8Array(total);
+	let offset = 0;
+	for (const c of chunks) {
+		out.set(c, offset);
+		offset += c.length;
+	}
+	return out;
+}
+
+/**
+ * PAE — Pre-Authentication Encoding (PASETO spec). Binds every piece (header,
+ * message, footer, implicit assertion) length-prefixed so a signature cannot be
+ * replayed across a different framing.
+ */
+function pae(pieces: Uint8Array[]): Uint8Array {
+	const parts: Uint8Array[] = [le64(pieces.length)];
+	for (const piece of pieces) {
+		parts.push(le64(piece.length));
+		parts.push(piece);
+	}
+	return concatBytes(parts);
+}
+
+function base64UrlEncodeBytes(bytes: Uint8Array): string {
+	return Buffer.from(bytes)
+		.toString("base64")
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_")
+		.replace(/=+$/, "");
+}
+
+function base64UrlDecodeBytes(input: string): Uint8Array {
+	const pad = input.length % 4 === 0 ? "" : "=".repeat(4 - (input.length % 4));
+	const normalized = input.replace(/-/g, "+").replace(/_/g, "/") + pad;
+	return new Uint8Array(Buffer.from(normalized, "base64"));
+}
+
+/** Decode a base64 or base64url string (with or without padding) to bytes. */
+function decodeBase64Flexible(input: string): Uint8Array {
+	return base64UrlDecodeBytes(input.trim());
+}
+
+/**
+ * Import a base64-encoded raw 32-byte Ed25519 public key (the `PASETO_PUBLIC_KEY`
+ * env format, ADR-0006 D2) into a `node:crypto` `KeyObject`. Throws on any
+ * malformed input — callers verifying tokens MUST treat a throw as "reject".
+ */
+export function importEd25519PublicKey(base64Raw: string): KeyObject {
+	const raw = decodeBase64Flexible(base64Raw);
+	if (raw.length !== ED25519_PUBLIC_KEY_BYTES) {
+		throw new Error(
+			`Ed25519 public key must be ${ED25519_PUBLIC_KEY_BYTES} bytes, got ${raw.length}`,
+		);
+	}
+	const der = concatBytes([ED25519_SPKI_PREFIX, raw]);
+	return createPublicKey({
+		key: Buffer.from(der),
+		format: "der",
+		type: "spki",
+	});
+}
+
+/**
+ * Export the raw 32-byte Ed25519 public key from a `KeyObject` as base64 — the
+ * inverse of {@link importEd25519PublicKey}. Used by tests to derive the
+ * `PASETO_PUBLIC_KEY` value for a freshly generated keypair.
+ */
+export function exportEd25519PublicKeyBase64(key: KeyObject): string {
+	const spki = key.export({ format: "der", type: "spki" });
+	const bytes = new Uint8Array(spki);
+	return Buffer.from(
+		bytes.subarray(bytes.length - ED25519_PUBLIC_KEY_BYTES),
+	).toString("base64");
+}
+
+/** Decoded result of a successful {@link verifyV4Public} call. */
+export interface VerifiedV4Public {
+	/** The signed message body (the claims JSON, as a string). */
+	payload: string;
+	/** The decoded footer string (empty when absent). */
+	footer: string;
+}
+
+/**
+ * Sign a `v4.public` token. PRODUCTION DOES NOT CALL THIS — only the platform
+ * signs (it holds the secret key). Present for tests/tooling and to keep the PAE
+ * construction symmetric with {@link verifyV4Public}.
+ */
+export function signV4Public(
+	payload: string,
+	secretKey: KeyObject,
+	footer = "",
+	implicit = "",
+): string {
+	const message = textEncoder.encode(payload);
+	const footerBytes = textEncoder.encode(footer);
+	const m2 = pae([
+		textEncoder.encode(V4_PUBLIC_HEADER),
+		message,
+		footerBytes,
+		textEncoder.encode(implicit),
+	]);
+	const signature = new Uint8Array(nodeSign(null, m2, secretKey));
+	const body = base64UrlEncodeBytes(concatBytes([message, signature]));
+	let token = `${V4_PUBLIC_HEADER}${body}`;
+	if (footer) token += `.${base64UrlEncodeBytes(footerBytes)}`;
+	return token;
+}
+
+/**
+ * Verify a `v4.public` token against an Ed25519 public key. Returns the decoded
+ * payload + footer on success, or `null` on ANY failure (malformed token, wrong
+ * header, bad base64, short body, or signature mismatch). Never throws.
+ *
+ * `implicit` is the implicit assertion bound into the signature; it defaults to
+ * empty and must match the value used at signing time.
+ */
+export function verifyV4Public(
+	token: string,
+	publicKey: KeyObject,
+	implicit = "",
+): VerifiedV4Public | null {
+	const parts = token.split(".");
+	if (parts.length !== 3 && parts.length !== 4) return null;
+	if (parts[0] !== "v4" || parts[1] !== "public") return null;
+
+	let raw: Uint8Array;
+	let footer = "";
+	try {
+		raw = base64UrlDecodeBytes(parts[2] ?? "");
+		if (parts.length === 4) {
+			footer = textDecoder.decode(base64UrlDecodeBytes(parts[3] ?? ""));
+		}
+	} catch {
+		return null;
+	}
+	if (raw.length < ED25519_SIGNATURE_BYTES) return null;
+
+	const message = raw.subarray(0, raw.length - ED25519_SIGNATURE_BYTES);
+	const signature = raw.subarray(raw.length - ED25519_SIGNATURE_BYTES);
+	const m2 = pae([
+		textEncoder.encode(V4_PUBLIC_HEADER),
+		message,
+		textEncoder.encode(footer),
+		textEncoder.encode(implicit),
+	]);
+
+	let ok = false;
+	try {
+		ok = nodeVerify(null, m2, publicKey, signature);
+	} catch {
+		return null;
+	}
+	if (!ok) return null;
+
+	return { payload: textDecoder.decode(message), footer };
+}

--- a/apps/backend/src/modules/remote-control/channel.ts
+++ b/apps/backend/src/modules/remote-control/channel.ts
@@ -1,0 +1,415 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Remote Control Plane v2.0 — device-side control channel
+ * (remote-relay-support spec §4, §9, §10).
+ *
+ * This is a SECOND, INDEPENDENT outbound WebSocket from the device to the
+ * platform device-gateway hub. It is deliberately NOT multiplexed onto the BCRPT
+ * relay socket (`modules/remote/remote.ts`): it dials a different (build-time
+ * pinned) endpoint, presents a different token audience (`purpose:
+ * "device-control"`, not `"relay-config"`), runs its own reconnect/keepalive
+ * lifecycle, and NEVER calls `addAuthedSocket` — so it carries zero local
+ * UI-client authority. The two channels share no socket and no token.
+ *
+ * Lifecycle:
+ *   1. Gate (spec §9): never dial until identity is resolved AND paired —
+ *      `canDialControlChannel()` (paired && device_id available). An unpaired
+ *      device returns immediately without dialing.
+ *   2. Dial the pinned hub URL (`resolveControlChannelEndpoint().url`).
+ *   3. On open: send the `device.hello` handshake advertising the serviceable
+ *      command types + device capabilities (spec §4 / §14.2).
+ *   4. WS-level keepalive ping while connected.
+ *   5. On drop: reconnect with exponential backoff + jitter.
+ *
+ * Fail-soft, like `initIdentity()`: a missing pin / transient failure never
+ * throws out of `initControlChannel()` and never blocks boot. Inbound command
+ * routing is Task 14; status relay is Task 15 — both build on `sendFrame()` /
+ * `isConnected()` exported here.
+ */
+
+import WebSocket, { type RawData } from "ws";
+
+import { logger } from "../../helpers/logger.ts";
+import { canDialControlChannel } from "../identity/index.ts";
+import { verifyDeviceControlToken } from "../pairing/device-token.ts";
+import {
+	type ControlChannelEndpoint,
+	resolveControlChannelEndpoint,
+} from "../remote/control-endpoint.ts";
+import {
+	COMMAND_REGISTRY,
+	CommandSchema,
+	type Frame,
+	type Handshake,
+	PROTOCOL_VERSION,
+} from "./protocol.ts";
+
+/**
+ * Reconnect backoff bounds. Independent of the BCRPT relay's fixed 1s retry: the
+ * control channel must not hammer the hub on a hard outage, so it backs off
+ * exponentially up to a 30s ceiling.
+ */
+export const RECONNECT_BASE_MS = 1_000;
+export const RECONNECT_MAX_MS = 30_000;
+
+/**
+ * WS-level keepalive cadence (spec §4 keepalive). This is a WebSocket control
+ * ping, NOT an application frame — the protocol envelope has no `ping` kind.
+ */
+export const KEEPALIVE_INTERVAL_MS = 30_000;
+
+type TimerHandle = ReturnType<typeof setTimeout>;
+type IntervalHandle = ReturnType<typeof setInterval>;
+
+/**
+ * Structural seam over the outbound WebSocket so the channel is unit-testable
+ * without a real network socket (same DI posture as the rest of the backend).
+ * The default factory wraps `ws`; tests inject a controllable fake.
+ */
+export interface ControlSocket {
+	send(data: string): void;
+	ping(): void;
+	close(): void;
+	onOpen(listener: () => void): void;
+	onClose(listener: () => void): void;
+	onMessage(listener: (data: string) => void): void;
+	onError(listener: (err: Error) => void): void;
+}
+
+export interface ControlChannelLogger {
+	info: (message: string) => void;
+	warn: (message: string) => void;
+	error: (message: string) => void;
+}
+
+export interface ControlChannelDeps {
+	/** Spec §9 gate: paired AND device_id resolved. */
+	canDial: () => boolean;
+	/** Build-time pinned hub endpoint (throws if not provisioned — fail-closed). */
+	resolveEndpoint: () => ControlChannelEndpoint;
+	createSocket: (url: string, authToken?: string) => ControlSocket;
+	/**
+	 * Control-channel PASETO token source, self-verified before presentation. No
+	 * on-device source is wired yet (the token is short-TTL + hub-refreshed, out
+	 * of this skeleton's scope), so the default yields none and the channel
+	 * connects on the key-less MVP path. Tasks that obtain a token inject it here.
+	 */
+	getControlToken: () => string | undefined;
+	/** Local token verification (spec §10): never present a token we know is bad. */
+	verifyToken: (token: string) => unknown;
+	logger: ControlChannelLogger;
+	random: () => number;
+	setTimer: (fn: () => void, ms: number) => TimerHandle;
+	clearTimer: (timer: TimerHandle) => void;
+	setKeepalive: (fn: () => void, ms: number) => IntervalHandle;
+	clearKeepalive: (timer: IntervalHandle) => void;
+	uuid: () => string;
+}
+
+function defaultCreateSocket(url: string, authToken?: string): ControlSocket {
+	const ws =
+		authToken !== undefined
+			? new WebSocket(url, {
+					headers: { Authorization: `Bearer ${authToken}` },
+				})
+			: new WebSocket(url);
+	return {
+		send: (data) => ws.send(data),
+		ping: () => ws.ping(),
+		close: () => ws.close(),
+		onOpen: (listener) => ws.on("open", listener),
+		onClose: (listener) => ws.on("close", listener),
+		onMessage: (listener) =>
+			ws.on("message", (raw: RawData) => listener(String(raw))),
+		onError: (listener) => ws.on("error", listener),
+	};
+}
+
+function defaultDeps(): ControlChannelDeps {
+	return {
+		canDial: canDialControlChannel,
+		resolveEndpoint: () => resolveControlChannelEndpoint(),
+		createSocket: defaultCreateSocket,
+		getControlToken: () => undefined,
+		verifyToken: (token) => verifyDeviceControlToken(token),
+		logger,
+		random: Math.random,
+		setTimer: (fn, ms) => setTimeout(fn, ms),
+		clearTimer: (timer) => clearTimeout(timer),
+		setKeepalive: (fn, ms) => setInterval(fn, ms),
+		clearKeepalive: (timer) => clearInterval(timer),
+		uuid: () => crypto.randomUUID(),
+	};
+}
+
+interface ChannelState {
+	deps: ControlChannelDeps;
+	socket: ControlSocket | undefined;
+	connected: boolean;
+	reconnectAttempt: number;
+	reconnectTimer: TimerHandle | undefined;
+	keepaliveTimer: IntervalHandle | undefined;
+}
+
+// Process-wide singleton (mirrors remote.ts module-state posture).
+let state: ChannelState | undefined;
+
+/**
+ * Exponential backoff with equal jitter: `base·2^attempt` capped at `max`, then
+ * a random point in the upper half `[cap/2, cap]`. The jitter de-synchronises a
+ * fleet reconnecting after a hub blip so they don't thundering-herd the gateway,
+ * while staying close to the intended step (≈1s on the first attempt).
+ */
+export function backoffDelay(attempt: number, random: () => number): number {
+	const capped = Math.min(RECONNECT_BASE_MS * 2 ** attempt, RECONNECT_MAX_MS);
+	return capped / 2 + random() * (capped / 2);
+}
+
+/**
+ * Build the `device.hello` handshake frame (spec §4 / §14.2). The hello body
+ * (`v`, `supportedTypes`, `deviceCaps`) rides in `payload` per the envelope
+ * contract — the hub validates `payload` against its `HandshakeDeviceSchema`.
+ */
+function buildDeviceHello(deps: ControlChannelDeps): Handshake {
+	return {
+		v: PROTOCOL_VERSION,
+		kind: "handshake",
+		type: "device.hello",
+		cid: deps.uuid(),
+		payload: {
+			v: PROTOCOL_VERSION,
+			supportedTypes: [...COMMAND_REGISTRY],
+			deviceCaps: {},
+		},
+	};
+}
+
+/** Resolve + self-verify the control token; drop it if it doesn't verify locally. */
+function resolveAuthToken(deps: ControlChannelDeps): string | undefined {
+	const token = deps.getControlToken();
+	if (token === undefined) return undefined;
+
+	if (deps.verifyToken(token) === null) {
+		deps.logger.warn(
+			"control-channel: stored control token failed local verification; connecting without it",
+		);
+		return undefined;
+	}
+	return token;
+}
+
+function startKeepalive(): void {
+	if (!state) return;
+	stopKeepalive();
+	state.keepaliveTimer = state.deps.setKeepalive(() => {
+		if (state?.socket && state.connected) {
+			state.socket.ping();
+		}
+	}, KEEPALIVE_INTERVAL_MS);
+}
+
+function stopKeepalive(): void {
+	if (state?.keepaliveTimer !== undefined) {
+		state.deps.clearKeepalive(state.keepaliveTimer);
+		state.keepaliveTimer = undefined;
+	}
+}
+
+function handleOpen(): void {
+	if (!state) return;
+	const { deps } = state;
+	state.connected = true;
+	state.reconnectAttempt = 0;
+
+	deps.logger.info("control-channel: connected, sending device.hello");
+	sendFrame(buildDeviceHello(deps));
+	startKeepalive();
+}
+
+function handleClose(): void {
+	if (!state) return;
+	const { deps } = state;
+	const wasConnected = state.connected;
+	state.connected = false;
+	state.socket = undefined;
+	stopKeepalive();
+
+	if (wasConnected) {
+		deps.logger.warn("control-channel: disconnected, scheduling reconnect");
+	}
+	scheduleReconnect();
+}
+
+function handleError(err: Error): void {
+	// `ws` always fires `close` after `error`, so reconnect is scheduled there.
+	state?.deps.logger.error(`control-channel: socket error: ${err.message}`);
+}
+
+function handleMessage(data: string): void {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(data);
+	} catch {
+		state?.deps.logger.warn("control-channel: dropped non-JSON inbound frame");
+		return;
+	}
+
+	// Only `command` frames are routed here (spec §5). Non-command inbound frames
+	// (the hub.hello handshake, acks) and malformed commands are silently ignored;
+	// the handshake reply is sent on open and status relay is the outbound path.
+	const command = CommandSchema.safeParse(parsed);
+	if (!command.success) {
+		return;
+	}
+
+	// Lazy import keeps the heavy streaming/RPC dispatch graph off the channel's
+	// module-load path (and breaks the channel↔router import cycle): it is pulled
+	// in only when the first command actually arrives. routeCommand is best-effort
+	// and never throws — fire-and-forget.
+	void import("./command-router.ts").then((m) => m.routeCommand(command.data));
+}
+
+function scheduleReconnect(): void {
+	if (!state) return;
+	const { deps } = state;
+
+	// Never stack timers — a single in-flight reconnect at a time.
+	if (state.reconnectTimer !== undefined) return;
+
+	const delay = backoffDelay(state.reconnectAttempt, deps.random);
+	state.reconnectAttempt += 1;
+
+	deps.logger.info(
+		`control-channel: reconnecting in ${Math.round(delay)}ms (attempt ${state.reconnectAttempt})`,
+	);
+	state.reconnectTimer = deps.setTimer(() => {
+		if (state) state.reconnectTimer = undefined;
+		dial();
+	}, delay);
+}
+
+function dial(): void {
+	if (!state) return;
+	const { deps } = state;
+
+	let endpoint: ControlChannelEndpoint;
+	try {
+		endpoint = deps.resolveEndpoint();
+	} catch (err) {
+		// Endpoint pinning is fail-closed (control-endpoint.ts throws when the hub
+		// URL is not provisioned). That is a build-time constant — it won't appear
+		// at runtime — so log and stop rather than retry-loop. Boot is unaffected.
+		deps.logger.warn(
+			`control-channel: hub endpoint unavailable, not dialing: ${
+				err instanceof Error ? err.message : String(err)
+			}`,
+		);
+		return;
+	}
+
+	const authToken = resolveAuthToken(deps);
+
+	deps.logger.info(`control-channel: dialing hub ${endpoint.host}`);
+	const socket = deps.createSocket(endpoint.url, authToken);
+	state.socket = socket;
+
+	socket.onOpen(handleOpen);
+	socket.onClose(handleClose);
+	socket.onMessage(handleMessage);
+	socket.onError(handleError);
+}
+
+/**
+ * Tear down any live socket/timers so `initControlChannel()` is idempotent
+ * across reboots and test cases.
+ */
+function teardown(): void {
+	if (!state) return;
+	if (state.reconnectTimer !== undefined) {
+		state.deps.clearTimer(state.reconnectTimer);
+	}
+	stopKeepalive();
+	if (state.socket !== undefined) {
+		try {
+			state.socket.close();
+		} catch {
+			// best-effort close
+		}
+	}
+	state = undefined;
+}
+
+/**
+ * Best-effort send of a control frame (spec §6 — NOT a delivery guarantee).
+ * Returns `false` (without throwing) when the channel is not connected or the
+ * underlying send fails. Other modules (status relay, command results) call this
+ * after checking {@link isConnected}.
+ */
+export function sendFrame(frame: Frame): boolean {
+	if (!state || state.socket === undefined || !state.connected) {
+		return false;
+	}
+	try {
+		state.socket.send(JSON.stringify(frame));
+		return true;
+	} catch (err) {
+		state.deps.logger.warn(
+			`control-channel: sendFrame failed: ${
+				err instanceof Error ? err.message : String(err)
+			}`,
+		);
+		return false;
+	}
+}
+
+/** Whether the control channel is currently connected to the hub. */
+export function isConnected(): boolean {
+	return state?.connected === true;
+}
+
+/**
+ * Boot entry point. Resolves the gate and, if paired, dials the pinned hub and
+ * starts the reconnect/keepalive lifecycle. Fail-soft: never throws, never
+ * blocks boot. Idempotent — a prior channel is torn down first.
+ */
+export async function initControlChannel(
+	overrides: Partial<ControlChannelDeps> = {},
+): Promise<void> {
+	const deps: ControlChannelDeps = { ...defaultDeps(), ...overrides };
+
+	teardown();
+	state = {
+		deps,
+		socket: undefined,
+		connected: false,
+		reconnectAttempt: 0,
+		reconnectTimer: undefined,
+		keepaliveTimer: undefined,
+	};
+
+	// Gate (spec §9): an unpaired / unresolved device MUST NOT dial.
+	if (!deps.canDial()) {
+		deps.logger.info(
+			"control-channel: unpaired, control channel gated (no dial)",
+		);
+		return;
+	}
+
+	dial();
+}

--- a/apps/backend/src/modules/remote-control/command-router.ts
+++ b/apps/backend/src/modules/remote-control/command-router.ts
@@ -1,0 +1,276 @@
+/**
+ * Remote Control Plane v2.0 — inbound command routing (hub → device).
+ *
+ * This is the device half of the spec §5 "Command Registry" / §6 "Result Frame"
+ * flow: an inbound `kind:command` frame on the dedicated control channel is
+ * dispatched to the matching existing oRPC procedure, and the device replies with
+ * a best-effort `kind:result` frame echoing the command's `cid`.
+ *
+ * Reuse, not reinvention: every registered command maps to a procedure that
+ * already implements the real validation/clamp/persist logic (the same handlers
+ * the local UI socket drives). We invoke them through oRPC's `call()` with a
+ * synthesized authenticated context, so there is exactly one code path for "apply
+ * a streaming change" regardless of whether it arrived locally or over the hub.
+ *
+ * Authority model (spec §12): the control channel is authenticated at the
+ * transport layer (PASETO, Task 7) and the connection `role` is hub-stamped. The
+ * device trusts the verified channel + role claim and executes only `owner`
+ * frames. Never-remote ops (spec §5) are rejected defensively even if a malformed
+ * hub forwards one — they are NEVER invoked here.
+ *
+ * Self_fencing ops (the brick-risk connectivity/lifecycle commands) are handled
+ * by the commit-confirm watchdog via `handleSelfFencingOp` and
+ * `handleSelfFencingConfirm`, fully implemented and wired below.
+ */
+
+import { call } from "@orpc/server";
+
+import { logger } from "../../helpers/logger.ts";
+import {
+	getConfigProcedure,
+	getPipelinesProcedure,
+	setBitrateProcedure,
+	setConfigProcedure,
+	streamingStartProcedure,
+	streamingStopProcedure,
+} from "../../rpc/procedures/streaming.procedure.ts";
+import type { AppWebSocket, RPCContext } from "../../rpc/types.ts";
+import { sendFrame } from "./channel.ts";
+import {
+	COMMAND_REGISTRY,
+	type Command,
+	NEVER_REMOTE,
+	PROTOCOL_VERSION,
+	type Result,
+	type ResultPayload,
+	SELF_FENCING_TYPES,
+} from "./protocol.ts";
+import {
+	handleSelfFencingConfirm,
+	handleSelfFencingOp,
+	type SelfFencingDeps,
+} from "./self-fencing.ts";
+
+/**
+ * Invokes the oRPC procedure backing a single command, given the inbound frame
+ * and the synthesized authenticated context. Returns the raw procedure result;
+ * the caller maps it onto the `{ ok, applied }` result payload.
+ */
+type ProcedureDispatcher = (
+	frame: Command,
+	context: RPCContext,
+) => Promise<unknown>;
+
+/**
+ * The wire carries the bitrate as `bitrate_bps` (bits/s — the srtla-send telemetry
+ * convention from ADR-001); the `setBitrate` procedure speaks `max_br` in kbps.
+ * Convert at the boundary so the existing clamp/apply logic is reused unchanged.
+ * A missing/non-numeric value yields `NaN`, which the procedure's input schema
+ * rejects → surfaced as an `ok:false` result rather than a silent no-op.
+ */
+function toBitrateInput(payload: Command["payload"]): { max_br: number } {
+	const bps = payload?.bitrate_bps;
+	return {
+		max_br: typeof bps === "number" ? Math.round(bps / 1000) : Number.NaN,
+	};
+}
+
+/**
+ * Command type → procedure dispatch table (spec §5 standard commands). The
+ * command `type` IS the dotted oRPC procedure path, so this mirrors the local
+ * `appRouter` dispatch in `rpc/adapter.ts` — only the standard streaming commands
+ * are directly invocable; self_fencing ops route through the watchdog (Task 16).
+ */
+const STREAMING_DISPATCH: Record<string, ProcedureDispatcher> = {
+	"streaming.start": (frame, context) =>
+		call(streamingStartProcedure, frame.payload ?? {}, { context }),
+	"streaming.stop": (_frame, context) =>
+		call(streamingStopProcedure, undefined, { context }),
+	"streaming.setBitrate": (frame, context) =>
+		call(setBitrateProcedure, toBitrateInput(frame.payload), { context }),
+	"streaming.setConfig": (frame, context) =>
+		call(setConfigProcedure, frame.payload ?? {}, { context }),
+	"streaming.getConfig": (_frame, context) =>
+		call(getConfigProcedure, undefined, { context }),
+	"streaming.getPipelines": (_frame, context) =>
+		call(getPipelinesProcedure, undefined, { context }),
+};
+
+/**
+ * The five connectivity/lifecycle ops that route through the self_fencing
+ * commit-confirm watchdog (Task 16). The `self_fencing.confirm` acknowledgement is
+ * handled separately (it resolves a pending op by `cid` rather than starting one).
+ */
+const SELF_FENCING_TYPES_SET: ReadonlySet<string> = new Set(SELF_FENCING_TYPES);
+
+const COMMAND_REGISTRY_SET: ReadonlySet<string> = new Set(COMMAND_REGISTRY);
+const NEVER_REMOTE_SET: ReadonlySet<string> = new Set(NEVER_REMOTE);
+
+/**
+ * Injectable collaborators (same DI posture as `channel.ts`). Defaults wire the
+ * live channel `sendFrame`, the real procedure dispatch, and a synthesized
+ * authenticated context; tests override `sendResult` to capture emitted frames.
+ */
+export interface CommandRouterDeps {
+	/** Best-effort result-frame sink (spec §6). Defaults to the live channel. */
+	sendResult: (frame: Result) => boolean;
+	/** Command-type → procedure dispatch table. */
+	dispatch: Record<string, ProcedureDispatcher>;
+	/** Authenticated context the device trusts for hub-stamped owner frames. */
+	context: RPCContext;
+	/** Self_fencing watchdog overrides (Task 16), forwarded to handleSelfFencingOp. */
+	selfFencing: Partial<SelfFencingDeps>;
+}
+
+/**
+ * The control channel has no local UI socket behind a command — it is
+ * authenticated at the transport layer (PASETO + hub-stamped role). We synthesize
+ * an authenticated `RPCContext` so the existing `authMiddleware`-gated procedures
+ * run unchanged. The `ws` is a no-op stub: only `streaming.start` touches it (to
+ * message a local client that does not exist here), so its sends are harmless.
+ */
+function buildControlContext(): RPCContext {
+	const ws = {
+		send: () => {},
+		data: { isAuthenticated: true, lastActive: Date.now() },
+	} as unknown as AppWebSocket;
+
+	return {
+		ws,
+		isAuthenticated: () => true,
+		authenticate: () => {},
+		deauthenticate: () => {},
+		markActive: () => {},
+		getLastActive: () => Date.now(),
+		setSenderId: () => {},
+		getSenderId: () => undefined,
+		clearSenderId: () => {},
+	};
+}
+
+function defaultDeps(): CommandRouterDeps {
+	return {
+		sendResult: sendFrame,
+		dispatch: STREAMING_DISPATCH,
+		context: buildControlContext(),
+		selfFencing: {},
+	};
+}
+
+/**
+ * Map an RPC procedure's return onto the control-plane result payload (spec §6).
+ * The existing `{ success, applied }` setter convention becomes `{ ok, applied }`;
+ * read-only procedures (getConfig/getPipelines/setBitrate) carry no `success`
+ * field, so their whole return is the applied state.
+ */
+function toResultPayload(result: unknown): ResultPayload {
+	if (result !== null && typeof result === "object" && "success" in result) {
+		const r = result as {
+			success: boolean;
+			applied?: unknown;
+			error?: unknown;
+		};
+		if (r.success) {
+			return { ok: true, applied: r.applied ?? null };
+		}
+		return {
+			ok: false,
+			applied: null,
+			...(typeof r.error === "string" ? { error: r.error } : {}),
+		};
+	}
+	return { ok: true, applied: result ?? null };
+}
+
+/**
+ * Build a `kind:result` frame echoing the command's `cid` (spec §6). `role` is
+ * only echoed when present (exactOptionalPropertyTypes: never set it to
+ * `undefined`).
+ */
+function buildResult(frame: Command, payload: ResultPayload): Result {
+	return {
+		v: PROTOCOL_VERSION,
+		kind: "result",
+		type: frame.type,
+		cid: frame.cid,
+		...(frame.role !== undefined ? { role: frame.role } : {}),
+		payload,
+	};
+}
+
+function emit(
+	deps: CommandRouterDeps,
+	frame: Command,
+	payload: ResultPayload,
+): void {
+	deps.sendResult(buildResult(frame, payload));
+}
+
+/**
+ * Route a single inbound `command` frame to the matching procedure and emit a
+ * best-effort `result` frame echoing its `cid` (spec §5, §6). Never throws — a
+ * rejected or failing command becomes an `ok:false` result, not an exception.
+ */
+export async function routeCommand(
+	frame: Command,
+	overrides: Partial<CommandRouterDeps> = {},
+): Promise<void> {
+	const deps: CommandRouterDeps = { ...defaultDeps(), ...overrides };
+
+	// 1. Never-remote ops are rejected defensively (spec §5) — NEVER executed,
+	//    even if a malformed hub forwards one.
+	if (NEVER_REMOTE_SET.has(frame.type)) {
+		emit(deps, frame, {
+			ok: false,
+			applied: null,
+			error: "not_remote_invokable",
+		});
+		return;
+	}
+
+	// 2. Only registered command types are invocable (spec §5 closed registry).
+	if (!COMMAND_REGISTRY_SET.has(frame.type)) {
+		emit(deps, frame, { ok: false, applied: null, error: "unknown_command" });
+		return;
+	}
+
+	// 3. Authority derives from the hub-stamped role (spec §12). v2.0 is
+	//    owner-only: only `owner` frames execute.
+	if (frame.role !== "owner") {
+		emit(deps, frame, { ok: false, applied: null, error: "unauthorized" });
+		return;
+	}
+
+	// 4. Self_fencing ops route through the commit-confirm watchdog (Task 16). A
+	//    `self_fencing.confirm` resolves a pending op by `cid` (commit a revertible
+	//    op, or execute a gated non-revertible one); the five connectivity/lifecycle
+	//    ops apply behind the watchdog (revertible) or gate behind a pre-confirm
+	//    (non-revertible). Result frames flow through the same best-effort sink.
+	if (frame.type === "self_fencing.confirm") {
+		await handleSelfFencingConfirm(frame.cid);
+		return;
+	}
+	if (SELF_FENCING_TYPES_SET.has(frame.type)) {
+		await handleSelfFencingOp(frame, {
+			sendResult: deps.sendResult,
+			...deps.selfFencing,
+		});
+		return;
+	}
+
+	// 5. Dispatch to the matching RPC procedure and echo its applied state.
+	const dispatcher = deps.dispatch[frame.type];
+	if (dispatcher === undefined) {
+		emit(deps, frame, { ok: false, applied: null, error: "unknown_command" });
+		return;
+	}
+
+	try {
+		const result = await dispatcher(frame, deps.context);
+		emit(deps, frame, toResultPayload(result));
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		logger.warn(`control-command: ${frame.type} failed: ${message}`);
+		emit(deps, frame, { ok: false, applied: null, error: message });
+	}
+}

--- a/apps/backend/src/modules/remote-control/protocol.contract.test.ts
+++ b/apps/backend/src/modules/remote-control/protocol.contract.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Contract test for the Remote Control Plane v2.0 wire envelope (Task 6).
+ *
+ * The conformance vectors are the §14 JSON fixtures from
+ * `openspec/specs/remote-relay-support/spec.md`. They are INLINED verbatim here
+ * rather than read from the spec file: CeraUI is built and tested standalone in
+ * CI, where the `ceralive/` workspace parent (and `openspec/`) does not exist
+ * (Rule D — repos are self-contained; a test MUST NOT read above its checkout
+ * root). The spec itself permits inlining the fixtures.
+ *
+ * Each fixture is asserted to parse with its matching schema; invalid frames
+ * (missing `v`, unknown `kind`) are asserted to reject with a ZodError.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { ZodError } from "zod";
+
+import {
+	AckSchema,
+	CommandSchema,
+	EnvelopeSchema,
+	FrameSchema,
+	HandshakeDeviceSchema,
+	HandshakeHubSchema,
+	HandshakeSchema,
+	ResultSchema,
+	StatusSchema,
+} from "./protocol.ts";
+
+// ── §14 wire fixtures (verbatim from spec.md) ──────────────────────────────
+
+/** §14.1 Minimal valid envelope */
+const FIXTURE_14_1 = {
+	v: 1,
+	kind: "command",
+	type: "streaming.getConfig",
+	cid: "9b2c5e7a-1f3d-4a8b-bc6e-2d4f6a8c0e12",
+};
+
+/** §14.2 Handshake — device hello */
+const FIXTURE_14_2 = {
+	v: 1,
+	kind: "handshake",
+	type: "device.hello",
+	cid: "1a4d8f02-7c3e-4b1a-9e2d-5f6a7b8c9d0e",
+	payload: {
+		v: 1,
+		supportedTypes: [
+			"streaming.start",
+			"streaming.stop",
+			"streaming.setBitrate",
+			"streaming.setConfig",
+			"streaming.getConfig",
+			"streaming.getPipelines",
+			"network.reconfig",
+			"modem.reconfig",
+			"device.remoteKeyChange",
+			"system.reboot",
+			"device.factoryReset",
+			"self_fencing.confirm",
+		],
+		deviceCaps: {
+			engine: "cerastream",
+			selfFencing: true,
+			maxBitrateBps: 12000000,
+		},
+	},
+};
+
+/** §14.3 Handshake — hub hello */
+const FIXTURE_14_3 = {
+	v: 1,
+	kind: "handshake",
+	type: "hub.hello",
+	cid: "2b5e9a13-8d4f-4c2b-af3e-6a7b8c9d0e1f",
+	payload: {
+		v: 1,
+		role: "owner",
+	},
+};
+
+/** §14.4 Handshake — version mismatch ack */
+const FIXTURE_14_4 = {
+	v: 1,
+	kind: "ack",
+	type: "version.mismatch",
+	cid: "3c6f0b24-9e5a-4d3c-b04f-7b8c9d0e1f2a",
+	payload: {
+		supported: [1],
+	},
+};
+
+/** §14.5 Command — streaming.getConfig */
+const FIXTURE_14_5 = {
+	v: 1,
+	kind: "command",
+	type: "streaming.getConfig",
+	cid: "4d70a135-0f6b-4e4d-815a-8c9d0e1f2a3b",
+	payload: {},
+};
+
+/** §14.6 Command — streaming.setBitrate */
+const FIXTURE_14_6 = {
+	v: 1,
+	kind: "command",
+	type: "streaming.setBitrate",
+	cid: "a1b2c3d4-5e6f-4a7b-8c9d-0e1f2a3b4c5d",
+	payload: {
+		bitrate_bps: 6000000,
+	},
+};
+
+/** §14.7 Result — success */
+const FIXTURE_14_7 = {
+	v: 1,
+	kind: "result",
+	type: "streaming.getConfig",
+	cid: "4d70a135-0f6b-4e4d-815a-8c9d0e1f2a3b",
+	payload: {
+		ok: true,
+		applied: {
+			max_br: 8000,
+			encoder: "cerastream",
+			delay: 2000,
+		},
+	},
+};
+
+/** §14.8 Result — error */
+const FIXTURE_14_8 = {
+	v: 1,
+	kind: "result",
+	type: "streaming.setBitrate",
+	cid: "a1b2c3d4-5e6f-4a7b-8c9d-0e1f2a3b4c5d",
+	payload: {
+		ok: false,
+		applied: null,
+		error: "not_streaming",
+	},
+};
+
+/** §14.9 self_fencing — revertible command (network.reconfig) */
+const FIXTURE_14_9 = {
+	v: 1,
+	kind: "command",
+	type: "network.reconfig",
+	cid: "5e81b246-1a7c-4f5e-9261-9d0e1f2a3b4c",
+	self_fencing: true,
+	payload: {
+		iface: "eth0",
+		dhcp: false,
+		address: "192.168.1.50/24",
+		gateway: "192.168.1.1",
+	},
+};
+
+/** §14.10 self_fencing — confirm */
+const FIXTURE_14_10 = {
+	v: 1,
+	kind: "command",
+	type: "self_fencing.confirm",
+	cid: "5e81b246-1a7c-4f5e-9261-9d0e1f2a3b4c",
+};
+
+/** §14.11 self_fencing — auto-reverted result */
+const FIXTURE_14_11 = {
+	v: 1,
+	kind: "result",
+	type: "network.reconfig",
+	cid: "5e81b246-1a7c-4f5e-9261-9d0e1f2a3b4c",
+	payload: {
+		ok: true,
+		applied: null,
+		reverted: true,
+	},
+};
+
+/** §14.12 self_fencing — non-revertible command (system.reboot) */
+const FIXTURE_14_12 = {
+	v: 1,
+	kind: "command",
+	type: "system.reboot",
+	cid: "b2c3d4e5-6f70-4b8c-9d0e-1f2a3b4c5d6e",
+	self_fencing: true,
+};
+
+/** §14.13 Status frame */
+const FIXTURE_14_13 = {
+	v: 1,
+	kind: "status",
+	type: "status",
+	cid: "6f92c357-2b8d-4a6f-a372-0e1f2a3b4c5d",
+	seq: 42,
+	payload: {
+		is_streaming: true,
+		max_br: 8000,
+		linkTelemetry: {
+			links: [
+				{
+					conn_id: "0",
+					iface: "eth0",
+					rtt_ms: 0,
+					nak_count: 3,
+					weight_percent: 100,
+					stale: false,
+				},
+			],
+		},
+	},
+};
+
+/** §14.14 Forbidden command ack (never-remote) */
+const FIXTURE_14_14 = {
+	v: 1,
+	kind: "ack",
+	type: "command.forbidden",
+	cid: "c3d4e5f6-7081-4c9d-8e1f-2a3b4c5d6e7f",
+	payload: {
+		rejected: "auth.login",
+		reason: "never_remote",
+	},
+};
+
+describe("control-plane protocol — §14 wire fixtures parse", () => {
+	it("§14.1 minimal valid envelope parses as base Envelope and Command", () => {
+		expect(EnvelopeSchema.parse(FIXTURE_14_1)).toMatchObject({
+			v: 1,
+			kind: "command",
+		});
+		expect(CommandSchema.parse(FIXTURE_14_1).type).toBe("streaming.getConfig");
+	});
+
+	it("§14.2 device hello parses as Handshake frame + HandshakeDevice body", () => {
+		const frame = HandshakeSchema.parse(FIXTURE_14_2);
+		expect(frame.type).toBe("device.hello");
+		const body = HandshakeDeviceSchema.parse(frame.payload);
+		expect(body.v).toBe(1);
+		expect(body.supportedTypes).toContain("self_fencing.confirm");
+		expect(body.deviceCaps.engine).toBe("cerastream");
+	});
+
+	it("§14.3 hub hello parses as Handshake frame + HandshakeHub body", () => {
+		const frame = HandshakeSchema.parse(FIXTURE_14_3);
+		const body = HandshakeHubSchema.parse(frame.payload);
+		expect(body.role).toBe("owner");
+	});
+
+	it("§14.4 version.mismatch parses as Ack", () => {
+		expect(AckSchema.parse(FIXTURE_14_4).type).toBe("version.mismatch");
+	});
+
+	it("§14.5 streaming.getConfig command parses (empty payload)", () => {
+		expect(CommandSchema.parse(FIXTURE_14_5).payload).toEqual({});
+	});
+
+	it("§14.6 streaming.setBitrate command parses", () => {
+		const cmd = CommandSchema.parse(FIXTURE_14_6);
+		expect(cmd.payload?.bitrate_bps).toBe(6000000);
+	});
+
+	it("§14.7 success result parses with applied object", () => {
+		const res = ResultSchema.parse(FIXTURE_14_7);
+		expect(res.payload.ok).toBe(true);
+		expect(res.payload.applied).toMatchObject({ max_br: 8000 });
+	});
+
+	it("§14.8 error result parses with applied:null + error code", () => {
+		const res = ResultSchema.parse(FIXTURE_14_8);
+		expect(res.payload.ok).toBe(false);
+		expect(res.payload.applied).toBeNull();
+		expect(res.payload.error).toBe("not_streaming");
+	});
+
+	it("§14.9 self_fencing command reads self_fencing off the top level", () => {
+		const cmd = CommandSchema.parse(FIXTURE_14_9);
+		expect(cmd.self_fencing).toBe(true);
+		expect(cmd.type).toBe("network.reconfig");
+	});
+
+	it("§14.10 self_fencing.confirm command parses with no payload", () => {
+		const cmd = CommandSchema.parse(FIXTURE_14_10);
+		expect(cmd.type).toBe("self_fencing.confirm");
+		expect(cmd.payload).toBeUndefined();
+	});
+
+	it("§14.11 auto-reverted result carries reverted:true", () => {
+		const res = ResultSchema.parse(FIXTURE_14_11);
+		expect(res.payload.reverted).toBe(true);
+	});
+
+	it("§14.12 non-revertible self_fencing command parses with no payload", () => {
+		const cmd = CommandSchema.parse(FIXTURE_14_12);
+		expect(cmd.self_fencing).toBe(true);
+		expect(cmd.payload).toBeUndefined();
+	});
+
+	it("§14.13 status frame requires and parses seq", () => {
+		const status = StatusSchema.parse(FIXTURE_14_13);
+		expect(status.seq).toBe(42);
+	});
+
+	it("§14.14 forbidden command ack parses", () => {
+		const ack = AckSchema.parse(FIXTURE_14_14);
+		expect(ack.type).toBe("command.forbidden");
+	});
+
+	it("every frame fixture routes through the FrameSchema discriminated union", () => {
+		const frameFixtures = [
+			FIXTURE_14_1,
+			FIXTURE_14_2,
+			FIXTURE_14_3,
+			FIXTURE_14_4,
+			FIXTURE_14_5,
+			FIXTURE_14_6,
+			FIXTURE_14_7,
+			FIXTURE_14_8,
+			FIXTURE_14_9,
+			FIXTURE_14_10,
+			FIXTURE_14_11,
+			FIXTURE_14_12,
+			FIXTURE_14_13,
+			FIXTURE_14_14,
+		];
+		for (const fixture of frameFixtures) {
+			expect(() => FrameSchema.parse(fixture)).not.toThrow();
+		}
+	});
+});
+
+describe("control-plane protocol — invalid frames reject", () => {
+	it("rejects an envelope missing `v`", () => {
+		const { v: _omitted, ...missingV } = FIXTURE_14_1;
+		const result = EnvelopeSchema.safeParse(missingV);
+		expect(result.success).toBe(false);
+		expect(() => EnvelopeSchema.parse(missingV)).toThrow(ZodError);
+	});
+
+	it("rejects an unknown `kind`", () => {
+		const badKind = { ...FIXTURE_14_1, kind: "frobnicate" };
+		expect(EnvelopeSchema.safeParse(badKind).success).toBe(false);
+		expect(() => FrameSchema.parse(badKind)).toThrow(ZodError);
+	});
+
+	it("rejects a wrong protocol version `v`", () => {
+		const badVersion = { ...FIXTURE_14_1, v: 2 };
+		expect(EnvelopeSchema.safeParse(badVersion).success).toBe(false);
+	});
+
+	it("rejects a non-UUID cid", () => {
+		const badCid = { ...FIXTURE_14_1, cid: "not-a-uuid" };
+		expect(EnvelopeSchema.safeParse(badCid).success).toBe(false);
+	});
+
+	it("rejects a status frame missing seq", () => {
+		const { seq: _omitted, ...missingSeq } = FIXTURE_14_13;
+		expect(StatusSchema.safeParse(missingSeq).success).toBe(false);
+	});
+
+	it("rejects a result frame missing the required ok flag", () => {
+		const badResult = {
+			...FIXTURE_14_7,
+			payload: { applied: null },
+		};
+		expect(ResultSchema.safeParse(badResult).success).toBe(false);
+	});
+});

--- a/apps/backend/src/modules/remote-control/protocol.ts
+++ b/apps/backend/src/modules/remote-control/protocol.ts
@@ -1,0 +1,213 @@
+/**
+ * Remote Control Plane v2.0 — device-side wire-envelope Zod schema.
+ *
+ * This module is the device's OWN validator for the bidirectional control
+ * channel defined by `openspec/specs/remote-relay-support/spec.md`. Per that
+ * spec (and Rule D — repos are self-contained), there is NO shared schema
+ * package across the device/hub boundary: each repo writes its own Zod from the
+ * spec, and the spec's §14 JSON fixtures are the conformance vectors. The
+ * matching contract test (`protocol.contract.test.ts`) parses those fixtures
+ * against the schemas below.
+ *
+ * Scope: framing + capability handshake only. This file does NOT touch the
+ * BCRPT relay socket (`modules/remote/remote.ts`) and shares no token audience
+ * with it — the control channel is a second, independent outbound WS.
+ */
+
+import { z } from "zod";
+
+/** Protocol version carried in the envelope `v` field. Currently `1` (spec §3, §13). */
+export const PROTOCOL_VERSION = 1 as const;
+
+/** Frame discriminator values (spec §3 `kind`). */
+export const FRAME_KINDS = [
+	"command",
+	"status",
+	"result",
+	"ack",
+	"handshake",
+] as const;
+export type FrameKind = (typeof FRAME_KINDS)[number];
+
+/**
+ * Connection roles (spec §3 `role`, §12). v2.0 is owner-only and hub-stamped;
+ * `copilot`/`viewer` are reserved for v2.1 delegation. Clients MUST NOT set
+ * `role` and MUST ignore it inbound in v2.0.
+ */
+export const ROLES = ["owner", "copilot", "viewer"] as const;
+export type Role = (typeof ROLES)[number];
+
+/**
+ * The closed, explicit list of every remote-invokable command type in v2.0
+ * (spec §5 + §7 `self_fencing.confirm`). A `command` frame's `type` MUST be one
+ * of these. This is the exact set advertised in the device `device.hello`
+ * `supportedTypes` (spec §4 / §14.2).
+ */
+export const COMMAND_REGISTRY = [
+	"streaming.start",
+	"streaming.stop",
+	"streaming.setBitrate",
+	"streaming.setConfig",
+	"streaming.getConfig",
+	"streaming.getPipelines",
+	"network.reconfig",
+	"modem.reconfig",
+	"device.remoteKeyChange",
+	"system.reboot",
+	"device.factoryReset",
+	"self_fencing.confirm",
+] as const;
+export type CommandType = (typeof COMMAND_REGISTRY)[number];
+
+/**
+ * Commands that opt into the self_fencing commit-confirm watchdog (spec §5, §7).
+ * Carry `self_fencing: true` at the TOP LEVEL of the frame (not in `payload`).
+ */
+export const SELF_FENCING_TYPES = [
+	"network.reconfig",
+	"modem.reconfig",
+	"device.remoteKeyChange",
+	"system.reboot",
+	"device.factoryReset",
+] as const;
+export type SelfFencingType = (typeof SELF_FENCING_TYPES)[number];
+
+/**
+ * Local-only types that MUST NEVER be exposed on the control channel (spec §5).
+ * The device rejects these defensively even if a malformed hub forwards one.
+ */
+export const NEVER_REMOTE = ["auth.login", "auth.setPassword"] as const;
+export type NeverRemoteType = (typeof NEVER_REMOTE)[number];
+
+/** Relayable upstream status `type` values — the closed v2.0 set (spec §8). */
+export const STATUS_TYPES = [
+	"status",
+	"config",
+	"sensors",
+	"netif",
+	"modems",
+	"device-stats",
+	"notifications",
+] as const;
+export type StatusType = (typeof STATUS_TYPES)[number];
+
+/** Default self_fencing watchdog window in milliseconds (spec §7 — NOT wire-negotiated). */
+export const SELF_FENCING_WATCHDOG_MS = 30_000;
+
+/** UUID v4 correlation id (spec §3 `cid`). Commands mint it; `result`/`ack` echo it. */
+const cidSchema = z.uuidv4();
+
+/** Free-form type-specific body. Unknown keys allowed (forward compat, spec §3). */
+const payloadSchema = z.record(z.string(), z.unknown());
+
+/**
+ * Base envelope shared by every frame in either direction (spec §3).
+ *
+ * `payload`, `role`, `seq`, and `self_fencing` are optional at the envelope
+ * level; the per-`kind` schemas below tighten them where the spec requires it
+ * (e.g. `status` requires `seq`, `result` requires its structured payload).
+ * Unknown top-level keys are ignored by receivers per §3 — Zod strips them by
+ * default, which is the desired forward-compatible behavior.
+ */
+export const EnvelopeSchema = z.object({
+	v: z.literal(PROTOCOL_VERSION),
+	kind: z.enum(FRAME_KINDS),
+	type: z.string().min(1),
+	cid: cidSchema,
+	role: z.enum(ROLES).optional(),
+	payload: payloadSchema.optional(),
+	seq: z.number().int().optional(),
+	self_fencing: z.boolean().optional(),
+});
+export type Envelope = z.infer<typeof EnvelopeSchema>;
+
+/**
+ * `command` frame (spec §5, §7). Downstream hub→device. `payload` is optional
+ * (absent or `{}` for no-arg types). `self_fencing` rides the top level for the
+ * connectivity/lifecycle ops in {@link SELF_FENCING_TYPES}.
+ */
+export const CommandSchema = EnvelopeSchema.extend({
+	kind: z.literal("command"),
+	payload: payloadSchema.optional(),
+});
+export type Command = z.infer<typeof CommandSchema>;
+
+/**
+ * Result payload (spec §6). `applied` is the post-validation, post-clamp state
+ * actually written (mirrors the existing `{ success, applied }` RPC convention);
+ * `null` for commands with no applied state. `reverted: true` marks an
+ * auto-reverted self_fencing op.
+ */
+export const ResultPayloadSchema = z.object({
+	ok: z.boolean(),
+	applied: z.unknown(),
+	error: z.string().optional(),
+	reverted: z.boolean().optional(),
+});
+export type ResultPayload = z.infer<typeof ResultPayloadSchema>;
+
+/** `result` frame (spec §6). Device→hub reply to a command; echoes its `cid`. */
+export const ResultSchema = EnvelopeSchema.extend({
+	kind: z.literal("result"),
+	payload: ResultPayloadSchema,
+});
+export type Result = z.infer<typeof ResultSchema>;
+
+/**
+ * `status` frame (spec §8). Upstream device→hub event. Always carries `seq`, a
+ * monotonic-per-`type` integer for drop detection (resets to 0 on restart).
+ */
+export const StatusSchema = EnvelopeSchema.extend({
+	kind: z.literal("status"),
+	seq: z.number().int().nonnegative(),
+});
+export type Status = z.infer<typeof StatusSchema>;
+
+/** `ack` frame (spec §4, §5, §13) — hub negotiation/rejection signal. */
+export const AckSchema = EnvelopeSchema.extend({
+	kind: z.literal("ack"),
+});
+export type Ack = z.infer<typeof AckSchema>;
+
+/** `handshake` frame envelope (spec §4). Body lives in `payload`; `cid` is informational. */
+export const HandshakeSchema = EnvelopeSchema.extend({
+	kind: z.literal("handshake"),
+	payload: payloadSchema.optional(),
+});
+export type Handshake = z.infer<typeof HandshakeSchema>;
+
+/**
+ * Device→Hub `device.hello` body (spec §4 / §14.2) — carried in the handshake
+ * frame's `payload`. Advertises the protocol version, the serviceable message
+ * types, and a free-form capability object.
+ */
+export const HandshakeDeviceSchema = z.object({
+	v: z.literal(PROTOCOL_VERSION),
+	supportedTypes: z.array(z.string()),
+	deviceCaps: z.record(z.string(), z.unknown()),
+});
+export type HandshakeDevice = z.infer<typeof HandshakeDeviceSchema>;
+
+/**
+ * Hub→Device `hub.hello` body (spec §4 / §14.3) — carried in the handshake
+ * frame's `payload`. Confirms the version and stamps the connection role
+ * (always `owner` in v2.0).
+ */
+export const HandshakeHubSchema = z.object({
+	v: z.literal(PROTOCOL_VERSION),
+	role: z.enum(ROLES),
+});
+export type HandshakeHub = z.infer<typeof HandshakeHubSchema>;
+
+/**
+ * Discriminated union over every frame kind — the single entry point for
+ * routing an inbound frame to its precise schema (downstream Tasks 13–15).
+ */
+export const FrameSchema = z.discriminatedUnion("kind", [
+	CommandSchema,
+	ResultSchema,
+	StatusSchema,
+	AckSchema,
+	HandshakeSchema,
+]);
+export type Frame = z.infer<typeof FrameSchema>;

--- a/apps/backend/src/modules/remote-control/self-fencing.ts
+++ b/apps/backend/src/modules/remote-control/self-fencing.ts
@@ -1,0 +1,382 @@
+/**
+ * Remote Control Plane v2.0 — device-side self_fencing commit-confirm watchdog
+ * (remote-relay-support spec §7).
+ *
+ * `self_fencing` protects the operator from a remote command that could sever the
+ * very channel carrying it (e.g. reconfiguring the network the device dials out
+ * on). Two shapes, keyed off whether the op can be rolled back:
+ *
+ *   - **Revertible** (`network.reconfig`, `modem.reconfig`, `device.remoteKeyChange`):
+ *     snapshot → apply → start a 30s watchdog. A `self_fencing.confirm` carrying the
+ *     original `cid` commits the change; otherwise the watchdog fires and the snapshot
+ *     is restored. The first result frame carries the new state with `self_fencing:true`
+ *     to tell the operator a confirm is owed; the terminal frame reports committed
+ *     (`reverted:false`) or rolled-back (`reverted:true`).
+ *
+ *   - **Non-revertible** (`system.reboot`, `device.factoryReset`): there is no rollback,
+ *     so the op is gated BEHIND the confirm — it never runs on receipt. The device
+ *     emits `ok:false, error:"self_fencing_confirm_required"` and waits; the matching
+ *     confirm executes it. If the watchdog fires first the pending op is discarded with
+ *     `ok:false, error:"self_fencing_unconfirmed"`.
+ *
+ * The watchdog default is 30s and is NOT wire-negotiated in v2.0 (spec §7) — hub and
+ * device hardcode the same {@link SELF_FENCING_WATCHDOG_MS}.
+ *
+ * The actual resource mutations are an injected seam ({@link SelfFencingOps}) so the
+ * watchdog is unit-testable with a fake clock and fake ops — the same DI posture as
+ * `channel.ts` / `command-router.ts`. The default ops persist+restore config (the safe
+ * reversible floor) and spawn the real lifecycle command; richer per-resource wiring is
+ * injected, not hardcoded here.
+ */
+
+import { logger } from "../../helpers/logger.ts";
+import { sendFrame } from "./channel.ts";
+import {
+	type Command,
+	PROTOCOL_VERSION,
+	type Result,
+	type ResultPayload,
+	SELF_FENCING_WATCHDOG_MS,
+	type SelfFencingType,
+} from "./protocol.ts";
+
+type TimerHandle = ReturnType<typeof setTimeout>;
+type CommandPayload = Command["payload"];
+
+/**
+ * A revertible self_fencing op (spec §7). `snapshot` captures the pre-change state,
+ * `apply` performs the change and returns the new state, `revert` restores the snapshot
+ * if the watchdog fires before a confirm arrives.
+ */
+export interface RevertibleOp {
+	revertible: true;
+	snapshot: (payload: CommandPayload) => Promise<unknown>;
+	apply: (payload: CommandPayload) => Promise<unknown>;
+	revert: (snapshot: unknown) => Promise<void>;
+}
+
+/**
+ * A non-revertible self_fencing op (spec §7). It cannot be rolled back, so `execute`
+ * only runs once the matching confirm has arrived — never on receipt of the command.
+ */
+export interface NonRevertibleOp {
+	revertible: false;
+	execute: (payload: CommandPayload) => Promise<void>;
+}
+
+export type SelfFencingOp = RevertibleOp | NonRevertibleOp;
+
+/** Op handlers keyed by the self_fencing command `type` (spec §5 / §7). */
+export type SelfFencingOps = Record<SelfFencingType, SelfFencingOp>;
+
+/**
+ * Injectable collaborators (same DI posture as `channel.ts`). Defaults wire the live
+ * channel `sendFrame`, the real op table, the 30s watchdog, and real timers; tests
+ * override `sendResult`/`ops` to capture frames and a fake clock via `setTimer`.
+ */
+export interface SelfFencingDeps {
+	/** Best-effort result-frame sink (spec §6). Defaults to the live channel. */
+	sendResult: (frame: Result) => boolean;
+	/** Resource-mutation handlers, one per self_fencing op type. */
+	ops: SelfFencingOps;
+	/** Watchdog window in milliseconds (spec §7 — defaults to 30s, not negotiated). */
+	watchdogMs: number;
+	setTimer: (fn: () => void, ms: number) => TimerHandle;
+	clearTimer: (timer: TimerHandle) => void;
+	logger: { info: (message: string) => void; warn: (message: string) => void };
+}
+
+/**
+ * A self_fencing op that is mid-flight: applied (revertible) or gated (non-revertible)
+ * and waiting for its `self_fencing.confirm`. Keyed by the original command `cid`.
+ */
+interface PendingOp {
+	frame: Command;
+	deps: SelfFencingDeps;
+	op: SelfFencingOp;
+	timer: TimerHandle;
+	/** Pre-change state to restore on auto-revert (revertible ops only). */
+	snapshot: unknown;
+	/** Post-apply state echoed on commit (revertible ops only). */
+	applied: unknown;
+}
+
+// Process-wide pending table (mirrors the module-state posture of channel.ts). A
+// confirm or a watchdog timeout resolves and removes its entry by `cid`.
+const pending = new Map<string, PendingOp>();
+
+/**
+ * Build the default op table. Each handler defers its heavy module import to call time
+ * (dynamic `import`) so this module never pulls the config/remote/network graph — or
+ * triggers a `setup.json` read — at load time (the same fail-soft posture the rest of
+ * the control plane relies on for standalone test loads).
+ */
+function defaultSelfFencingOps(): SelfFencingOps {
+	return {
+		"network.reconfig": configSnapshotOp(),
+		"modem.reconfig": configSnapshotOp(),
+		"device.remoteKeyChange": configSnapshotOp(),
+		"system.reboot": spawnOp(["reboot"]),
+		"device.factoryReset": spawnOp(["ceralive-factory-reset"]),
+	};
+}
+
+/**
+ * The safe reversible floor for a connectivity/lifecycle reconfig: snapshot the full
+ * runtime config, persist the requested fields, and restore the snapshot verbatim on
+ * timeout. Persisted config is the device's source of truth, so a config restore is a
+ * correct, conservative revert — the low-level interface bring-up is layered by
+ * injecting a richer op rather than guessing driver semantics here.
+ */
+function configSnapshotOp(): RevertibleOp {
+	return {
+		revertible: true,
+		snapshot: async () => {
+			const { getConfig } = await import("../config.ts");
+			return structuredClone(getConfig());
+		},
+		apply: async (payload) => {
+			const { getConfig, saveConfig } = await import("../config.ts");
+			const config = getConfig() as Record<string, unknown>;
+			Object.assign(config, payload ?? {});
+			saveConfig();
+			return structuredClone(config);
+		},
+		revert: async (snapshot) => {
+			const { getConfig, saveConfig } = await import("../config.ts");
+			const config = getConfig() as Record<string, unknown>;
+			for (const key of Object.keys(config)) {
+				delete config[key];
+			}
+			Object.assign(config, snapshot as Record<string, unknown>);
+			saveConfig();
+		},
+	};
+}
+
+/** A non-revertible op whose execution is a single privileged spawn (e.g. reboot). */
+function spawnOp(argv: string[]): NonRevertibleOp {
+	return {
+		revertible: false,
+		execute: async () => {
+			Bun.spawnSync(argv);
+		},
+	};
+}
+
+function defaultDeps(): SelfFencingDeps {
+	return {
+		sendResult: sendFrame,
+		ops: defaultSelfFencingOps(),
+		watchdogMs: SELF_FENCING_WATCHDOG_MS,
+		setTimer: (fn, ms) => setTimeout(fn, ms),
+		clearTimer: (timer) => clearTimeout(timer),
+		logger,
+	};
+}
+
+/**
+ * Build a `kind:result` frame echoing the command's `cid` (spec §6). `role` is echoed
+ * only when present and `self_fencing` only when flagged (exactOptionalPropertyTypes:
+ * never assign `undefined`).
+ */
+function resultFrame(
+	frame: Command,
+	payload: ResultPayload,
+	options: { selfFencing?: boolean } = {},
+): Result {
+	return {
+		v: PROTOCOL_VERSION,
+		kind: "result",
+		type: frame.type,
+		cid: frame.cid,
+		...(frame.role !== undefined ? { role: frame.role } : {}),
+		...(options.selfFencing === true ? { self_fencing: true } : {}),
+		payload,
+	};
+}
+
+function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Restore the snapshot for a revertible op whose watchdog fired with no confirm, then
+ * emit the rolled-back result (`ok:true, applied:<old-state>, reverted:true`, spec §7).
+ * A no-op if the entry was already resolved (confirm raced the timer).
+ */
+async function autoRevert(cid: string): Promise<void> {
+	const entry = pending.get(cid);
+	if (entry === undefined || !entry.op.revertible) return;
+	pending.delete(cid);
+
+	const { frame, deps, op, snapshot } = entry;
+	try {
+		await op.revert(snapshot);
+		deps.logger.warn(
+			`self_fencing: ${frame.type} (${cid}) unconfirmed within watchdog, auto-reverted`,
+		);
+		deps.sendResult(
+			resultFrame(frame, { ok: true, applied: snapshot, reverted: true }),
+		);
+	} catch (err) {
+		const message = errorMessage(err);
+		deps.logger.warn(
+			`self_fencing: ${frame.type} (${cid}) revert failed: ${message}`,
+		);
+		deps.sendResult(
+			resultFrame(frame, { ok: false, applied: null, error: message }),
+		);
+	}
+}
+
+/**
+ * Discard a non-revertible op whose pre-confirm watchdog fired (spec §7): the operator
+ * never confirmed, so the brick-risk op is dropped with `self_fencing_unconfirmed`.
+ */
+function discardUnconfirmed(cid: string): void {
+	const entry = pending.get(cid);
+	if (entry === undefined || entry.op.revertible) return;
+	pending.delete(cid);
+
+	const { frame, deps } = entry;
+	deps.logger.warn(
+		`self_fencing: ${frame.type} (${cid}) unconfirmed within watchdog, discarded`,
+	);
+	deps.sendResult(
+		resultFrame(frame, {
+			ok: false,
+			applied: null,
+			error: "self_fencing_unconfirmed",
+		}),
+	);
+}
+
+/**
+ * Handle an inbound self_fencing op command (spec §7). Revertible ops apply behind a
+ * watchdog; non-revertible ops are gated behind a pre-confirm and never run on receipt.
+ * Never throws — a failing op becomes an `ok:false` result, not an exception.
+ */
+export async function handleSelfFencingOp(
+	frame: Command,
+	overrides: Partial<SelfFencingDeps> = {},
+): Promise<void> {
+	const deps: SelfFencingDeps = { ...defaultDeps(), ...overrides };
+	const op = deps.ops[frame.type as SelfFencingType];
+
+	if (op === undefined) {
+		deps.sendResult(
+			resultFrame(frame, {
+				ok: false,
+				applied: null,
+				error: "self_fencing_unsupported",
+			}),
+		);
+		return;
+	}
+
+	if (op.revertible) {
+		// Snapshot → apply → arm the watchdog. On any failure before the timer is armed
+		// the op simply did not take effect, so report the error and arm nothing.
+		try {
+			const snapshot = await op.snapshot(frame.payload);
+			const applied = await op.apply(frame.payload);
+			const timer = deps.setTimer(() => {
+				void autoRevert(frame.cid);
+			}, deps.watchdogMs);
+			pending.set(frame.cid, { frame, deps, op, timer, snapshot, applied });
+			deps.logger.info(
+				`self_fencing: ${frame.type} (${frame.cid}) applied, awaiting confirm`,
+			);
+			deps.sendResult(
+				resultFrame(frame, { ok: true, applied }, { selfFencing: true }),
+			);
+		} catch (err) {
+			const message = errorMessage(err);
+			deps.logger.warn(
+				`self_fencing: ${frame.type} (${frame.cid}) apply failed: ${message}`,
+			);
+			deps.sendResult(
+				resultFrame(frame, { ok: false, applied: null, error: message }),
+			);
+		}
+		return;
+	}
+
+	// Non-revertible: gate behind the confirm. Arm the watchdog, register the pending
+	// op, and tell the operator a confirm is required — the op does NOT run yet.
+	const timer = deps.setTimer(() => {
+		discardUnconfirmed(frame.cid);
+	}, deps.watchdogMs);
+	pending.set(frame.cid, {
+		frame,
+		deps,
+		op,
+		timer,
+		snapshot: undefined,
+		applied: undefined,
+	});
+	deps.logger.info(
+		`self_fencing: ${frame.type} (${frame.cid}) pre-confirm required, not executing`,
+	);
+	deps.sendResult(
+		resultFrame(frame, {
+			ok: false,
+			applied: null,
+			error: "self_fencing_confirm_required",
+		}),
+	);
+}
+
+/**
+ * Handle a `self_fencing.confirm` carrying the original op's `cid` (spec §7). Cancels
+ * the watchdog and either commits a revertible op (`reverted:false`) or executes a
+ * gated non-revertible op. A confirm for an unknown/already-resolved `cid` is ignored
+ * (best-effort — a late confirm racing the watchdog must not double-fire).
+ */
+export async function handleSelfFencingConfirm(cid: string): Promise<void> {
+	const entry = pending.get(cid);
+	if (entry === undefined) return;
+	pending.delete(cid);
+
+	const { frame, deps, op } = entry;
+	deps.clearTimer(entry.timer);
+
+	if (op.revertible) {
+		deps.logger.info(
+			`self_fencing: ${frame.type} (${cid}) confirmed, committed`,
+		);
+		deps.sendResult(
+			resultFrame(frame, { ok: true, applied: entry.applied, reverted: false }),
+		);
+		return;
+	}
+
+	// Non-revertible: the confirm authorizes execution. There is no rollback once run.
+	try {
+		await op.execute(frame.payload);
+		deps.logger.info(
+			`self_fencing: ${frame.type} (${cid}) confirmed, executed`,
+		);
+		deps.sendResult(resultFrame(frame, { ok: true, applied: null }));
+	} catch (err) {
+		const message = errorMessage(err);
+		deps.logger.warn(
+			`self_fencing: ${frame.type} (${cid}) execute failed: ${message}`,
+		);
+		deps.sendResult(
+			resultFrame(frame, { ok: false, applied: null, error: message }),
+		);
+	}
+}
+
+/**
+ * Cancel every in-flight watchdog and clear the pending table. Test-only isolation
+ * (mirrors `resetMockState`); never call this from production code.
+ */
+export function resetSelfFencingState(): void {
+	for (const entry of pending.values()) {
+		entry.deps.clearTimer(entry.timer);
+	}
+	pending.clear();
+}

--- a/apps/backend/src/modules/remote-control/status-relay.ts
+++ b/apps/backend/src/modules/remote-control/status-relay.ts
@@ -1,0 +1,129 @@
+/**
+ * Remote Control Plane v2.0 — outbound status relay (device → hub).
+ *
+ * This is the device half of the spec §8 "Status Frames" flow: the same
+ * broadcast event types CeraUI already pushes to local clients are wrapped in a
+ * `kind:status` envelope frame and emitted on the dedicated control channel, so
+ * the hub can fan them out to subscribed operator clients.
+ *
+ * It is the resolution of the "v2 relay planned" TODOs in `rpc/compat.ts`
+ * (`broadcastMsg` / `broadcastMsgExcept`). Local broadcast and the BCRPT relay
+ * socket (`modules/remote/remote.ts`) are entirely untouched — this is a second,
+ * independent outbound path.
+ *
+ * The control channel itself (the WS dialer, Task 13) is injected via
+ * {@link setControlChannel}. Until it is wired, {@link relayStatusToGateway} is a
+ * safe no-op (no channel set, or channel reports disconnected), so broadcasting
+ * never throws or blocks the local path.
+ */
+
+import { advanceSeq } from "../../rpc/events.ts";
+import { PROTOCOL_VERSION, type Status } from "./protocol.ts";
+
+/**
+ * Structural seam for the control-channel WS (Task 13 provides the concrete
+ * impl). Kept intentionally minimal — the relay only needs to ask whether the
+ * channel is up and hand it a fully-built frame to serialize and send.
+ */
+export interface ControlChannel {
+	/** True when the control WS is open and the handshake has completed. */
+	isConnected(): boolean;
+	/** Serialize and send a single control frame. Best-effort (spec §8). */
+	sendFrame(frame: unknown): void;
+}
+
+/**
+ * The closed v2.0 set of relayable upstream status `type` values (spec §8).
+ * This is exactly the broadcast set the hub fans out — it carries NO
+ * secret-bearing or local-only types (see the no-secrets contract test).
+ */
+export const RELAYABLE_TYPES = [
+	"status",
+	"config",
+	"sensors",
+	"netif",
+	"modems",
+	"device-stats",
+	"notifications",
+] as const;
+export type RelayableType = (typeof RELAYABLE_TYPES)[number];
+
+const RELAYABLE_SET: ReadonlySet<string> = new Set(RELAYABLE_TYPES);
+
+/** Whether a broadcast `type` is relayable onto the control channel (spec §8). */
+export function isRelayable(type: string): boolean {
+	return RELAYABLE_SET.has(type);
+}
+
+/**
+ * The injected control channel. `null` until Task 13 wires the WS dialer; while
+ * null the relay is a no-op so the local broadcast path is unaffected.
+ */
+let channel: ControlChannel | null = null;
+
+/** Wire (or clear) the control channel. Task 13 calls this once the WS is up. */
+export function setControlChannel(next: ControlChannel | null): void {
+	channel = next;
+}
+
+/** Current control channel, or `null` if none is wired. */
+export function getControlChannel(): ControlChannel | null {
+	return channel;
+}
+
+/**
+ * Per-`type` monotonic sequence counters for the relay path. Mirrors the local
+ * fan-out machinery (`rpc/events.ts` `advanceSeq`) so each status `type` carries
+ * an independently increasing `seq` for hub-side drop detection. Resets to 0 on
+ * process restart (spec §8).
+ */
+const relaySeqCounters = new Map<string, number>();
+
+/**
+ * Advance and return the next relay `seq` for a status `type` (1-based,
+ * monotonic per type). Exported so the broadcast bridge can stamp the frame.
+ */
+export function nextRelaySeq(type: string): number {
+	return advanceSeq(relaySeqCounters, type);
+}
+
+/**
+ * Wrap a relayable broadcast payload in a `kind:status` envelope frame and emit
+ * it on the control channel — but only when a channel is wired and reports
+ * connected. A missing or disconnected channel is a silent no-op (best-effort,
+ * spec §8); it never throws and never disturbs the local broadcast.
+ *
+ * `cid` is a fresh UUID v4 — status is unsolicited and does not correlate to any
+ * command (spec §8).
+ */
+export function relayStatusToGateway(
+	type: string,
+	payload: unknown,
+	seq: number,
+): void {
+	if (!channel?.isConnected()) {
+		return;
+	}
+
+	const frame: Status = {
+		v: PROTOCOL_VERSION,
+		kind: "status",
+		type,
+		cid: crypto.randomUUID(),
+		seq,
+		...(payload === undefined
+			? {}
+			: { payload: payload as Record<string, unknown> }),
+	};
+
+	channel.sendFrame(frame);
+}
+
+/**
+ * Test-only: clear the wired channel and reset the per-type relay seq counters
+ * so each test starts from a clean slate.
+ */
+export function resetStatusRelay(): void {
+	channel = null;
+	relaySeqCounters.clear();
+}

--- a/apps/backend/src/modules/remote/control-endpoint.ts
+++ b/apps/backend/src/modules/remote/control-endpoint.ts
@@ -1,0 +1,95 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Device-control channel endpoint pinning (ADR-0006, spec §10).
+ *
+ * Platform authentication for the control channel has two halves: the device
+ * authenticates the platform's TOKEN with PASETO v4.public ({@link ../pairing/device-token.ts}),
+ * and the device authenticates the platform's IDENTITY by pinning the hub URL.
+ *
+ * Endpoint pinning is the second half: the device-control hub URL is provisioned
+ * at image-build time and is NEVER operator-configurable. This is the deliberate
+ * difference from the BCRPT relay host (`modules/remote/remote.ts`), which DOES
+ * honour an operator-entered `custom_provider`. Reusing the relay's
+ * operator-configurable provider for the control channel would let a malicious
+ * or mis-set `custom_provider` redirect the channel — and the credentials it
+ * presents — to an attacker-controlled host. The control channel therefore reads
+ * ONLY the pinned source and ignores all operator provider config.
+ *
+ * Kept out of `remote.ts` on purpose: that module's relay logic must not be
+ * touched, and importing it pulls the boot-time `setup.json` read into any test
+ * that exercises pinning. This module has no such dependency.
+ */
+
+/**
+ * Build-time pinned device-control hub URL. Provisioned into the device image
+ * (like `PASETO_PUBLIC_KEY`); absent on a dev host that has no control channel.
+ */
+export const CONTROL_HUB_URL_ENV = "CERALIVE_CONTROL_HUB_URL";
+
+export interface ControlChannelEndpoint {
+	url: string;
+	host: string;
+	/** Always `true`: this endpoint is build-time pinned, not operator-set. */
+	pinned: true;
+}
+
+/**
+ * The operator-set provider config that steers the BCRPT relay host. Accepted by
+ * {@link resolveControlChannelEndpoint} only to make explicit that it is IGNORED
+ * for the control channel.
+ */
+export interface OperatorProviderConfig {
+	custom_provider?: { host?: string } & Record<string, unknown>;
+	remote_provider?: string;
+}
+
+/**
+ * Resolve the device-control channel hub endpoint from the build-time pinned
+ * source ONLY. `operatorConfig` (`custom_provider` / `remote_provider`) is
+ * deliberately ignored — it cannot redirect this channel. Throws when the pin is
+ * missing or malformed (fail-closed: never silently fall back to an unpinned or
+ * operator-supplied host).
+ */
+export function resolveControlChannelEndpoint(
+	_operatorConfig?: OperatorProviderConfig,
+	env: Record<string, string | undefined> = process.env,
+): ControlChannelEndpoint {
+	const pinned = env[CONTROL_HUB_URL_ENV]?.trim();
+	if (!pinned) {
+		throw new Error(
+			`${CONTROL_HUB_URL_ENV} is not provisioned: the device-control channel requires a build-time pinned hub URL (ADR-0006 / remote-relay-support spec §10 endpoint pinning).`,
+		);
+	}
+
+	let parsed: URL;
+	try {
+		parsed = new URL(pinned);
+	} catch {
+		throw new Error(
+			`${CONTROL_HUB_URL_ENV} is not a valid URL: ${JSON.stringify(pinned)}`,
+		);
+	}
+	if (parsed.protocol !== "wss:" && parsed.protocol !== "ws:") {
+		throw new Error(
+			`${CONTROL_HUB_URL_ENV} must be a ws:// or wss:// URL, got ${parsed.protocol}`,
+		);
+	}
+
+	return { url: pinned, host: parsed.host, pinned: true };
+}

--- a/apps/backend/src/rpc/compat.ts
+++ b/apps/backend/src/rpc/compat.ts
@@ -5,6 +5,11 @@
  */
 import type WebSocket from "ws";
 
+import {
+	isRelayable,
+	nextRelaySeq,
+	relayStatusToGateway,
+} from "../modules/remote-control/status-relay.ts";
 import { broadcast, buildMessage } from "./events.ts";
 import type { AppWebSocket } from "./types.ts";
 
@@ -39,9 +44,12 @@ export function broadcastMsgLocal(
 }
 
 /**
- * Broadcast to all clients including remote (compatible with old broadcastMsg)
- * Note: Remote relay support is tracked in openspec/changes/remote-relay-support/
- * See: https://github.com/CERALIVE/ceralive/issues/XXX (remote relay tracking issue)
+ * Broadcast to all clients including remote (compatible with old broadcastMsg).
+ *
+ * Local clients are served first (unchanged); relayable status types are then
+ * mirrored onto the control channel as `kind:status` frames (spec §8). The relay
+ * is a no-op until the control channel is wired (Task 13) and only fires while
+ * it reports connected — the local path is never affected.
  */
 export function broadcastMsg(
 	type: string,
@@ -50,12 +58,16 @@ export function broadcastMsg(
 	authedOnly = true,
 ): void {
 	broadcastMsgLocal(type, data, activeMin, undefined, authedOnly);
-	// Remote relay support planned for v2 phase — see openspec/changes/remote-relay-support/
+	if (isRelayable(type)) {
+		relayStatusToGateway(type, data, nextRelaySeq(type));
+	}
 }
 
 /**
- * Broadcast to all except one client (compatible with old broadcastMsgExcept)
- * Note: Remote relay support is tracked in openspec/changes/remote-relay-support/
+ * Broadcast to all except one client (compatible with old broadcastMsgExcept).
+ *
+ * Same dual delivery as {@link broadcastMsg}: unchanged local broadcast, then a
+ * control-channel `kind:status` relay for relayable types (spec §8).
  */
 export function broadcastMsgExcept(
 	conn: WebSocket | AppWebSocket,
@@ -63,7 +75,9 @@ export function broadcastMsgExcept(
 	data: unknown,
 ): void {
 	broadcastMsgLocal(type, data, 0, conn);
-	// Remote relay support planned for v2 phase — see openspec/changes/remote-relay-support/
+	if (isRelayable(type)) {
+		relayStatusToGateway(type, data, nextRelaySeq(type));
+	}
 }
 
 /**

--- a/apps/backend/src/tests/control-channel.test.ts
+++ b/apps/backend/src/tests/control-channel.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+	backoffDelay,
+	type ControlChannelDeps,
+	type ControlChannelLogger,
+	type ControlSocket,
+	initControlChannel,
+	isConnected,
+	RECONNECT_BASE_MS,
+	RECONNECT_MAX_MS,
+	sendFrame,
+} from "../modules/remote-control/channel.ts";
+import {
+	COMMAND_REGISTRY,
+	type Frame,
+	HandshakeDeviceSchema,
+	HandshakeSchema,
+} from "../modules/remote-control/protocol.ts";
+
+const HUB_URL = "wss://hub.example.test/ws/control";
+const HUB_HOST = "hub.example.test";
+const FIXED_CID = "11111111-1111-4111-8111-111111111111";
+
+const silent: ControlChannelLogger = {
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+};
+
+interface FakeSocket {
+	socket: ControlSocket;
+	url: string;
+	authToken: string | undefined;
+	sent: string[];
+	fireOpen: () => void;
+	fireClose: () => void;
+}
+
+function makeFakeSocket(
+	url: string,
+	authToken: string | undefined,
+): FakeSocket {
+	const openListeners: Array<() => void> = [];
+	const closeListeners: Array<() => void> = [];
+	const sent: string[] = [];
+	const socket: ControlSocket = {
+		send: (data) => sent.push(data),
+		ping: () => {},
+		close: () => {},
+		onOpen: (listener) => openListeners.push(listener),
+		onClose: (listener) => closeListeners.push(listener),
+		onMessage: () => {},
+		onError: () => {},
+	};
+	return {
+		socket,
+		url,
+		authToken,
+		sent,
+		fireOpen: () => {
+			for (const listener of openListeners) listener();
+		},
+		fireClose: () => {
+			for (const listener of closeListeners) listener();
+		},
+	};
+}
+
+interface CapturedTimer {
+	fn: () => void;
+	ms: number;
+}
+
+interface Harness {
+	deps: Partial<ControlChannelDeps>;
+	sockets: FakeSocket[];
+	timers: CapturedTimer[];
+}
+
+function harness(overrides: Partial<ControlChannelDeps> = {}): Harness {
+	const sockets: FakeSocket[] = [];
+	const timers: CapturedTimer[] = [];
+	let timerId = 0;
+	let keepaliveId = 0;
+
+	const deps: Partial<ControlChannelDeps> = {
+		canDial: () => true,
+		resolveEndpoint: () => ({ url: HUB_URL, host: HUB_HOST, pinned: true }),
+		createSocket: (url, authToken) => {
+			const fake = makeFakeSocket(url, authToken);
+			sockets.push(fake);
+			return fake.socket;
+		},
+		getControlToken: () => undefined,
+		verifyToken: () => null,
+		logger: silent,
+		// random=1 makes the equal-jitter backoff land at its upper bound (= cap)
+		// so the per-attempt delay is deterministic for assertions.
+		random: () => 1,
+		setTimer: (fn, ms) => {
+			timers.push({ fn, ms });
+			timerId += 1;
+			return timerId as unknown as ReturnType<typeof setTimeout>;
+		},
+		clearTimer: () => {},
+		setKeepalive: () => {
+			keepaliveId += 1;
+			return keepaliveId as unknown as ReturnType<typeof setInterval>;
+		},
+		clearKeepalive: () => {},
+		uuid: () => FIXED_CID,
+		...overrides,
+	};
+
+	return { deps, sockets, timers };
+}
+
+// The channel is a process-wide singleton; tear it down to the gated floor
+// before each case so a paired socket never leaks into the next test.
+beforeEach(async () => {
+	await initControlChannel({ canDial: () => false, logger: silent });
+});
+
+describe("control channel gating", () => {
+	test("unpaired device does not dial (gated)", async () => {
+		const h = harness({ canDial: () => false });
+		await initControlChannel(h.deps);
+
+		expect(h.sockets.length).toBe(0);
+		expect(isConnected()).toBe(false);
+	});
+});
+
+describe("control channel when paired", () => {
+	test("dials the pinned hub url from resolveControlChannelEndpoint", async () => {
+		const h = harness();
+		await initControlChannel(h.deps);
+
+		expect(h.sockets.length).toBe(1);
+		expect(h.sockets[0]?.url).toBe(HUB_URL);
+	});
+
+	test("sends the device.hello handshake on connect", async () => {
+		const h = harness();
+		await initControlChannel(h.deps);
+		const socket = h.sockets[0];
+		expect(socket).toBeDefined();
+		expect(socket?.sent.length).toBe(0);
+
+		socket?.fireOpen();
+
+		expect(socket?.sent.length).toBe(1);
+		const frame = HandshakeSchema.parse(JSON.parse(socket?.sent[0] ?? "{}"));
+		expect(frame.kind).toBe("handshake");
+		expect(frame.type).toBe("device.hello");
+
+		const hello = HandshakeDeviceSchema.parse(frame.payload);
+		expect(hello.supportedTypes).toEqual([...COMMAND_REGISTRY]);
+		expect(hello.deviceCaps).toEqual({});
+		expect(isConnected()).toBe(true);
+	});
+
+	test("reconnects with exponential backoff on disconnect", async () => {
+		const h = harness();
+		await initControlChannel(h.deps);
+		expect(h.sockets.length).toBe(1);
+
+		h.sockets[0]?.fireClose();
+		expect(h.timers.length).toBe(1);
+		const firstDelay = h.timers[0]?.ms ?? 0;
+		expect(firstDelay).toBeGreaterThanOrEqual(RECONNECT_BASE_MS / 2);
+		expect(firstDelay).toBeLessThanOrEqual(RECONNECT_MAX_MS);
+
+		h.timers[0]?.fn();
+		expect(h.sockets.length).toBe(2);
+
+		h.sockets[1]?.fireClose();
+		expect(h.timers.length).toBe(2);
+		expect(h.timers[1]?.ms ?? 0).toBeGreaterThan(firstDelay);
+	});
+
+	test("sendFrame is a no-op before connect and after disconnect", async () => {
+		const h = harness();
+		await initControlChannel(h.deps);
+		const frame: Frame = {
+			v: 1,
+			kind: "status",
+			type: "status",
+			cid: FIXED_CID,
+			seq: 0,
+			payload: {},
+		};
+
+		expect(sendFrame(frame)).toBe(false);
+
+		h.sockets[0]?.fireOpen();
+		expect(sendFrame(frame)).toBe(true);
+
+		h.sockets[0]?.fireClose();
+		expect(sendFrame(frame)).toBe(false);
+	});
+});
+
+describe("backoff", () => {
+	test("grows exponentially and is capped at the max", () => {
+		const upper = () => 1;
+		expect(backoffDelay(0, upper)).toBe(RECONNECT_BASE_MS);
+		expect(backoffDelay(1, upper)).toBe(2 * RECONNECT_BASE_MS);
+		expect(backoffDelay(100, upper)).toBe(RECONNECT_MAX_MS);
+		expect(backoffDelay(0, () => 0)).toBe(RECONNECT_BASE_MS / 2);
+	});
+});

--- a/apps/backend/src/tests/control-command-routing.test.ts
+++ b/apps/backend/src/tests/control-command-routing.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { routeCommand } from "../modules/remote-control/command-router.ts";
+import type { Command, Result } from "../modules/remote-control/protocol.ts";
+import {
+	type NonRevertibleOp,
+	type RevertibleOp,
+	resetSelfFencingState,
+	type SelfFencingOps,
+} from "../modules/remote-control/self-fencing.ts";
+
+function capture(): { sink: (frame: Result) => boolean; frames: Result[] } {
+	const frames: Result[] = [];
+	return {
+		frames,
+		sink: (frame: Result) => {
+			frames.push(frame);
+			return true;
+		},
+	};
+}
+
+function makeCommand(overrides: Partial<Command>): Command {
+	return {
+		v: 1,
+		kind: "command",
+		type: "streaming.getConfig",
+		cid: "c1",
+		role: "owner",
+		...overrides,
+	};
+}
+
+afterEach(() => {
+	resetSelfFencingState();
+});
+
+describe("control command routing", () => {
+	test("getConfig command dispatches to the procedure and returns ok result echoing cid", async () => {
+		const { sink, frames } = capture();
+
+		await routeCommand(
+			makeCommand({ type: "streaming.getConfig", cid: "c1" }),
+			{
+				sendResult: sink,
+			},
+		);
+
+		expect(frames).toHaveLength(1);
+		const result = frames[0];
+		expect(result?.v).toBe(1);
+		expect(result?.kind).toBe("result");
+		expect(result?.type).toBe("streaming.getConfig");
+		expect(result?.cid).toBe("c1");
+		expect(result?.role).toBe("owner");
+		expect(result?.payload.ok).toBe(true);
+		expect(result?.payload).toHaveProperty("applied");
+	});
+
+	test("never-remote auth.setPassword is rejected with not_remote_invokable and never executed", async () => {
+		const { sink, frames } = capture();
+		let dispatched = false;
+
+		await routeCommand(makeCommand({ type: "auth.setPassword", cid: "c2" }), {
+			sendResult: sink,
+			dispatch: {
+				"auth.setPassword": async () => {
+					dispatched = true;
+					return { success: true };
+				},
+			},
+		});
+
+		expect(dispatched).toBe(false);
+		expect(frames[0]?.cid).toBe("c2");
+		expect(frames[0]?.payload).toEqual({
+			ok: false,
+			applied: null,
+			error: "not_remote_invokable",
+		});
+	});
+
+	test("unknown command type is rejected with unknown_command", async () => {
+		const { sink, frames } = capture();
+
+		await routeCommand(makeCommand({ type: "streaming.teleport", cid: "c3" }), {
+			sendResult: sink,
+		});
+
+		expect(frames[0]?.cid).toBe("c3");
+		expect(frames[0]?.payload).toEqual({
+			ok: false,
+			applied: null,
+			error: "unknown_command",
+		});
+	});
+
+	test("non-owner role is rejected with unauthorized", async () => {
+		const { sink, frames } = capture();
+		let dispatched = false;
+
+		await routeCommand(
+			makeCommand({ type: "streaming.getConfig", cid: "c4", role: "viewer" }),
+			{
+				sendResult: sink,
+				dispatch: {
+					"streaming.getConfig": async () => {
+						dispatched = true;
+						return {};
+					},
+				},
+			},
+		);
+
+		expect(dispatched).toBe(false);
+		expect(frames[0]?.cid).toBe("c4");
+		expect(frames[0]?.payload).toEqual({
+			ok: false,
+			applied: null,
+			error: "unauthorized",
+		});
+	});
+
+	test("self_fencing op routes to the commit-confirm watchdog (applied, awaiting confirm)", async () => {
+		const { sink, frames } = capture();
+		const reverts: unknown[] = [];
+		const revertible: RevertibleOp = {
+			revertible: true,
+			snapshot: async () => ({ dhcp: true }),
+			apply: async () => ({ dhcp: false }),
+			revert: async (snapshot) => {
+				reverts.push(snapshot);
+			},
+		};
+		const unexpected: NonRevertibleOp = {
+			revertible: false,
+			execute: async () => {
+				throw new Error("unexpected op invocation");
+			},
+		};
+		const ops: SelfFencingOps = {
+			"network.reconfig": revertible,
+			"modem.reconfig": unexpected,
+			"device.remoteKeyChange": unexpected,
+			"system.reboot": unexpected,
+			"device.factoryReset": unexpected,
+		};
+
+		await routeCommand(makeCommand({ type: "network.reconfig", cid: "c5" }), {
+			sendResult: sink,
+			selfFencing: {
+				ops,
+				setTimer: () => 0 as unknown as ReturnType<typeof setTimeout>,
+				clearTimer: () => {},
+			},
+		});
+
+		expect(frames).toHaveLength(1);
+		expect(frames[0]?.cid).toBe("c5");
+		expect(frames[0]?.self_fencing).toBe(true);
+		expect(frames[0]?.payload).toEqual({ ok: true, applied: { dhcp: false } });
+		expect(reverts).toEqual([]);
+	});
+});

--- a/apps/backend/src/tests/device-token.test.ts
+++ b/apps/backend/src/tests/device-token.test.ts
@@ -1,0 +1,289 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { generateKeyPairSync, type KeyObject } from "node:crypto";
+import {
+	DEVICE_CONTROL_PURPOSE,
+	DEVICE_TOKEN_PUBLIC_KEY_ENV,
+	DEVICE_TOKEN_SKEW_SECONDS,
+	mintStubDeviceControlToken,
+	mintStubDeviceToken,
+	verifyDeviceControlToken,
+	verifyStubDeviceToken,
+} from "../modules/pairing/device-token.ts";
+import {
+	exportEd25519PublicKeyBase64,
+	importEd25519PublicKey,
+	signV4Public,
+	verifyV4Public,
+} from "../modules/pairing/paseto-v4.ts";
+import {
+	CONTROL_HUB_URL_ENV,
+	resolveControlChannelEndpoint,
+} from "../modules/remote/control-endpoint.ts";
+
+const NOW = 1_700_000_000_000;
+const NOW_SECONDS = Math.floor(NOW / 1000);
+
+// A provisioned key makes verification mandatory; mutate-and-restore so the gate
+// never leaks into the other pairing suites running in the same process.
+let savedKey: string | undefined;
+
+// The platform's signing keypair for the suite. The public half is what the
+// device is provisioned with; the private half stands in for PASETO_SIGNING_KEY.
+let platform: { publicKey: KeyObject; privateKey: KeyObject };
+let platformPublicKeyB64: string;
+
+beforeEach(() => {
+	savedKey = process.env[DEVICE_TOKEN_PUBLIC_KEY_ENV];
+	delete process.env[DEVICE_TOKEN_PUBLIC_KEY_ENV];
+	platform = generateKeyPairSync("ed25519");
+	platformPublicKeyB64 = exportEd25519PublicKeyBase64(platform.publicKey);
+});
+
+afterEach(() => {
+	if (savedKey === undefined) {
+		delete process.env[DEVICE_TOKEN_PUBLIC_KEY_ENV];
+	} else {
+		process.env[DEVICE_TOKEN_PUBLIC_KEY_ENV] = savedKey;
+	}
+});
+
+function controlClaims(overrides: Record<string, unknown> = {}) {
+	return {
+		device_id: "7a03d468-3c9e-4b7a-8483-1f2a3b4c5d6e",
+		tenant_id: "ten_8b14e579",
+		serial: "CERA-RK3588-000123",
+		role: "owner",
+		aud: "ceralive-control-plane",
+		purpose: DEVICE_CONTROL_PURPOSE,
+		jti: "8b14e579-4d0f-4c8b-9594-2a3b4c5d6e7f",
+		iat: NOW_SECONDS,
+		exp: NOW_SECONDS + 15 * 60,
+		...overrides,
+	};
+}
+
+function signControlToken(
+	claims: Record<string, unknown>,
+	secret: KeyObject = platform.privateKey,
+): string {
+	return signV4Public(JSON.stringify(claims), secret);
+}
+
+describe("device-control token — real PASETO v4.public verification (spec §10)", () => {
+	test("a validly signed token is accepted and its claims returned", () => {
+		process.env[DEVICE_TOKEN_PUBLIC_KEY_ENV] = platformPublicKeyB64;
+		const token = signControlToken(controlClaims());
+
+		const claims = verifyDeviceControlToken(token, NOW);
+
+		expect(claims).not.toBeNull();
+		expect(claims?.device_id).toBe("7a03d468-3c9e-4b7a-8483-1f2a3b4c5d6e");
+		expect(claims?.tenant_id).toBe("ten_8b14e579");
+		expect(claims?.purpose).toBe(DEVICE_CONTROL_PURPOSE);
+		expect(claims?.role).toBe("owner");
+	});
+
+	test("an unsigned (forged) token is rejected when the public key is set", () => {
+		process.env[DEVICE_TOKEN_PUBLIC_KEY_ENV] = platformPublicKeyB64;
+		// Unsigned stub token: real claim shape, real header, NO signature.
+		const unsigned = mintStubDeviceControlToken({
+			deviceId: "7a03d468-3c9e-4b7a-8483-1f2a3b4c5d6e",
+			tenantId: "ten_8b14e579",
+			serial: "CERA-RK3588-000123",
+			jti: "8b14e579-4d0f-4c8b-9594-2a3b4c5d6e7f",
+			now: NOW,
+		});
+
+		expect(verifyDeviceControlToken(unsigned, NOW)).toBeNull();
+	});
+
+	test("a token signed by a DIFFERENT key is rejected (signature mismatch)", () => {
+		process.env[DEVICE_TOKEN_PUBLIC_KEY_ENV] = platformPublicKeyB64;
+		const attacker = generateKeyPairSync("ed25519");
+		const forged = signControlToken(controlClaims(), attacker.privateKey);
+
+		expect(verifyDeviceControlToken(forged, NOW)).toBeNull();
+	});
+
+	test("a validly signed relay-config (wrong-purpose) token is rejected", () => {
+		process.env[DEVICE_TOKEN_PUBLIC_KEY_ENV] = platformPublicKeyB64;
+		// Correct signature, wrong audience: purpose gate must reject it before
+		// trusting any claim, proving audience separation is not just a side
+		// effect of signature failure.
+		const wrongPurpose = signControlToken(
+			controlClaims({ purpose: "relay-config" }),
+		);
+
+		expect(verifyDeviceControlToken(wrongPurpose, NOW)).toBeNull();
+	});
+
+	test("an expired token is rejected beyond the ±30s skew band", () => {
+		process.env[DEVICE_TOKEN_PUBLIC_KEY_ENV] = platformPublicKeyB64;
+		const expiredAt = NOW_SECONDS - 60;
+		const token = signControlToken(
+			controlClaims({ iat: expiredAt - 900, exp: expiredAt }),
+		);
+
+		const past = (expiredAt + DEVICE_TOKEN_SKEW_SECONDS + 5) * 1000;
+		expect(verifyDeviceControlToken(token, past)).toBeNull();
+	});
+
+	test("a token within the ±30s skew band is still accepted", () => {
+		process.env[DEVICE_TOKEN_PUBLIC_KEY_ENV] = platformPublicKeyB64;
+		const expiredAt = NOW_SECONDS;
+		const token = signControlToken(
+			controlClaims({ iat: expiredAt - 900, exp: expiredAt }),
+		);
+
+		const justAfter = (expiredAt + DEVICE_TOKEN_SKEW_SECONDS - 5) * 1000;
+		expect(verifyDeviceControlToken(token, justAfter)).not.toBeNull();
+	});
+
+	test("a token missing required claims is rejected even when signed", () => {
+		process.env[DEVICE_TOKEN_PUBLIC_KEY_ENV] = platformPublicKeyB64;
+		const { tenant_id: _omitted, ...withoutTenant } = controlClaims();
+		const token = signControlToken(withoutTenant);
+
+		expect(verifyDeviceControlToken(token, NOW)).toBeNull();
+	});
+});
+
+describe("device-control token — unsigned dev path (no key provisioned)", () => {
+	test("an unsigned token is accepted when no public key is set", () => {
+		const token = mintStubDeviceControlToken({
+			deviceId: "dev-device",
+			tenantId: "dev-tenant",
+			serial: "DEVSERIAL01",
+			jti: "dev-jti-0001",
+			now: NOW,
+		});
+
+		const claims = verifyDeviceControlToken(token, NOW);
+		expect(claims?.purpose).toBe(DEVICE_CONTROL_PURPOSE);
+	});
+
+	test("the purpose gate still rejects a wrong-purpose token on the dev path", () => {
+		const body = Buffer.from(
+			JSON.stringify(controlClaims({ purpose: "relay-config" })),
+			"utf8",
+		)
+			.toString("base64")
+			.replace(/\+/g, "-")
+			.replace(/\//g, "_")
+			.replace(/=+$/, "");
+		const token = `v4.public.${body}`;
+
+		expect(verifyDeviceControlToken(token, NOW)).toBeNull();
+	});
+});
+
+describe("relay-config token — real verification when key provisioned", () => {
+	test("a validly signed relay-config token is accepted", () => {
+		process.env[DEVICE_TOKEN_PUBLIC_KEY_ENV] = platformPublicKeyB64;
+		const token = signV4Public(
+			JSON.stringify({
+				device_id: "CERASERIAL0001",
+				sub_status: "ACTIVE",
+				iat: NOW_SECONDS,
+				exp: NOW_SECONDS + 3600,
+			}),
+			platform.privateKey,
+		);
+
+		const claims = verifyStubDeviceToken(token, NOW);
+		expect(claims?.device_id).toBe("CERASERIAL0001");
+		expect(claims?.sub_status).toBe("ACTIVE");
+	});
+
+	test("an unsigned relay-config token is rejected when the key is set", () => {
+		process.env[DEVICE_TOKEN_PUBLIC_KEY_ENV] = platformPublicKeyB64;
+		const unsigned = mintStubDeviceToken({
+			deviceId: "CERASERIAL0001",
+			subStatus: "ACTIVE",
+			now: NOW,
+		});
+
+		expect(verifyStubDeviceToken(unsigned, NOW)).toBeNull();
+	});
+});
+
+describe("control channel endpoint pinning (spec §10)", () => {
+	test("custom_provider cannot redirect the control channel to another host", () => {
+		const endpoint = resolveControlChannelEndpoint(
+			{
+				remote_provider: "custom",
+				custom_provider: {
+					name: "attacker",
+					host: "evil.example.com",
+					path: "/ws/remote",
+					secure: true,
+				},
+			},
+			{ [CONTROL_HUB_URL_ENV]: "wss://hub.ceralive.tv/ws/control" },
+		);
+
+		expect(endpoint.host).toBe("hub.ceralive.tv");
+		expect(endpoint.url).toBe("wss://hub.ceralive.tv/ws/control");
+		expect(endpoint.host).not.toBe("evil.example.com");
+		expect(endpoint.pinned).toBe(true);
+	});
+
+	test("a missing pin fails closed (throws, never falls back to operator host)", () => {
+		expect(() =>
+			resolveControlChannelEndpoint(
+				{ custom_provider: { name: "x", host: "evil.example.com" } },
+				{},
+			),
+		).toThrow();
+	});
+
+	test("a non-ws(s) pinned URL is rejected", () => {
+		expect(() =>
+			resolveControlChannelEndpoint(undefined, {
+				[CONTROL_HUB_URL_ENV]: "https://hub.ceralive.tv/ws/control",
+			}),
+		).toThrow();
+	});
+});
+
+describe("PASETO v4.public — official spec test vectors (interop lock)", () => {
+	// Genuine vectors from github.com/paseto-standard/test-vectors (v4.json).
+	// They lock the PAE + base64url + Ed25519 construction against the spec so a
+	// real platform-signed token verifies on-device.
+	const PUBLIC_KEY_HEX =
+		"1eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415d0e20b1a2";
+	const PAYLOAD =
+		'{"data":"this is a signed message","exp":"2022-01-01T00:00:00+00:00"}';
+
+	const publicKeyB64 = Buffer.from(PUBLIC_KEY_HEX, "hex").toString("base64");
+
+	test("4-S-1 (no footer) verifies", () => {
+		const key = importEd25519PublicKey(publicKeyB64);
+		const token =
+			"v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9bg_XBBzds8lTZShVlwwKSgeKpLT3yukTw6JUz3W4h_ExsQV-P0V54zemZDcAxFaSeef1QlXEFtkqxT1ciiQEDA";
+		const result = verifyV4Public(token, key);
+		expect(result?.payload).toBe(PAYLOAD);
+		expect(result?.footer).toBe("");
+	});
+
+	test("4-S-2 (with footer) verifies", () => {
+		const key = importEd25519PublicKey(publicKeyB64);
+		const token =
+			"v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9v3Jt8mx_TdM2ceTGoqwrh4yDFn0XsHvvV_D0DtwQxVrJEBMl0F2caAdgnpKlt4p7xBnx1HcO-SPo8FPp214HDw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
+		const result = verifyV4Public(token, key);
+		expect(result?.payload).toBe(PAYLOAD);
+		expect(result?.footer).toBe(
+			'{"kid":"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN"}',
+		);
+	});
+
+	test("4-S-3 (footer + implicit assertion) verifies", () => {
+		const key = importEd25519PublicKey(publicKeyB64);
+		const token =
+			"v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9NPWciuD3d0o5eXJXG5pJy-DiVEoyPYWs1YSTwWHNJq6DZD3je5gf-0M4JR9ipdUSJbIovzmBECeaWmaqcaP0DQ.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
+		const implicit = '{"test-vector":"4-S-3"}';
+		expect(verifyV4Public(token, key, implicit)?.payload).toBe(PAYLOAD);
+		// Wrong implicit assertion must fail — it is bound into the signature.
+		expect(verifyV4Public(token, key, "")).toBeNull();
+	});
+});

--- a/apps/backend/src/tests/identity-init.test.ts
+++ b/apps/backend/src/tests/identity-init.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { RuntimeConfig } from "../helpers/config-schemas.ts";
+import {
+	canDialControlChannel,
+	getIdentity,
+	type IdentityLogger,
+	initIdentity,
+	UNPAIRED_IDENTITY,
+} from "../modules/identity/index.ts";
+
+const DEVICE_ID = "7a03d468-3c9e-4b7a-8483-1f2a3b4c5d6e";
+const REMOTE_KEY = "v4.public.stub-token-payload";
+
+const silent: IdentityLogger = {
+	info: () => {},
+	warn: () => {},
+};
+
+function readConfig(
+	partial: Partial<RuntimeConfig>,
+): () => Pick<RuntimeConfig, "device_id" | "remote_key"> {
+	return () => partial;
+}
+
+// Module identity is process-wide; reset to the unpaired floor before each case
+// so a paired result never leaks into an unpaired assertion.
+beforeEach(async () => {
+	await initIdentity({ readConfig: readConfig({}), logger: silent });
+});
+
+describe("initIdentity when the device is paired", () => {
+	test("resolves device_id and reports paired", async () => {
+		const identity = await initIdentity({
+			readConfig: readConfig({ remote_key: REMOTE_KEY, device_id: DEVICE_ID }),
+			logger: silent,
+		});
+
+		expect(identity).toEqual({ paired: true, deviceId: DEVICE_ID });
+		expect(getIdentity()).toEqual({ paired: true, deviceId: DEVICE_ID });
+	});
+
+	test("opens the control-channel gate", async () => {
+		await initIdentity({
+			readConfig: readConfig({ remote_key: REMOTE_KEY, device_id: DEVICE_ID }),
+			logger: silent,
+		});
+
+		expect(canDialControlChannel()).toBe(true);
+	});
+
+	test("keeps the gate closed when paired but device_id is missing", async () => {
+		const identity = await initIdentity({
+			readConfig: readConfig({ remote_key: REMOTE_KEY }),
+			logger: silent,
+		});
+
+		expect(identity).toEqual({ paired: true, deviceId: undefined });
+		expect(canDialControlChannel()).toBe(false);
+	});
+});
+
+describe("initIdentity when the device has never been paired", () => {
+	test("resolves to the unpaired floor without throwing", async () => {
+		const identity = await initIdentity({
+			readConfig: readConfig({ device_id: DEVICE_ID }),
+			logger: silent,
+		});
+
+		expect(identity).toEqual({ paired: false, deviceId: undefined });
+		expect(getIdentity()).toEqual(UNPAIRED_IDENTITY);
+	});
+
+	test("leaves the control-channel gate flag false", async () => {
+		await initIdentity({ readConfig: readConfig({}), logger: silent });
+
+		expect(getIdentity().paired).toBe(false);
+		expect(canDialControlChannel()).toBe(false);
+	});
+
+	test("falls back to unpaired when the config read throws (fail-soft)", async () => {
+		const throwingRead = () => {
+			throw new Error("config unreadable");
+		};
+
+		const identity = await initIdentity({
+			readConfig: throwingRead,
+			logger: silent,
+		});
+
+		expect(identity).toEqual(UNPAIRED_IDENTITY);
+		expect(canDialControlChannel()).toBe(false);
+	});
+});

--- a/apps/backend/src/tests/self-fencing.test.ts
+++ b/apps/backend/src/tests/self-fencing.test.ts
@@ -1,0 +1,283 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type { Command, Result } from "../modules/remote-control/protocol.ts";
+import {
+	handleSelfFencingConfirm,
+	handleSelfFencingOp,
+	type NonRevertibleOp,
+	type RevertibleOp,
+	resetSelfFencingState,
+	type SelfFencingDeps,
+	type SelfFencingOps,
+} from "../modules/remote-control/self-fencing.ts";
+
+const CID_A = "5e81b246-1a7c-4f5e-9261-9d0e1f2a3b40";
+const CID_B = "5e81b246-1a7c-4f5e-9261-9d0e1f2a3b41";
+const CID_C = "5e81b246-1a7c-4f5e-9261-9d0e1f2a3b42";
+const CID_D = "5e81b246-1a7c-4f5e-9261-9d0e1f2a3b43";
+const CID_E = "5e81b246-1a7c-4f5e-9261-9d0e1f2a3b44";
+
+interface FakeTimer {
+	fn: () => void;
+	ms: number;
+	cleared: boolean;
+}
+
+interface FakeClock {
+	timers: FakeTimer[];
+	setTimer: SelfFencingDeps["setTimer"];
+	clearTimer: SelfFencingDeps["clearTimer"];
+	fire: () => Promise<void>;
+}
+
+/** A real macrotask tick so the void-detached watchdog continuation settles. */
+function flush(): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function fakeClock(): FakeClock {
+	const timers: FakeTimer[] = [];
+	return {
+		timers,
+		setTimer: (fn, ms) => {
+			const timer: FakeTimer = { fn, ms, cleared: false };
+			timers.push(timer);
+			return timer as unknown as ReturnType<typeof setTimeout>;
+		},
+		clearTimer: (handle) => {
+			(handle as unknown as FakeTimer).cleared = true;
+		},
+		fire: async () => {
+			for (const timer of timers) {
+				if (!timer.cleared) timer.fn();
+			}
+			await flush();
+		},
+	};
+}
+
+function capture(): { frames: Result[]; sink: (frame: Result) => boolean } {
+	const frames: Result[] = [];
+	return {
+		frames,
+		sink: (frame: Result) => {
+			frames.push(frame);
+			return true;
+		},
+	};
+}
+
+function revertibleSpy(states: { old: unknown; new: unknown }): {
+	op: RevertibleOp;
+	calls: { snapshot: number; apply: number; revert: unknown[] };
+} {
+	const calls = { snapshot: 0, apply: 0, revert: [] as unknown[] };
+	const op: RevertibleOp = {
+		revertible: true,
+		snapshot: async () => {
+			calls.snapshot += 1;
+			return states.old;
+		},
+		apply: async () => {
+			calls.apply += 1;
+			return states.new;
+		},
+		revert: async (snapshot) => {
+			calls.revert.push(snapshot);
+		},
+	};
+	return { op, calls };
+}
+
+function nonRevertibleSpy(): {
+	op: NonRevertibleOp;
+	calls: { execute: unknown[] };
+} {
+	const calls = { execute: [] as unknown[] };
+	const op: NonRevertibleOp = {
+		revertible: false,
+		execute: async (payload) => {
+			calls.execute.push(payload);
+		},
+	};
+	return { op, calls };
+}
+
+/** Fill the full op table with a throwing default, then overlay the op under test. */
+function makeOps(partial: Partial<SelfFencingOps>): SelfFencingOps {
+	const unexpected: NonRevertibleOp = {
+		revertible: false,
+		execute: async () => {
+			throw new Error("unexpected op invocation");
+		},
+	};
+	return {
+		"network.reconfig": unexpected,
+		"modem.reconfig": unexpected,
+		"device.remoteKeyChange": unexpected,
+		"system.reboot": unexpected,
+		"device.factoryReset": unexpected,
+		...partial,
+	};
+}
+
+function makeDeps(
+	ops: SelfFencingOps,
+	clock: FakeClock,
+	sink: (frame: Result) => boolean,
+): Partial<SelfFencingDeps> {
+	return {
+		sendResult: sink,
+		ops,
+		watchdogMs: 30_000,
+		setTimer: clock.setTimer,
+		clearTimer: clock.clearTimer,
+		logger: { info: () => {}, warn: () => {} },
+	};
+}
+
+function makeCommand(overrides: Partial<Command>): Command {
+	return {
+		v: 1,
+		kind: "command",
+		type: "network.reconfig",
+		cid: CID_A,
+		role: "owner",
+		self_fencing: true,
+		...overrides,
+	};
+}
+
+afterEach(() => {
+	resetSelfFencingState();
+});
+
+describe("self_fencing revertible ops", () => {
+	test("network.reconfig auto-reverts to the snapshot when no confirm arrives", async () => {
+		const { frames, sink } = capture();
+		const clock = fakeClock();
+		const { op, calls } = revertibleSpy({
+			old: { dhcp: true },
+			new: { dhcp: false },
+		});
+
+		await handleSelfFencingOp(
+			makeCommand({ type: "network.reconfig", cid: CID_A }),
+			makeDeps(makeOps({ "network.reconfig": op }), clock, sink),
+		);
+
+		expect(calls.snapshot).toBe(1);
+		expect(calls.apply).toBe(1);
+		expect(frames).toHaveLength(1);
+		expect(frames[0]?.kind).toBe("result");
+		expect(frames[0]?.cid).toBe(CID_A);
+		expect(frames[0]?.self_fencing).toBe(true);
+		expect(frames[0]?.payload).toEqual({ ok: true, applied: { dhcp: false } });
+		expect(clock.timers).toHaveLength(1);
+		expect(clock.timers[0]?.ms).toBe(30_000);
+
+		await clock.fire();
+
+		expect(calls.revert).toEqual([{ dhcp: true }]);
+		expect(frames).toHaveLength(2);
+		expect(frames[1]?.payload).toEqual({
+			ok: true,
+			applied: { dhcp: true },
+			reverted: true,
+		});
+	});
+
+	test("network.reconfig commits without reverting when confirmed in time", async () => {
+		const { frames, sink } = capture();
+		const clock = fakeClock();
+		const { op, calls } = revertibleSpy({
+			old: { dhcp: true },
+			new: { dhcp: false },
+		});
+
+		await handleSelfFencingOp(
+			makeCommand({ type: "network.reconfig", cid: CID_B }),
+			makeDeps(makeOps({ "network.reconfig": op }), clock, sink),
+		);
+		await handleSelfFencingConfirm(CID_B);
+
+		expect(calls.revert).toEqual([]);
+		expect(clock.timers[0]?.cleared).toBe(true);
+		expect(frames).toHaveLength(2);
+		expect(frames[1]?.payload).toEqual({
+			ok: true,
+			applied: { dhcp: false },
+			reverted: false,
+		});
+
+		// Firing the cancelled watchdog is a no-op — the op was already resolved.
+		await clock.fire();
+		expect(calls.revert).toEqual([]);
+		expect(frames).toHaveLength(2);
+	});
+});
+
+describe("self_fencing non-revertible ops", () => {
+	test("system.reboot without a confirm yields self_fencing_confirm_required and does not execute", async () => {
+		const { frames, sink } = capture();
+		const clock = fakeClock();
+		const { op, calls } = nonRevertibleSpy();
+
+		await handleSelfFencingOp(
+			makeCommand({ type: "system.reboot", cid: CID_C }),
+			makeDeps(makeOps({ "system.reboot": op }), clock, sink),
+		);
+
+		expect(calls.execute).toEqual([]);
+		expect(frames).toHaveLength(1);
+		expect(frames[0]?.payload).toEqual({
+			ok: false,
+			applied: null,
+			error: "self_fencing_confirm_required",
+		});
+		expect(clock.timers).toHaveLength(1);
+	});
+
+	test("system.reboot executes only after a matching confirm", async () => {
+		const { frames, sink } = capture();
+		const clock = fakeClock();
+		const { op, calls } = nonRevertibleSpy();
+
+		await handleSelfFencingOp(
+			makeCommand({
+				type: "system.reboot",
+				cid: CID_D,
+				payload: { mode: "graceful" },
+			}),
+			makeDeps(makeOps({ "system.reboot": op }), clock, sink),
+		);
+		expect(calls.execute).toEqual([]);
+
+		await handleSelfFencingConfirm(CID_D);
+
+		expect(calls.execute).toEqual([{ mode: "graceful" }]);
+		expect(clock.timers[0]?.cleared).toBe(true);
+		expect(frames).toHaveLength(2);
+		expect(frames[1]?.payload).toEqual({ ok: true, applied: null });
+	});
+
+	test("system.reboot is discarded with self_fencing_unconfirmed when the watchdog fires", async () => {
+		const { frames, sink } = capture();
+		const clock = fakeClock();
+		const { op, calls } = nonRevertibleSpy();
+
+		await handleSelfFencingOp(
+			makeCommand({ type: "system.reboot", cid: CID_E }),
+			makeDeps(makeOps({ "system.reboot": op }), clock, sink),
+		);
+		await clock.fire();
+
+		expect(calls.execute).toEqual([]);
+		expect(frames).toHaveLength(2);
+		expect(frames[1]?.payload).toEqual({
+			ok: false,
+			applied: null,
+			error: "self_fencing_unconfirmed",
+		});
+	});
+});

--- a/apps/backend/src/tests/status-relay.test.ts
+++ b/apps/backend/src/tests/status-relay.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { StatusSchema } from "../modules/remote-control/protocol.ts";
+import {
+	type ControlChannel,
+	isRelayable,
+	RELAYABLE_TYPES,
+	relayStatusToGateway,
+	resetStatusRelay,
+	setControlChannel,
+} from "../modules/remote-control/status-relay.ts";
+import { broadcastMsg, broadcastMsgLocal } from "../rpc/compat.ts";
+import { addClient, removeClient } from "../rpc/events.ts";
+import type { AppWebSocket } from "../rpc/types.ts";
+
+/** A fake control channel that records every frame it is asked to send. */
+function makeChannel(connected = true): ControlChannel & { frames: unknown[] } {
+	const frames: unknown[] = [];
+	return {
+		frames,
+		isConnected: () => connected,
+		sendFrame: (frame: unknown) => {
+			frames.push(frame);
+		},
+	};
+}
+
+/** A fake authenticated local client that records the raw messages it receives. */
+function makeClient(sent: string[]): AppWebSocket {
+	return {
+		data: { isAuthenticated: true, lastActive: 0 },
+		send: (msg: string) => {
+			sent.push(msg);
+		},
+	} as unknown as AppWebSocket;
+}
+
+afterEach(() => {
+	resetStatusRelay();
+});
+
+describe("relayStatusToGateway", () => {
+	it("emits a spec-valid kind:status frame with correct type, payload, and seq", () => {
+		const channel = makeChannel();
+		setControlChannel(channel);
+
+		broadcastMsg("status", { is_streaming: true });
+
+		expect(channel.frames).toHaveLength(1);
+		const frame = channel.frames[0];
+
+		// The frame must parse as a spec §8 status frame.
+		const parsed = StatusSchema.parse(frame);
+		expect(parsed.kind).toBe("status");
+		expect(parsed.type).toBe("status");
+		expect(parsed.payload).toEqual({ is_streaming: true });
+		expect(parsed.seq).toBeGreaterThanOrEqual(0);
+		expect(Number.isInteger(parsed.seq)).toBe(true);
+		expect(parsed.v).toBe(1);
+	});
+
+	it("stamps an independently increasing seq per status type", () => {
+		const channel = makeChannel();
+		setControlChannel(channel);
+
+		broadcastMsg("status", { a: 1 });
+		broadcastMsg("status", { a: 2 });
+		broadcastMsg("config", { b: 1 });
+
+		const first = StatusSchema.parse(channel.frames[0]);
+		const second = StatusSchema.parse(channel.frames[1]);
+		const configFrame = StatusSchema.parse(channel.frames[2]);
+
+		expect(second.seq).toBe(first.seq + 1);
+		// config has its own counter, independent of status
+		expect(configFrame.type).toBe("config");
+		expect(configFrame.seq).toBe(first.seq);
+	});
+
+	it("does NOT relay when the channel reports disconnected", () => {
+		const channel = makeChannel(false);
+		setControlChannel(channel);
+
+		broadcastMsg("status", { is_streaming: true });
+
+		expect(channel.frames).toHaveLength(0);
+	});
+
+	it("is a safe no-op when no control channel is wired (Task 13 pending)", () => {
+		// No setControlChannel call → channel is null.
+		expect(() => broadcastMsg("status", { is_streaming: true })).not.toThrow();
+	});
+
+	it("does NOT relay a non-relayable broadcast type", () => {
+		const channel = makeChannel();
+		setControlChannel(channel);
+
+		broadcastMsg("wifi", { ssid: "x" });
+		broadcastMsg("relays", { list: [] });
+		broadcastMsg("ping", { t: 1 });
+
+		expect(channel.frames).toHaveLength(0);
+	});
+
+	it("relayStatusToGateway can be called directly with an explicit seq", () => {
+		const channel = makeChannel();
+		setControlChannel(channel);
+
+		relayStatusToGateway("netif", { eth0: { up: true } }, 7);
+
+		const parsed = StatusSchema.parse(channel.frames[0]);
+		expect(parsed.type).toBe("netif");
+		expect(parsed.seq).toBe(7);
+		expect(parsed.payload).toEqual({ eth0: { up: true } });
+	});
+});
+
+describe("dual delivery (local + relay)", () => {
+	it("a relayed status still reaches local clients unchanged", () => {
+		const channel = makeChannel();
+		setControlChannel(channel);
+
+		const sent: string[] = [];
+		const client = makeClient(sent);
+		addClient(client);
+		try {
+			broadcastMsg("status", { is_streaming: true });
+		} finally {
+			removeClient(client);
+		}
+
+		// Local delivery: the client received the same payload under the type key.
+		expect(sent).toHaveLength(1);
+		const localMsg = JSON.parse(sent[0] as string);
+		expect(localMsg.status).toEqual({ is_streaming: true });
+		expect(typeof localMsg.seq).toBe("number");
+
+		// Relay delivery: the control channel got the kind:status frame.
+		expect(channel.frames).toHaveLength(1);
+		const relayed = StatusSchema.parse(channel.frames[0]);
+		expect(relayed.payload).toEqual({ is_streaming: true });
+	});
+});
+
+describe("broadcastMsgLocal is local-only", () => {
+	it("does NOT relay to the control channel", () => {
+		const channel = makeChannel();
+		setControlChannel(channel);
+
+		const sent: string[] = [];
+		const client = makeClient(sent);
+		addClient(client);
+		try {
+			broadcastMsgLocal("status", { is_streaming: true });
+		} finally {
+			removeClient(client);
+		}
+
+		// Local clients still receive it...
+		expect(sent).toHaveLength(1);
+		// ...but nothing was relayed to the gateway.
+		expect(channel.frames).toHaveLength(0);
+	});
+});
+
+describe("no-secrets contract", () => {
+	it("RELAYABLE_TYPES is exactly the closed v2.0 status set (spec §8)", () => {
+		expect([...RELAYABLE_TYPES]).toEqual([
+			"status",
+			"config",
+			"sensors",
+			"netif",
+			"modems",
+			"device-stats",
+			"notifications",
+		]);
+	});
+
+	it("carries no secret-bearing or local-only types", () => {
+		const forbidden = [
+			"auth",
+			"auth.login",
+			"auth.setPassword",
+			"token",
+			"password",
+			"secret",
+			"paseto",
+			"pin",
+			"remote_key",
+			"bcrpt",
+		];
+		for (const type of forbidden) {
+			expect(isRelayable(type)).toBe(false);
+		}
+
+		// Defensive: no relayable type name contains a secret-shaped substring.
+		const secretLike = /auth|token|password|secret|paseto|pin|key/i;
+		for (const type of RELAYABLE_TYPES) {
+			expect(secretLike.test(type)).toBe(false);
+		}
+	});
+});


### PR DESCRIPTION
**Affected repo & language:** CeraUI / TypeScript (apps/backend)

## What

Adds a second, independent outbound WebSocket **control channel** from the device backend to the platform `device-gateway` hub, enabling remote device control from the cloud dashboard. Key pieces:

- **Device identity bootstrap** — `initIdentity()` boot step derives/persists the device identity; `config-schemas` gains a `device_id` field.
- **Real PASETO v4.public verification** — Ed25519 primitives (`pairing/paseto-v4.ts`) replace the previous device-token stub with genuine signature verification.
- **Endpoint pinning** — `remote/control-endpoint.ts` pins the gateway endpoint the channel dials.
- **Bidirectional control channel** (`modules/remote-control/`) — WS transport, inbound command routing into RPC with best-effort result frames, outbound status relay (broadcast → gateway), and a `self_fencing` commit-confirm watchdog with auto-revert.

## Why

Enables remote device control from the cloud dashboard across different networks. The existing BCRPT relay (proto-v16, `modules/remote/remote.ts`) is **untouched** — this is a second, fully independent channel with its own token audience and zero local authority.

## How to verify

```bash
cd apps/backend
bun tsc --noEmit          # typecheck → clean (exit 0)
bun test                  # → 1025 pass / 0 fail
grep -rn "addAuthedSocket" src/modules/remote-control/   # → no matches (channel carries zero local authority)
```

## Risks

The `CERALIVE_CONTROL_HUB_URL` env var must be provisioned at image build time before the control channel can dial in production. Until then the channel stays gated (fail-soft) — no impact on the SRT/SRTLA media path or the BCRPT relay.

Note: backend typecheck is clean here; the previously-reported `setup.apt_update_enabled` TS2339 in `main.ts` did not surface and is out of scope for this PR regardless.

---

**Checklist**

- [x] Docs updated if behavior or structure changed (`apps/backend/AGENTS.md` synced)
- [x] Started from updated main; branch rebased on latest canonical branch (absorbed squash-merge #106)
- [x] `git grep -n '.omo' -- ':!.gitignore'` returns nothing
- [x] Tests pass (1025 pass / 0 fail); typecheck clean
