### PR TITLE
docs(readme): add CI/Release status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # CeraUI
 
+[![CI](https://github.com/CERALIVE/CeraUI/actions/workflows/build-check.yml/badge.svg)](https://github.com/CERALIVE/CeraUI/actions/workflows/build-check.yml)
+[![Release](https://github.com/CERALIVE/CeraUI/actions/workflows/publish-release.yml/badge.svg)](https://github.com/CERALIVE/CeraUI/actions/workflows/publish-release.yml)
+
 Web-based control interface for live video streaming with cellular bonding. Built with Svelte 5 (frontend) and Bun (backend).
 
 ## Quick Start


### PR DESCRIPTION
## What

Add CI and Release workflow status badges to the CeraUI README.md, positioned immediately after the project title.

## Why

Status badges provide at-a-glance visibility into the health of the project's CI/CD pipelines. They signal to users and contributors that the project is actively maintained and tested. This follows the badge-accuracy policy merged in root CONTRIBUTING.md (PR#18, 2026-06-16), which requires:

- Badge URLs must return HTTP 200 (verified with curl)
- Workflow filenames must be accurate and cited
- Badges must link to the actual workflow runs

## How to verify

1. Check that both badge URLs return HTTP 200:
   ```bash
   curl -sI https://github.com/CERALIVE/CeraUI/actions/workflows/build-check.yml/badge.svg | head -1
   curl -sI https://github.com/CERALIVE/CeraUI/actions/workflows/publish-release.yml/badge.svg | head -1
   ```
   Both should return `HTTP/2 200`.

2. Verify the README.md contains the badge markdown:
   ```bash
   grep -A1 'CeraUI' README.md | grep -E '\[\[CI\]|\[\[Release\]'
   ```

3. Verify only README.md changed:
   ```bash
   git diff --name-only origin/main
   ```

## Risks

- **None.** This is a documentation-only change. No code, tests, or build artifacts are affected.
- The badge URLs are verified to return HTTP 200 before commit.
- The change is minimal (3 lines added) and easily reverted if needed.