### PR TITLE
fix(packaging): retire legacy direct-R2 publish + standardize dispatch + Debian-valid version string

### DIFF
--- a/.github/workflows/publish-deb.yml
+++ b/.github/workflows/publish-deb.yml
@@ -1,0 +1,162 @@
+name: Publish ceralive-device .deb
+
+# Tag-triggered release publisher for the on-device control-plane package.
+# A `v*` tag push builds the `ceralive-device` .deb for arm64 + amd64 via the
+# canonical `scripts/build/build-debian-package.sh` recipe, attaches each arch's
+# .deb to the GitHub release, then hands off to the central index owner
+# (CERALIVE/apt-worker) via an `apt-reindex` repository_dispatch.
+#
+# This workflow does NO R2 upload and NO per-repo APT metadata generation or
+# signing. Both the object-store upload and Packages/Release/InRelease ownership
+# live in apt-worker, which pulls the .deb from the release asset, then
+# regenerates and signs once per channel (no per-repo reindex race). The legacy
+# workflow_dispatch `publish-release.yml` is left untouched for manual/beta cuts.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  NODE_VERSION: "24"
+
+permissions:
+  contents: read
+
+jobs:
+  # Derive the package version from the tag (strip the leading `v`). The build
+  # recipe reads $BUILD_VERSION first (shared-build-functions.sh::get_version),
+  # so the .deb version tracks the tag exactly.
+  resolve-version:
+    name: Resolve version from tag
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
+    steps:
+      - name: Strip leading v from tag
+        id: ver
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: ${VERSION} (from tag ${GITHUB_REF_NAME})"
+
+  build-deb:
+    name: Build ceralive-device .deb (${{ matrix.architecture }})
+    runs-on: ubuntu-latest
+    needs: resolve-version
+    strategy:
+      matrix:
+        architecture: [arm64, amd64]
+    steps:
+      - name: Checkout CeraUI
+        uses: actions/checkout@v4
+        with:
+          path: CeraUI
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: CeraUI/package.json
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+          cache-dependency-path: CeraUI/pnpm-lock.yaml
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install Ruby and FPM
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ruby-dev gcc g++
+          sudo gem install fpm
+
+      # Resolves @ceralive/cerastream into node_modules so the build recipe can
+      # derive cerastream-ipc-<major> from the installed bindings' constants.js
+      # (the engine↔UI protocol-skew guard). Without this install the recipe
+      # aborts — the major is NEVER hardcoded.
+      - name: Install dependencies
+        working-directory: CeraUI
+        run: pnpm install --frozen-lockfile
+
+      # arm64 and amd64 are both produced on this amd64 runner: the backend is a
+      # bun --compile cross-target (build:backend-only maps BUILD_ARCH→bun target,
+      # i.e. bun-linux-arm64 / bun-linux-x64) and fpm stamps Architecture from -a
+      # without inspecting the ELF.
+      - name: Build Debian package for ${{ matrix.architecture }}
+        working-directory: CeraUI
+        run: ./scripts/build/build-debian-package.sh
+        env:
+          BUILD_VERSION: ${{ needs.resolve-version.outputs.version }}
+          BUILD_ARCH: ${{ matrix.architecture }}
+
+      - name: Upload Debian package artifact (${{ matrix.architecture }})
+        uses: actions/upload-artifact@v4
+        with:
+          name: ceralive-device-${{ matrix.architecture }}
+          path: CeraUI/dist/debian/*.deb
+
+  publish:
+    name: Attach .debs to release + dispatch reindex
+    runs-on: ubuntu-latest
+    needs: [resolve-version, build-deb]
+    # contents:write is required to attach the .deb assets to the GitHub release.
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Stage .debs for release
+        run: |
+          mkdir -p dist
+          cp artifacts/ceralive-device-arm64/*.deb dist/
+          cp artifacts/ceralive-device-amd64/*.deb dist/
+          echo "Staged .debs:"
+          ls -la dist
+
+      # Attach both arch .debs to the GitHub release for this tag. apt-worker
+      # pulls the assets from here on the apt-reindex dispatch below — there is
+      # no R2 upload and no per-repo APT metadata generation in this repo.
+      - name: Attach .debs to GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: CeraUI ${{ github.ref_name }}
+          files: dist/*.deb
+
+      # Hand off to the central index owner: apt-worker fetches the release
+      # assets, uploads to R2, then regenerates and signs Packages/Release for
+      # the stable channel — once per channel, no per-repo reindex race.
+      # CERALIVE_DISPATCH_TOKEN: fine-grained PAT, contents:write on CERALIVE/apt-worker only
+      - name: Trigger centralized APT reindex
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CERALIVE_DISPATCH_TOKEN }}
+          repository: CERALIVE/apt-worker
+          event-type: apt-reindex
+          client-payload: >-
+            {"component":"ceralive-device","version":"${{ needs.resolve-version.outputs.version }}","channel":"stable","tag":"${{ github.ref_name }}"}
+
+      - name: Publish Summary
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          {
+            echo "## Published ceralive-device"
+            echo ""
+            echo "**Version:** \`${VERSION}\`"
+            echo "**Tag:** \`${TAG}\`"
+            echo "**Channel:** \`stable\`"
+            echo ""
+            echo "Attached arm64 + amd64 .debs to the GitHub release."
+            echo "Dispatched \`apt-reindex\` to CERALIVE/apt-worker for centralized R2 upload + metadata regen."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-deb.yml
+++ b/.github/workflows/publish-deb.yml
@@ -143,7 +143,7 @@ jobs:
           repository: CERALIVE/apt-worker
           event-type: apt-reindex
           client-payload: >-
-            {"component":"ceralive-device","version":"${{ needs.resolve-version.outputs.version }}","channel":"stable","tag":"${{ github.ref_name }}"}
+            {"component":"ceralive-device","repo":"CeraUI","channel":"stable","tag":"${{ github.ref_name }}","version":"${{ needs.resolve-version.outputs.version }}"}
 
       - name: Publish Summary
         env:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -239,15 +239,10 @@ jobs:
       - name: Prepare release assets
         run: |
           mkdir -p final-assets
-          mkdir -p dist/arm64 dist/amd64
 
           # Move all archives and packages to final-assets
           find release-assets -name "*.tar.gz" -exec mv {} final-assets/ \;
           find release-assets -name "*.deb" -exec cp {} final-assets/ \;
-
-          # Also organize .deb files by arch for R2 upload
-          find release-assets -name "*arm64*.deb" -exec cp {} dist/arm64/ \;
-          find release-assets -name "*amd64*.deb" -exec cp {} dist/amd64/ \;
 
           # Generate checksums
           cd final-assets
@@ -358,85 +353,3 @@ jobs:
           ls -1 final-assets/ | while read f; do echo "- \`$f\`" >> $GITHUB_STEP_SUMMARY; done
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "🔗 [View Release](https://github.com/${{ github.repository }}/releases/tag/${{ needs.calculate-version.outputs.tag }})" >> $GITHUB_STEP_SUMMARY
-
-  sign-and-publish-r2:
-    name: Sign and Publish to R2
-    runs-on: ubuntu-latest
-    needs: [calculate-version, build-debian-package, create-release]
-    steps:
-      - name: Download Debian artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-
-      - name: Prepare dist directory
-        run: |
-          mkdir -p dist/arm64 dist/amd64
-          find artifacts -name "*arm64*.deb" -exec cp {} dist/arm64/ \;
-          find artifacts -name "*amd64*.deb" -exec cp {} dist/amd64/ \;
-
-      - name: Import GPG key
-        run: |
-          echo "${{ secrets.DEB_SIGNING_KEY_B64 }}" | base64 -d | gpg --batch --import
-
-      - name: Install apt-utils
-        run: sudo apt-get update && sudo apt-get install -y apt-utils
-
-      - name: Generate and sign repo metadata (arm64)
-        run: |
-          cd dist/arm64
-          dpkg-scanpackages . > Packages
-          gzip -k Packages
-          apt-ftparchive release . > Release
-          gpg --batch --yes -abs -o Release.gpg Release
-          gpg --batch --yes --clearsign -o InRelease Release
-
-      - name: Generate and sign repo metadata (amd64)
-        run: |
-          cd dist/amd64
-          dpkg-scanpackages . > Packages
-          gzip -k Packages
-          apt-ftparchive release . > Release
-          gpg --batch --yes -abs -o Release.gpg Release
-          gpg --batch --yes --clearsign -o InRelease Release
-
-      - name: Install AWS CLI
-        run: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip -q awscliv2.zip
-          sudo ./aws/install
-
-      - name: Determine channel
-        id: channel
-        run: |
-          if [ "${{ needs.calculate-version.outputs.is_beta }}" == "true" ]; then
-            echo "channel=beta" >> $GITHUB_OUTPUT
-          else
-            echo "channel=stable" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Upload to R2
-        env:
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
-          R2_BUCKET: ${{ secrets.R2_BUCKET }}
-          CHANNEL: ${{ steps.channel.outputs.channel }}
-        run: |
-          aws configure set aws_access_key_id "$R2_ACCESS_KEY_ID"
-          aws configure set aws_secret_access_key "$R2_SECRET_ACCESS_KEY"
-
-          aws s3 sync dist/arm64/ "s3://$R2_BUCKET/dists/$CHANNEL/binary-arm64/" \
-            --endpoint-url "$R2_ENDPOINT"
-          aws s3 sync dist/amd64/ "s3://$R2_BUCKET/dists/$CHANNEL/binary-amd64/" \
-            --endpoint-url "$R2_ENDPOINT"
-
-      - name: R2 Upload Summary
-        run: |
-          echo "## 📦 Published to R2" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Channel:** \`${{ steps.channel.outputs.channel }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Uploaded Files:" >> $GITHUB_STEP_SUMMARY
-          echo "- ARM64: \`dists/${{ steps.channel.outputs.channel }}/binary-arm64/\`" >> $GITHUB_STEP_SUMMARY
-          echo "- AMD64: \`dists/${{ steps.channel.outputs.channel }}/binary-amd64/\`" >> $GITHUB_STEP_SUMMARY

--- a/scripts/build/shared-build-functions.sh
+++ b/scripts/build/shared-build-functions.sh
@@ -22,7 +22,7 @@ get_commit() {
 }
 
 get_build_date() {
-    date -u +"%Y%m%d_%H%M%S"
+    date -u +"%Y%m%dT%H%M%S"
 }
 
 get_architecture() {


### PR DESCRIPTION
## What
- Fix `get_build_date()` in `scripts/build/shared-build-functions.sh`: `%Y%m%d_%H%M%S` → `%Y%m%dT%H%M%S` (underscore forbidden in Debian version revision)
- Add `publish-deb.yml`: tag-triggered ceralive-device .deb publish + apt-reindex dispatch (5-key standard payload)
- Retire legacy direct-R2 APT publish from `publish-release.yml`: remove `aws s3 sync`, `dpkg-scanpackages`, `apt-ftparchive`, `gpg --clearsign`, and all R2/signing secrets

## Why
The underscore in the version string caused `dpkg-deb -f` to hard-error and `apt` to refuse the package. The legacy direct-R2 publish path is retired in favor of the centralized apt-worker sole-publisher model.

## How to verify
- `grep -rE 'aws s3|R2_SECRET|apt-ftparchive|dpkg-scanpackages|--clearsign' .github/workflows/` → ZERO
- `grep client-payload .github/workflows/publish-deb.yml` → 5 keys including `repo:"CeraUI"`
- Build a .deb and verify `dpkg-deb -f` succeeds (no underscore in version)

## Risks
Low. The version fix is a 1-character change (underscore → T). The legacy publish path removal is safe since apt-worker now handles all R2 uploads.
