### PR TITLE
feat(ceraui): multi-cloud provider picker, pairing-gate store, relay provider tagging, encoder preset order, auto-select

### DIFF
--- a/apps/backend/src/helpers/config-schemas.ts
+++ b/apps/backend/src/helpers/config-schemas.ts
@@ -52,6 +52,7 @@ import {
 	parseNamespacedRelayId,
 	type RelayProtocol,
 	relayProtocolSchema,
+	relayProviderMetaSchema,
 } from "@ceraui/rpc/schemas";
 import { z } from "zod";
 import { logger } from "./logger.ts";
@@ -321,6 +322,9 @@ export const relayServerSchema = z.object({
 	port: z.number().int().min(1).max(65535),
 	default: z.literal(true).optional(),
 	bcrp_port: z.string().optional(),
+	// Provider origin; optional so legacy untagged caches round-trip. Shape
+	// frozen in @ceraui/rpc relay.schema.ts — reused here, never redefined.
+	provider: relayProviderMetaSchema.optional(),
 });
 
 export type RelayServer = z.infer<typeof relayServerSchema>;
@@ -333,6 +337,9 @@ export const relayAccountSchema = z.object({
 	name: z.string(),
 	ingest_key: z.string(),
 	disabled: z.literal(true).optional(),
+	// Provider origin; optional so legacy untagged caches round-trip. Shape
+	// frozen in @ceraui/rpc relay.schema.ts — reused here, never redefined.
+	provider: relayProviderMetaSchema.optional(),
 });
 
 export type RelayAccount = z.infer<typeof relayAccountSchema>;

--- a/apps/backend/src/mocks/mock-config.ts
+++ b/apps/backend/src/mocks/mock-config.ts
@@ -244,6 +244,17 @@ export const mockWifiNetworks = [
 	},
 ] satisfies MockWifiNetwork[];
 
+// Pairing fields seeded into the device config under shouldUseMocks() (wired in
+// modules/config.ts loadConfig) so isPairedToManagedCloud() reads "paired" in
+// dev/e2e and the managed destination enables — matching the `ceralive`
+// provider metadata the mock relay catalog (providers/relays.ts) already
+// carries. Never applied in production (shouldUseMocks() is false on real
+// devices).
+export const MOCK_CONFIG_PAIRING_DEFAULTS = {
+	remote_key: "mock-pairing-key",
+	remote_provider: "ceralive",
+} as const;
+
 // Active scenario state
 let activeScenario: MockScenario = "multi-modem-wifi";
 

--- a/apps/backend/src/mocks/providers/relays.ts
+++ b/apps/backend/src/mocks/providers/relays.ts
@@ -3,8 +3,15 @@
 	Static RelaysCache with 3-5 multi-region servers and 2 accounts
 */
 
+import { relayProviderMetaForId } from "@ceraui/rpc/schemas";
+
 import type { RelaysCache } from "../../helpers/config-schemas.ts";
 import { buildMockRelay } from "../fixture-factory.ts";
+
+// Provider tags for the mock catalog. Both ids are predefined CLOUD_PROVIDERS,
+// so these resolve to defined `{ id, name, kind }` metadata (never undefined).
+const CERALIVE_PROVIDER = relayProviderMetaForId("ceralive");
+const BELABOX_PROVIDER = relayProviderMetaForId("belabox");
 
 // ─── Stable server IDs for T5 (RTT generator) and T7 (rebroadcast) ──────────
 
@@ -40,29 +47,35 @@ export function getMockRelaysCache(): RelaysCache {
 				addr: "relay-eu-west.example.com",
 				default: true,
 				bcrp_port: "2002",
+				provider: CERALIVE_PROVIDER,
 			}),
 			[MOCK_RELAY_SERVER_IDS.US_EAST]: buildMockRelay({
 				name: "US-East",
 				addr: "relay-us-east.example.com",
+				provider: CERALIVE_PROVIDER,
 			}),
 			[MOCK_RELAY_SERVER_IDS.ASIA_SE]: buildMockRelay({
 				name: "Asia-SE",
 				addr: "relay-asia-se.example.com",
+				provider: BELABOX_PROVIDER,
 			}),
 			[MOCK_RELAY_SERVER_IDS.US_WEST]: buildMockRelay({
 				name: "US-West",
 				addr: "relay-us-west.example.com",
+				provider: BELABOX_PROVIDER,
 			}),
 		},
 		accounts: {
 			[MOCK_RELAY_ACCOUNT_IDS.PRIMARY]: {
 				name: "Primary Account",
 				ingest_key: "primary-ingest-key-abc123def456",
+				provider: CERALIVE_PROVIDER,
 			},
 			[MOCK_RELAY_ACCOUNT_IDS.SECONDARY]: {
 				name: "Secondary Account",
 				ingest_key: "secondary-ingest-key-xyz789uvw012",
 				disabled: true,
+				provider: BELABOX_PROVIDER,
 			},
 		},
 	};

--- a/apps/backend/src/modules/config.ts
+++ b/apps/backend/src/modules/config.ts
@@ -29,6 +29,8 @@ import {
 	runtimeConfigSchema,
 } from "../helpers/config-schemas.ts";
 import { logger } from "../helpers/logger.ts";
+import { MOCK_CONFIG_PAIRING_DEFAULTS } from "../mocks/mock-config.ts";
+import { shouldUseMocks } from "../mocks/mock-service.ts";
 import { getPasswordHash, setPasswordHash } from "../rpc/state/password.ts";
 import { setup } from "./setup.ts";
 import { getSshPasswordHash, setSshPasswordHash } from "./system/ssh.ts";
@@ -53,6 +55,12 @@ export async function loadConfig() {
 				? "HDMI"
 				: "USB audio";
 			break;
+	}
+
+	// Seed mock pairing state so the managed-cloud gate (isPairedToManagedCloud)
+	// reads paired in dev/e2e; shouldUseMocks() is false on real devices.
+	if (shouldUseMocks()) {
+		Object.assign(platformDefaults, MOCK_CONFIG_PAIRING_DEFAULTS);
 	}
 
 	const result = await loadJsonConfig(

--- a/apps/backend/src/modules/config.ts
+++ b/apps/backend/src/modules/config.ts
@@ -57,18 +57,18 @@ export async function loadConfig() {
 			break;
 	}
 
-	// Seed mock pairing state so the managed-cloud gate (isPairedToManagedCloud)
-	// reads paired in dev/e2e; shouldUseMocks() is false on real devices.
-	if (shouldUseMocks()) {
-		Object.assign(platformDefaults, MOCK_CONFIG_PAIRING_DEFAULTS);
-	}
-
 	const result = await loadJsonConfig(
 		CONFIG_FILE,
 		runtimeConfigSchema,
 		platformDefaults,
 	);
 	config = result.data;
+
+	// Apply mock pairing AFTER file load so it overrides any absent/undefined remote_key in config.json
+	// shouldUseMocks() is false on real devices.
+	if (shouldUseMocks()) {
+		Object.assign(config, MOCK_CONFIG_PAIRING_DEFAULTS);
+	}
 
 	logger.debug("config loaded", config);
 

--- a/apps/backend/src/modules/remote/remote-relays.ts
+++ b/apps/backend/src/modules/remote/remote-relays.ts
@@ -17,6 +17,11 @@
 
 import assert from "node:assert";
 
+import {
+	type RelayProviderMeta,
+	relayProviderMetaForId,
+} from "@ceraui/rpc/schemas";
+
 import { loadJsonConfig } from "../../helpers/config-loader.ts";
 import {
 	DEFAULT_RELAY_PROVIDER_ID,
@@ -47,6 +52,7 @@ type RelaysResponseMessage = {
 			default?: true;
 			addr?: string;
 			port?: number;
+			provider?: RelayProviderMeta;
 		}
 	>;
 	accounts: Record<
@@ -54,6 +60,7 @@ type RelaysResponseMessage = {
 		{
 			name: string;
 			disabled?: true;
+			provider?: RelayProviderMeta;
 		}
 	>;
 };
@@ -119,6 +126,7 @@ export function buildRelaysMsg(): RelaysResponseMessage {
 			default: srv.default,
 			addr: srv.addr,
 			port: srv.port,
+			provider: srv.provider,
 		};
 	});
 
@@ -126,7 +134,11 @@ export function buildRelaysMsg(): RelaysResponseMessage {
 	Object.entries(relaysCache.accounts).forEach(([id, relayAccount]) => {
 		if (!relayAccount) return;
 		const displayName = `${relayAccount.name}${relayAccount.disabled ? " [disabled]" : ""}`;
-		msg.accounts[id] = { name: displayName, disabled: relayAccount.disabled };
+		msg.accounts[id] = {
+			name: displayName,
+			disabled: relayAccount.disabled,
+			provider: relayAccount.provider,
+		};
 	});
 
 	return msg;
@@ -143,7 +155,10 @@ export async function updateCachedRelays(relays: RelaysCache | undefined) {
 	}
 }
 
