### PR TITLE
docs(dev): add generic local dev hub override examples

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -19,3 +19,16 @@ VITE_SOCKET_PORT=3002
 # Hardware mock scenario consumed by the Bun backend (process.env.MOCK_SCENARIO).
 # Scenarios: single-modem | multi-modem-wifi | streaming-active.
 MOCK_SCENARIO=multi-modem-wifi
+
+# ── Local dev: device-control channel override (both OPTIONAL, unset by default) ──
+# The control channel only dials when CERALIVE_CONTROL_HUB_URL is provisioned, so
+# leaving these commented keeps dev exactly as today. Uncomment both to point the
+# device at any local WS hub and verify device-control tokens for real.
+#
+# Hub URL the device should dial (any ws:// or wss:// endpoint).
+# CERALIVE_CONTROL_HUB_URL=ws://localhost:8099
+#
+# Ed25519 public key used to verify the device-control token, as a raw-base64
+# 32-byte key (node:crypto encoding) — NOT a PASERK "k4.public.…" string. Generate
+# an Ed25519 keypair and use the raw-base64 public-key encoding here.
+# PASETO_PUBLIC_KEY=<raw-base64 32-byte Ed25519 public key>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,6 +357,17 @@ Override for tests: set `CERALIVE_DEVICE_TYPE=emulated` or `=real` in `beforeEac
 
 Fast-reload development loop (dev-sync / dev-push): [`image-building-pipeline/v2/docs/fast-reload.md`](../image-building-pipeline/v2/docs/fast-reload.md)
 
+## LOCAL DEV: CONTROL-CHANNEL OVERRIDE
+
+For local dev, set `CERALIVE_CONTROL_HUB_URL=ws://localhost:<hub-port>` and
+`PASETO_PUBLIC_KEY=<raw-base64 32-byte Ed25519 public key>` in `.env.development`
+to point the device-control channel at any WS hub. No source changes are needed —
+both vars are read from `process.env` at runtime (`modules/remote/control-endpoint.ts`
+resolves the hub URL; `modules/pairing/device-token.ts` reads the raw-base64 key).
+Both are unset by default, so the control channel stays gated until provisioned.
+`PASETO_PUBLIC_KEY` here is the raw-base64 encoding (node:crypto), never a PASERK
+`k4.public.…` string.
+
 ## CONVENTIONS
 
 - Linting/formatting: Biome 2.5 via `@ceralive/biome-config` — ESLint and Prettier are fully removed. The root `biome.json` extends `@ceralive/biome-config` (`"extends": ["@ceralive/biome-config"]`). Run `biome check .` (or `pnpm lint`) from the workspace root. Nested non-root configs live in `apps/frontend/`, `apps/backend/`, `packages/i18n/`.


### PR DESCRIPTION
**What**
Adds commented examples to `.env.development` for `CERALIVE_CONTROL_HUB_URL` and `PASETO_PUBLIC_KEY`; updates `AGENTS.md` with a generic dev-override note.

**Why**
Enables pairing a local CeraUI device against any WS hub (e.g. a local mock-hub) without modifying source code. The device reads these env vars at runtime.

**How to verify**
`git diff --name-only HEAD` shows only `.env.development` and `AGENTS.md`; no source files changed; no platform-proprietary detail in either file.

**Risks**
None — both files are commented examples only; the vars are unset by default so existing behaviour is unchanged.