### PR TITLE
feat: #72 modal preview + #67 Phase-0 connect-phone QR + Biome 2.5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,8 +357,8 @@ Fast-reload development loop (dev-sync / dev-push): [`image-building-pipeline/v2
 
 ## CONVENTIONS
 
-- Linting/formatting: Biome only (`@biomejs/biome` 2.4.16) — ESLint and Prettier are fully removed. Run `biome check .` (or `pnpm lint`) from the workspace root. Nested non-root configs live in `apps/frontend/`, `apps/backend/`, `packages/i18n/`.
-- Svelte+TS: Biome's experimental HTML/Svelte support is enabled in the root `biome.json` (`html.experimentalFullSupportEnabled: true` + `html.formatter.enabled: true`). `.svelte` files are linted by Biome; their formatter is disabled in `apps/frontend/biome.json` (`overrides`) because Biome's experimental HTML formatter rewrites the `<script>` block to double quotes and cannot parse Svelte control-flow — so `.svelte` markup is still formatted by the Svelte VS Code extension. The same override silences false-positive `noUnusedVariables`/`noUnusedImports`/`useImportType`/`useConst` that Biome's partial template analysis emits for script vars used in markup.
+- Linting/formatting: Biome 2.5 via `@ceralive/biome-config` — ESLint and Prettier are fully removed. The root `biome.json` extends `@ceralive/biome-config` (`"extends": ["@ceralive/biome-config"]`). Run `biome check .` (or `pnpm lint`) from the workspace root. Nested non-root configs live in `apps/frontend/`, `apps/backend/`, `packages/i18n/`.
+- Svelte+TS: Biome's experimental HTML/Svelte support is enabled via the shared config (`html.experimentalFullSupportEnabled: true` + `html.formatter.enabled: true`). `.svelte` files are linted by Biome; their formatter is disabled in `apps/frontend/biome.json` (`overrides`) because Biome's experimental HTML formatter rewrites the `<script>` block to double quotes and cannot parse Svelte control-flow — so `.svelte` markup is still formatted by the Svelte VS Code extension. The same override silences false-positive `noUnusedVariables`/`noUnusedImports`/`useImportType`/`useConst` that Biome's partial template analysis emits for script vars used in markup.
 - Strict TS: `strict` + `noUncheckedIndexedAccess` + `exactOptionalPropertyTypes` are enabled in `tsconfig.json` (root), `apps/backend`, and `packages/rpc`. The frontend app (`apps/frontend/tsconfig.app.json`) and `tsconfig.node.json` enable `strict` + `noUncheckedIndexedAccess`; `exactOptionalPropertyTypes` is intentionally omitted there because it is incompatible with bits-ui v2 / shadcn-svelte and vite-plugin-pwa types (unfixable "union too complex" errors in CLI-managed components). The e2e tsconfig stays at baseline `strict` (ungated Playwright test code).
 - Mock hardware in dev via `MOCK_SCENARIO` env var (`multi-modem-wifi` default). Use `shouldUseMocks()` — never raw `isDevelopment()` — to gate mock paths.
 - `LOG_LEVEL` env var overrides the Winston transport level for ALL transports (console + file). Unset = per-transport defaults (dev console `info`, prod console `warn`, file `debug`). Set `LOG_LEVEL=debug` to enable per-RPC trace lines.
@@ -422,6 +422,11 @@ CeraUI and is NOT part of the `get-capabilities` response. Three enforcement lay
   persistence. Rendered in the HUD bar as a compact bitrate history.
 - **Session summary** — post-stream summary panel showing duration, average bitrate,
   and per-link stats for the completed session.