-function validateRemoteRelays(msg: ValidateRemoteRelaysMessage["relays"]) {
+export function validateRemoteRelays(
+	msg: ValidateRemoteRelaysMessage["relays"],
+	providerMeta?: RelayProviderMeta,
+) {
 	try {
 		const out: RelaysCache = { servers: {}, accounts: {} };
 		for (const r_id in msg.servers) {
@@ -171,6 +186,7 @@ function validateRemoteRelays(msg: ValidateRemoteRelaysMessage["relays"]) {
 				out.servers[r_id].bcrp_port = r.bcrp_port;
 			}
 			if (r.default) out.servers[r_id].default = true;
+			if (providerMeta) out.servers[r_id].provider = providerMeta;
 		}
 
 		for (const a_id in msg.accounts) {
@@ -180,6 +196,7 @@ function validateRemoteRelays(msg: ValidateRemoteRelaysMessage["relays"]) {
 
 			out.accounts[a_id] = { name: a.name, ingest_key: a.ingest_key };
 			if (a.disabled) out.accounts[a_id].disabled = true;
+			if (providerMeta) out.accounts[a_id].provider = providerMeta;
 		}
 
 		if (msg.bcrp_key !== undefined) {
@@ -315,7 +332,11 @@ export function autoPreloadSubscriptionRelays(): boolean {
 export async function handleRemoteRelays(
 	msg: ValidateRemoteRelaysMessage["relays"],
 ) {
-	const validatedUpdate = validateRemoteRelays(msg);
+	const providerId = getConfig().remote_provider ?? DEFAULT_RELAY_PROVIDER_ID;
+	const validatedUpdate = validateRemoteRelays(
+		msg,
+		relayProviderMetaForId(providerId),
+	);
 	if (!validatedUpdate) return;
 
 	const hasUpdated = await updateCachedRelays(validatedUpdate);

--- a/apps/backend/src/modules/remote/remote.ts
+++ b/apps/backend/src/modules/remote/remote.ts
@@ -57,6 +57,7 @@ import {
 	verifyStubDeviceToken,
 } from "../pairing/device-token.ts";
 import { setup } from "../setup.ts";
+import { shouldUseMocks } from "../../mocks/mock-service.ts";
 import { addAuthedSocket } from "../ui/auth.ts";
 import { type StatusResponseMessage, sendInitialStatus } from "../ui/status.ts";
 import {
@@ -311,8 +312,17 @@ function remoteClose(conn: WebSocket) {
  * the device drops to the unpaired floor and surfaces re-pairing locally, then
  * push the re-pair status. `remoteStatusHandled` is latched first so the
  * follow-on socket close does not also broadcast a spurious network error.
+ *
+ * In mock/dev mode, skip the repair — the control channel won't connect (no real
+ * platform), but the pairing state must stay intact for e2e tests that exercise
+ * the managed-cloud destination surface.
  */
 export function forceRepairMigration(reason: RemoteRepairReason): void {
+	// In mock/dev mode, never clear the mock pairing key — the control channel
+	// won't connect (no real platform), but the pairing state must stay intact
+	// for e2e tests that exercise the managed-cloud destination surface.
+	if (shouldUseMocks()) return;
+
 	logger.warn(
 		`remote: paired device holds no valid PASETO token (${reason}); forcing re-pair (ADR-0006 D3)`,
 	);

--- a/apps/backend/src/tests/fixture-factory.test.ts
+++ b/apps/backend/src/tests/fixture-factory.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { AddonDescriptorSchema, AddonStateSchema } from "@ceraui/rpc/schemas";
+import {
+	AddonDescriptorSchema,
+	AddonStateSchema,
+	relayProviderMetaForId,
+} from "@ceraui/rpc/schemas";
 
 import { relayServerSchema } from "../helpers/config-schemas.ts";
 import {
@@ -132,9 +136,10 @@ describe("buildMockRelay", () => {
 		expect(relayServerSchema.safeParse(buildMockRelay()).success).toBe(true);
 	});
 
-	test("default matches the plain US-East server in the relay cache", () => {
+	test("the CeraLive-tagged US-East server reproduces from the builder", () => {
 		const usEast = getMockRelaysCache().servers[MOCK_RELAY_SERVER_IDS.US_EAST];
-		expect(buildMockRelay()).toEqual(usEast);
+		const built = buildMockRelay({ provider: relayProviderMetaForId("ceralive") });
+		expect(built).toEqual(usEast);
 	});
 
 	test("overrides reproduce the default-marked EU-West server", () => {
@@ -144,6 +149,7 @@ describe("buildMockRelay", () => {
 			addr: "relay-eu-west.example.com",
 			default: true,
 			bcrp_port: "2002",
+			provider: relayProviderMetaForId("ceralive"),
 		});
 		expect(built).toEqual(euWest);
 	});

--- a/apps/backend/src/tests/relay-provider-metadata.test.ts
+++ b/apps/backend/src/tests/relay-provider-metadata.test.ts
@@ -1,0 +1,100 @@
+/*
+ * T9 — relay servers carry provider metadata (CeraLive/BELABOX).
+ *
+ * Locks two boundaries:
+ *   1. the runtime relay-cache schema round-trips `provider:{id,name,kind}`, and
+ *   2. the mock catalog seeds at least one CeraLive and one BELABOX server, with
+ *      every server's `provider.kind` in {ceralive, belabox} (T10/T12 depend on
+ *      this multi-provider mock data being present).
+ *
+ * Also asserts the real relay-catalog push (`validateRemoteRelays`) tags every
+ * validated server/account with the active provider's metadata.
+ */
+import { describe, expect, it } from "bun:test";
+import {
+	RELAY_PROVIDER_KINDS,
+	relayProviderMetaForId,
+} from "@ceraui/rpc/schemas";
+
+import { relaysCacheSchema } from "../helpers/config-schemas.ts";
+import { getMockRelaysCache } from "../mocks/providers/relays.ts";
+import { validateRemoteRelays } from "../modules/remote/remote-relays.ts";
+
+const TAGGABLE_KINDS = new Set(["ceralive", "belabox"]);
+
+describe("relay provider metadata (T9)", () => {
+	it("round-trips provider metadata through the runtime relay-cache schema", () => {
+		const parsed = relaysCacheSchema.parse(getMockRelaysCache());
+
+		for (const server of Object.values(parsed.servers)) {
+			expect(server.provider).toBeDefined();
+			expect(RELAY_PROVIDER_KINDS).toContain(server.provider?.kind);
+		}
+	});
+
+	it("seeds at least one CeraLive and one BELABOX mock server", () => {
+		const servers = Object.values(getMockRelaysCache().servers);
+		const kinds = servers.map((server) => server.provider?.kind);
+
+		expect(kinds).toContain("ceralive");
+		expect(kinds).toContain("belabox");
+	});
+
+	it("tags every mock server with provider.kind in {ceralive, belabox}", () => {
+		const servers = Object.values(getMockRelaysCache().servers);
+		expect(servers.length).toBeGreaterThanOrEqual(2);
+
+		for (const server of servers) {
+			const kind = server.provider?.kind;
+			expect(kind).toBeDefined();
+			expect(TAGGABLE_KINDS.has(kind as string)).toBe(true);
+		}
+	});
+
+	it("exposes at least two distinct providers across the mock catalog", () => {
+		const servers = Object.values(getMockRelaysCache().servers);
+		const providerIds = new Set(servers.map((s) => s.provider?.id));
+		expect(providerIds.size).toBeGreaterThanOrEqual(2);
+	});
+
+	it("tags a real relay-catalog push with the active provider metadata", () => {
+		const belabox = relayProviderMetaForId("belabox");
+		const validated = validateRemoteRelays(
+			{
+				servers: {
+					"0": {
+						type: "srtla",
+						name: "Pushed Server",
+						addr: "relay.example.com",
+						port: 2001,
+						default: true,
+					},
+				},
+				accounts: {
+					acc: { name: "Pushed Account", ingest_key: "key-123" },
+				},
+			},
+			belabox,
+		);
+
+		expect(validated).toBeDefined();
+		expect(validated?.servers["0"]?.provider).toEqual(belabox);
+		expect(validated?.accounts.acc?.provider).toEqual(belabox);
+	});
+
+	it("leaves provider absent on an untagged push (legacy-safe)", () => {
+		const validated = validateRemoteRelays({
+			servers: {
+				"0": {
+					type: "srtla",
+					name: "Legacy Server",
+					addr: "relay.example.com",
+					port: 2001,
+				},
+			},
+			accounts: {},
+		});
+
+		expect(validated?.servers["0"]?.provider).toBeUndefined();
+	});
+});

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -33,6 +33,8 @@ if (process.env.CI || !fs.existsSync(configPath)) {
 			srtla_port: 5000,
 			srt_streamid: 'e2e',
 			max_br: 5000,
+			remote_key: 'mock-pairing-key',
+			remote_provider: 'ceralive',
 		}),
 		'utf8',
 	);

--- a/apps/frontend/src/lib/rpc/subscriptions.svelte.ts
+++ b/apps/frontend/src/lib/rpc/subscriptions.svelte.ts
@@ -37,6 +37,10 @@ import {
 	dismiss as dismissNotification,
 	push as pushNotification,
 } from "$lib/stores/notifications.svelte";
+import {
+	resetPairingState,
+	setControlChannelConnected,
+} from "$lib/stores/pairing.svelte";
 import { ingestStreamHealth } from "$lib/stores/stream-health.svelte";
 import type { ManagedIngestAccount } from "$lib/streaming/receiver-experience";
 
@@ -573,6 +577,17 @@ function handleMessage(type: string, data: unknown, seq?: number): void {
 			}
 			break;
 
+		case "remote-control":
+			// Device-control channel up/down (the second outbound WS to the cloud
+			// hub). Pairing comes from `config.remote_key`, never this frame; read
+			// defensively so a partial frame can't throw.
+			if (data && typeof data === "object") {
+				setControlChannelConnected(
+					(data as { connected?: unknown }).connected === true,
+				);
+			}
+			break;
+
 		case "health":
 			// Tri-state stream-liveness rollup (Task 13). Read-only: feeds the HUD
 			// indicator + raises a transition toast; never drives restart logic.
@@ -762,6 +777,7 @@ export function resetState(): void {
 	devicesState = [];
 	activeInputState = undefined;
 	connectionReadyState = false;
+	resetPairingState();
 
 	if (lockExpiryTick !== undefined) {
 		clearInterval(lockExpiryTick);

--- a/apps/frontend/src/lib/stores/pairing.svelte.test.ts
+++ b/apps/frontend/src/lib/stores/pairing.svelte.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Pairing & remote-control store (Task 8 / N1).
+ *
+ * Covers the 3-state remote-control rollup, the multi-cloud-safe pairing reads
+ * (NEVER a `=== 'ceralive'` gate), the managed-cloud gate (custom/self-hosted
+ * always reachable), and the presence of the new i18n keys in every locale.
+ */
+import type { ProviderSelection } from "@ceraui/rpc/schemas";
+import { existingLocales, loadLocale } from "@ceraui/i18n";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const subs = vi.hoisted(() => ({
+	config: undefined as
+		| { remote_key?: string; remote_provider?: ProviderSelection }
+		| undefined,
+}));
+
+vi.mock("$lib/rpc/subscriptions.svelte", () => ({
+	getConfig: () => subs.config,
+}));
+
+import {
+	deriveRemoteControlStatus,
+	getRemoteControlStatus,
+	getRemoteProvider,
+	isManagedProvider,
+	isPairedToCloud,
+	isPairedToManagedCloud,
+	resetPairingState,
+	setControlChannelConnected,
+} from "./pairing.svelte";
+
+afterEach(() => {
+	subs.config = undefined;
+	resetPairingState();
+	vi.restoreAllMocks();
+});
+
+describe("deriveRemoteControlStatus — the 3 states (pure)", () => {
+	it("is not-paired when there is no remote_key (control channel ignored)", () => {
+		expect(deriveRemoteControlStatus(false, false)).toBe("not-paired");
+		expect(deriveRemoteControlStatus(false, true)).toBe("not-paired");
+	});
+
+	it("is paired-disconnected when paired but the control channel is down", () => {
+		expect(deriveRemoteControlStatus(true, false)).toBe("paired-disconnected");
+	});
+
+	it("is connected when paired and the control channel is up", () => {
+		expect(deriveRemoteControlStatus(true, true)).toBe("connected");
+	});
+});
+
+describe("getRemoteControlStatus — end-to-end over config + control channel", () => {
+	it("reports not-paired with no remote_key regardless of channel state", () => {
+		subs.config = undefined;
+		setControlChannelConnected(true);
+		expect(getRemoteControlStatus()).toBe("not-paired");
+	});
+
+	it("reports paired-disconnected with a remote_key while the channel is down", () => {
+		subs.config = { remote_key: "abc", remote_provider: "ceralive" };
+		setControlChannelConnected(false);
+		expect(getRemoteControlStatus()).toBe("paired-disconnected");
+	});
+
+	it("reports connected with a remote_key once the channel comes up", () => {
+		subs.config = { remote_key: "abc", remote_provider: "belabox" };
+		setControlChannelConnected(true);
+		expect(getRemoteControlStatus()).toBe("connected");
+	});
+});
+
+describe("pairing reads — multi-cloud safe", () => {
+	it("treats any remote_key as paired, independent of provider", () => {
+		subs.config = { remote_key: "k" };
+		expect(isPairedToCloud()).toBe(true);
+		subs.config = { remote_key: "k", remote_provider: "belabox" };
+		expect(isPairedToCloud()).toBe(true);
+		subs.config = undefined;
+		expect(isPairedToCloud()).toBe(false);
+	});
+
+	it("never defaults the provider to ceralive when it is absent", () => {
+		subs.config = { remote_key: "k" };
+		expect(getRemoteProvider()).toBeUndefined();
+		subs.config = { remote_key: "k", remote_provider: "belabox" };
+		expect(getRemoteProvider()).toBe("belabox");
+	});
+
+	it("classifies managed providers without a single-provider gate", () => {
+		expect(isManagedProvider("ceralive")).toBe(true);
+		expect(isManagedProvider("belabox")).toBe(true);
+		expect(isManagedProvider("custom")).toBe(false);
+		expect(isManagedProvider(undefined)).toBe(false);
+	});
+});
+
+describe("isPairedToManagedCloud — managed-cloud surface gate", () => {
+	it("is true for a managed provider pairing (ceralive or belabox)", () => {
+		subs.config = { remote_key: "k", remote_provider: "ceralive" };
+		expect(isPairedToManagedCloud()).toBe(true);
+		subs.config = { remote_key: "k", remote_provider: "belabox" };
+		expect(isPairedToManagedCloud()).toBe(true);
+	});
+
+	it("is false for custom/self-hosted pairing (custom path stays available)", () => {
+		subs.config = { remote_key: "k", remote_provider: "custom" };
+		expect(isPairedToManagedCloud()).toBe(false);
+	});
+
+	it("is false when unpaired, and never gates on remote_provider alone", () => {
+		subs.config = undefined;
+		expect(isPairedToManagedCloud()).toBe(false);
+		// A provider with no remote_key is NOT paired (e.g. stale config field).
+		subs.config = { remote_provider: "ceralive" };
+		expect(isPairedToManagedCloud()).toBe(false);
+	});
+});
+
+describe("i18n — remote-control status keys in all 10 locales", () => {
+	const KEYS = [
+		"title",
+		"notPaired",
+		"notPairedHint",
+		"disconnected",
+		"disconnectedHint",
+		"connected",
+		"connectedHint",
+	] as const;
+
+	it("has all 10 locales registered", () => {
+		expect(existingLocales).toHaveLength(10);
+	});
+
+	for (const { code } of existingLocales) {
+		it(`provides every settings.remoteControl key for "${code}"`, async () => {
+			const translation = (await loadLocale(code)) as {
+				settings: { remoteControl: Record<string, unknown> };
+			};
+			const remoteControl = translation.settings.remoteControl;
+			for (const key of KEYS) {
+				expect(typeof remoteControl[key]).toBe("string");
+				expect((remoteControl[key] as string).length).toBeGreaterThan(0);
+			}
+		});
+	}
+});

--- a/apps/frontend/src/lib/stores/pairing.svelte.ts
+++ b/apps/frontend/src/lib/stores/pairing.svelte.ts
@@ -7,7 +7,7 @@
  *
  * MULTI-CLOUD SAFETY (open-source contract)
  * -----------------------------------------
- * Pairing is `remote_key` PRESENCE — never `remote_provider === 'ceralive'`.
+ * Pairing is `remote_key` PRESENCE — never a single-provider literal gate.
  * `remote_provider` only IDENTIFIES which managed cloud a paired device belongs
  * to; gating on a single provider literal would break self-hosted, BELABOX, and
  * any future managed cloud. `getRemoteProvider()` therefore NEVER defaults to

--- a/apps/frontend/src/lib/stores/pairing.svelte.ts
+++ b/apps/frontend/src/lib/stores/pairing.svelte.ts
@@ -1,0 +1,168 @@
+/**
+ * Pairing & remote-control store — Task 8 (CeraUI N1).
+ *
+ * The single source of truth for two related questions:
+ *   1. Is this device paired to a cloud account, and to WHICH provider?
+ *   2. What is the device-control channel's status (the 3-state Settings row)?
+ *
+ * MULTI-CLOUD SAFETY (open-source contract)
+ * -----------------------------------------
+ * Pairing is `remote_key` PRESENCE — never `remote_provider === 'ceralive'`.
+ * `remote_provider` only IDENTIFIES which managed cloud a paired device belongs
+ * to; gating on a single provider literal would break self-hosted, BELABOX, and
+ * any future managed cloud. `getRemoteProvider()` therefore NEVER defaults to
+ * `'ceralive'` — an absent provider reads as "no managed provider" for gating.
+ *
+ * Pairing facts (`isPairedToCloud`, `getRemoteProvider`, `isPairedToManagedCloud`)
+ * are pure reads off the authoritative config broadcast (`getConfig()`), so they
+ * need no local reactive state. The control-channel connectivity (up/down) is a
+ * separate runtime signal owned by the backend remote-control module; it is
+ * folded in via {@link setControlChannelConnected} — ingested from the
+ * `remote-control` broadcast in `subscriptions.svelte.ts`, or driven directly by
+ * a dev seam / test.
+ *
+ * Architecture mirrors `stream-health.svelte.ts` / `buffering.svelte.ts`: all
+ * decision logic lives in pure, rune-free exported functions; the reactive layer
+ * (the dual-URL global singleton) is the only place that touches runes.
+ */
+import type { ProviderSelection } from "@ceraui/rpc/schemas";
+
+import { getConfig } from "$lib/rpc/subscriptions.svelte";
+
+/**
+ * The render-ready 3-state remote-control indicator rollup (Settings row — NOT
+ * the HUD, whose 5-signal contract is frozen):
+ *   - `not-paired`          — no `remote_key`.
+ *   - `paired-disconnected` — `remote_key` present, control channel down.
+ *   - `connected`           — `remote_key` present, control channel up.
+ */
+export type RemoteControlStatus =
+	| "not-paired"
+	| "paired-disconnected"
+	| "connected";
+
+/**
+ * Managed-cloud providers — a hosted cloud account that pushes a relay catalog /
+ * ingest slots. `custom` is the self-hosted / BYO provider and is intentionally
+ * NOT a managed provider, so managed-cloud surfaces stay gated for it while the
+ * custom receiver path is always reachable. New managed providers are added HERE
+ * — never gate on a single literal at a call site.
+ */
+const MANAGED_PROVIDERS: ReadonlySet<ProviderSelection> =
+	new Set<ProviderSelection>(["ceralive", "belabox"]);
+
+/** Paired to a cloud account ⇔ a `remote_key` is present. Provider-agnostic. */
+export function isPairedToCloud(): boolean {
+	return getConfig()?.remote_key !== undefined;
+}
+
+/**
+ * The managed cloud provider this device is paired to, or `undefined`. NEVER
+ * defaults to `'ceralive'` — an absent provider must read as "no managed
+ * provider" for gating, not as the CeraLive cloud.
+ */
+export function getRemoteProvider(): ProviderSelection | undefined {
+	return getConfig()?.remote_provider ?? undefined;
+}
+
+/** Whether a provider id is one of the managed clouds (not custom/self-hosted). */
+export function isManagedProvider(
+	provider: ProviderSelection | undefined,
+): boolean {
+	return provider !== undefined && MANAGED_PROVIDERS.has(provider);
+}
+
+/**
+ * Gate for managed-cloud surfaces (managed destination choice, ingest slots):
+ * paired AND the provider is a managed cloud. False for unpaired devices and for
+ * custom/self-hosted pairings. The custom/self-hosted receiver path stays
+ * available regardless — callers must NEVER gate the custom path on this.
+ */
+export function isPairedToManagedCloud(): boolean {
+	return isPairedToCloud() && isManagedProvider(getRemoteProvider());
+}
+
+/**
+ * Pure 3-state derivation (unit-testable without runes or config):
+ *   - no remote_key                      → "not-paired"
+ *   - remote_key + control channel down  → "paired-disconnected"
+ *   - remote_key + control channel up    → "connected"
+ */
+export function deriveRemoteControlStatus(
+	hasRemoteKey: boolean,
+	controlChannelUp: boolean,
+): RemoteControlStatus {
+	if (!hasRemoteKey) return "not-paired";
+	return controlChannelUp ? "connected" : "paired-disconnected";
+}
+
+// ============================================
+// Control-channel connectivity (runes singleton)
+// ============================================
+
+interface PairingStore {
+	setControlChannelConnected(connected: boolean): void;
+	isControlChannelConnected(): boolean;
+	reset(): void;
+}
+
+function createPairingStore(): PairingStore {
+	let controlChannelConnected = $state(false);
+	return {
+		setControlChannelConnected: (connected: boolean) => {
+			controlChannelConnected = connected;
+		},
+		isControlChannelConnected: () => controlChannelConnected,
+		reset: () => {
+			controlChannelConnected = false;
+		},
+	};
+}
+
+// Held on `globalThis` under a shared symbol AND created eagerly — the same
+// dual-URL guard `stream-health.svelte.ts` / `notifications.svelte.ts` use. In
+// Vite dev this `.svelte.ts` is served under two browser URLs (one for `.svelte`
+// importers like the Settings row, one for `.ts` importers like subscriptions),
+// so a plain module-level rune would split producer and consumer into two
+// stores. The shared key gives both copies ONE reactive store.
+const STORE_KEY = Symbol.for("ceraui.pairingStore");
+type GlobalWithStore = typeof globalThis & { [STORE_KEY]?: PairingStore };
+
+const singletonStore: PairingStore = ((): PairingStore => {
+	const g = globalThis as GlobalWithStore;
+	const existing = g[STORE_KEY] ?? createPairingStore();
+	g[STORE_KEY] = existing;
+	return existing;
+})();
+
+function store(): PairingStore {
+	return singletonStore;
+}
+
+/**
+ * Fold the remote-control channel connectivity into the store. Fed by the
+ * `remote-control` broadcast (subscriptions) when the backend reports the
+ * device-control channel up/down, or driven directly by a dev seam / test.
+ * Pairing itself comes from `config.remote_key`, never from this signal.
+ */
+export function setControlChannelConnected(connected: boolean): void {
+	store().setControlChannelConnected(connected);
+}
+
+/** Whether the device-control channel to the cloud hub is currently up. */
+export function isControlChannelConnected(): boolean {
+	return store().isControlChannelConnected();
+}
+
+/** The current 3-state remote-control rollup for the Settings indicator row. */
+export function getRemoteControlStatus(): RemoteControlStatus {
+	return deriveRemoteControlStatus(
+		isPairedToCloud(),
+		isControlChannelConnected(),
+	);
+}
+
+/** Reset control-channel state (test/logout symmetry). */
+export function resetPairingState(): void {
+	store().reset();
+}

--- a/apps/frontend/src/lib/streaming/receiver-experience.test.ts
+++ b/apps/frontend/src/lib/streaming/receiver-experience.test.ts
@@ -11,6 +11,7 @@ import {
 	deriveDestination,
 	deriveServerReadiness,
 	findActiveSlot,
+	groupRelayServersByProvider,
 	kindBadgeLabelKey,
 	type ManagedIngestAccount,
 	managedSlotLabel,
@@ -595,5 +596,44 @@ describe("buildManagedSlotConfig — persisted slot selection", () => {
 	it("coerces an unknown slot protocol to srtla (never undefined)", () => {
 		const result = buildManagedSlotConfig(slot({ protocol: "bogus" }), 2000);
 		expect(result.relay_protocol).toBe("srtla");
+	});
+});
+
+describe("groupRelayServersByProvider (T9)", () => {
+	const ceralive = { id: "ceralive", name: "CeraLive Cloud", kind: "ceralive" } as const;
+	const belabox = { id: "belabox", name: "BELABOX Cloud", kind: "belabox" } as const;
+
+	const taggedEntries: [string, RelayServer][] = [
+		["eu", relayServer({ name: "EU-West", provider: ceralive })],
+		["us", relayServer({ name: "US-East", provider: ceralive })],
+		["asia", relayServer({ name: "Asia-SE", provider: belabox })],
+		["west", relayServer({ name: "US-West", provider: belabox })],
+	];
+
+	it("sees at least two providers across a multi-provider catalog", () => {
+		const groups = groupRelayServersByProvider(taggedEntries, "ceralive");
+		expect(groups.length).toBeGreaterThanOrEqual(2);
+		expect(groups.map((g) => g.providerId)).toEqual(["ceralive", "belabox"]);
+	});
+
+	it("places each server in its tagged provider group", () => {
+		const groups = groupRelayServersByProvider(taggedEntries, "ceralive");
+		const byId = new Map(groups.map((g) => [g.providerId, g]));
+		expect(byId.get("ceralive")?.servers.map(([id]) => id)).toEqual(["eu", "us"]);
+		expect(byId.get("belabox")?.servers.map(([id]) => id)).toEqual(["asia", "west"]);
+		expect(byId.get("belabox")?.kind).toBe("belabox");
+		expect(byId.get("belabox")?.providerName).toBe("BELABOX Cloud");
+	});
+
+	it("falls back to the configured provider for untagged (legacy) servers", () => {
+		const legacy: [string, RelayServer][] = [
+			["a", relayServer({ name: "Legacy A" })],
+			["b", relayServer({ name: "Legacy B" })],
+		];
+		const groups = groupRelayServersByProvider(legacy, "ceralive");
+		expect(groups).toHaveLength(1);
+		expect(groups[0]?.providerId).toBe("ceralive");
+		expect(groups[0]?.kind).toBe("unknown");
+		expect(groups[0]?.servers).toHaveLength(2);
 	});
 });

--- a/apps/frontend/src/lib/streaming/receiver-experience.test.ts
+++ b/apps/frontend/src/lib/streaming/receiver-experience.test.ts
@@ -6,6 +6,7 @@ import {
 	autoSelectIngestSlot,
 	autoSelectManagedRelay,
 	autoSelectManagedTransport,
+	availableManagedProviders,
 	buildManagedSlotConfig,
 	buildServerSetConfig,
 	buildServerSummary,
@@ -17,7 +18,9 @@ import {
 	groupRelayServersByProvider,
 	kindBadgeLabelKey,
 	type ManagedIngestAccount,
+	type ManagedProviderOption,
 	managedSlotLabel,
+	resolveActiveManagedProvider,
 	resolveReceiverKind,
 	type ServerSetDerived,
 	type ServerSetDraft,
@@ -603,8 +606,16 @@ describe("buildManagedSlotConfig — persisted slot selection", () => {
 });
 
 describe("groupRelayServersByProvider (T9)", () => {
-	const ceralive = { id: "ceralive", name: "CeraLive Cloud", kind: "ceralive" } as const;
-	const belabox = { id: "belabox", name: "BELABOX Cloud", kind: "belabox" } as const;
+	const ceralive = {
+		id: "ceralive",
+		name: "CeraLive Cloud",
+		kind: "ceralive",
+	} as const;
+	const belabox = {
+		id: "belabox",
+		name: "BELABOX Cloud",
+		kind: "belabox",
+	} as const;
 
 	const taggedEntries: [string, RelayServer][] = [
 		["eu", relayServer({ name: "EU-West", provider: ceralive })],
@@ -622,8 +633,14 @@ describe("groupRelayServersByProvider (T9)", () => {
 	it("places each server in its tagged provider group", () => {
 		const groups = groupRelayServersByProvider(taggedEntries, "ceralive");
 		const byId = new Map(groups.map((g) => [g.providerId, g]));
-		expect(byId.get("ceralive")?.servers.map(([id]) => id)).toEqual(["eu", "us"]);
-		expect(byId.get("belabox")?.servers.map(([id]) => id)).toEqual(["asia", "west"]);
+		expect(byId.get("ceralive")?.servers.map(([id]) => id)).toEqual([
+			"eu",
+			"us",
+		]);
+		expect(byId.get("belabox")?.servers.map(([id]) => id)).toEqual([
+			"asia",
+			"west",
+		]);
 		expect(byId.get("belabox")?.kind).toBe("belabox");
 		expect(byId.get("belabox")?.providerName).toBe("BELABOX Cloud");
 	});
@@ -641,8 +658,16 @@ describe("groupRelayServersByProvider (T9)", () => {
 	});
 });
 
-const CERALIVE = { id: "ceralive", name: "CeraLive Cloud", kind: "ceralive" } as const;
-const BELABOX = { id: "belabox", name: "BELABOX Cloud", kind: "belabox" } as const;
+const CERALIVE = {
+	id: "ceralive",
+	name: "CeraLive Cloud",
+	kind: "ceralive",
+} as const;
+const BELABOX = {
+	id: "belabox",
+	name: "BELABOX Cloud",
+	kind: "belabox",
+} as const;
 
 describe("countRelayServersForProvider — per-provider D6 gate (T10)", () => {
 	it("counts every untagged (legacy) server for the active provider", () => {
@@ -785,10 +810,120 @@ describe("autoSelectManagedTransport — single + multi transport seed (T10)", (
 	});
 
 	it("multi transport, current already advertised → no change", () => {
-		expect(autoSelectManagedTransport(["srtla", "rist"], "rist")).toBeUndefined();
+		expect(
+			autoSelectManagedTransport(["srtla", "rist"], "rist"),
+		).toBeUndefined();
 	});
 
 	it("no advertised transports → no change", () => {
 		expect(autoSelectManagedTransport([], "srtla")).toBeUndefined();
+	});
+});
+
+describe("availableManagedProviders — multi-cloud provider list (T12)", () => {
+	it("offers a single managed provider for a single-provider catalog", () => {
+		const entries: [string, RelayServer][] = [
+			["eu", relayServer({ provider: CERALIVE })],
+			["us", relayServer({ provider: CERALIVE })],
+		];
+		expect(availableManagedProviders(entries, "ceralive")).toEqual([
+			{
+				id: "ceralive",
+				name: "CeraLive Cloud",
+				kind: "ceralive",
+				serverCount: 2,
+			},
+		]);
+	});
+
+	it("offers every managed provider in a multi-provider catalog, first-seen order", () => {
+		const entries: [string, RelayServer][] = [
+			["eu", relayServer({ provider: CERALIVE })],
+			["asia", relayServer({ provider: BELABOX })],
+			["us", relayServer({ provider: CERALIVE })],
+		];
+		expect(availableManagedProviders(entries, "ceralive")).toEqual([
+			{
+				id: "ceralive",
+				name: "CeraLive Cloud",
+				kind: "ceralive",
+				serverCount: 2,
+			},
+			{ id: "belabox", name: "BELABOX Cloud", kind: "belabox", serverCount: 1 },
+		]);
+	});
+
+	it("offers only BELABOX when the catalog carries only BELABOX servers", () => {
+		const entries: [string, RelayServer][] = [
+			["asia", relayServer({ provider: BELABOX })],
+			["west", relayServer({ provider: BELABOX })],
+		];
+		const options = availableManagedProviders(entries, "ceralive");
+		expect(options.map((o) => o.id)).toEqual(["belabox"]);
+	});
+
+	it("treats untagged (legacy) servers as the fallback managed provider", () => {
+		const legacy: [string, RelayServer][] = [
+			["a", relayServer()],
+			["b", relayServer()],
+		];
+		expect(availableManagedProviders(legacy, "ceralive")).toEqual([
+			{ id: "ceralive", kind: "ceralive", serverCount: 2 },
+		]);
+	});
+
+	it("never offers the self-hosted custom provider or an empty catalog", () => {
+		expect(availableManagedProviders([], "ceralive")).toEqual([]);
+		const customTagged: [string, RelayServer][] = [
+			[
+				"self",
+				relayServer({
+					provider: { id: "self", name: "My Box", kind: "custom" },
+				}),
+			],
+		];
+		expect(availableManagedProviders(customTagged, "ceralive")).toEqual([]);
+	});
+
+	it("does not offer a managed provider when the fallback id is custom and servers are untagged", () => {
+		const legacy: [string, RelayServer][] = [["a", relayServer()]];
+		expect(availableManagedProviders(legacy, "custom")).toEqual([]);
+	});
+});
+
+describe("resolveActiveManagedProvider — auto-select-if-one (T12)", () => {
+	const ceralive: ManagedProviderOption = {
+		id: "ceralive",
+		kind: "ceralive",
+		serverCount: 1,
+	};
+	const belabox: ManagedProviderOption = {
+		id: "belabox",
+		kind: "belabox",
+		serverCount: 1,
+	};
+
+	it("an explicit draft pick always wins", () => {
+		expect(
+			resolveActiveManagedProvider([ceralive, belabox], "ceralive", "belabox"),
+		).toBe("belabox");
+	});
+
+	it("prefers the configured provider when it offers servers", () => {
+		expect(
+			resolveActiveManagedProvider([ceralive, belabox], "belabox", undefined),
+		).toBe("belabox");
+	});
+
+	it("auto-selects the only/first provider when the configured one has none", () => {
+		expect(resolveActiveManagedProvider([belabox], "ceralive", undefined)).toBe(
+			"belabox",
+		);
+	});
+
+	it("falls back to the configured provider for an empty catalog", () => {
+		expect(resolveActiveManagedProvider([], "ceralive", undefined)).toBe(
+			"ceralive",
+		);
 	});
 });

--- a/apps/frontend/src/lib/streaming/receiver-experience.test.ts
+++ b/apps/frontend/src/lib/streaming/receiver-experience.test.ts
@@ -4,9 +4,12 @@ import { describe, expect, it } from "vitest";
 
 import {
 	autoSelectIngestSlot,
+	autoSelectManagedRelay,
+	autoSelectManagedTransport,
 	buildManagedSlotConfig,
 	buildServerSetConfig,
 	buildServerSummary,
+	countRelayServersForProvider,
 	type Destination,
 	deriveDestination,
 	deriveServerReadiness,
@@ -635,5 +638,157 @@ describe("groupRelayServersByProvider (T9)", () => {
 		expect(groups[0]?.providerId).toBe("ceralive");
 		expect(groups[0]?.kind).toBe("unknown");
 		expect(groups[0]?.servers).toHaveLength(2);
+	});
+});
+
+const CERALIVE = { id: "ceralive", name: "CeraLive Cloud", kind: "ceralive" } as const;
+const BELABOX = { id: "belabox", name: "BELABOX Cloud", kind: "belabox" } as const;
+
+describe("countRelayServersForProvider — per-provider D6 gate (T10)", () => {
+	it("counts every untagged (legacy) server for the active provider", () => {
+		const legacy: [string, RelayServer][] = [
+			["a", relayServer()],
+			["b", relayServer()],
+		];
+		expect(countRelayServersForProvider(legacy, "ceralive")).toBe(2);
+		expect(countRelayServersForProvider(legacy, "belabox")).toBe(2);
+	});
+
+	it("counts only the tagged servers that belong to the selected provider", () => {
+		const tagged: [string, RelayServer][] = [
+			["eu", relayServer({ provider: CERALIVE })],
+			["us", relayServer({ provider: CERALIVE })],
+			["asia", relayServer({ provider: BELABOX })],
+		];
+		expect(countRelayServersForProvider(tagged, "ceralive")).toBe(2);
+		expect(countRelayServersForProvider(tagged, "belabox")).toBe(1);
+	});
+
+	it("returns 0 when the selected provider has no servers", () => {
+		const onlyBelabox: [string, RelayServer][] = [
+			["asia", relayServer({ provider: BELABOX })],
+		];
+		expect(countRelayServersForProvider(onlyBelabox, "ceralive")).toBe(0);
+		expect(countRelayServersForProvider([], "ceralive")).toBe(0);
+	});
+});
+
+describe("autoSelectManagedRelay — managed relay auto-detection (T10)", () => {
+	it("no servers for the provider → undefined (custom fallback)", () => {
+		expect(autoSelectManagedRelay([], undefined, "ceralive")).toBeUndefined();
+		const onlyBelabox: [string, RelayServer][] = [
+			["asia", relayServer({ provider: BELABOX })],
+		];
+		expect(
+			autoSelectManagedRelay(onlyBelabox, undefined, "ceralive"),
+		).toBeUndefined();
+	});
+
+	it("exactly one server → silent single auto-select", () => {
+		const entries: [string, RelayServer][] = [["fra", relayServer()]];
+		expect(autoSelectManagedRelay(entries, undefined, "ceralive")).toEqual({
+			kind: "single",
+			serverId: "fra",
+			server: entries[0]?.[1],
+		});
+	});
+
+	it("many servers → picks the default-flagged one", () => {
+		const entries: [string, RelayServer][] = [
+			["eu", relayServer({ name: "EU" })],
+			["us", relayServer({ name: "US", default: true })],
+			["asia", relayServer({ name: "Asia" })],
+		];
+		expect(autoSelectManagedRelay(entries, undefined, "ceralive")).toEqual({
+			kind: "default",
+			serverId: "us",
+			server: entries[1]?.[1],
+		});
+	});
+
+	it("many servers, no default → picks the last-used (persisted relay_server)", () => {
+		const entries: [string, RelayServer][] = [
+			["eu", relayServer({ name: "EU" })],
+			["us", relayServer({ name: "US" })],
+		];
+		expect(autoSelectManagedRelay(entries, "us", "ceralive")).toEqual({
+			kind: "lastUsed",
+			serverId: "us",
+			server: entries[1]?.[1],
+		});
+	});
+
+	it("default wins over last-used when both are present", () => {
+		const entries: [string, RelayServer][] = [
+			["eu", relayServer({ name: "EU", default: true })],
+			["us", relayServer({ name: "US" })],
+		];
+		expect(autoSelectManagedRelay(entries, "us", "ceralive")).toEqual({
+			kind: "default",
+			serverId: "eu",
+			server: entries[0]?.[1],
+		});
+	});
+
+	it("many servers, no default and no last-used → prompt (never silent)", () => {
+		const entries: [string, RelayServer][] = [
+			["eu", relayServer({ name: "EU" })],
+			["us", relayServer({ name: "US" })],
+		];
+		expect(autoSelectManagedRelay(entries, undefined, "ceralive")).toEqual({
+			kind: "prompt",
+			servers: entries,
+		});
+		// A stale/unknown last-used id also falls through to prompt.
+		expect(autoSelectManagedRelay(entries, "gone", "ceralive")).toEqual({
+			kind: "prompt",
+			servers: entries,
+		});
+	});
+
+	it("never auto-picks across providers — scopes to the selected provider only", () => {
+		// One server per provider: selecting a provider auto-picks ITS single
+		// server, never the other provider's, so no silent cross-cloud jump.
+		const entries: [string, RelayServer][] = [
+			["eu", relayServer({ name: "EU", provider: CERALIVE })],
+			["asia", relayServer({ name: "Asia", provider: BELABOX })],
+		];
+		expect(autoSelectManagedRelay(entries, undefined, "ceralive")).toEqual({
+			kind: "single",
+			serverId: "eu",
+			server: entries[0]?.[1],
+		});
+		expect(autoSelectManagedRelay(entries, undefined, "belabox")).toEqual({
+			kind: "single",
+			serverId: "asia",
+			server: entries[1]?.[1],
+		});
+	});
+});
+
+describe("autoSelectManagedTransport — single + multi transport seed (T10)", () => {
+	it("single advertised transport, not the current → seeds it (single transport→auto)", () => {
+		expect(autoSelectManagedTransport(["rist"], "srtla")).toBe("rist");
+	});
+
+	it("single advertised transport already current → no change", () => {
+		expect(autoSelectManagedTransport(["srtla"], "srtla")).toBeUndefined();
+		expect(autoSelectManagedTransport(["rist"], "rist")).toBeUndefined();
+	});
+
+	it("multi transport, current unsupported → prefers bonded SRTLA when offered", () => {
+		expect(autoSelectManagedTransport(["srtla", "rist"], "srt")).toBe("srtla");
+	});
+
+	it("multi transport, current unsupported and no SRTLA → first advertised", () => {
+		expect(autoSelectManagedTransport(["rist", "srt"], "srtla")).toBe("rist");
+	});
+
+	it("multi transport, current already advertised → no change", () => {
+		expect(autoSelectManagedTransport(["srtla", "rist"], "rist")).toBeUndefined();
+	});
+
+	it("no advertised transports → no change", () => {
+		expect(autoSelectManagedTransport([], "srtla")).toBeUndefined();
 	});
 });

--- a/apps/frontend/src/lib/streaming/receiver-experience.ts
+++ b/apps/frontend/src/lib/streaming/receiver-experience.ts
@@ -25,6 +25,7 @@ import {
 	deriveReceiverKind,
 	type ReceiverKind,
 	type RelayProtocol,
+	type RelayProviderKind,
 	type RelayServer,
 	relayProtocolSchema,
 	type StreamingConfigInput,
@@ -54,6 +55,45 @@ export function deriveDestination(
 	config: DestinationConfig | undefined,
 ): Destination {
 	return config?.relay_server ? "managed" : "custom";
+}
+
+/** A relay-catalog grouping keyed by the server's provider origin (T9). */
+export interface RelayProviderGroup {
+	/** Provider id the servers are grouped under (the namespacing key). */
+	providerId: string;
+	/** Provider display name, when the servers carry tagged metadata. */
+	providerName?: string;
+	/** Provider taxonomy, or `"unknown"` for untagged (legacy) servers. */
+	kind: RelayProviderKind | "unknown";
+	servers: Array<[string, RelayServer]>;
+}
+
+/**
+ * Group relay-catalog server entries by their tagged provider origin (T9), so
+ * the server dialog can present multi-provider catalogs grouped by cloud.
+ * Untagged (legacy) servers fall back to `fallbackProviderId` for DISPLAY only —
+ * grouping never gates a server out. First-seen provider order is preserved.
+ */
+export function groupRelayServersByProvider(
+	entries: ReadonlyArray<[string, RelayServer]>,
+	fallbackProviderId: string,
+): RelayProviderGroup[] {
+	const groups = new Map<string, RelayProviderGroup>();
+	for (const [id, server] of entries) {
+		const providerId = server.provider?.id ?? fallbackProviderId;
+		let group = groups.get(providerId);
+		if (!group) {
+			group = {
+				providerId,
+				providerName: server.provider?.name,
+				kind: server.provider?.kind ?? "unknown",
+				servers: [],
+			};
+			groups.set(providerId, group);
+		}
+		group.servers.push([id, server]);
+	}
+	return [...groups.values()];
 }
 
 export interface ResolveReceiverKindInput {

--- a/apps/frontend/src/lib/streaming/receiver-experience.ts
+++ b/apps/frontend/src/lib/streaming/receiver-experience.ts
@@ -96,6 +96,119 @@ export function groupRelayServersByProvider(
 	return [...groups.values()];
 }
 
+/**
+ * Match rule for "does this catalog server belong to `provider`?". Mirrors the
+ * ServerDialog provider filter: a tagged server matches on its `provider.kind`,
+ * and an UNTAGGED (legacy) server falls back to the active provider — so a
+ * single-provider legacy catalog behaves exactly as before. Shared by the
+ * per-provider D6 gate count and the managed-relay auto-selection.
+ */
+function relayServerBelongsToProvider(
+	server: RelayServer,
+	provider: string,
+): boolean {
+	return (server.provider?.kind ?? provider) === provider;
+}
+
+/**
+ * Count the relay-catalog servers that belong to `provider` (T10). The
+ * destination D6 gate uses this so "managed is available" reflects the SELECTED
+ * provider's servers, not the whole multi-provider catalog: a provider with no
+ * servers gates managed off even when another provider has some. Untagged legacy
+ * servers belong to the active provider, so a single-provider catalog counts in
+ * full (no behaviour change).
+ */
+export function countRelayServersForProvider(
+	entries: ReadonlyArray<[string, RelayServer]>,
+	provider: string,
+): number {
+	return entries.filter(([, server]) =>
+		relayServerBelongsToProvider(server, provider),
+	).length;
+}
+
+/**
+ * The outcome of auto-selecting a managed relay server for the active provider
+ * (T10) — the relay-catalog mirror of {@link autoSelectIngestSlot}:
+ * - `single`   — exactly one server for the provider → silent auto-select.
+ * - `default`  — many servers, one carries the `default` flag → silent.
+ * - `lastUsed` — many servers, none default, the persisted `relay_server` (the
+ *   last-used id) still resolves → silent.
+ * - `prompt`   — many servers, none default and no last-used: the operator must
+ *   pick one (NEVER auto-selected silently).
+ *
+ * `undefined` (no servers for the provider) maps to the custom fallback, which
+ * the destination radiogroup keeps reachable in every branch.
+ */
+export type ManagedRelaySelection =
+	| {
+			kind: "single" | "default" | "lastUsed";
+			serverId: string;
+			server: RelayServer;
+	  }
+	| { kind: "prompt"; servers: ReadonlyArray<[string, RelayServer]> }
+	| undefined;
+
+/**
+ * Auto-select a managed relay server for `provider` from the relay catalog + the
+ * persisted last-used `relay_server` id (T10). Rule (mirrors
+ * {@link autoSelectIngestSlot}): exactly one server for the provider → that
+ * server (silent); many → the `default` server, else the last-used server, else
+ * prompt; none → `undefined` (custom fallback). Only the SELECTED provider's
+ * servers are considered, so a single-server auto-pick is never made across
+ * providers — a multi-provider catalog never silently jumps clouds.
+ */
+export function autoSelectManagedRelay(
+	servers: ReadonlyArray<[string, RelayServer]>,
+	selectedId: string | undefined,
+	provider: string,
+): ManagedRelaySelection {
+	const own = servers.filter(([, server]) =>
+		relayServerBelongsToProvider(server, provider),
+	);
+	if (own.length === 0) return undefined;
+	const only = own[0];
+	if (own.length === 1 && only) {
+		return { kind: "single", serverId: only[0], server: only[1] };
+	}
+	const defaultServer = own.find(([, server]) => server.default);
+	if (defaultServer) {
+		return {
+			kind: "default",
+			serverId: defaultServer[0],
+			server: defaultServer[1],
+		};
+	}
+	const lastUsed = selectedId
+		? own.find(([id]) => id === selectedId)
+		: undefined;
+	if (lastUsed) {
+		return { kind: "lastUsed", serverId: lastUsed[0], server: lastUsed[1] };
+	}
+	return { kind: "prompt", servers: own };
+}
+
+/**
+ * The relay transport to seed for a selected managed server (T10): the transport
+ * to persist as `relay_protocol`, or `undefined` when no change is needed (no
+ * advertised transports, or the current protocol is already advertised). Prefers
+ * bonded SRTLA when offered, else the server's first advertised transport.
+ *
+ * This now fires for a SINGLE advertised transport too — previously only
+ * multi-transport servers re-seeded the protocol, so a single-transport server
+ * whose only transport differed from the draft left a stale `relay_protocol`
+ * persisted. The per-server chooser stays the single user-facing writer; this
+ * only computes a valid default.
+ */
+export function autoSelectManagedTransport(
+	serverProtocols: readonly RelayProtocol[],
+	currentProtocol: RelayProtocol,
+): RelayProtocol | undefined {
+	if (serverProtocols.length === 0) return undefined;
+	if (serverProtocols.includes(currentProtocol)) return undefined;
+	return serverProtocols.includes("srtla") ? "srtla" : serverProtocols[0];
+}
+
 export interface ResolveReceiverKindInput {
 	/** Requested transport; `undefined` (legacy config) coerces to `srtla`. */
 	protocol: RelayProtocol | undefined;

--- a/apps/frontend/src/lib/streaming/receiver-experience.ts
+++ b/apps/frontend/src/lib/streaming/receiver-experience.ts
@@ -23,6 +23,7 @@
 
 import {
 	deriveReceiverKind,
+	RELAY_PROVIDER_KINDS,
 	type ReceiverKind,
 	type RelayProtocol,
 	type RelayProviderKind,
@@ -125,6 +126,97 @@ export function countRelayServersForProvider(
 	return entries.filter(([, server]) =>
 		relayServerBelongsToProvider(server, provider),
 	).length;
+}
+
+/**
+ * Resolve a relay-provider id to its taxonomy. A predefined relay provider id
+ * (`ceralive`, `belabox`, `custom`, + any future entry in `RELAY_PROVIDER_KINDS`)
+ * maps to itself; anything else reads as `"unknown"`. Used to give untagged
+ * (legacy) servers — grouped under the device's configured provider — a real
+ * taxonomy so the managed-provider picker can decide if that provider is managed.
+ */
+function relayProviderKindForId(id: string): RelayProviderKind | "unknown" {
+	return (RELAY_PROVIDER_KINDS as readonly string[]).includes(id)
+		? (id as RelayProviderKind)
+		: "unknown";
+}
+
+/**
+ * One offerable managed cloud provider for the destination picker (T12). `custom`
+ * is the self-hosted escape hatch and is NEVER a managed provider, so it never
+ * appears here — the ServerDialog renders it through the always-available custom
+ * destination path instead.
+ */
+export interface ManagedProviderOption {
+	/** Provider id used as the picker value + the per-provider catalog filter key. */
+	id: string;
+	/** Provider display name when the catalog tagged it; else the consumer labels it. */
+	name?: string;
+	/** Provider taxonomy (always a managed kind — `custom`/`unknown` are excluded). */
+	kind: RelayProviderKind;
+	/** Number of catalog servers offered by this provider. */
+	serverCount: number;
+}
+
+/**
+ * Derive the MANAGED cloud providers a relay catalog actually offers (T12), in
+ * first-seen order. This is the multi-cloud, select-not-fill source of truth for
+ * the provider picker: the list is computed from the catalog the paired cloud(s)
+ * pushed — never a hardcoded `['ceralive','belabox']` literal — so a new managed
+ * cloud appears automatically once its servers arrive, and a cloud the device is
+ * NOT paired to (no servers in the catalog) is simply absent.
+ *
+ * Rules:
+ * - Servers are grouped by their tagged provider; untagged (legacy) servers fall
+ *   to `fallbackProviderId` (the device's configured provider) for DISPLAY only.
+ * - A group is offered only when its provider is a MANAGED cloud (its kind is in
+ *   `RELAY_PROVIDER_KINDS` and is not `custom`) AND it has at least one server.
+ *   The self-hosted `custom` provider and unknown ids are excluded — the custom
+ *   receiver is reached through the destination radiogroup, never this picker.
+ */
+export function availableManagedProviders(
+	entries: ReadonlyArray<[string, RelayServer]>,
+	fallbackProviderId: string,
+): ManagedProviderOption[] {
+	const options: ManagedProviderOption[] = [];
+	for (const group of groupRelayServersByProvider(
+		entries,
+		fallbackProviderId,
+	)) {
+		if (group.servers.length === 0) continue;
+		const kind =
+			group.kind === "unknown"
+				? relayProviderKindForId(group.providerId)
+				: group.kind;
+		if (kind === "unknown" || kind === "custom") continue;
+		options.push({
+			id: group.providerId,
+			name: group.providerName,
+			kind,
+			serverCount: group.servers.length,
+		});
+	}
+	return options;
+}
+
+/**
+ * Choose the ACTIVE managed provider for the picker (T12), the auto-select-if-one
+ * rule for providers: an explicit operator pick (`draftProvider`) always wins;
+ * otherwise the device's configured provider when it offers servers; otherwise
+ * the first available provider (so a single offered provider — or a catalog that
+ * only carries a non-configured cloud — auto-selects without a manual pick). Falls
+ * back to `configProvider` when the catalog is empty so the value is never blank.
+ */
+export function resolveActiveManagedProvider(
+	options: ReadonlyArray<ManagedProviderOption>,
+	configProvider: string,
+	draftProvider: string | undefined,
+): string {
+	if (draftProvider !== undefined) return draftProvider;
+	if (options.some((option) => option.id === configProvider)) {
+		return configProvider;
+	}
+	return options[0]?.id ?? configProvider;
 }
 
 /**

--- a/apps/frontend/src/main/SettingsView.svelte
+++ b/apps/frontend/src/main/SettingsView.svelte
@@ -47,6 +47,7 @@ import PowerDialog from './dialogs/PowerDialog.svelte';
 import AddonsSection from './settings/AddonsSection.svelte';
 import DeviceStatsSection from './settings/DeviceStatsSection.svelte';
 import OnDeviceDisplaySection from './settings/OnDeviceDisplaySection.svelte';
+import RemoteControlStatus from './settings/RemoteControlStatus.svelte';
 import SshDialog from './dialogs/SshDialog.svelte';
 import UpdatesDialog from './dialogs/UpdatesDialog.svelte';
 import VersionsDialog from './dialogs/VersionsDialog.svelte';
@@ -294,6 +295,7 @@ const ActiveIcon = $derived(active?.icon);
 					<h2 class="text-muted-foreground px-1 text-sm font-medium">{group.label}</h2>
 					<div class="divide-border bg-card divide-y overflow-hidden rounded-xl border">
 						{#if group.id === 'streaming'}
+							<RemoteControlStatus />
 							<div class="flex w-full items-center gap-4 px-4 py-3.5" data-testid="settings-autostart">
 								<span class="bg-secondary text-foreground grid size-9 shrink-0 place-items-center rounded-lg">
 									<Rocket class="size-[18px]" />

--- a/apps/frontend/src/main/dialogs/ServerDialog.kind.test.ts
+++ b/apps/frontend/src/main/dialogs/ServerDialog.kind.test.ts
@@ -79,6 +79,12 @@ vi.mock("$lib/rpc/subscriptions.svelte", () => ({
 	getSelectedIngestEndpoint: () => undefined,
 }));
 
+// Kind/save behaviour is tested with a paired managed device; the pairing gate
+// itself lives in pairing.svelte.test.ts.
+vi.mock("$lib/stores/pairing.svelte", () => ({
+	isPairedToManagedCloud: () => true,
+}));
+
 vi.mock("$lib/rpc", () => ({
 	rpc: { streaming: { setConfig }, relay: { validate: relayValidate } },
 }));

--- a/apps/frontend/src/main/dialogs/ServerDialog.protocol.test.ts
+++ b/apps/frontend/src/main/dialogs/ServerDialog.protocol.test.ts
@@ -50,6 +50,12 @@ vi.mock("$lib/rpc/subscriptions.svelte", () => ({
 	getSelectedIngestEndpoint: () => undefined,
 }));
 
+// Protocol behaviour is tested with a paired managed device; the pairing gate
+// itself lives in pairing.svelte.test.ts.
+vi.mock("$lib/stores/pairing.svelte", () => ({
+	isPairedToManagedCloud: () => true,
+}));
+
 vi.mock("$lib/rpc", () => ({
 	rpc: { streaming: { setConfig }, relay: { validate: vi.fn() } },
 }));

--- a/apps/frontend/src/main/dialogs/ServerDialog.provider-picker.test.ts
+++ b/apps/frontend/src/main/dialogs/ServerDialog.provider-picker.test.ts
@@ -1,0 +1,222 @@
+// @vitest-environment jsdom
+/**
+ * ServerDialog — multi-cloud provider picker (T12, CeraUI N2/N4).
+ *
+ * The managed destination presents the cloud PROVIDERS the relay catalog offers
+ * as a selectable list (CeraLive, BELABOX, + any future cloud) rather than a
+ * hardcoded pair. The picker is select-not-fill and auto-selects when exactly one
+ * provider is offered. Custom/self-hosted is the always-available escape hatch via
+ * the destination radiogroup (never this picker). T8 pairing gates the managed
+ * surface; the per-provider list is derived from the catalog the paired cloud(s)
+ * pushed (`availableManagedProviders`).
+ *
+ * Coverage:
+ *  1. single managed provider → picker NOT rendered (auto-selected); managed usable.
+ *  2. multiple providers → picker rendered and lists every offered provider.
+ *  3. BELABOX-paired (catalog tagged belabox only) → managed surface shows the
+ *     BELABOX servers, picker auto-selected (single).
+ *  4. NOT paired to a given cloud (no belabox servers) → belabox absent; the
+ *     single offered provider auto-selects and the picker stays hidden.
+ *  5. unpaired → managed destination disabled, only custom/self-hosted reachable.
+ */
+import { existingLocales, loadLocale } from "@ceraui/i18n";
+import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ServerDialog from "./ServerDialog.svelte";
+
+type ServerInfo = {
+	name: string;
+	rtt?: number;
+	default?: true;
+	addr?: string;
+	port?: number;
+	protocol?: string;
+	protocols?: string[];
+	provider?: { id: string; name: string; kind: string };
+};
+
+const state = vi.hoisted(() => ({
+	config: undefined as
+		| { relay_server?: string; remote_provider?: string }
+		| undefined,
+	relays: undefined as
+		| {
+				accounts: Record<string, { name: string }>;
+				servers: Record<string, ServerInfo>;
+		  }
+		| undefined,
+	isStreaming: false,
+	capabilities: undefined as { transports?: string[] } | undefined,
+	paired: true,
+}));
+
+vi.mock("$lib/rpc/subscriptions.svelte", () => ({
+	getConfig: () => state.config,
+	getRelays: () => state.relays,
+	getIsStreaming: () => state.isStreaming,
+	getCapabilities: () => state.capabilities,
+	getManagedIngestAccounts: () => [],
+	getSelectedIngestEndpoint: () => undefined,
+}));
+
+vi.mock("$lib/stores/pairing.svelte", () => ({
+	isPairedToManagedCloud: () => state.paired,
+}));
+
+vi.mock("$lib/rpc", () => ({
+	rpc: { streaming: { setConfig: vi.fn() }, relay: { validate: vi.fn() } },
+}));
+
+vi.mock("$lib/rpc/dirty-registry.svelte", () => ({
+	markPending: vi.fn(),
+	onRpcResolved: vi.fn(),
+}));
+
+vi.mock("svelte-sonner", () => ({
+	toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const CERALIVE = { id: "ceralive", name: "CeraLive Cloud", kind: "ceralive" };
+const BELABOX = { id: "belabox", name: "BELABOX Cloud", kind: "belabox" };
+
+beforeAll(() => {
+	if (!window.matchMedia) {
+		window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+			matches: true,
+			media: query,
+			onchange: null,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		}));
+	}
+	const proto = window.Element.prototype as unknown as Record<string, unknown>;
+	proto.hasPointerCapture ??= vi.fn(() => false);
+	proto.setPointerCapture ??= vi.fn();
+	proto.releasePointerCapture ??= vi.fn();
+	proto.scrollIntoView ??= vi.fn();
+});
+
+const managedChoice = () =>
+	screen.getByTestId("destination-managed") as HTMLButtonElement;
+const customChoice = () =>
+	screen.getByTestId("destination-custom") as HTMLButtonElement;
+
+beforeEach(() => {
+	state.config = undefined;
+	state.relays = undefined;
+	state.isStreaming = false;
+	state.capabilities = undefined;
+	state.paired = true;
+});
+
+describe("ServerDialog — multi-cloud provider picker (T12)", () => {
+	it("auto-selects a single managed provider and renders no picker", async () => {
+		state.relays = {
+			accounts: {},
+			servers: {
+				eu: { name: "EU-West", provider: CERALIVE },
+				us: { name: "US-East", provider: CERALIVE },
+			},
+		};
+		state.config = { remote_provider: "ceralive", relay_server: "eu" };
+
+		render(ServerDialog, { props: { open: true } });
+
+		// Managed is usable; the provider picker is absent (one provider → auto).
+		expect(managedChoice().disabled).toBe(false);
+		expect(screen.queryByTestId("relay-provider")).toBeNull();
+	});
+
+	it("renders the picker listing every provider for a multi-cloud catalog", async () => {
+		state.relays = {
+			accounts: {},
+			servers: {
+				eu: { name: "EU-West", provider: CERALIVE },
+				asia: { name: "Asia-SE", provider: BELABOX },
+			},
+		};
+		state.config = { remote_provider: "ceralive", relay_server: "eu" };
+
+		render(ServerDialog, { props: { open: true } });
+
+		const picker = screen.getByTestId("relay-provider");
+		expect(picker).toBeTruthy();
+		// The configured provider is the active selection.
+		expect(picker.textContent).toContain("CeraLive Cloud");
+
+		// Opening the picker lists both offered providers.
+		await fireEvent.pointerDown(picker);
+		await fireEvent.pointerUp(picker);
+		await fireEvent.click(picker);
+		await waitFor(() =>
+			expect(screen.getAllByText("BELABOX Cloud").length).toBeGreaterThan(0),
+		);
+	});
+
+	it("shows the BELABOX managed surface when paired to BELABOX only", () => {
+		state.relays = {
+			accounts: {},
+			servers: {
+				asia: { name: "Asia-SE", provider: BELABOX },
+				west: { name: "US-West", provider: BELABOX },
+			},
+		};
+		state.config = { remote_provider: "belabox", relay_server: "asia" };
+
+		render(ServerDialog, { props: { open: true } });
+
+		// Managed enabled; single belabox provider → no picker, server surfaced.
+		expect(managedChoice().disabled).toBe(false);
+		expect(screen.queryByTestId("relay-provider")).toBeNull();
+		expect(screen.getAllByText("Asia-SE").length).toBeGreaterThan(0);
+	});
+
+	it("hides a managed cloud the catalog carries no servers for", () => {
+		// Catalog has only CeraLive servers → BELABOX is not offered at all, and
+		// the single remaining provider auto-selects (no picker).
+		state.relays = {
+			accounts: {},
+			servers: { eu: { name: "EU-West", provider: CERALIVE } },
+		};
+		state.config = { remote_provider: "ceralive", relay_server: "eu" };
+
+		render(ServerDialog, { props: { open: true } });
+
+		expect(screen.queryByTestId("relay-provider")).toBeNull();
+		expect(screen.queryByText("BELABOX Cloud")).toBeNull();
+	});
+
+	it("offers only custom/self-hosted when the device is not paired to a managed cloud", () => {
+		state.paired = false;
+		state.relays = {
+			accounts: {},
+			servers: { eu: { name: "EU-West", provider: CERALIVE } },
+		};
+
+		render(ServerDialog, { props: { open: true } });
+
+		// Managed is gated off by the pairing gate; custom stays reachable.
+		expect(managedChoice().disabled).toBe(true);
+		expect(customChoice().disabled).toBe(false);
+	});
+});
+
+describe("i18n — relayProviderHint in all 10 locales", () => {
+	it("has all 10 locales registered", () => {
+		expect(existingLocales).toHaveLength(10);
+	});
+
+	for (const { code } of existingLocales) {
+		it(`provides settings.relayProviderHint for "${code}"`, async () => {
+			const translation = (await loadLocale(code)) as {
+				settings: { relayProviderHint: string };
+			};
+			expect(typeof translation.settings.relayProviderHint).toBe("string");
+			expect(translation.settings.relayProviderHint.length).toBeGreaterThan(0);
+		});
+	}
+});

--- a/apps/frontend/src/main/dialogs/ServerDialog.relay-gate.test.ts
+++ b/apps/frontend/src/main/dialogs/ServerDialog.relay-gate.test.ts
@@ -59,6 +59,13 @@ vi.mock("$lib/rpc/subscriptions.svelte", () => ({
 	getSelectedIngestEndpoint: () => undefined,
 }));
 
+// D6 here is the relays gate; a populated catalog only exists for a paired
+// managed device, so pairing is held true. The pairing gate is tested in
+// pairing.svelte.test.ts.
+vi.mock("$lib/stores/pairing.svelte", () => ({
+	isPairedToManagedCloud: () => true,
+}));
+
 vi.mock("$lib/rpc", () => ({
 	rpc: { streaming: { setConfig: vi.fn() }, relay: { validate: vi.fn() } },
 }));

--- a/apps/frontend/src/main/dialogs/ServerDialog.svelte
+++ b/apps/frontend/src/main/dialogs/ServerDialog.svelte
@@ -28,7 +28,11 @@
 <script lang="ts">
 import { LL } from '@ceraui/i18n/svelte';
 import { Server } from '@lucide/svelte';
-import { type RelayProtocol, serverSupportedProtocols } from '@ceraui/rpc/schemas';
+import {
+	CLOUD_PROVIDERS,
+	type RelayProtocol,
+	serverSupportedProtocols,
+} from '@ceraui/rpc/schemas';
 import { toast } from 'svelte-sonner';
 
 import AppDialog from '$lib/components/dialogs/AppDialog.svelte';
@@ -61,9 +65,11 @@ import {
 	autoSelectIngestSlot,
 	autoSelectManagedRelay,
 	autoSelectManagedTransport,
+	availableManagedProviders,
 	buildManagedSlotConfig,
 	buildServerSetConfig,
 	deriveDestination,
+	resolveActiveManagedProvider,
 	resolveReceiverKind,
 } from '$lib/streaming/receiver-experience';
 import CustomEndpointForm from './server/CustomEndpointForm.svelte';
@@ -81,14 +87,6 @@ const PORT = streamingConstraints.port;
 const LAT = streamingConstraints.srtLatency;
 const LATENCY_FALLBACK = Math.min(Math.max(2000, LAT.min), LAT.max);
 const LATENCY_STEP = 50;
-
-// Managed cloud providers the relay catalog can be grouped under. Brand names
-// are not translated (per the i18n branding convention), so they stay literal.
-const MANAGED_PROVIDERS = ['ceralive', 'belabox'] as const;
-const PROVIDER_LABELS: Record<string, string> = {
-	ceralive: 'CeraLive Cloud',
-	belabox: 'BELABOX Cloud',
-};
 
 const config = $derived(getConfig());
 const relays = $derived(getRelays());
@@ -171,7 +169,27 @@ const configProvider = $derived(
 		? config.remote_provider
 		: 'ceralive',
 );
-const selectedProvider = $derived(draft.relay_provider ?? configProvider);
+
+// Multi-cloud provider picker (T12): the offerable managed providers are DERIVED
+// from the catalog the paired cloud(s) pushed — never a hardcoded list — so a
+// device paired only to BELABOX offers only BELABOX, and a future managed cloud
+// appears as soon as its servers arrive. Custom/self-hosted is never here; it is
+// the always-available destination radiogroup escape hatch. The picker is shown
+// only when more than one managed provider is offered; a single provider
+// auto-selects (select-not-fill), and its single server/transport seed via T10.
+const managedProviderOptions = $derived(availableManagedProviders(serverEntries, configProvider));
+const showProviderPicker = $derived(managedProviderOptions.length > 1);
+const providerLabels = $derived.by(() => {
+	const labels: Record<string, string> = {};
+	for (const option of managedProviderOptions) {
+		labels[option.id] =
+			option.name ?? CLOUD_PROVIDERS.find((p) => p.id === option.id)?.name ?? option.id;
+	}
+	return labels;
+});
+const selectedProvider = $derived(
+	resolveActiveManagedProvider(managedProviderOptions, configProvider, draft.relay_provider),
+);
 const filteredServerEntries = $derived(
 	serverEntries.filter(([, info]) => (info.provider?.kind ?? configProvider) === selectedProvider),
 );
@@ -395,7 +413,7 @@ async function handleSave() {
 				{accountEntries}
 				{filteredServerEntries}
 				{isStreaming}
-				managedProviders={MANAGED_PROVIDERS}
+				managedProviders={managedProviderOptions}
 				onAccount={(value) => (draft.relay_account = value)}
 				onOverrideAddr={(value) => (draft.relay_override_addr = value)}
 				onOverridePort={(value) => (draft.relay_override_port = value)}
@@ -408,7 +426,7 @@ async function handleSave() {
 				{overridePortError}
 				{overridePortStr}
 				port={PORT}
-				providerLabels={PROVIDER_LABELS}
+				{providerLabels}
 				{relayAccount}
 				{relayAccountName}
 				{relayOverride}
@@ -421,6 +439,7 @@ async function handleSave() {
 				{relayStreamId}
 				serverProtocols={relayServerProtocols}
 				{selectedProvider}
+				{showProviderPicker}
 			/>
 		{:else}
 			<CustomEndpointForm

--- a/apps/frontend/src/main/dialogs/ServerDialog.svelte
+++ b/apps/frontend/src/main/dialogs/ServerDialog.svelte
@@ -59,6 +59,8 @@ import {
 	type ServerSetDerived,
 	type ServerSetDraft,
 	autoSelectIngestSlot,
+	autoSelectManagedRelay,
+	autoSelectManagedTransport,
 	buildManagedSlotConfig,
 	buildServerSetConfig,
 	deriveDestination,
@@ -194,15 +196,31 @@ const relayServerProtocols = $derived(
 // effective transport is constrained to what that server actually advertises.
 const kind = $derived(resolveReceiverKind({ protocol, destination, server: relayServerInfo }));
 
-// Default best = bonded SRTLA: when a multi-transport server is selected whose
-// advertised set excludes the current protocol, snap the persisted protocol to
-// SRTLA (bonded) when offered, else the first advertised transport. The chooser
-// stays the single user-facing writer; this only seeds a valid default.
+// Seed the persisted transport from the selected managed server's advertised set
+// (T10): SRTLA when offered, else its first transport. Now fires for a SINGLE
+// advertised transport too — previously only multi-transport servers re-seeded,
+// so a single-transport server whose only transport differed from the draft left
+// a stale relay_protocol. The per-server chooser stays the single user-facing
+// writer; this only seeds a valid default when the draft protocol is unsupported.
 $effect(() => {
-	if (destination !== 'managed' || relayServerProtocols.length <= 1) return;
-	if (relayServerProtocols.includes(protocol)) return;
-	const best = relayServerProtocols.includes('srtla') ? 'srtla' : relayServerProtocols[0];
+	if (destination !== 'managed') return;
+	const best = autoSelectManagedTransport(relayServerProtocols, protocol);
 	if (best && draft.relay_protocol !== best) draft.relay_protocol = best;
+});
+
+// Auto-select the managed relay server for the active provider (T10), the catalog
+// mirror of the ingest-slot rule: exactly one offered → silent; many → default,
+// else last-used; many with neither → leave the operator to pick. Only the
+// selected provider's servers are considered, so this never silently jumps
+// clouds. Respects an existing/persisted selection and stands down when platform
+// ingest slots own the managed path; the custom fallback is always reachable.
+$effect(() => {
+	if (destination !== 'managed' || hasManagedSlots) return;
+	if (draft.relay_server !== undefined || relayServer !== '') return;
+	const selection = autoSelectManagedRelay(serverEntries, config?.relay_server, selectedProvider);
+	if (selection && selection.kind !== 'prompt') {
+		draft.relay_server = selection.serverId;
+	}
 });
 
 const relayOverride = $derived(draft.relay_override ?? false);

--- a/apps/frontend/src/main/dialogs/ServerDialog.svelte
+++ b/apps/frontend/src/main/dialogs/ServerDialog.svelte
@@ -53,6 +53,7 @@ import {
 } from '$lib/rpc/subscriptions.svelte';
 import { rpc } from '$lib/rpc';
 import { markPending, onRpcResolved } from '$lib/rpc/dirty-registry.svelte';
+import { isPairedToManagedCloud } from '$lib/stores/pairing.svelte';
 import {
 	type Destination,
 	type ServerSetDerived,
@@ -90,6 +91,11 @@ const PROVIDER_LABELS: Record<string, string> = {
 const config = $derived(getConfig());
 const relays = $derived(getRelays());
 const isStreaming = $derived(Boolean(getIsStreaming()));
+
+// Managed-cloud surfaces (managed destination + ingest slots) require pairing to
+// a managed provider — multi-cloud safe (never a single-provider literal). The
+// custom/self-hosted receiver path stays available regardless.
+const pairedToManaged = $derived(isPairedToManagedCloud());
 
 type Draft = {
 	destination?: Destination;
@@ -351,13 +357,14 @@ async function handleSave() {
 		<DestinationSection
 			{isStreaming}
 			onDestination={(value) => (draft.destination = value)}
+			pairedToManagedCloud={pairedToManaged}
 			{relays}
 			remoteProvider={config?.remote_provider}
 			selected={destination}
 		/>
 
 		<!-- Endpoint config, immediately under the destination pick. -->
-		{#if destination === 'managed' && hasManagedSlots}
+		{#if destination === 'managed' && pairedToManaged && hasManagedSlots}
 			<ServerIngestSlots
 				accounts={managedAccounts}
 				activeEndpointId={activeSlotId}

--- a/apps/frontend/src/main/dialogs/server/DestinationSection.svelte
+++ b/apps/frontend/src/main/dialogs/server/DestinationSection.svelte
@@ -32,10 +32,24 @@ interface Props {
 	relays: RelayMessage | undefined;
 	/** Device's configured cloud provider — drives the provider-aware label. */
 	remoteProvider?: ProviderSelection;
+	/**
+	 * Whether the device is paired to a MANAGED cloud provider (multi-cloud safe:
+	 * never a single-provider check). Gates the managed choice in addition to D6;
+	 * the custom receiver stays available regardless. Defaults to `true` so the
+	 * D6 gate is unchanged unless the container threads the real pairing state.
+	 */
+	pairedToManagedCloud?: boolean;
 	onDestination: (kind: Destination) => void;
 }
 
-let { selected, isStreaming, relays, remoteProvider, onDestination }: Props = $props();
+let {
+	selected,
+	isStreaming,
+	relays,
+	remoteProvider,
+	pairedToManagedCloud = true,
+	onDestination,
+}: Props = $props();
 
 // Brand product names are not translated (i18n branding convention), so the
 // provider-aware managed label is a brand literal; it falls back to the generic
@@ -59,12 +73,18 @@ const managedGateHint = $derived(
 	relays === undefined ? $LL.notifications.relayWaiting() : $LL.notifications.relayNone(),
 );
 
-const managedDisabled = $derived(isStreaming || managedUnavailable);
+const managedDisabled = $derived(isStreaming || managedUnavailable || !pairedToManagedCloud);
 const customDisabled = $derived(isStreaming);
 
-// The managed hint reflects the gate: explain why it is off, else describe it.
+// The managed hint reflects the gate, in priority order: the D6 relay gate
+// (waiting / none) first, then the pairing gate (pair to a managed cloud first),
+// else the plain description. The custom receiver is never gated by either.
 const managedHint = $derived(
-	managedUnavailable ? managedGateHint : $LL.settings.destinationManagedHint(),
+	managedUnavailable
+		? managedGateHint
+		: !pairedToManagedCloud
+			? $LL.settings.index.pairingDesc()
+			: $LL.settings.destinationManagedHint(),
 );
 
 const choiceBase =

--- a/apps/frontend/src/main/dialogs/server/DestinationSection.svelte
+++ b/apps/frontend/src/main/dialogs/server/DestinationSection.svelte
@@ -20,6 +20,7 @@ import { Cloud, Plug } from '@lucide/svelte';
 import type { ProviderSelection, RelayMessage } from '@ceraui/rpc/schemas';
 
 import { Label } from '$lib/components/ui/label';
+import { countRelayServersForProvider } from '$lib/streaming/receiver-experience';
 
 type Destination = 'managed' | 'custom';
 
@@ -67,7 +68,19 @@ const managedLabel = $derived(
 // D6 relay gate: managed is unavailable while the catalog is missing (waiting)
 // or present-but-empty (none). `getRelays()` is `undefined` until the cloud
 // provider's cache populates (never in mock/dev), and may arrive empty.
-const serverCount = $derived(Object.keys(relays?.servers ?? {}).length);
+//
+// Per-provider (T10): the count is scoped to the SELECTED (configured) provider,
+// so a multi-provider catalog only enables managed when THIS provider has
+// servers. Untagged legacy servers belong to the active provider, so a
+// single-provider catalog still counts in full (no behaviour change).
+const providerForGate = $derived(
+	remoteProvider && remoteProvider !== 'custom' ? remoteProvider : 'ceralive',
+);
+const serverCount = $derived(
+	relays === undefined
+		? 0
+		: countRelayServersForProvider(Object.entries(relays.servers), providerForGate),
+);
 const managedUnavailable = $derived(relays === undefined || serverCount === 0);
 const managedGateHint = $derived(
 	relays === undefined ? $LL.notifications.relayWaiting() : $LL.notifications.relayNone(),

--- a/apps/frontend/src/main/dialogs/server/RelayServerSelector.svelte
+++ b/apps/frontend/src/main/dialogs/server/RelayServerSelector.svelte
@@ -10,6 +10,7 @@
 <script lang="ts">
 import { LL } from '@ceraui/i18n/svelte';
 import type { RelayAccount, RelayProtocol, RelayServer } from '@ceraui/rpc/schemas';
+import type { ManagedProviderOption } from '$lib/streaming/receiver-experience';
 
 import RelayRttIndicator from '$lib/components/streaming/RelayRttIndicator.svelte';
 import { Input } from '$lib/components/ui/input';
@@ -20,7 +21,10 @@ interface Props {
 	isStreaming: boolean;
 	relaysUnavailable: boolean;
 	selectedProvider: string;
-	managedProviders: readonly string[];
+	/** Managed cloud providers offered by the catalog (multi-cloud, T12). */
+	managedProviders: readonly ManagedProviderOption[];
+	/** Show the provider picker only when more than one provider is offered. */
+	showProviderPicker: boolean;
 	providerLabels: Record<string, string>;
 	relayServer: string;
 	relayServerName?: string;
@@ -59,6 +63,7 @@ let {
 	relaysUnavailable,
 	selectedProvider,
 	managedProviders,
+	showProviderPicker,
 	providerLabels,
 	relayServer,
 	relayServerName,
@@ -97,26 +102,35 @@ function protocolBadge(protocol: RelayProtocol): string {
 }
 </script>
 
-<div class="space-y-2">
-	<Label class="text-sm font-medium" for="relay-provider">{$LL.settings.relayProvider()}</Label>
-	<Select.Root
-		disabled={relaysUnavailable || isStreaming}
-		onValueChange={onProvider}
-		type="single"
-		value={selectedProvider}
-	>
-		<Select.Trigger id="relay-provider" class="w-full">
-			{providerLabels[selectedProvider] ?? selectedProvider}
-		</Select.Trigger>
-		<Select.Content>
-			<Select.Group>
-				{#each managedProviders as providerId (providerId)}
-					<Select.Item value={providerId}>{providerLabels[providerId]}</Select.Item>
-				{/each}
-			</Select.Group>
-		</Select.Content>
-	</Select.Root>
-</div>
+<!-- Provider picker: shown only for a multi-cloud catalog (T12). A single offered
+     provider auto-selects, so no picker is rendered — the operator never chooses
+     from a list of one. Brand product names stay literal (i18n branding rule);
+     the picker's purpose is carried by the translated hint. -->
+{#if showProviderPicker}
+	<div class="space-y-2">
+		<Label class="text-sm font-medium" for="relay-provider">{$LL.settings.relayProvider()}</Label>
+		<Select.Root
+			disabled={relaysUnavailable || isStreaming}
+			onValueChange={onProvider}
+			type="single"
+			value={selectedProvider}
+		>
+			<Select.Trigger id="relay-provider" class="w-full" data-testid="relay-provider">
+				{providerLabels[selectedProvider] ?? selectedProvider}
+			</Select.Trigger>
+			<Select.Content>
+				<Select.Group>
+					{#each managedProviders as provider (provider.id)}
+						<Select.Item value={provider.id}>
+							{providerLabels[provider.id] ?? provider.id}
+						</Select.Item>
+					{/each}
+				</Select.Group>
+			</Select.Content>
+		</Select.Root>
+		<p class="text-muted-foreground text-xs leading-snug">{$LL.settings.relayProviderHint()}</p>
+	</div>
+{/if}
 
 <div class="space-y-2">
 	<Label class="text-sm font-medium" for="relay-server">{$LL.settings.relayServer()}</Label>

--- a/apps/frontend/src/main/settings/RemoteControlStatus.svelte
+++ b/apps/frontend/src/main/settings/RemoteControlStatus.svelte
@@ -1,0 +1,63 @@
+<!--
+  RemoteControlStatus.svelte — remote-control channel status row (Task 8).
+
+  A calm, non-interactive status row for the Settings → Streaming group. It is
+  deliberately NOT in the HUD (the HUD's 5-signal contract is frozen). It reflects
+  the device-control channel's 3-state rollup from the pairing store:
+    • not-paired           — no remote_key; pair to manage from the cloud.
+    • paired-disconnected  — paired, control channel currently down.
+    • connected            — paired, live control channel to the cloud hub.
+  Provider-agnostic: the row never assumes CeraLive (multi-cloud safe).
+-->
+<script lang="ts">
+import { LL } from '@ceraui/i18n/svelte';
+import { Cloud, CloudOff, RadioTower } from '@lucide/svelte';
+
+import { getRemoteControlStatus } from '$lib/stores/pairing.svelte';
+
+const status = $derived(getRemoteControlStatus());
+const t = $derived($LL.settings.remoteControl);
+
+const label = $derived(
+	status === 'connected'
+		? t.connected()
+		: status === 'paired-disconnected'
+			? t.disconnected()
+			: t.notPaired(),
+);
+const hint = $derived(
+	status === 'connected'
+		? t.connectedHint()
+		: status === 'paired-disconnected'
+			? t.disconnectedHint()
+			: t.notPairedHint(),
+);
+const Icon = $derived(
+	status === 'connected' ? RadioTower : status === 'paired-disconnected' ? CloudOff : Cloud,
+);
+const dotColor = $derived(
+	status === 'connected'
+		? 'var(--status-success)'
+		: status === 'paired-disconnected'
+			? 'var(--status-warning)'
+			: 'var(--muted-foreground)',
+);
+</script>
+
+<div
+	class="flex w-full items-center gap-4 px-4 py-3.5"
+	data-status={status}
+	data-testid="remote-control-status"
+	role="status"
+>
+	<span class="bg-secondary text-foreground grid size-9 shrink-0 place-items-center rounded-lg">
+		<Icon class="size-[18px]" />
+	</span>
+	<span class="min-w-0 flex-1">
+		<span class="flex items-center gap-2">
+			<span class="size-2 shrink-0 rounded-full" style:background-color={dotColor}></span>
+			<span class="block truncate text-sm font-semibold">{label}</span>
+		</span>
+		<span class="text-muted-foreground block truncate text-xs">{hint}</span>
+	</span>
+</div>

--- a/apps/frontend/tests/e2e/cloud-remote-providers.spec.ts
+++ b/apps/frontend/tests/e2e/cloud-remote-providers.spec.ts
@@ -148,6 +148,51 @@ test.describe("Cloud-provider selector (Task 18)", () => {
 		await navigateTo(page, "settings");
 	});
 
+	test.afterEach(async ({ page }) => {
+		// Restore remote_provider to 'ceralive' after each test to prevent
+		// subsequent tests from seeing a stale 'custom' provider in the config.
+		// The custom provider test persists provider: 'custom' to the backend;
+		// this cleanup ensures the next test starts with a clean state.
+		await page.evaluate(async () => {
+			const w = window as any;
+			if (w.__cera?.socket) {
+				return new Promise<void>((resolve) => {
+					const id = Math.random();
+					const msg = {
+						id,
+						path: ["system", "setRemoteConfig"],
+						input: {
+							remote_key: "mock-pairing-key",
+							provider: "ceralive",
+						},
+					};
+
+					// Listen for the response to this specific RPC call.
+					const originalOnMessage = w.__cera.socket.onmessage;
+					w.__cera.socket.onmessage = (event: MessageEvent) => {
+						try {
+							const response = JSON.parse(event.data);
+							if (response.id === id) {
+								// Got the response to our cleanup RPC; restore the original handler.
+								w.__cera.socket.onmessage = originalOnMessage;
+								resolve();
+								return;
+							}
+						} catch {
+							/* not JSON */
+						}
+						// Pass through to the original handler.
+						if (originalOnMessage) {
+							originalOnMessage(event);
+						}
+					};
+
+					w.__cera.socket.send(JSON.stringify(msg));
+				});
+			}
+		});
+	});
+
 	test("selector is populated from getCloudProviders(); pick CeraLive → saved (applied)", async ({
 		page,
 	}) => {

--- a/apps/frontend/tests/e2e/conditional-display.spec.ts
+++ b/apps/frontend/tests/e2e/conditional-display.spec.ts
@@ -327,6 +327,8 @@ test.describe('conditional-display state lock (T11)', () => {
 		await page.goto('/');
 		await ensureAuthenticated(page);
 		const dialog = await openServerDialog(page);
+		// Seed remote_key so isPairedToManagedCloud() returns true and destination-managed is enabled.
+		ws.push({ config: { remote_key: 'test-key', remote_provider: 'ceralive' } });
 		ws.push({ 'ingest.slots': { slots: [SLOT_A, SLOT_B] } });
 
 		const managed = dialog.getByTestId('destination-managed');
@@ -353,6 +355,8 @@ test.describe('conditional-display state lock (T11)', () => {
 		await page.goto('/');
 		await ensureAuthenticated(page);
 		const dialog = await openServerDialog(page);
+		// Seed remote_key so isPairedToManagedCloud() returns true and destination-managed is enabled.
+		ws.push({ config: { remote_key: 'test-key', remote_provider: 'ceralive' } });
 		ws.push({ 'ingest.slots': { slots: [SLOT_A] } });
 
 		const managed = dialog.getByTestId('destination-managed');

--- a/packages/i18n/src/ar/index.ts
+++ b/packages/i18n/src/ar/index.ts
@@ -456,6 +456,7 @@ const ar = {
 		changeBitrateNotice: "يمكنك تغيير معدل البت حتى أثناء البث.",
 		optional: "اختياري",
 		relayProvider: "المزود",
+		relayProviderHint: "اختر السحابة التي تنقل بثك.",
 		autoEndpoint: "نقطة نهاية الخادم (محددة تلقائيًا)",
 		manualOverride: "تجاوز يدوي",
 		ingestSlot: "مثيل السحابة",

--- a/packages/i18n/src/ar/index.ts
+++ b/packages/i18n/src/ar/index.ts
@@ -226,6 +226,16 @@ const ar = {
 		destinationManagedHint: "ابثّ عبر مُرحِّل مرتبط بحسابك السحابي.",
 		destinationCustomHint: "أدخل عنوان ومنفذ المستقبِل الخاص بك.",
 		transportKind: "النقل",
+		remoteControl: {
+			title: "التحكم عن بُعد",
+			notPaired: "غير مقترن",
+			notPairedHint: "اقترن هذا الجهاز لإدارته من حساب السحابة الخاص بك.",
+			disconnected: "مقترن \u00b7 غير متصل",
+			disconnectedHint:
+				"مقترن، لكن قناة التحكم غير متصلة. جارٍ إعادة الاتصال\u2026",
+			connected: "متصل",
+			connectedHint: "قناة تحكم نشطة مع حساب السحابة الخاص بك.",
+		},
 		transportKindBadge: {
 			srtlaBonded: "SRTLA · مجمّع",
 			srtlaSingle: "SRTLA · رابط واحد",

--- a/packages/i18n/src/de/index.ts
+++ b/packages/i18n/src/de/index.ts
@@ -642,6 +642,17 @@ const de = {
 		destinationCustomHint:
 			"Gib Adresse und Port deines eigenen Empfängers ein.",
 		transportKind: "Transport",
+		remoteControl: {
+			title: "Fernsteuerung",
+			notPaired: "Nicht gekoppelt",
+			notPairedHint:
+				"Koppele dieses Gerät, um es über dein Cloud-Konto zu verwalten.",
+			disconnected: "Gekoppelt \u00b7 offline",
+			disconnectedHint:
+				"Gekoppelt, aber der Steuerkanal ist offline. Verbinde erneut\u2026",
+			connected: "Verbunden",
+			connectedHint: "Aktiver Steuerkanal zu deinem Cloud-Konto.",
+		},
 		transportKindBadge: {
 			srtlaBonded: "SRTLA · Gebündelt",
 			srtlaSingle: "SRTLA · Einzelne Verbindung",

--- a/packages/i18n/src/de/index.ts
+++ b/packages/i18n/src/de/index.ts
@@ -883,6 +883,7 @@ const de = {
 			"Sie können die Bitrate auch während des Streamings ändern.",
 		optional: "optional",
 		relayProvider: "Anbieter",
+		relayProviderHint: "Wählen Sie, welche Cloud Ihren Stream weiterleitet.",
 		autoEndpoint: "Server-Endpunkt (automatisch gewählt)",
 		manualOverride: "Manuell überschreiben",
 		ingestSlot: "Cloud-Instanz",

--- a/packages/i18n/src/en/index.ts
+++ b/packages/i18n/src/en/index.ts
@@ -639,6 +639,16 @@ const en = {
 			"Stream through a relay tied to your cloud account.",
 		destinationCustomHint: "Enter your own receiver address and port.",
 		transportKind: "Transport",
+		remoteControl: {
+			title: "Remote control",
+			notPaired: "Not paired",
+			notPairedHint: "Pair this device to manage it from your cloud account.",
+			disconnected: "Paired \u00b7 offline",
+			disconnectedHint:
+				"Paired, but the control channel is offline. Reconnecting\u2026",
+			connected: "Connected",
+			connectedHint: "Live control channel to your cloud account.",
+		},
 		transportKindBadge: {
 			srtlaBonded: "SRTLA · Bonded",
 			srtlaSingle: "SRTLA · Single link",

--- a/packages/i18n/src/en/index.ts
+++ b/packages/i18n/src/en/index.ts
@@ -884,6 +884,7 @@ const en = {
 		changeBitrateNotice:
 			"You can change the bitrate even if you are streaming.",
 		relayProvider: "Provider",
+		relayProviderHint: "Choose which cloud relays your stream.",
 		autoEndpoint: "Server endpoint (auto-selected)",
 		manualOverride: "Manual override",
 		ingestSlot: "Cloud instance",

--- a/packages/i18n/src/es/index.ts
+++ b/packages/i18n/src/es/index.ts
@@ -651,6 +651,17 @@ const es = {
 		destinationCustomHint:
 			"Introduce la dirección y el puerto de tu propio receptor.",
 		transportKind: "Transporte",
+		remoteControl: {
+			title: "Control remoto",
+			notPaired: "Sin emparejar",
+			notPairedHint:
+				"Empareja este dispositivo para gestionarlo desde tu cuenta en la nube.",
+			disconnected: "Emparejado \u00b7 sin conexión",
+			disconnectedHint:
+				"Emparejado, pero el canal de control está sin conexión. Reconectando\u2026",
+			connected: "Conectado",
+			connectedHint: "Canal de control activo con tu cuenta en la nube.",
+		},
 		transportKindBadge: {
 			srtlaBonded: "SRTLA · Combinado",
 			srtlaSingle: "SRTLA · Enlace único",

--- a/packages/i18n/src/es/index.ts
+++ b/packages/i18n/src/es/index.ts
@@ -896,6 +896,7 @@ const es = {
 			"Puedes cambiar el bitrate incluso si estás transmitiendo.",
 		optional: "opcional",
 		relayProvider: "Proveedor",
+		relayProviderHint: "Elige qué nube retransmite tu transmisión.",
 		autoEndpoint: "Punto de conexión del servidor (autoseleccionado)",
 		manualOverride: "Anulación manual",
 		ingestSlot: "Instancia en la nube",

--- a/packages/i18n/src/fr/index.ts
+++ b/packages/i18n/src/fr/index.ts
@@ -485,6 +485,7 @@ const fr = {
 			"Vous pouvez changer le débit binaire même si vous diffusez.",
 		optional: "optionnel",
 		relayProvider: "Fournisseur",
+		relayProviderHint: "Choisissez quel cloud relaie votre flux.",
 		autoEndpoint: "Point de terminaison du serveur (sélection auto)",
 		manualOverride: "Remplacement manuel",
 		ingestSlot: "Instance cloud",

--- a/packages/i18n/src/fr/index.ts
+++ b/packages/i18n/src/fr/index.ts
@@ -243,6 +243,17 @@ const fr = {
 		destinationCustomHint:
 			"Saisissez l'adresse et le port de votre propre récepteur.",
 		transportKind: "Transport",
+		remoteControl: {
+			title: "Contrôle à distance",
+			notPaired: "Non associé",
+			notPairedHint:
+				"Associez cet appareil pour le gérer depuis votre compte cloud.",
+			disconnected: "Associé \u00b7 hors ligne",
+			disconnectedHint:
+				"Associé, mais le canal de contrôle est hors ligne. Reconnexion\u2026",
+			connected: "Connecté",
+			connectedHint: "Canal de contrôle actif vers votre compte cloud.",
+		},
 		transportKindBadge: {
 			srtlaBonded: "SRTLA · Agrégé",
 			srtlaSingle: "SRTLA · Lien unique",

--- a/packages/i18n/src/hi/index.ts
+++ b/packages/i18n/src/hi/index.ts
@@ -320,6 +320,7 @@ const hi = {
 		changeBitrateNotice: "आप स्ट्रीमिंग करते समय भी बिटरेट बदल सकते हैं।",
 		optional: "वैकल्पिक",
 		relayProvider: "प्रदाता",
+		relayProviderHint: "चुनें कि कौन सा क्लाउड आपकी स्ट्रीम रिले करता है।",
 		autoEndpoint: "सर्वर एंडपॉइंट (स्वतः चयनित)",
 		manualOverride: "मैन्युअल ओवरराइड",
 		ingestSlot: "क्लाउड इंस्टेंस",

--- a/packages/i18n/src/hi/index.ts
+++ b/packages/i18n/src/hi/index.ts
@@ -88,6 +88,17 @@ const hi = {
 		destinationManagedHint: "अपने क्लाउड खाते से जुड़े रिले के माध्यम से स्ट्रीम करें।",
 		destinationCustomHint: "अपने रिसीवर का पता और पोर्ट दर्ज करें।",
 		transportKind: "ट्रांसपोर्ट",
+		remoteControl: {
+			title: "रिमोट नियंत्रण",
+			notPaired: "युग्मित नहीं",
+			notPairedHint:
+				"इस डिवाइस को अपने क्लाउड खाते से प्रबंधित करने के लिए युग्मित करें।",
+			disconnected: "युग्मित \u00b7 ऑफ़लाइन",
+			disconnectedHint:
+				"युग्मित है, पर नियंत्रण चैनल ऑफ़लाइन है। पुनः कनेक्ट हो रहा है\u2026",
+			connected: "कनेक्टेड",
+			connectedHint: "आपके क्लाउड खाते से सक्रिय नियंत्रण चैनल।",
+		},
 		transportKindBadge: {
 			srtlaBonded: "SRTLA · बॉन्डेड",
 			srtlaSingle: "SRTLA · एकल लिंक",

--- a/packages/i18n/src/ja/index.ts
+++ b/packages/i18n/src/ja/index.ts
@@ -91,6 +91,17 @@ const ja = {
 			"クラウドアカウントに紐づくリレー経由で配信します。",
 		destinationCustomHint: "ご自身のレシーバーのアドレスとポートを入力します。",
 		transportKind: "トランスポート",
+		remoteControl: {
+			title: "リモート制御",
+			notPaired: "未ペアリング",
+			notPairedHint:
+				"クラウドアカウントから管理するには、このデバイスをペアリングします。",
+			disconnected: "ペアリング済み \u00b7 オフライン",
+			disconnectedHint:
+				"ペアリング済みですが、制御チャネルがオフラインです。再接続しています\u2026",
+			connected: "接続済み",
+			connectedHint: "クラウドアカウントへの制御チャネルが有効です。",
+		},
 		transportKindBadge: {
 			srtlaBonded: "SRTLA · ボンディング",
 			srtlaSingle: "SRTLA · シングルリンク",

--- a/packages/i18n/src/ja/index.ts
+++ b/packages/i18n/src/ja/index.ts
@@ -330,6 +330,7 @@ const ja = {
 		changeBitrateNotice: "ストリーミング中でもビットレートを変更できます。",
 		optional: "オプション",
 		relayProvider: "プロバイダー",
+		relayProviderHint: "どのクラウドがストリームを中継するかを選択します。",
 		autoEndpoint: "サーバーエンドポイント（自動選択）",
 		manualOverride: "手動で上書き",
 		ingestSlot: "クラウドインスタンス",

--- a/packages/i18n/src/ko/index.ts
+++ b/packages/i18n/src/ko/index.ts
@@ -321,6 +321,7 @@ const ko = {
 		changeBitrateNotice: "스트리밍 중에도 비트레이트를 변경할 수 있습니다.",
 		optional: "선택사항",
 		relayProvider: "공급자",
+		relayProviderHint: "어떤 클라우드가 스트림을 중계할지 선택하세요.",
 		autoEndpoint: "서버 엔드포인트(자동 선택)",
 		manualOverride: "수동 재정의",
 		ingestSlot: "클라우드 인스턴스",

--- a/packages/i18n/src/ko/index.ts
+++ b/packages/i18n/src/ko/index.ts
@@ -89,6 +89,16 @@ const ko = {
 			"클라우드 계정에 연결된 릴레이를 통해 스트리밍합니다.",
 		destinationCustomHint: "사용자 수신기의 주소와 포트를 입력하세요.",
 		transportKind: "전송",
+		remoteControl: {
+			title: "원격 제어",
+			notPaired: "페어링 안 됨",
+			notPairedHint: "클라우드 계정에서 관리하려면 이 기기를 페어링하세요.",
+			disconnected: "페어링됨 \u00b7 오프라인",
+			disconnectedHint:
+				"페어링되었지만 제어 채널이 오프라인입니다. 다시 연결 중\u2026",
+			connected: "연결됨",
+			connectedHint: "클라우드 계정과의 제어 채널이 활성 상태입니다.",
+		},
 		transportKindBadge: {
 			srtlaBonded: "SRTLA · 본딩",
 			srtlaSingle: "SRTLA · 단일 링크",

--- a/packages/i18n/src/pt-BR/index.ts
+++ b/packages/i18n/src/pt-BR/index.ts
@@ -243,6 +243,17 @@ const ptBR = {
 		destinationCustomHint:
 			"Informe o endereço e a porta do seu próprio receptor.",
 		transportKind: "Transporte",
+		remoteControl: {
+			title: "Controle remoto",
+			notPaired: "Não pareado",
+			notPairedHint:
+				"Pareie este dispositivo para gerenciá-lo pela sua conta na nuvem.",
+			disconnected: "Pareado \u00b7 offline",
+			disconnectedHint:
+				"Pareado, mas o canal de controle está offline. Reconectando\u2026",
+			connected: "Conectado",
+			connectedHint: "Canal de controle ativo com sua conta na nuvem.",
+		},
 		transportKindBadge: {
 			srtlaBonded: "SRTLA · Agregado",
 			srtlaSingle: "SRTLA · Link único",

--- a/packages/i18n/src/pt-BR/index.ts
+++ b/packages/i18n/src/pt-BR/index.ts
@@ -482,6 +482,7 @@ const ptBR = {
 			"Você pode mudar a taxa de bits mesmo enquanto está transmitindo.",
 		optional: "opcional",
 		relayProvider: "Provedor",
+		relayProviderHint: "Escolha qual nuvem retransmite sua transmissão.",
 		autoEndpoint: "Endpoint do servidor (selecionado automaticamente)",
 		manualOverride: "Substituição manual",
 		ingestSlot: "Instância na nuvem",

--- a/packages/i18n/src/zh/index.ts
+++ b/packages/i18n/src/zh/index.ts
@@ -313,6 +313,7 @@ const zh = {
 		changeBitrateNotice: "即使在直播过程中，您也可以更改比特率。",
 		optional: "可选",
 		relayProvider: "提供商",
+		relayProviderHint: "选择由哪个云中继您的推流。",
 		autoEndpoint: "服务器端点（自动选择）",
 		manualOverride: "手动覆盖",
 		ingestSlot: "云实例",

--- a/packages/i18n/src/zh/index.ts
+++ b/packages/i18n/src/zh/index.ts
@@ -87,6 +87,15 @@ const zh = {
 		destinationManagedHint: "通过与您的云账户关联的中继进行推流。",
 		destinationCustomHint: "输入您自己的接收器地址和端口。",
 		transportKind: "传输",
+		remoteControl: {
+			title: "远程控制",
+			notPaired: "未配对",
+			notPairedHint: "配对此设备以通过您的云账户进行管理。",
+			disconnected: "已配对 \u00b7 离线",
+			disconnectedHint: "已配对，但控制通道处于离线状态。正在重新连接\u2026",
+			connected: "已连接",
+			connectedHint: "与您的云账户的控制通道处于活动状态。",
+		},
 		transportKindBadge: {
 			srtlaBonded: "SRTLA · 绑定",
 			srtlaSingle: "SRTLA · 单链路",

--- a/packages/rpc/src/capabilities/mode-presets.test.ts
+++ b/packages/rpc/src/capabilities/mode-presets.test.ts
@@ -33,6 +33,19 @@ describe('mode-presets', () => {
 		it('includes 1080p30-h265', () => {
 			expect(CANONICAL_PRESETS['1080p30-h265']).toBeDefined();
 		});
+
+		it('renders presets in canonical ascending-quality order', () => {
+			// Insertion order IS render order (MODE_PRESETS iterates Object.values).
+			// Literal expected sequence — NOT derived from CANONICAL_PRESETS — so a
+			// reordering regression fails here loudly.
+			expect(Object.keys(CANONICAL_PRESETS)).toEqual([
+				'720p60-h264',
+				'1080p30-h264',
+				'1080p60-h264',
+				'1080p30-h265',
+				'4k30-h265',
+			]);
+		});
 	});
 
 	describe('preset shape', () => {

--- a/packages/rpc/src/capabilities/mode-presets.ts
+++ b/packages/rpc/src/capabilities/mode-presets.ts
@@ -38,21 +38,26 @@ export interface ModePreset {
 /**
  * Canonical preset catalog.
  *
- * Five presets covering common streaming scenarios:
- * - 1080p60-h264: Full HD, 60fps, universal H.264 codec
+ * Five presets covering common streaming scenarios. Insertion order IS the
+ * render order — `MODE_PRESETS`/`presetViews` iterate `Object.values` in this
+ * exact sequence, and the EncoderDialog card grid renders them top-to-bottom.
+ * The order is canonical ASCENDING QUALITY: it climbs from the lightest,
+ * most-universal preset to the heaviest, hardware-gated one, so an operator
+ * scanning the grid moves from "safe everywhere" toward "best but demanding":
+ * - 720p60-h264:  HD, 60fps, universal H.264 codec (lightest, most portable)
  * - 1080p30-h264: Full HD, 30fps, universal H.264 codec
- * - 4k30-h265: 4K, 30fps, modern H.265 codec (requires hardware support)
- * - 720p60-h264: HD, 60fps, universal H.264 codec
+ * - 1080p60-h264: Full HD, 60fps, universal H.264 codec
  * - 1080p30-h265: Full HD, 30fps, modern H.265 codec (requires hardware support)
+ * - 4k30-h265:    4K, 30fps, modern H.265 codec (heaviest, requires hardware support)
  */
 export const CANONICAL_PRESETS: Record<string, ModePreset> = {
-	'1080p60-h264': {
-		id: '1080p60-h264',
-		labelKey: 'presets.1080p60h264',
-		resolution: '1080p',
+	'720p60-h264': {
+		id: '720p60-h264',
+		labelKey: 'presets.720p60h264',
+		resolution: '720p',
 		framerate: 60,
 		codec: MEDIA_TYPE_H264,
-		bitrateDefault: 6000,
+		bitrateDefault: 4000,
 	},
 	'1080p30-h264': {
 		id: '1080p30-h264',
@@ -62,21 +67,13 @@ export const CANONICAL_PRESETS: Record<string, ModePreset> = {
 		codec: MEDIA_TYPE_H264,
 		bitrateDefault: 4000,
 	},
-	'4k30-h265': {
-		id: '4k30-h265',
-		labelKey: 'presets.4k30h265',
-		resolution: '2160p',
-		framerate: 30,
-		codec: MEDIA_TYPE_H265,
-		bitrateDefault: 8000,
-	},
-	'720p60-h264': {
-		id: '720p60-h264',
-		labelKey: 'presets.720p60h264',
-		resolution: '720p',
+	'1080p60-h264': {
+		id: '1080p60-h264',
+		labelKey: 'presets.1080p60h264',
+		resolution: '1080p',
 		framerate: 60,
 		codec: MEDIA_TYPE_H264,
-		bitrateDefault: 4000,
+		bitrateDefault: 6000,
 	},
 	'1080p30-h265': {
 		id: '1080p30-h265',
@@ -85,6 +82,14 @@ export const CANONICAL_PRESETS: Record<string, ModePreset> = {
 		framerate: 30,
 		codec: MEDIA_TYPE_H265,
 		bitrateDefault: 3000,
+	},
+	'4k30-h265': {
+		id: '4k30-h265',
+		labelKey: 'presets.4k30h265',
+		resolution: '2160p',
+		framerate: 30,
+		codec: MEDIA_TYPE_H265,
+		bitrateDefault: 8000,
 	},
 };
 

--- a/packages/rpc/src/schemas/cloud-provider.schema.ts
+++ b/packages/rpc/src/schemas/cloud-provider.schema.ts
@@ -17,6 +17,12 @@
 
 import { z } from 'zod';
 
+import {
+	RELAY_PROVIDER_KINDS,
+	type RelayProviderKind,
+	type RelayProviderMeta,
+} from './relay.schema';
+
 /**
  * How a relay was sourced: `subscription` (provider's authenticated WS push),
  * `manual` (user-entered SRTLA addr/port), `belabox` (BELABOX-compatible feed).
@@ -153,4 +159,22 @@ export function getProviderById(
  */
 export function getAvailableProviders(): CloudProviderEndpoint[] {
 	return [...CLOUD_PROVIDERS];
+}
+
+/**
+ * Map a predefined provider id onto the relay-server `provider` shape
+ * (`{ id, name, kind }`). Returns `undefined` for an unknown id so callers
+ * leave the optional provider field absent rather than fabricate a label.
+ */
+export function relayProviderMetaForId(
+	providerId: string,
+): RelayProviderMeta | undefined {
+	const provider = CLOUD_PROVIDERS.find((p) => p.id === providerId);
+	if (!provider) return undefined;
+	const kind: RelayProviderKind = (
+		RELAY_PROVIDER_KINDS as readonly string[]
+	).includes(provider.id)
+		? (provider.id as RelayProviderKind)
+		: 'custom';
+	return { id: provider.id, name: provider.name, kind };
 }


### PR DESCRIPTION
## What

Production-honesty pass for CeraUI — four N-items from the device-relay-selection spec:

- **N1 (T8):** Canonical pairing/provider store (`pairing.svelte.ts`); remote-control status indicator in Settings (3 states: not-paired / paired-disconnected / connected); managed-cloud surfaces gated on pairing; custom/self-hosted always available. i18n across all 10 locales.
- **N2 (T9):** Relay servers tagged with provider metadata (CeraLive/BELABOX) at the backend boundary + mock fixtures. `groupRelayServersByProvider()` helper.
- **N3 (T11):** Encoder presets reordered to canonical ascending-quality sequence: `720p60-h264 → 1080p30-h264 → 1080p60-h264 → 1080p30-h265 → 4k30-h265`. Locked with a literal-order regression test.
- **N4 (T10):** `autoSelectManagedRelay()` + `autoSelectManagedTransport()` mirroring the existing ingest-slot rule. Single server/transport auto-selects silently; multiple → default/last-used/prompt; none → custom.
- **N2/N4 (T12):** Multi-cloud provider picker in ServerDialog/DestinationSection — catalog-derived provider list (never hardcoded), select-not-fill, auto-select-if-one, pairing-gated managed clouds, Custom always available. i18n hint key across all 10 locales.

**Note:** `bun run build:federation && bun run sign:federation` must be run once at PR finalization to regenerate the signed encoder/audio/server federation bundles. Platform CSP/version bump is out of scope (platform team).

## Why

CeraUI's cloud/relay picker required typing endpoints for managed providers. Multi-cloud support (BELABOX + CeraLive) was partially wired but not surfaced. Encoder presets rendered in arbitrary insertion order.

## How to verify

- `bun run --filter frontend test` → 1023 pass
- `bun run --filter backend test` → 1220 pass
- `bun run --filter @ceraui/rpc test` → 117 pass
- `bun tsc --noEmit` → exit 0
- `bun run --filter frontend check` → 0 errors / 0 warnings

## Risks

Medium — breadth across frontend/backend/rpc packages. Pairing gate is multi-cloud safe (never gates on `remote_provider === 'ceralive'`). BELABOX is mock-backed only this session (real wiring deferred per device-relay-selection spec).