### PR TITLE
ci: standardize CeraUI workflows (concurrency, latest actions) + add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns: ["*"]
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm:
+        patterns: ["*"]

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -12,23 +12,27 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test (unit + E2E guardrails)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout CeraUI
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: CeraUI
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           package_json_file: CeraUI/package.json
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
@@ -98,17 +102,17 @@ jobs:
         arch: [arm64, amd64]
     steps:
       - name: Checkout CeraUI
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: CeraUI
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           package_json_file: CeraUI/package.json
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
@@ -159,9 +163,11 @@ jobs:
 
       - name: Build Summary
         run: |
-          echo "## ✅ Build Check Passed" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Architecture:** ${{ matrix.arch }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Build Artifacts:" >> $GITHUB_STEP_SUMMARY
-          ls -1 CeraUI/dist/ | while read f; do echo "- \`$f\`" >> $GITHUB_STEP_SUMMARY; done
+          {
+            echo "## ✅ Build Check Passed"
+            echo ""
+            echo "**Architecture:** ${{ matrix.arch }}"
+            echo ""
+            echo "### Build Artifacts:"
+            for f in CeraUI/dist/*; do echo "- \`$(basename "$f")\`"; done
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-deb.yml
+++ b/.github/workflows/publish-deb.yml
@@ -23,6 +23,10 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # Derive the package version from the tag (strip the leading `v`). The build
   # recipe reads $BUILD_VERSION first (shared-build-functions.sh::get_version),
@@ -49,17 +53,17 @@ jobs:
         architecture: [arm64, amd64]
     steps:
       - name: Checkout CeraUI
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: CeraUI
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           package_json_file: CeraUI/package.json
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
@@ -96,7 +100,7 @@ jobs:
           BUILD_ARCH: ${{ matrix.architecture }}
 
       - name: Upload Debian package artifact (${{ matrix.architecture }})
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ceralive-device-${{ matrix.architecture }}
           path: CeraUI/dist/debian/*.deb
@@ -110,7 +114,7 @@ jobs:
       contents: write
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 
@@ -126,7 +130,7 @@ jobs:
       # pulls the assets from here on the apt-reindex dispatch below — there is
       # no R2 upload and no per-repo APT metadata generation in this repo.
       - name: Attach .debs to GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: CeraUI ${{ github.ref_name }}
@@ -137,7 +141,7 @@ jobs:
       # the stable channel — once per channel, no per-repo reindex race.
       # CERALIVE_DISPATCH_TOKEN: fine-grained PAT, contents:write on CERALIVE/apt-worker only
       - name: Trigger centralized APT reindex
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.CERALIVE_DISPATCH_TOKEN }}
           repository: CERALIVE/apt-worker

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,6 +26,10 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # Calculate the next CalVer version automatically
   calculate-version:
@@ -37,7 +41,7 @@ jobs:
       is_beta: ${{ steps.calver.outputs.is_beta }}
     steps:
       - name: Checkout CeraUI
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Need full history for tags
           path: CeraUI
@@ -98,9 +102,11 @@ jobs:
 
           TAG="v${VERSION}"
 
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "tag=${TAG}" >> $GITHUB_OUTPUT
-          echo "is_beta=${IS_BETA}" >> $GITHUB_OUTPUT
+          {
+            echo "version=${VERSION}"
+            echo "tag=${TAG}"
+            echo "is_beta=${IS_BETA}"
+          } >> "$GITHUB_OUTPUT"
 
           echo "✅ Next version: ${VERSION}"
           echo "🏷️  Tag: ${TAG}"
@@ -108,11 +114,13 @@ jobs:
 
       - name: Version Summary
         run: |
-          echo "## 🏷️ Version Calculated" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** \`${{ steps.calver.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Tag:** \`${{ steps.calver.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Type:** ${{ steps.calver.outputs.is_beta == 'true' && '🧪 Beta' || '✅ Stable' }}" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## 🏷️ Version Calculated"
+            echo ""
+            echo "**Version:** \`${{ steps.calver.outputs.version }}\`"
+            echo "**Tag:** \`${{ steps.calver.outputs.tag }}\`"
+            echo "**Type:** ${{ steps.calver.outputs.is_beta == 'true' && '🧪 Beta' || '✅ Stable' }}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   build-ceraui-system:
     name: Build CeraUI Full System
@@ -123,17 +131,17 @@ jobs:
         architecture: [arm64, amd64]
     steps:
       - name: Checkout CeraUI
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: CeraUI
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: "11.6.0"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
@@ -165,7 +173,7 @@ jobs:
           done
 
       - name: Upload compressed distribution (${{ matrix.architecture }})
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ceraui-system-${{ matrix.architecture }}
           path: CeraUI/dist/compressed/*.tar.gz
@@ -179,17 +187,17 @@ jobs:
         architecture: [arm64, amd64]
     steps:
       - name: Checkout CeraUI
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: CeraUI
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: "11.6.0"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
@@ -218,7 +226,7 @@ jobs:
           BUILD_ARCH: ${{ matrix.architecture }}
 
       - name: Upload Debian package (${{ matrix.architecture }})
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ceraui-debian-${{ matrix.architecture }}
           path: CeraUI/dist/debian/*.deb
@@ -231,12 +239,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout CeraUI
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: CeraUI
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: release-assets
 
@@ -271,7 +279,7 @@ jobs:
           # Generate changelog
           if [ -n "$PREV_TAG" ]; then
             CHANGELOG_HEADER="Changes since ${PREV_TAG}:"
-            CHANGELOG=$(git log ${PREV_TAG}..HEAD --pretty=format:"- %s" --no-merges | head -20)
+            CHANGELOG=$(git log "${PREV_TAG}..HEAD" --pretty=format:"- %s" --no-merges | head -20)
           else
             CHANGELOG_HEADER="Recent commits:"
             CHANGELOG=$(git log --pretty=format:"- %s" --no-merges -20)
@@ -335,7 +343,7 @@ jobs:
           cat release-body.md
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.calculate-version.outputs.tag }}
           name: CeraUI ${{ needs.calculate-version.outputs.tag }}${{ needs.calculate-version.outputs.is_beta == 'true' && ' (Beta)' || '' }}
@@ -346,14 +354,16 @@ jobs:
 
       - name: Release Summary
         run: |
-          echo "## 🎉 Release Created!" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** \`${{ needs.calculate-version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Tag:** \`${{ needs.calculate-version.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Type:** ${{ needs.calculate-version.outputs.is_beta == 'true' && '🧪 Beta (Pre-release)' || '✅ Stable' }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Assets Uploaded:" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          ls -1 final-assets/ | while read f; do echo "- \`$f\`" >> $GITHUB_STEP_SUMMARY; done
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "🔗 [View Release](https://github.com/${{ github.repository }}/releases/tag/${{ needs.calculate-version.outputs.tag }})" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## 🎉 Release Created!"
+            echo ""
+            echo "**Version:** \`${{ needs.calculate-version.outputs.version }}\`"
+            echo "**Tag:** \`${{ needs.calculate-version.outputs.tag }}\`"
+            echo "**Type:** ${{ needs.calculate-version.outputs.is_beta == 'true' && '🧪 Beta (Pre-release)' || '✅ Stable' }}"
+            echo ""
+            echo "### Assets Uploaded:"
+            echo ""
+            for f in final-assets/*; do echo "- \`$(basename "$f")\`"; done
+            echo ""
+            echo "🔗 [View Release](https://github.com/${{ github.repository }}/releases/tag/${{ needs.calculate-version.outputs.tag }})"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What

- Add `concurrency:` to all 3 workflows (build-check: cancel-in-progress: true; publish-deb + publish-release: cancel-in-progress: false)
- Pin all `uses:` to resolved-latest major (checkout@v7, setup-node@v6, pnpm/action-setup@v6, setup-bun@v2, upload-artifact@v7, download-artifact@v8, action-gh-release@v3, repository-dispatch@v4)
- Load-bearing pins preserved byte-identical: `bun-version: 1.3.14`, `version: "11.6.0"` (pnpm)
- Add `.github/dependabot.yml` (npm + github-actions, weekly)

## Why

Part of the cicd-standardization effort. Root policy PR (#25) merged first. Per Rule F (R2), ceralive-platform merges before CeraUI — open this PR now but merge after ceralive-platform.

## How to verify

- `actionlint .github/workflows/*.yml` exits 0
- `grep -c 'version: "11.6.0"' .github/workflows/publish-release.yml` ≥ 1 (pnpm pin preserved)
- `grep -c 'bun-version: 1.3.14' .github/workflows/build-check.yml` ≥ 1 (Bun pin preserved)
- CI runs green on this branch

## Risks

Low — CI config only. Bun 1.3.14 and pnpm 11.6.0 load-bearing pins preserved.