+- **EncoderDialog modal preview (#72)** — live encoder settings preview rendered inside
+  the EncoderDialog modal before the user applies changes.
+- **HotspotDialog connect-phone section (#67, Phase-0)** — QR-code section in
+  HotspotDialog that lets a phone scan and join the device hotspot. Backed by the
+  `wifi.hotspotInfo` RPC and the `generateDeviceAccessQr` helper.
 
 ## STREAMING BACKEND QUALITY [EXISTS]
 

--- a/apps/backend/biome.json
+++ b/apps/backend/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
 	"files": {
 		"includes": [
 			"package.json",

--- a/apps/backend/src/modules/wifi/wifi-hotspot-info.ts
+++ b/apps/backend/src/modules/wifi/wifi-hotspot-info.ts
@@ -1,0 +1,64 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { HotspotInfo } from "@ceraui/rpc/schemas";
+
+import { nmConnGetFields } from "../network/network-manager.ts";
+import { getWifiInterfacesByMacAddress } from "./wifi-connections.ts";
+import { isHotspot } from "./wifi-hotspot-types.ts";
+import type { WifiInterface } from "./wifi-interfaces.ts";
+
+const NM_DEFAULT_HOTSPOT_GATEWAY = "10.42.0.1";
+
+export function parseGatewayIp(raw: string | undefined): string {
+	const ip = raw?.split("/")[0]?.trim() ?? "";
+	return ip === "" ? NM_DEFAULT_HOTSPOT_GATEWAY : ip;
+}
+
+export type HotspotInfoDeps = {
+	interfaces: () => Readonly<Record<string, WifiInterface>>;
+	getConnIpv4Address: (uuid: string) => Promise<string | undefined>;
+};
+
+export const defaultHotspotInfoDeps: HotspotInfoDeps = {
+	interfaces: () => getWifiInterfacesByMacAddress(),
+	getConnIpv4Address: async (uuid) => {
+		const fields = await nmConnGetFields(uuid, ["ipv4.addresses"] as const);
+		return fields?.[0];
+	},
+};
+
+export async function resolveHotspotInfo(
+	deps: HotspotInfoDeps,
+): Promise<HotspotInfo> {
+	const interfaces = deps.interfaces();
+	for (const mac in interfaces) {
+		const wifiInterface = interfaces[mac];
+		if (!wifiInterface || !isHotspot(wifiInterface)) continue;
+
+		const conn = wifiInterface.hotspot.conn;
+		if (!conn) continue;
+
+		const raw = await deps.getConnIpv4Address(conn);
+		return {
+			ssid: wifiInterface.hotspot.name ?? "",
+			gatewayIp: parseGatewayIp(raw),
+			isActive: true,
+		};
+	}
+	return { ssid: "", gatewayIp: "", isActive: false };
+}

--- a/apps/backend/src/rpc/procedures/wifi.procedure.ts
+++ b/apps/backend/src/rpc/procedures/wifi.procedure.ts
@@ -9,6 +9,7 @@
  */
 
 import {
+	HotspotInfoOutput,
 	hotspotConfigInputSchema,
 	hotspotToggleInputSchema,
 	successResponseSchema,
@@ -34,6 +35,10 @@ import { setMockHotspotConfig } from "../../mocks/providers/wifi.ts";
 import { withDeviceLock } from "../../modules/network/state/device-lock.ts";
 import { handleWifi, wifiBuildMsg } from "../../modules/wifi/wifi.ts";
 import { getWifiInterfacesByMacAddress } from "../../modules/wifi/wifi-connections.ts";
+import {
+	defaultHotspotInfoDeps,
+	resolveHotspotInfo,
+} from "../../modules/wifi/wifi-hotspot-info.ts";
 import { broadcast } from "../events.ts";
 import { authMiddleware } from "../middleware/auth.middleware.ts";
 import type { RPCContext } from "../types.ts";
@@ -106,6 +111,13 @@ export const getWifiStatusProcedure = authedProcedure
 	.handler(() => {
 		return wifiBuildMsg();
 	});
+
+/**
+ * Get hotspot info procedure (SSID + gateway IP + active flag; never a password)
+ */
+export const hotspotInfoProcedure = authedProcedure
+	.output(HotspotInfoOutput)
+	.handler(() => resolveHotspotInfo(defaultHotspotInfoDeps));
 
 /**
  * Connect to saved WiFi procedure

--- a/apps/backend/src/rpc/router.ts
+++ b/apps/backend/src/rpc/router.ts
@@ -79,6 +79,7 @@ import {
 import {
 	getWifiStatusProcedure,
 	hotspotConfigureProcedure,
+	hotspotInfoProcedure,
 	hotspotStartProcedure,
 	hotspotStopProcedure,
 	wifiConnectNewProcedure,
@@ -123,6 +124,7 @@ const stableRoutes = {
 
 	wifi: os.router({
 		getStatus: getWifiStatusProcedure,
+		hotspotInfo: hotspotInfoProcedure,
 		connect: wifiConnectProcedure,
 		disconnect: wifiDisconnectProcedure,
 		connectNew: wifiConnectNewProcedure,

--- a/apps/backend/src/tests/parity.test.ts
+++ b/apps/backend/src/tests/parity.test.ts
@@ -37,7 +37,7 @@ const BOARDS: ReadonlyArray<PipelineHardwareType> = [
 
 // `decklink` (Blackmagic SDI) has no cerastream pipeline, so a real HAL/capability
 // contract never emits it. The registry intentionally drops it.
-const DROPPED_SOURCES: ReadonlySet<VideoSource> = new Set<VideoSource>([
+const _DROPPED_SOURCES: ReadonlySet<VideoSource> = new Set<VideoSource>([
 	"decklink",
 ]);
 

--- a/apps/backend/src/tests/wifi-hotspot-info.test.ts
+++ b/apps/backend/src/tests/wifi-hotspot-info.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+
+import { HotspotInfoOutput } from "@ceraui/rpc/schemas";
+import { call } from "@orpc/server";
+
+import {
+	type HotspotInfoDeps,
+	parseGatewayIp,
+	resolveHotspotInfo,
+} from "../modules/wifi/wifi-hotspot-info.ts";
+import type { WifiInterface } from "../modules/wifi/wifi-interfaces.ts";
+import { hotspotInfoProcedure } from "../rpc/procedures/wifi.procedure.ts";
+import type { AppWebSocket, RPCContext } from "../rpc/types.ts";
+
+// Build an active-hotspot interface: isHotspot() requires hotspot.conn truthy
+// AND the active conn equal to it.
+function makeActiveHotspotIface(opts: {
+	ssid: string;
+	conn?: string;
+}): WifiInterface {
+	const conn = opts.conn ?? "hotspot-uuid";
+	return {
+		id: 0,
+		ifname: "wlan0",
+		conn,
+		hw: "Realtek RTL8812AU",
+		available: new Map(),
+		saved: {},
+		hotspot: {
+			conn,
+			name: opts.ssid,
+			availableChannels: ["auto"],
+			warnings: {},
+		},
+	} as unknown as WifiInterface;
+}
+
+function makeContext(): RPCContext {
+	const ws = {
+		send: () => {},
+		data: { isAuthenticated: true, lastActive: Date.now() },
+	} as unknown as AppWebSocket;
+	return {
+		ws,
+		isAuthenticated: () => true,
+		authenticate: () => {},
+		deauthenticate: () => {},
+		markActive: () => {},
+		getLastActive: () => 0,
+		setSenderId: () => {},
+		getSenderId: () => undefined,
+		clearSenderId: () => {},
+	};
+}
+
+// ─── parseGatewayIp ──────────────────────────────────────────────────────────
+
+describe("parseGatewayIp", () => {
+	test("strips the CIDR prefix from an nmcli IPv4 address", () => {
+		expect(parseGatewayIp("10.42.0.1/24")).toBe("10.42.0.1");
+	});
+
+	test("returns the address unchanged when there is no prefix", () => {
+		expect(parseGatewayIp("10.42.0.1")).toBe("10.42.0.1");
+	});
+
+	test("defaults to the NM hotspot gateway when the value is empty/undefined", () => {
+		expect(parseGatewayIp(undefined)).toBe("10.42.0.1");
+		expect(parseGatewayIp("")).toBe("10.42.0.1");
+	});
+});
+
+// ─── resolveHotspotInfo — happy path (active hotspot) ────────────────────────
+
+describe("resolveHotspotInfo — active hotspot", () => {
+	test("returns ssid + stripped gateway IP + isActive, with NO password key", async () => {
+		const deps: HotspotInfoDeps = {
+			interfaces: () => ({
+				"dc:a6:32:00:00:01": makeActiveHotspotIface({ ssid: "CeraLive-AP" }),
+			}),
+			getConnIpv4Address: async () => "10.42.0.1/24",
+		};
+
+		const result = await resolveHotspotInfo(deps);
+
+		expect(result).toEqual({
+			ssid: "CeraLive-AP",
+			gatewayIp: "10.42.0.1",
+			isActive: true,
+		});
+		// G3: the surface must never carry a password.
+		expect(result).not.toHaveProperty("password");
+		// Output must validate against the public schema (which has no password).
+		expect(HotspotInfoOutput.safeParse(result).success).toBe(true);
+	});
+});
+
+// ─── resolveHotspotInfo — edge (no active hotspot) ───────────────────────────
+
+describe("resolveHotspotInfo — no active hotspot", () => {
+	test("returns isActive:false and an empty gatewayIp", async () => {
+		const deps: HotspotInfoDeps = {
+			interfaces: () => ({}),
+			// Must not be consulted when nothing is active.
+			getConnIpv4Address: async () => {
+				throw new Error("should not query IP when no hotspot is active");
+			},
+		};
+
+		const result = await resolveHotspotInfo(deps);
+
+		expect(result).toEqual({ ssid: "", gatewayIp: "", isActive: false });
+		expect(result).not.toHaveProperty("password");
+	});
+});
+
+// ─── procedure wiring (authed) ───────────────────────────────────────────────
+
+describe("wifi.hotspotInfo procedure", () => {
+	test("is callable and returns a schema-valid, password-free payload", async () => {
+		const result = await call(hotspotInfoProcedure, undefined, {
+			context: makeContext(),
+		});
+
+		expect(HotspotInfoOutput.safeParse(result).success).toBe(true);
+		expect(result).not.toHaveProperty("password");
+		expect(typeof result.isActive).toBe("boolean");
+	});
+});

--- a/apps/frontend/biome.json
+++ b/apps/frontend/biome.json
@@ -1,6 +1,6 @@
 {
 	"root": false,
-	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
 	"files": {
 		"includes": [
 			"package.json",

--- a/apps/frontend/src/lib/components/preview/PreviewCanvas.svelte
+++ b/apps/frontend/src/lib/components/preview/PreviewCanvas.svelte
@@ -25,9 +25,15 @@ import { cn } from '$lib/utils';
 
 interface Props {
 	class?: string;
+	/**
+	 * Drop the standalone card chrome (border/padding) for hosts that already
+	 * supply their own — e.g. the EncoderDialog modal (#72). Behaviour is
+	 * otherwise identical; default keeps the full Live-view card.
+	 */
+	compact?: boolean;
 }
 
-const { class: className = undefined }: Props = $props();
+const { class: className = undefined, compact = false }: Props = $props();
 
 type PreviewStatus =
 	| 'idle'
@@ -340,7 +346,8 @@ const overlayText = $derived.by(() => {
 	data-testid="preview"
 	data-status={status}
 	data-tier={tier}
-	class={cn('bg-card rounded-xl border p-4 sm:p-5', className)}
+	data-compact={compact ? 'true' : 'false'}
+	class={cn(compact ? undefined : 'bg-card rounded-xl border p-4 sm:p-5', className)}
 >
 	<div class="mb-3 flex items-center gap-2">
 		<Eye aria-hidden="true" class="text-primary size-4 shrink-0" />

--- a/apps/frontend/src/lib/helpers/NetworkHelper.test.ts
+++ b/apps/frontend/src/lib/helpers/NetworkHelper.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { generateDeviceAccessQr } from "./NetworkHelper";
+
+describe("NetworkHelper", () => {
+	describe("generateDeviceAccessQr", () => {
+		it("should generate a data URL QR code for a valid device URL", async () => {
+			const result = await generateDeviceAccessQr("http://10.42.0.1/");
+			expect(result).toMatch(/^data:image\/png;base64,/);
+		});
+
+		it("should throw on empty string input", async () => {
+			await expect(generateDeviceAccessQr("")).rejects.toThrow();
+		});
+	});
+});

--- a/apps/frontend/src/lib/helpers/NetworkHelper.ts
+++ b/apps/frontend/src/lib/helpers/NetworkHelper.ts
@@ -368,3 +368,12 @@ export async function generateWifiQr(
 		width: 256,
 	});
 }
+
+export async function generateDeviceAccessQr(url: string): Promise<string> {
+	if (!url) throw new Error("Device URL is required");
+
+	return QRCode.toDataURL(url, {
+		errorCorrectionLevel: "H",
+		width: 256,
+	});
+}

--- a/apps/frontend/src/lib/rpc/client.ts
+++ b/apps/frontend/src/lib/rpc/client.ts
@@ -15,6 +15,7 @@ import type {
 	CompletePairingOutput,
 	GetEngineOutput,
 	HotspotConfigInput,
+	HotspotInfo,
 	HotspotToggleInput,
 	KioskConfigureInput,
 	KioskConfigureOutput,
@@ -514,6 +515,7 @@ export interface TypedRPC {
 		hotspotStart: (input: HotspotToggleInput) => Promise<SuccessResponse>;
 		hotspotStop: (input: HotspotToggleInput) => Promise<SuccessResponse>;
 		hotspotConfigure: (input: HotspotConfigInput) => Promise<SuccessResponse>;
+		hotspotInfo: () => Promise<HotspotInfo>;
 	};
 	network: {
 		getInterfaces: () => Promise<unknown>;

--- a/apps/frontend/src/main/dialogs/EncoderDialog.preview.test.ts
+++ b/apps/frontend/src/main/dialogs/EncoderDialog.preview.test.ts
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+/**
+ * EncoderDialog — live preview mount (#72).
+ *
+ * The encoder dialog hosts the SAME `PreviewCanvas` used on the Live view, in a
+ * constrained `compact` form so the modal doesn't double up the card chrome the
+ * dialog already provides. The preview owns its own WebSocket + toggle, so the
+ * dialog only has to mount it near the source/codec controls and rely on the
+ * component's effect-cleanup for teardown.
+ *
+ * Coverage:
+ *  1. The compact PreviewCanvas renders inside the open dialog.
+ *  2. Toggling the preview mounts the canvas + audio meter WITHOUT closing the
+ *     dialog (the toggle is local to the component, not a dialog action).
+ *  3. Unmounting the dialog tears the preview socket down (no stale WebSocket
+ *     leaks across dialog open/close).
+ */
+import { fireEvent, render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import {
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+
+import EncoderDialog from "./EncoderDialog.svelte";
+
+// EncoderDialog reads exclusively through the subscriptions surface; an all-empty
+// snapshot is the pre-capability state the real LiveView mounts it in, and every
+// ValidationAdapter helper is undefined-safe for it.
+vi.mock("$lib/rpc/subscriptions.svelte", () => ({
+	getPipelines: () => undefined,
+	getCapabilities: () => undefined,
+	getDevices: () => undefined,
+	getIsStreaming: () => false,
+	getConfig: () => undefined,
+}));
+
+// Save-path only — never invoked by a render/toggle test. Mocking it keeps the
+// SystemHelper → rpc/WebSocket chain out of the component test entirely.
+vi.mock("$lib/components/streaming/StreamingUtils", () => ({
+	normalizeValue: (value: number) => value,
+	updateMaxBitrate: vi.fn(),
+}));
+
+// A minimal in-memory WebSocket so toggling the preview on never opens a real
+// socket; mirrors the PreviewCanvas unit test's fake.
+class FakeWebSocket {
+	static instances: FakeWebSocket[] = [];
+	binaryType = "blob";
+	onopen: ((e: unknown) => void) | null = null;
+	onmessage: ((e: unknown) => void) | null = null;
+	onerror: ((e: unknown) => void) | null = null;
+	onclose: ((e: unknown) => void) | null = null;
+	readyState = 0;
+	sent: unknown[] = [];
+	constructor(public url: string) {
+		FakeWebSocket.instances.push(this);
+	}
+	send(data: unknown): void {
+		this.sent.push(data);
+	}
+	close(): void {
+		this.readyState = 3;
+	}
+}
+
+function previewSection(): HTMLElement | null {
+	return document.body.querySelector<HTMLElement>('[data-testid="preview"]');
+}
+
+beforeAll(() => {
+	// The bitrate Slider (bits-ui) installs a ResizeObserver, absent in jsdom.
+	if (!("ResizeObserver" in window)) {
+		(window as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+			observe(): void {}
+			unobserve(): void {}
+			disconnect(): void {}
+		};
+	}
+	// AppDialog selects Dialog vs Sheet via `new MediaQuery(...)` → matchMedia,
+	// absent in jsdom. Force the desktop Dialog branch (portaled to body).
+	if (!window.matchMedia) {
+		window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+			matches: true,
+			media: query,
+			onchange: null,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		}));
+	}
+});
+
+beforeEach(() => {
+	vi.stubGlobal(
+		"VideoDecoder",
+		class {
+			state = "configured";
+			configure(): void {}
+			decode(): void {}
+			close(): void {}
+		},
+	);
+	vi.stubGlobal("WebSocket", FakeWebSocket);
+});
+
+afterEach(() => {
+	FakeWebSocket.instances = [];
+	vi.unstubAllGlobals();
+});
+
+describe("EncoderDialog — live preview (#72)", () => {
+	it("mounts a compact PreviewCanvas inside the open dialog", () => {
+		render(EncoderDialog, { props: { open: true } });
+
+		const preview = previewSection();
+		expect(preview, "preview must render inside the dialog").not.toBeNull();
+		// Compact form: the dialog supplies the chrome, so the preview drops its
+		// own card border/padding and flags it for downstream styling/QA.
+		expect(preview?.getAttribute("data-compact")).toBe("true");
+		// Toggle is present but the preview is OFF until the operator enables it.
+		expect(
+			document.body.querySelector('[data-testid="preview-toggle"]'),
+		).not.toBeNull();
+		expect(
+			document.body.querySelector('[data-testid="preview-canvas"]'),
+		).toBeNull();
+	});
+
+	it("toggles the preview on without closing the dialog", async () => {
+		render(EncoderDialog, { props: { open: true } });
+
+		const toggle = document.body.querySelector<HTMLElement>(
+			'[data-testid="preview-toggle"]',
+		);
+		expect(toggle).not.toBeNull();
+		await fireEvent.click(toggle as HTMLElement);
+		await tick();
+
+		// Media surface + audio meter mount in-place…
+		expect(
+			document.body.querySelector('[data-testid="preview-canvas"]'),
+		).not.toBeNull();
+		expect(
+			document.body.querySelector('[data-testid="audio-level-meter"]'),
+		).not.toBeNull();
+		// …and the dialog is still open (the toggle is component-local).
+		expect(document.body.querySelector('[role="dialog"]')).not.toBeNull();
+		expect(previewSection()).not.toBeNull();
+
+		// The session handshake is sent on socket open.
+		const ws = FakeWebSocket.instances.at(-1);
+		expect(ws).toBeDefined();
+		ws?.onopen?.({});
+		expect(ws?.sent).toContain(
+			JSON.stringify({ action: "start", tier: "webcodecs" }),
+		);
+	});
+
+	it("tears the preview socket down when the dialog unmounts", async () => {
+		const view = render(EncoderDialog, { props: { open: true } });
+
+		await fireEvent.click(
+			document.body.querySelector(
+				'[data-testid="preview-toggle"]',
+			) as HTMLElement,
+		);
+		await tick();
+		const ws = FakeWebSocket.instances.at(-1);
+		const closeSpy = vi.spyOn(ws as FakeWebSocket, "close");
+
+		view.unmount();
+		await tick();
+
+		expect(closeSpy).toHaveBeenCalled();
+	});
+});

--- a/apps/frontend/src/main/dialogs/EncoderDialog.svelte
+++ b/apps/frontend/src/main/dialogs/EncoderDialog.svelte
@@ -50,6 +50,7 @@ import { BITRATE_DEFAULT_MIN, type Pipeline } from '@ceraui/rpc/schemas';
 
 import LabeledSwitch from '$lib/components/custom/LabeledSwitch.svelte';
 import AppDialog from '$lib/components/dialogs/AppDialog.svelte';
+import PreviewCanvas from '$lib/components/preview/PreviewCanvas.svelte';
 import {
 	bitrateBoundsFromCaps,
 	deriveCodecOptions,
@@ -320,6 +321,11 @@ function handleSave() {
 				{/each}
 			</div>
 		</div>
+
+		<!-- Live preview (#72): the same PreviewCanvas as the Live view, compact so
+		     the dialog supplies the chrome. Active-encode-only — it owns its socket
+		     + toggle and tears down on dialog close (unmount). -->
+		<PreviewCanvas compact />
 
 		<!-- Resolution: every rung is shown; rungs outside the capability-offered
 		     set render disabled (aria-disabled + reason title), never hidden. -->

--- a/apps/frontend/src/main/dialogs/HotspotDialog.svelte
+++ b/apps/frontend/src/main/dialogs/HotspotDialog.svelte
@@ -32,6 +32,8 @@ import {
 } from '$lib/helpers/NetworkHelper';
 import { cn } from '$lib/utils';
 
+import ConnectPhoneSection from './hotspot/ConnectPhoneSection.svelte';
+
 interface Props {
 	open?: boolean;
 	/** WiFi interface device key (record key in the wifi status map). */
@@ -340,6 +342,9 @@ async function copyPassword() {
 				{/if}
 			</div>
 		{/if}
+
+		<!-- Connect-your-phone: device URL + device-access QR (own RPC source) -->
+		<ConnectPhoneSection />
 	</div>
 
 	{#snippet actions()}

--- a/apps/frontend/src/main/dialogs/hotspot/ConnectPhoneSection.svelte
+++ b/apps/frontend/src/main/dialogs/hotspot/ConnectPhoneSection.svelte
@@ -1,0 +1,114 @@
+<!--
+  ConnectPhoneSection.svelte — "connect your phone" surface inside HotspotDialog
+  (#67 Phase-0).
+
+  Calls `wifi.hotspotInfo` (SSID + gateway IP + active flag — NEVER a password,
+  guardrail G3) and, when the hotspot is broadcasting, renders the on-device URL
+  (`http://<gatewayIp>/`) plus a device-access QR so a phone can open CeraUI after
+  joining the hotspot. Captive-portal is image-side and out of scope here, so a
+  visible "navigate manually" note replaces it. When the hotspot is off (or no
+  gateway is known yet) the section shows a calm "start the hotspot first" prompt
+  instead of a broken QR.
+
+  This sits ALONGSIDE the existing WiFi-join QR (live credentials) in
+  HotspotDialog — it does not replace or modify it. The two QRs answer different
+  questions: "how do I join the hotspot" vs "how do I open the control UI".
+-->
+<script lang="ts">
+import { LL } from '@ceraui/i18n/svelte';
+import type { HotspotInfo } from '@ceraui/rpc/schemas';
+import { Smartphone } from '@lucide/svelte';
+
+import { generateDeviceAccessQr } from '$lib/helpers/NetworkHelper';
+import { rpc } from '$lib/rpc/client';
+
+// ── Hotspot info (SSID + gateway IP + active flag; no password by contract) ──
+let info = $state<HotspotInfo | null>(null);
+$effect(() => {
+	let cancelled = false;
+	rpc.wifi
+		.hotspotInfo()
+		.then((result) => {
+			if (!cancelled) info = result;
+		})
+		.catch(() => {
+			if (!cancelled) info = { ssid: '', gatewayIp: '', isActive: false };
+		});
+	return () => {
+		cancelled = true;
+	};
+});
+
+// Active = broadcasting AND we know the gateway to point the phone at.
+const active = $derived(Boolean(info?.isActive && info.gatewayIp));
+
+// Port 80 is served by the on-device reverse proxy in production, so the URL is
+// the bare gateway origin — no port literal (which would be a dev-only artifact).
+const deviceUrl = $derived(active ? `http://${info?.gatewayIp}/` : '');
+
+// ── Device-access QR encodes the URL only — never a credential ──
+let qrDataUrl = $state('');
+$effect(() => {
+	if (!deviceUrl) {
+		qrDataUrl = '';
+		return;
+	}
+	generateDeviceAccessQr(deviceUrl)
+		.then((url) => {
+			qrDataUrl = url;
+		})
+		.catch(() => {
+			qrDataUrl = '';
+		});
+});
+</script>
+
+<div class="space-y-2" data-testid="connect-phone-section">
+	<div class="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
+		<Smartphone class="size-3.5" />
+		<span>{$LL.network.hotspot.connectPhoneTitle()}</span>
+	</div>
+
+	{#if active}
+		<div class="bg-muted/40 flex flex-col items-center gap-3 rounded-lg border p-4">
+			<p class="text-muted-foreground text-center text-xs">
+				{$LL.network.hotspot.connectPhoneInstructions()}
+			</p>
+
+			{#if qrDataUrl}
+				<img
+					class="size-40 rounded-md bg-white p-2"
+					alt={$LL.network.hotspot.deviceAccessQrLabel()}
+					data-testid="device-access-qr"
+					src={qrDataUrl}
+				/>
+			{/if}
+
+			<!-- dir="ltr": the URL is always Latin/ASCII; never mirror it under RTL. -->
+			<a
+				class="text-primary text-sm font-medium underline-offset-4 hover:underline"
+				data-testid="device-access-url"
+				dir="ltr"
+				href={deviceUrl}
+				rel="noreferrer"
+				target="_blank"
+			>
+				{deviceUrl}
+			</a>
+
+			<p
+				class="text-muted-foreground text-center text-xs"
+				data-testid="navigate-manually-note"
+			>
+				{$LL.network.hotspot.navigateManuallyNote()}
+			</p>
+		</div>
+	{:else}
+		<div
+			class="bg-muted/40 text-muted-foreground rounded-lg border px-3 py-4 text-center text-xs"
+			data-testid="hotspot-off-prompt"
+		>
+			{$LL.network.hotspot.hotspotOffPrompt()}
+		</div>
+	{/if}
+</div>

--- a/apps/frontend/src/main/dialogs/hotspot/ConnectPhoneSection.test.ts
+++ b/apps/frontend/src/main/dialogs/hotspot/ConnectPhoneSection.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+/**
+ * ConnectPhoneSection — "connect your phone" surface in HotspotDialog (#67 Phase-0).
+ *
+ * The section calls `wifi.hotspotInfo` (SSID + gateway IP + active flag — NEVER a
+ * password, guardrail G3) and, when the hotspot is live, renders the on-device URL
+ * (`http://<gatewayIp>/`) plus a device-access QR so a phone can open CeraUI after
+ * joining the hotspot. Captive-portal is out of scope, so a visible "navigate
+ * manually" note replaces it. When the hotspot is off (or no gateway is known) the
+ * section shows a calm "start the hotspot first" prompt instead of a broken QR.
+ *
+ * Contract locked here:
+ *   1. Active   — device URL text "http://10.42.0.1/", a device-access QR image,
+ *                 and the navigate-manually note; the QR is generated from the URL,
+ *                 never from a password. No off-prompt.
+ *   2. Inactive — the off-prompt renders; no QR is generated, no URL is shown.
+ *   3. RTL-safe — the URL element carries dir="ltr" so it is never mirrored.
+ */
+
+import { render, waitFor } from "@testing-library/svelte";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { generateDeviceAccessQr } from "$lib/helpers/NetworkHelper";
+import { rpc } from "$lib/rpc/client";
+
+import ConnectPhoneSection from "./ConnectPhoneSection.svelte";
+
+// Isolate from the live WebSocket RPC client — `hotspotInfo` is a per-test spy.
+vi.mock("$lib/rpc/client", () => ({
+	rpc: { wifi: { hotspotInfo: vi.fn() } },
+}));
+
+// Stub the QR generator so the section stays hermetic (no real canvas/QRCode run)
+// and we can assert exactly what was encoded.
+vi.mock("$lib/helpers/NetworkHelper", () => ({
+	generateDeviceAccessQr: vi.fn(async () => "data:image/png;base64,DEVICEQR"),
+}));
+
+const hotspotInfo = vi.mocked(rpc.wifi.hotspotInfo);
+const deviceQr = vi.mocked(generateDeviceAccessQr);
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	deviceQr.mockResolvedValue("data:image/png;base64,DEVICEQR");
+});
+
+describe("ConnectPhoneSection — connect-your-phone (#67 Phase-0)", () => {
+	it("renders the device URL + device-access QR when the hotspot is active", async () => {
+		hotspotInfo.mockResolvedValue({
+			ssid: "CeraLive-Hotspot",
+			gatewayIp: "10.42.0.1",
+			isActive: true,
+		});
+
+		const { getByTestId, queryByTestId } = render(ConnectPhoneSection);
+
+		const url = await waitFor(() => getByTestId("device-access-url"));
+		expect(url.textContent).toContain("http://10.42.0.1/");
+
+		const qr = await waitFor(() => getByTestId("device-access-qr"));
+		expect(qr.getAttribute("src")).toBe("data:image/png;base64,DEVICEQR");
+
+		// The QR encodes the device URL — never a credential.
+		expect(deviceQr).toHaveBeenCalledWith("http://10.42.0.1/");
+
+		// Captive-portal is out: the manual-navigation note must be visible.
+		expect(getByTestId("navigate-manually-note")).toBeTruthy();
+
+		// Active state never shows the off prompt.
+		expect(queryByTestId("hotspot-off-prompt")).toBeNull();
+	});
+
+	it("shows the off prompt and no QR when the hotspot is inactive", async () => {
+		hotspotInfo.mockResolvedValue({
+			ssid: "",
+			gatewayIp: "",
+			isActive: false,
+		});
+
+		const { getByTestId, queryByTestId } = render(ConnectPhoneSection);
+
+		await waitFor(() => expect(hotspotInfo).toHaveBeenCalledTimes(1));
+		await waitFor(() => getByTestId("hotspot-off-prompt"));
+
+		expect(queryByTestId("device-access-qr")).toBeNull();
+		expect(queryByTestId("device-access-url")).toBeNull();
+		// No URL → no QR encode attempt (no broken image).
+		expect(deviceQr).not.toHaveBeenCalled();
+	});
+
+	it("wraps the URL element in dir=ltr for RTL safety", async () => {
+		hotspotInfo.mockResolvedValue({
+			ssid: "CeraLive-Hotspot",
+			gatewayIp: "10.42.0.1",
+			isActive: true,
+		});
+
+		const { getByTestId } = render(ConnectPhoneSection);
+
+		const url = await waitFor(() => getByTestId("device-access-url"));
+		expect(url.getAttribute("dir")).toBe("ltr");
+	});
+});

--- a/apps/frontend/tests/e2e/encoder-preview.spec.ts
+++ b/apps/frontend/tests/e2e/encoder-preview.spec.ts
@@ -1,0 +1,130 @@
+import { expect, type Page, test } from "@playwright/test";
+
+import {
+	expectNoOrphanPreviewSocket,
+	injectServerConfig,
+	installPreviewHarness,
+	loadE2EToken,
+	previewConfig,
+	previewFail,
+	previewSocketCount,
+} from "./helpers/preview-harness";
+import { navigateTo } from "./helpers";
+
+/**
+ * EncoderDialog live preview (#72) — the SAME PreviewCanvas as the Live view,
+ * mounted compact inside the encoder config dialog. Drives the real component
+ * against the deterministic preview harness (no cerastream preview backend in
+ * e2e): toggle, in-dialog media surface, clean teardown across open/close, and
+ * the distinct `waiting` (no active encode) and `error` states.
+ *
+ * Auth reuses the field-lock/capability WebSocket harness pattern. Preview-state
+ * control comes from `helpers/preview-harness.ts`.
+ */
+
+const TOKEN = loadE2EToken();
+
+async function openEncoder(page: Page): Promise<void> {
+	await navigateTo(page, "live");
+	await expect
+		.poll(
+			async () => {
+				await injectServerConfig(page);
+				return page.getByTestId("open-encoder-dialog").isVisible().catch(() => false);
+			},
+			{
+				timeout: 10_000,
+				message: "encoder edit row should render once a server config is present",
+			},
+		)
+		.toBe(true);
+	await page.getByTestId("open-encoder-dialog").click();
+	await expect(page.getByRole("dialog", { name: "Encoder Settings" })).toBeVisible();
+}
+
+function dialog(page: Page) {
+	return page.getByRole("dialog", { name: "Encoder Settings" });
+}
+
+test.describe("EncoderDialog live preview (#72)", () => {
+	test.skip(({ browserName }) => browserName !== "chromium", "single-browser preview proof");
+	test.skip(!TOKEN, "requires a backend persistent auth token");
+
+	test.beforeEach(async ({ page }, testInfo) => {
+		test.skip(testInfo.project.name !== "desktop", "desktop layout drives the encoder dialog");
+		await page.addInitScript(installPreviewHarness, TOKEN as string);
+		await page.goto("/");
+	});
+
+	test("toggles a compact preview with canvas + audio meter inside the dialog", async ({
+		page,
+	}) => {
+		await openEncoder(page);
+		const modal = dialog(page);
+
+		// The preview mounts compact (host supplies the chrome) and is off by default.
+		const preview = modal.getByTestId("preview");
+		await expect(preview).toBeVisible();
+		await expect(preview).toHaveAttribute("data-compact", "true");
+		await expect(modal.getByTestId("preview-canvas")).toBeHidden();
+
+		await modal.getByTestId("preview-toggle").click();
+
+		// Media surface + audio meter render IN the dialog, which stays open.
+		await expect(modal.getByTestId("preview-canvas")).toBeVisible();
+		await expect(modal.getByTestId("audio-level-meter")).toBeVisible();
+		await expect(modal).toBeVisible();
+	});
+
+	test("reopening the dialog leaves no orphaned preview socket or console error", async ({
+		page,
+	}) => {
+		const consoleErrors: string[] = [];
+		page.on("console", (msg) => {
+			if (msg.type() === "error") consoleErrors.push(msg.text());
+		});
+
+		await openEncoder(page);
+		await dialog(page).getByTestId("preview-toggle").click();
+		await expect(dialog(page).getByTestId("preview-canvas")).toBeVisible();
+		expect(await previewSocketCount(page)).toBe(1);
+
+		// Close → the preview unmounts and tears its socket down.
+		await page.keyboard.press("Escape");
+		await expect(dialog(page)).toBeHidden();
+		await expectNoOrphanPreviewSocket(page);
+
+		// Reopen → a fresh session, not a leaked second one stacked on the first.
+		await page.getByTestId("open-encoder-dialog").click();
+		await expect(dialog(page)).toBeVisible();
+		await dialog(page).getByTestId("preview-toggle").click();
+		await expect(dialog(page).getByTestId("preview-canvas")).toBeVisible();
+		expect(await previewSocketCount(page)).toBe(2);
+
+		expect(consoleErrors, consoleErrors.join("\n")).toHaveLength(0);
+	});
+
+	test("surfaces the waiting state with no active encode", async ({ page }) => {
+		await openEncoder(page);
+		const preview = dialog(page).getByTestId("preview");
+
+		await dialog(page).getByTestId("preview-toggle").click();
+		// Socket up + codec configured, but no access units flow (no active encode).
+		await previewConfig(page);
+
+		await expect(preview).toHaveAttribute("data-status", "waiting");
+		await expect(preview).toContainText(/waiting for video/i);
+	});
+
+	test("surfaces a distinct error state on a failed preview pipeline", async ({ page }) => {
+		await openEncoder(page);
+		const preview = dialog(page).getByTestId("preview");
+
+		await dialog(page).getByTestId("preview-toggle").click();
+		await previewConfig(page);
+		await previewFail(page);
+
+		await expect(preview).toHaveAttribute("data-status", "error");
+		await expect(preview).toContainText(/preview unavailable/i);
+	});
+});

--- a/apps/frontend/tests/e2e/helpers/preview-harness.ts
+++ b/apps/frontend/tests/e2e/helpers/preview-harness.ts
@@ -1,0 +1,235 @@
+/**
+ * Preview WebSocket + WebCodecs harness for the EncoderDialog live-preview specs
+ * (#72). cerastream serves the preview socket directly on its own port (9997),
+ * which the e2e mock backend does NOT run — so the real PreviewCanvas would only
+ * ever reach the transient `reconnecting` state. This harness lets a spec drive
+ * the component through its real states deterministically, with NO network dial:
+ *
+ *   • `installPreviewHarness(token)` (an `addInitScript` payload) replaces
+ *     `window.WebSocket` with a factory that hooks the RPC socket (auth-login
+ *     token rewrite, exactly like the field-lock/capability harness) and returns
+ *     a fully in-page fake for the preview socket (matched by the `:9997` port).
+ *   • It also installs a controllable `VideoDecoder` so the WebCodecs tier is
+ *     selected and `configure()`/decode-error are deterministic.
+ *   • Control surface on `window.__ceraPreview`: `config()` (codec-config →
+ *     `waiting`), `audio(rms, peak)` (audio-level event), `fail()` (decoder error
+ *     → `error`), plus `created` / `socket` for orphaned-socket assertions.
+ *
+ * The harness never references anything outside its own body so Playwright can
+ * serialize it for `addInitScript`.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+import { expect, type Page } from "@playwright/test";
+
+/** Load the seeded persistent auth token, or `null` when only the placeholder exists. */
+export function loadE2EToken(): string | null {
+	try {
+		const tokensPath = path.resolve(
+			import.meta.dirname,
+			"../../../../backend/auth_tokens.json",
+		);
+		const tokens = Object.keys(
+			JSON.parse(fs.readFileSync(tokensPath, "utf8")) as Record<string, true>,
+		).filter((key) => key !== "placeholder");
+		return tokens[0] ?? null;
+	} catch {
+		return null;
+	}
+}
+
+/** `addInitScript` payload — must be self-contained (no closed-over references). */
+export function installPreviewHarness(token: string): void {
+	// biome-ignore lint/suspicious/noExplicitAny: browser harness glue.
+	const w = window as any;
+	if (w.__ceraPreview) return;
+	const Real = w.WebSocket;
+	const PREVIEW_PORT = "9997";
+
+	w.__ceraPreview = {
+		socket: null,
+		rpcSocket: null,
+		created: 0,
+		_errorCb: null,
+		open() {
+			w.__ceraPreview.socket?.onopen?.({});
+		},
+		// Push a manual server config over the RPC socket so LiveView leaves its
+		// empty state and renders the encoder edit row (the mock login snapshot
+		// has no server). Mirrors the capability spec's `injectBroadcast`.
+		injectConfig() {
+			w.__ceraPreview.rpcSocket?.dispatchEvent(
+				new MessageEvent("message", {
+					data: JSON.stringify({
+						config: {
+							srtla_addr: "127.0.0.1",
+							srtla_port: 5000,
+							pipeline: "hdmi",
+							max_br: 6000,
+						},
+					}),
+				}),
+			);
+		},
+		config() {
+			w.__ceraPreview.socket?.onmessage?.({
+				data: JSON.stringify({
+					type: "codec-config",
+					codec: "avc1.42E01E",
+					coded_width: 1280,
+					coded_height: 720,
+				}),
+			});
+		},
+		audio(rms: number[], peak: number[]) {
+			w.__ceraPreview.socket?.onmessage?.({
+				data: JSON.stringify({ type: "audio-level", rms_db: rms, peak_db: peak }),
+			});
+		},
+		fail() {
+			w.__ceraPreview._errorCb?.(new Error("decode failed"));
+		},
+	};
+
+	class FakeVideoDecoder {
+		state = "unconfigured";
+		// biome-ignore lint/suspicious/noExplicitAny: VideoDecoderInit shape.
+		constructor(init: any) {
+			w.__ceraPreview._errorCb = init.error;
+		}
+		configure(): void {
+			this.state = "configured";
+		}
+		decode(): void {}
+		close(): void {
+			this.state = "closed";
+		}
+	}
+	w.VideoDecoder = FakeVideoDecoder;
+
+	class FakePreviewSocket {
+		url: string;
+		binaryType = "blob";
+		readyState = 1;
+		onopen: ((e: unknown) => void) | null = null;
+		onmessage: ((e: unknown) => void) | null = null;
+		onerror: ((e: unknown) => void) | null = null;
+		onclose: ((e: unknown) => void) | null = null;
+		sent: unknown[] = [];
+		constructor(url: string) {
+			this.url = url;
+			w.__ceraPreview.socket = this;
+			w.__ceraPreview.created += 1;
+			// Mirror a real socket: fire `open` after the caller wires its handlers.
+			queueMicrotask(() => this.onopen?.({}));
+		}
+		send(data: unknown): void {
+			this.sent.push(data);
+		}
+		close(): void {
+			this.readyState = 3;
+			w.__ceraPreview.socket = null;
+		}
+		addEventListener(): void {}
+		removeEventListener(): void {}
+	}
+
+	class HookedRpcWS extends Real {
+		// biome-ignore lint/suspicious/noExplicitAny: native ctor signature.
+		constructor(url: string, protocols?: any) {
+			super(url, protocols);
+			this.__realSend = Real.prototype.send.bind(this);
+			w.__ceraPreview.rpcSocket = this;
+		}
+		// biome-ignore lint/suspicious/noExplicitAny: WebSocket.send payload union.
+		send(data: any) {
+			try {
+				const msg = JSON.parse(data);
+				if (Array.isArray(msg.path) && msg.path.join(".") === "auth.login") {
+					msg.input = { token, persistent_token: true };
+					return this.__realSend(JSON.stringify(msg));
+				}
+			} catch {
+				/* non-RPC frame */
+			}
+			return this.__realSend(data);
+		}
+	}
+
+	// A constructor that returns an object yields that object from `new`, so the
+	// preview port routes to the fake while everything else stays a real socket.
+	// biome-ignore lint/suspicious/noExplicitAny: native ctor signature.
+	function WSFactory(this: unknown, url: string, protocols?: any) {
+		if (typeof url === "string" && url.includes(`:${PREVIEW_PORT}`)) {
+			return new FakePreviewSocket(url);
+		}
+		return new HookedRpcWS(url, protocols);
+	}
+	Object.assign(WSFactory, {
+		CONNECTING: 0,
+		OPEN: 1,
+		CLOSING: 2,
+		CLOSED: 3,
+	});
+	w.WebSocket = WSFactory;
+	try {
+		localStorage.setItem("auth", "e2e-token-marker");
+	} catch {
+		/* storage unavailable */
+	}
+}
+
+/** Inject a server config so LiveView renders the encoder edit row. */
+export function injectServerConfig(page: Page): Promise<void> {
+	return page.evaluate(() =>
+		(window as { __ceraPreview: { injectConfig: () => void } }).__ceraPreview.injectConfig(),
+	);
+}
+
+/** Drive the preview into `waiting` (codec configured, no frames yet). */
+export function previewConfig(page: Page): Promise<void> {
+	return page.evaluate(() =>
+		(window as { __ceraPreview: { config: () => void } }).__ceraPreview.config(),
+	);
+}
+
+/** Push an audio-level event so the meter renders active channels. */
+export function previewAudio(page: Page, rms: number[], peak: number[]): Promise<void> {
+	return page.evaluate(
+		([r, p]) =>
+			(
+				window as { __ceraPreview: { audio: (r: number[], p: number[]) => void } }
+			).__ceraPreview.audio(r, p),
+		[rms, peak] as const,
+	);
+}
+
+/** Drive the preview into the hard `error` state via a decoder failure. */
+export function previewFail(page: Page): Promise<void> {
+	return page.evaluate(() =>
+		(window as { __ceraPreview: { fail: () => void } }).__ceraPreview.fail(),
+	);
+}
+
+/** Number of preview sockets ever constructed (leak/orphan detection). */
+export function previewSocketCount(page: Page): Promise<number> {
+	return page.evaluate(
+		() => (window as { __ceraPreview: { created: number } }).__ceraPreview.created,
+	);
+}
+
+/** Assert no live preview socket remains (the component tore it down). */
+export async function expectNoOrphanPreviewSocket(page: Page): Promise<void> {
+	await expect
+		.poll(
+			() =>
+				page.evaluate(
+					() =>
+						(window as { __ceraPreview: { socket: unknown } }).__ceraPreview
+							.socket === null,
+				),
+			{ message: "preview socket should be torn down on dialog close" },
+		)
+		.toBe(true);
+}

--- a/apps/frontend/tests/e2e/liveview-preview.spec.ts
+++ b/apps/frontend/tests/e2e/liveview-preview.spec.ts
@@ -1,0 +1,179 @@
+import path from 'node:path';
+
+import type { Page, WebSocketRoute } from '@playwright/test';
+
+import { expect, test } from './fixtures/index.js';
+import { ensureAuthenticated, navigateTo } from './helpers/index.js';
+
+/**
+ * #72 — LiveView preview placement verification.
+ *
+ * Proves the already-shipped local preview meets the issue's intent against the
+ * real frontend in a browser:
+ *   1. <PreviewCanvas> (data-testid="preview") renders DIRECTLY under the
+ *      <InputPicker> device selector (data-testid="input-picker") in LiveView.
+ *   2. The preview toggle is operable (aria-pressed flips, canvas mounts).
+ *   3. The audio level meter mounts when the preview is on.
+ *   4. With no active encode the preview reaches the `waiting` state and shows
+ *      the i18n string live.preview.waiting ("Waiting for video…").
+ *
+ * Two WebSocket routes are installed:
+ *   • Backend (:3002) — proxied to the real mock backend. Status frames are
+ *     pinned to is_streaming:false (so the idle Live DOM is stable regardless of
+ *     what other workers broadcast via dev.emit), and a server `config` frame is
+ *     injected after navigation so the Live view leaves its empty state and
+ *     renders the InputPicker + PreviewCanvas siblings.
+ *   • Preview (:9997) — cerastream serves the preview WS here; it is unserved
+ *     under the mock stack, so we mock it: on the client's {action:"start"} we
+ *     reply with a codec-config (→ decoder configured → status "waiting") and an
+ *     audio-level frame, leaving the socket frame-less. With no video access
+ *     units the terminal state is "waiting" — exactly the no-active-encode case.
+ *
+ * The two @visual tests capture repo-local evidence PNGs (gitignored); the
+ * functional tests carry the real assertions and run under the @visual-excluded
+ * gate.
+ */
+
+// CeraUI repo-root test-results (gitignored). e2e -> tests -> frontend -> apps -> CeraUI.
+const EVIDENCE_DIR = path.resolve(import.meta.dirname, '../../../../test-results');
+
+const SERVER_CONFIG = {
+	srtla_addr: '127.0.0.1',
+	srtla_port: 5000,
+	srt_streamid: 'e2e',
+	max_br: 5000,
+};
+
+let pageWs: WebSocketRoute | null = null;
+
+/** Proxy the backend WS, force is_streaming:false on status frames. */
+async function routeBackend(page: Page): Promise<void> {
+	await page.routeWebSocket(/:3002/, (ws) => {
+		pageWs = ws;
+		const server = ws.connectToServer();
+		ws.onMessage((m) => server.send(m));
+		server.onMessage((m) => {
+			const text = typeof m === 'string' ? m : m.toString();
+			try {
+				const frame = JSON.parse(text) as { status?: Record<string, unknown> };
+				if (frame?.status?.is_streaming) {
+					frame.status.is_streaming = false;
+					ws.send(JSON.stringify(frame));
+					return;
+				}
+			} catch {
+				/* binary / non-JSON frame */
+			}
+			ws.send(m);
+		});
+	});
+}
+
+/** Inject a server config frame so the Live view leaves its empty state. */
+function injectServerConfig(): void {
+	pageWs?.send(JSON.stringify({ config: SERVER_CONFIG }));
+}
+
+/** Mock the cerastream preview WS: codec-config + one audio-level frame. */
+async function routePreview(page: Page): Promise<void> {
+	await page.routeWebSocket(/:9997/, (ws) => {
+		ws.onMessage((message) => {
+			const text = typeof message === 'string' ? message : message.toString();
+			let parsed: { action?: string };
+			try {
+				parsed = JSON.parse(text);
+			} catch {
+				return;
+			}
+			if (parsed?.action !== 'start') return;
+			ws.send(JSON.stringify({ type: 'codec-config', codec: 'avc1.42E01E' }));
+			ws.send(JSON.stringify({ type: 'audio-level', rms_db: [-18, -24], peak_db: [-6, -11] }));
+		});
+	});
+}
+
+test.describe('LiveView preview placement (#72)', () => {
+	test.beforeEach(async ({ page }) => {
+		pageWs = null;
+		await routeBackend(page);
+		await routePreview(page);
+		await page.goto('/');
+		await ensureAuthenticated(page);
+		await navigateTo(page, 'live');
+		injectServerConfig();
+	});
+
+	test('PreviewCanvas renders directly under the InputPicker, toggle + meter operable', async ({
+		page,
+	}) => {
+		const picker = page.getByTestId('input-picker');
+		const preview = page.getByTestId('preview');
+		await expect(picker).toBeVisible();
+		await expect(preview).toBeVisible();
+
+		// DOM proof: preview follows the picker in document order AND the picker's
+		// card is the element immediately preceding the preview section.
+		const adjacency = await page.evaluate(() => {
+			const p = document.querySelector('[data-testid="input-picker"]');
+			const v = document.querySelector('[data-testid="preview"]');
+			if (!p || !v) return 'missing';
+			const follows = !!(p.compareDocumentPosition(v) & Node.DOCUMENT_POSITION_FOLLOWING);
+			const card = v.previousElementSibling;
+			const adjacent = !!card && card.contains(p);
+			return follows && adjacent ? 'ok' : `follows=${follows} adjacent=${adjacent}`;
+		});
+		expect(adjacency).toBe('ok');
+
+		// Toggle the preview on: aria-pressed flips, canvas + audio meter mount.
+		const toggle = page.getByTestId('preview-toggle');
+		await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+		await toggle.click();
+		await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+
+		await expect(page.getByTestId('preview-canvas')).toBeVisible();
+		await expect(page.getByTestId('audio-level-meter')).toBeVisible();
+	});
+
+	test('no active encode → preview reaches the waiting state with the i18n string', async ({
+		page,
+	}) => {
+		const preview = page.getByTestId('preview');
+		await expect(preview).toBeVisible();
+		await page.getByTestId('preview-toggle').click();
+
+		// codec-config but no video access units → terminal status is "waiting".
+		await expect(preview).toHaveAttribute('data-status', 'waiting');
+		// live.preview.waiting === "Waiting for video…" (en base locale).
+		await expect(preview).toContainText('Waiting for video');
+		// Meter still mounts in the waiting state.
+		await expect(page.getByTestId('audio-level-meter')).toBeVisible();
+	});
+
+	test('@visual evidence: preview + meter adjacent to the input selector', {
+		tag: '@visual',
+	}, async ({ page }, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop', 'desktop viewport owns evidence');
+
+		await expect(page.getByTestId('input-picker')).toBeVisible();
+		await page.getByTestId('preview-toggle').click();
+		await expect(page.getByTestId('preview-canvas')).toBeVisible();
+		await expect(page.getByTestId('audio-level-meter')).toBeVisible();
+
+		await page
+			.getByRole('main')
+			.first()
+			.screenshot({ path: path.join(EVIDENCE_DIR, '72-liveview-verify.png') });
+	});
+
+	test('@visual evidence: waiting state', { tag: '@visual' }, async ({ page }, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop', 'desktop viewport owns evidence');
+
+		const preview = page.getByTestId('preview');
+		await expect(preview).toBeVisible();
+		await page.getByTestId('preview-toggle').click();
+		await expect(preview).toHaveAttribute('data-status', 'waiting');
+		await expect(preview).toContainText('Waiting for video');
+
+		await preview.screenshot({ path: path.join(EVIDENCE_DIR, '72-waiting.png') });
+	});
+});

--- a/apps/frontend/tests/e2e/visual/connect-phone.visual.spec.ts
+++ b/apps/frontend/tests/e2e/visual/connect-phone.visual.spec.ts
@@ -1,0 +1,179 @@
+import path from "node:path";
+
+import type { Page } from "@playwright/test";
+
+import { expect, test } from "../fixtures/index.js";
+import { ensureAuthenticated, navigateTo, setLocale } from "../helpers/index.js";
+
+/**
+ * @visual evidence + functional proof for the connect-your-phone section in
+ * HotspotDialog (#67 Phase-0).
+ *
+ * The section calls `wifi.hotspotInfo` and renders the on-device URL + a
+ * device-access QR alongside the existing WiFi-join QR. srtla/nmcli never run a
+ * real hotspot under the mock, so a WebSocket proxy makes both data sources
+ * deterministic:
+ *   - the `wifi.hotspotInfo` RPC is answered locally (active vs off, by flag);
+ *   - server `status` frames get a `hotspot` injected into the WiFi map so the
+ *     existing WiFi-join QR (live credentials) renders in the active case.
+ *
+ * PNGs land in CeraUI/test-results/ (repo-local, gitignored). Tagged @visual so
+ * the screenshot guard in fixtures permits the dialog screenshots here.
+ */
+
+const EVIDENCE_DIR = path.resolve(
+	import.meta.dirname,
+	"../../../../../test-results",
+);
+
+const ACTIVE_INFO = {
+	ssid: "CeraLive-Hotspot",
+	gatewayIp: "10.42.0.1",
+	isActive: true,
+};
+const OFF_INFO = { ssid: "", gatewayIp: "", isActive: false };
+const WIFI_PASSWORD = "ceralive123";
+
+type HotspotMode = "active" | "off";
+
+/** Add a live hotspot to the first WiFi interface so the WiFi-join QR renders. */
+function injectHotspot(wifi: Record<string, Record<string, unknown>>): void {
+	const firstKey = Object.keys(wifi)[0];
+	if (!firstKey) return;
+	const iface = wifi[firstKey];
+	if (!iface) return;
+	iface.supports_hotspot = true;
+	iface.mode = "hotspot";
+	iface.hotspot = {
+		conn: "hotspot-e2e",
+		name: ACTIVE_INFO.ssid,
+		password: WIFI_PASSWORD,
+		channel: "auto",
+		available_channels: {},
+	};
+}
+
+/** Open the hotspot dialog locale-agnostically (title is translated under ar). */
+async function openHotspotDialog(page: Page): Promise<void> {
+	await page.getByTestId("open-hotspot-dialog").click();
+	await expect(page.getByRole("dialog")).toBeVisible();
+}
+
+async function closeDialog(page: Page): Promise<void> {
+	await page.keyboard.press("Escape");
+	await expect(page.getByRole("dialog")).toBeHidden();
+}
+
+test.describe("@visual connect-your-phone section (#67)", () => {
+	// Mutable across the WS proxy closure; tests flip it before (re)opening.
+	let hotspotMode: HotspotMode = "active";
+
+	test.beforeEach(async ({ page }, testInfo) => {
+		test.skip(
+			testInfo.project.name !== "desktop",
+			"desktop viewport owns the evidence",
+		);
+		hotspotMode = "active";
+
+		await page.routeWebSocket(/:(3002|8090|8091)\//, (ws) => {
+			const server = ws.connectToServer();
+
+			// client -> server: answer hotspotInfo locally; forward everything else.
+			ws.onMessage((m) => {
+				const text = typeof m === "string" ? m : m.toString();
+				try {
+					const msg = JSON.parse(text) as { id?: string; path?: string[] };
+					if (Array.isArray(msg.path) && msg.path.join(".") === "wifi.hotspotInfo") {
+						ws.send(
+							JSON.stringify({
+								id: msg.id,
+								result: hotspotMode === "active" ? ACTIVE_INFO : OFF_INFO,
+							}),
+						);
+						return;
+					}
+				} catch {
+					/* non-JSON / binary frame */
+				}
+				server.send(m);
+			});
+
+			// server -> client: inject a live hotspot into status.wifi when active.
+			server.onMessage((m) => {
+				const text = typeof m === "string" ? m : m.toString();
+				try {
+					const frame = JSON.parse(text) as {
+						status?: { wifi?: Record<string, Record<string, unknown>> };
+					};
+					if (frame?.status?.wifi && hotspotMode === "active") {
+						injectHotspot(frame.status.wifi);
+						ws.send(JSON.stringify(frame));
+						return;
+					}
+				} catch {
+					/* non-JSON / binary frame */
+				}
+				ws.send(m);
+			});
+		});
+
+		await page.goto("/");
+		await ensureAuthenticated(page);
+		await navigateTo(page, "network");
+	});
+
+	test("active: device URL + device QR render beside the WiFi-join QR", async ({
+		page,
+	}) => {
+		await openHotspotDialog(page);
+		const dialog = page.getByRole("dialog");
+		const section = dialog.getByTestId("connect-phone-section");
+
+		// Device URL is the bare reverse-proxy origin (no dev port literal).
+		const url = section.getByTestId("device-access-url");
+		await expect(url).toBeVisible();
+		await expect(url).toHaveText("http://10.42.0.1/");
+
+		// Device-access QR + the existing WiFi-join QR both present.
+		await expect(section.getByTestId("device-access-qr")).toBeVisible();
+		await expect(dialog.getByRole("img", { name: "WiFi QR code" })).toBeVisible();
+
+		// Captive-portal is out: the manual-navigation note is shown.
+		await expect(section.getByTestId("navigate-manually-note")).toBeVisible();
+
+		// G3: this section never renders the password (no field, no leaked text).
+		await expect(section.locator('input[type="password"]')).toHaveCount(0);
+		await expect(section).not.toContainText(WIFI_PASSWORD);
+
+		await page.screenshot({
+			path: path.join(EVIDENCE_DIR, "67-connect-section.png"),
+		});
+	});
+
+	test("off + RTL: URL stays dir=ltr; off prompt replaces a broken QR", async ({
+		page,
+	}) => {
+		await setLocale(page, "ar");
+		await page.reload();
+		await ensureAuthenticated(page);
+		await navigateTo(page, "network");
+
+		// Active under ar: the URL element must stay left-to-right.
+		await openHotspotDialog(page);
+		const url = page.getByRole("dialog").getByTestId("device-access-url");
+		await expect(url).toBeVisible();
+		await expect(url).toHaveAttribute("dir", "ltr");
+		await closeDialog(page);
+
+		// Off: the off-prompt replaces the device QR (no broken image).
+		hotspotMode = "off";
+		await openHotspotDialog(page);
+		const section = page.getByRole("dialog").getByTestId("connect-phone-section");
+		await expect(section.getByTestId("hotspot-off-prompt")).toBeVisible();
+		await expect(section.getByTestId("device-access-qr")).toHaveCount(0);
+
+		await page.screenshot({
+			path: path.join(EVIDENCE_DIR, "67-off-rtl.png"),
+		});
+	});
+});

--- a/apps/frontend/tests/e2e/visual/encoder-preview.visual.spec.ts
+++ b/apps/frontend/tests/e2e/visual/encoder-preview.visual.spec.ts
@@ -1,0 +1,83 @@
+import { expect, type Page, test } from "@playwright/test";
+
+import { evidencePath, navigateTo } from "../helpers/index.js";
+import {
+	injectServerConfig,
+	installPreviewHarness,
+	loadE2EToken,
+	previewAudio,
+	previewConfig,
+	previewFail,
+} from "../helpers/preview-harness";
+
+/**
+ * EncoderDialog live preview (#72) — evidence screenshots (@visual). Captures the
+ * compact preview mounted inside the encoder dialog (toggled on, audio meter
+ * active) and its distinct waiting/error states, against the deterministic
+ * preview harness. Lives under tests/e2e/visual so the screenshot guard allows
+ * `page.screenshot`; excluded from the functional `--grep-invert @visual` run.
+ */
+
+const TOKEN = loadE2EToken();
+
+async function openEncoder(page: Page): Promise<void> {
+	await navigateTo(page, "live");
+	await expect
+		.poll(
+			async () => {
+				await injectServerConfig(page);
+				return page.getByTestId("open-encoder-dialog").isVisible().catch(() => false);
+			},
+			{
+				timeout: 10_000,
+				message: "encoder edit row should render once a server config is present",
+			},
+		)
+		.toBe(true);
+	await page.getByTestId("open-encoder-dialog").click();
+	await expect(page.getByRole("dialog", { name: "Encoder Settings" })).toBeVisible();
+}
+
+test.describe("@visual EncoderDialog live preview", () => {
+	test.skip(({ browserName }) => browserName !== "chromium", "single-browser preview proof");
+	test.skip(!TOKEN, "requires a backend persistent auth token");
+
+	test.beforeEach(async ({ page }, testInfo) => {
+		test.skip(testInfo.project.name !== "desktop", "desktop layout drives the encoder dialog");
+		await page.addInitScript(installPreviewHarness, TOKEN as string);
+		await page.goto("/");
+	});
+
+	test("renders the compact preview inside the dialog @visual", async ({ page }) => {
+		await openEncoder(page);
+		const modal = page.getByRole("dialog", { name: "Encoder Settings" });
+
+		await modal.getByTestId("preview-toggle").click();
+		await expect(modal.getByTestId("preview-canvas")).toBeVisible();
+		// Active codec + audio so the meter shows live channels in the capture.
+		await previewConfig(page);
+		await previewAudio(page, [-12, -18], [-6, -9]);
+		await expect(modal.getByTestId("audio-level-meter")).toBeVisible();
+
+		await page.screenshot({ path: evidencePath("72-modal-preview.png") });
+	});
+
+	test("renders the waiting then error states @visual", async ({ page }) => {
+		await openEncoder(page);
+		const preview = page
+			.getByRole("dialog", { name: "Encoder Settings" })
+			.getByTestId("preview");
+
+		await preview.getByTestId("preview-toggle").click();
+
+		// Waiting: socket up, codec configured, no frames (no active encode).
+		await previewConfig(page);
+		await expect(preview).toHaveAttribute("data-status", "waiting");
+
+		// Error: the preview pipeline fails — a distinct, calmer surface.
+		await previewFail(page);
+		await expect(preview).toHaveAttribute("data-status", "error");
+
+		await page.screenshot({ path: evidencePath("72-modal-states.png") });
+	});
+});

--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
-	"extends": ["../biome-config/biome.json"],
+	"extends": ["@ceralive/biome-config"],
 	"files": {
 		"ignoreUnknown": true,
 		"includes": [

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,6 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+	"extends": ["../biome-config/biome.json"],
 	"files": {
 		"ignoreUnknown": true,
 		"includes": [
@@ -19,37 +20,8 @@
 			"!**/.build-cache"
 		]
 	},
-	"html": {
-		"experimentalFullSupportEnabled": true,
-		"formatter": {
-			"enabled": true,
-			"indentStyle": "tab",
-			"indentWidth": 2,
-			"lineWidth": 100,
-			"lineEnding": "lf",
-			"selfCloseVoidElements": "always"
-		}
-	},
-	"assist": { "actions": { "source": { "organizeImports": "on" } } },
-	"formatter": {
-		"enabled": true,
-		"indentStyle": "tab",
-		"indentWidth": 2,
-		"lineWidth": 100,
-		"lineEnding": "lf"
-	},
-	"javascript": {
-		"formatter": {
-			"quoteStyle": "single",
-			"semicolons": "always",
-			"trailingCommas": "all"
-		}
-	},
 	"linter": {
-		"enabled": true,
 		"rules": {
-			"recommended": true,
-
 			"style": {
 				"noParameterAssign": "error",
 				"useAsConstAssertion": "error",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.0",
-		"@ceralive/biome-config": "^1.0.0",
+		"@ceralive/biome-config": "^2026.6.1",
 		"@types/node": "^25.9.3",
 		"dotenv-cli": "^11.0.0",
 		"glob": "^13.0.6",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.0",
+		"@ceralive/biome-config": "^1.0.0",
 		"@types/node": "^25.9.3",
 		"dotenv-cli": "^11.0.0",
 		"glob": "^13.0.6",

--- a/packages/i18n/src/ar/index.ts
+++ b/packages/i18n/src/ar/index.ts
@@ -544,6 +544,13 @@ const ar = {
 			name: "الاسم",
 			channel: "القناة",
 			password: "كلمة المرور",
+			connectPhoneTitle: "اتصل بهاتفك",
+			connectPhoneInstructions:
+				"انضم إلى نقطة الاتصال، ثم افتح الرابط أدناه في متصفحك",
+			deviceAccessQrLabel: "امسح للوصول إلى CeraUI",
+			navigateManuallyNote:
+				"إذا لم تفتح الصفحة تلقائيًا، انتقل يدويًا إلى الرابط",
+			hotspotOffPrompt: "شغّل نقطة الاتصال للاتصال بهاتفك",
 		},
 		wifi: {
 			ssid: "SSID",

--- a/packages/i18n/src/de/index.ts
+++ b/packages/i18n/src/de/index.ts
@@ -796,6 +796,13 @@ const de = {
 			name: "Name",
 			channel: "Kanal",
 			password: "Passwort",
+			connectPhoneTitle: "Handy verbinden",
+			connectPhoneInstructions:
+				"Verbinde dich mit dem Hotspot und öffne dann die URL unten im Browser",
+			deviceAccessQrLabel: "Scannen, um CeraUI zu öffnen",
+			navigateManuallyNote:
+				"Falls die Seite nicht automatisch öffnet, navigiere manuell zur URL",
+			hotspotOffPrompt: "Starte den Hotspot, um dein Handy zu verbinden",
 		},
 		wifi: {
 			ssid: "SSID",

--- a/packages/i18n/src/en/index.ts
+++ b/packages/i18n/src/en/index.ts
@@ -793,6 +793,13 @@ const en = {
 			name: "Name",
 			channel: "Channel",
 			password: "Password",
+			connectPhoneTitle: "Connect Your Phone",
+			connectPhoneInstructions:
+				"Join the hotspot, then open the URL below in your browser",
+			deviceAccessQrLabel: "Scan to open CeraUI",
+			navigateManuallyNote:
+				"If the page doesn't open automatically, navigate manually to the URL",
+			hotspotOffPrompt: "Start the hotspot to connect your phone",
 		},
 		wifi: {
 			ssid: "SSID",

--- a/packages/i18n/src/es/index.ts
+++ b/packages/i18n/src/es/index.ts
@@ -810,6 +810,13 @@ const es = {
 			name: "Nombre",
 			channel: "Canal",
 			password: "Contraseña",
+			connectPhoneTitle: "Conecta tu teléfono",
+			connectPhoneInstructions:
+				"Únete al hotspot y abre la URL de abajo en tu navegador",
+			deviceAccessQrLabel: "Escanea para abrir CeraUI",
+			navigateManuallyNote:
+				"Si la página no se abre automáticamente, navega manualmente a la URL",
+			hotspotOffPrompt: "Inicia el hotspot para conectar tu teléfono",
 		},
 		wifi: {
 			ssid: "SSID",

--- a/packages/i18n/src/fr/index.ts
+++ b/packages/i18n/src/fr/index.ts
@@ -587,6 +587,13 @@ const fr = {
 			name: "Nom",
 			channel: "Canal",
 			password: "Mot de passe",
+			connectPhoneTitle: "Connecter votre téléphone",
+			connectPhoneInstructions:
+				"Rejoignez le hotspot, puis ouvrez l'URL ci-dessous dans votre navigateur",
+			deviceAccessQrLabel: "Scanner pour ouvrir CeraUI",
+			navigateManuallyNote:
+				"Si la page ne s'ouvre pas automatiquement, naviguez manuellement vers l'URL",
+			hotspotOffPrompt: "Démarrez le hotspot pour connecter votre téléphone",
 		},
 		wifi: {
 			ssid: "SSID",

--- a/packages/i18n/src/hi/index.ts
+++ b/packages/i18n/src/hi/index.ts
@@ -406,6 +406,12 @@ const hi = {
 			name: "नाम",
 			channel: "चैनल",
 			password: "पासवर्ड",
+			connectPhoneTitle: "अपना फ़ोन कनेक्ट करें",
+			connectPhoneInstructions:
+				"हॉटस्पॉट से जुड़ें, फिर नीचे दिया URL अपने ब्राउज़र में खोलें",
+			deviceAccessQrLabel: "CeraUI खोलने के लिए स्कैन करें",
+			navigateManuallyNote: "अगर पेज अपने आप नहीं खुलता, तो URL पर मैन्युअल रूप से जाएं",
+			hotspotOffPrompt: "अपना फ़ोन कनेक्ट करने के लिए हॉटस्पॉट शुरू करें",
 		},
 		wifi: {
 			ssid: "SSID",

--- a/packages/i18n/src/ja/index.ts
+++ b/packages/i18n/src/ja/index.ts
@@ -417,6 +417,14 @@ const ja = {
 			name: "名前",
 			channel: "チャンネル",
 			password: "パスワード",
+			connectPhoneTitle: "スマートフォンを接続",
+			connectPhoneInstructions:
+				"ホットスポットに接続し、下のURLをブラウザで開いてください",
+			deviceAccessQrLabel: "スキャンしてCeraUIを開く",
+			navigateManuallyNote:
+				"ページが自動的に開かない場合は、URLに手動でアクセスしてください",
+			hotspotOffPrompt:
+				"スマートフォンを接続するにはホットスポットを起動してください",
 		},
 		wifi: {
 			ssid: "SSID",

--- a/packages/i18n/src/ko/index.ts
+++ b/packages/i18n/src/ko/index.ts
@@ -410,6 +410,13 @@ const ko = {
 			name: "이름",
 			channel: "채널",
 			password: "비밀번호",
+			connectPhoneTitle: "휴대폰 연결",
+			connectPhoneInstructions:
+				"핫스팟에 연결한 후 아래 URL을 브라우저에서 여세요",
+			deviceAccessQrLabel: "스캔하여 CeraUI 열기",
+			navigateManuallyNote:
+				"페이지가 자동으로 열리지 않으면 URL로 직접 이동하세요",
+			hotspotOffPrompt: "휴대폰을 연결하려면 핫스팟을 시작하세요",
 		},
 		wifi: {
 			ssid: "SSID",

--- a/packages/i18n/src/pt-BR/index.ts
+++ b/packages/i18n/src/pt-BR/index.ts
@@ -579,6 +579,13 @@ const ptBR = {
 			name: "Nome",
 			channel: "Canal",
 			password: "Senha",
+			connectPhoneTitle: "Conectar seu celular",
+			connectPhoneInstructions:
+				"Entre no hotspot e abra a URL abaixo no seu navegador",
+			deviceAccessQrLabel: "Escaneie para abrir o CeraUI",
+			navigateManuallyNote:
+				"Se a página não abrir automaticamente, navegue manualmente para a URL",
+			hotspotOffPrompt: "Inicie o hotspot para conectar seu celular",
 		},
 		wifi: {
 			ssid: "SSID",

--- a/packages/i18n/src/zh/index.ts
+++ b/packages/i18n/src/zh/index.ts
@@ -400,6 +400,11 @@ const zh = {
 			name: "名称",
 			channel: "频道",
 			password: "密码",
+			connectPhoneTitle: "连接您的手机",
+			connectPhoneInstructions: "加入热点，然后在浏览器中打开下方的网址",
+			deviceAccessQrLabel: "扫描以打开 CeraUI",
+			navigateManuallyNote: "如果页面未自动打开，请手动导航到该网址",
+			hotspotOffPrompt: "启动热点以连接您的手机",
 		},
 		wifi: {
 			ssid: "SSID",

--- a/packages/rpc/src/schemas/wifi.schema.ts
+++ b/packages/rpc/src/schemas/wifi.schema.ts
@@ -111,6 +111,16 @@ export const hotspotConfigInputSchema = z.object({
 });
 export type HotspotConfigInput = z.infer<typeof hotspotConfigInputSchema>;
 
+// Hotspot info output schema — connect-phone surface. Deliberately carries NO
+// password: it exposes only the SSID, the device's gateway IP on the hotspot
+// subnet, and whether the hotspot is currently active (G3).
+export const HotspotInfoOutput = z.object({
+	ssid: z.string(),
+	gatewayIp: z.string(),
+	isActive: z.boolean(),
+});
+export type HotspotInfo = z.infer<typeof HotspotInfoOutput>;
+
 // WiFi operation output schema
 export const wifiOperationOutputSchema = z.object({
 	success: z.boolean(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.5.0
         version: 2.5.0
       '@ceralive/biome-config':
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^2026.6.1
+        version: 2026.6.1
       '@types/node':
         specifier: ^25.9.3
         version: 25.9.3
@@ -855,8 +855,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@ceralive/biome-config@1.0.0':
-    resolution: {integrity: sha512-FzSY0lkw1X/b3GNDJx7UY5qdJj9Jj7tw3NqBLP5C0sJ5gdgPpT2k9Wlt1WJF4SYGuX/5xtzZFMIT+nSjmoWTUA==}
+  '@ceralive/biome-config@2026.6.1':
+    resolution: {integrity: sha512-azjL0i9UJ/hASfv8abvR+Vrt+yLEahSUdOqJFfF/ats3k6/1t9wwh1fUlq+xKRbrJxEVkuUgSpXn9Jxt+bTkrg==}
 
   '@ceralive/cerastream@2026.6.1':
     resolution: {integrity: sha512-2vR69eIMo7kAYG3gbMhSRsD5RiMwxi4BJskXIR2WyB7uNKHVrZ9yi3lyzLvH2wTQKzkC0zj5tCWO+Q/FyE/p5w==}
@@ -4587,7 +4587,7 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@ceralive/biome-config@1.0.0': {}
+  '@ceralive/biome-config@2026.6.1': {}
 
   '@ceralive/cerastream@2026.6.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.5.0
         version: 2.5.0
+      '@ceralive/biome-config':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@types/node':
         specifier: ^25.9.3
         version: 25.9.3
@@ -851,6 +854,9 @@ packages:
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
+
+  '@ceralive/biome-config@1.0.0':
+    resolution: {integrity: sha512-FzSY0lkw1X/b3GNDJx7UY5qdJj9Jj7tw3NqBLP5C0sJ5gdgPpT2k9Wlt1WJF4SYGuX/5xtzZFMIT+nSjmoWTUA==}
 
   '@ceralive/cerastream@2026.6.1':
     resolution: {integrity: sha512-2vR69eIMo7kAYG3gbMhSRsD5RiMwxi4BJskXIR2WyB7uNKHVrZ9yi3lyzLvH2wTQKzkC0zj5tCWO+Q/FyE/p5w==}
@@ -4580,6 +4586,8 @@ snapshots:
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
+
+  '@ceralive/biome-config@1.0.0': {}
 
   '@ceralive/cerastream@2026.6.1':
     dependencies:


### PR DESCRIPTION
## What

Bundles two product quick-wins plus the Biome 2.5 migration:

- **#72 — live preview inside `EncoderDialog`.** The existing `PreviewCanvas` is reused via an additive `compact` prop so the live LiveView preview now also renders inside the encoder modal. An e2e test proves the preview placement.
- **#67 Phase-0 — connect-your-phone QR in `HotspotDialog`.** A new "connect your phone" section renders a device-access QR, backed by a new `wifi.hotspotInfo` RPC that returns `{ ssid, gatewayIp, isActive }` and a `generateDeviceAccessQr` helper. Connect-phone strings are added across 10 locales.
- **Biome 2.5** via the shared `@ceralive/biome-config@^2026.6.1`.

## Why

#72 lets an operator see the live feed without leaving the encoder settings. #67 removes the friction of hand-typing the hotspot SSID/address on a phone. Standardizing on the shared Biome config removes per-repo lint drift.

## How to verify

- `pnpm check && pnpm lint && pnpm test`
- Playwright e2e green (LiveView preview placement spec)
- `wifi.hotspotInfo` returns `{ ssid, gatewayIp, isActive }` and never exposes a password

## Risks

The encoder preview is active-encode-only by design — waiting/error states are handled explicitly. No `cerastream` changes; the RPC is read-only and never returns secrets.
