### PR TITLE
feat: consume srtla-send control client; pass --control-socket; subscription with robust file-poll fallback

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -10,7 +10,7 @@
 	},
 	"dependencies": {
 		"@ceralive/cerastream": "2026.6.2",
-		"@ceralive/srtla-send": "2026.6.1",
+		"@ceralive/srtla-send": "2026.6.2",
 		"@ceraui/rpc": "workspace:*",
 		"@orpc/server": "^1.14.6",
 		"finalhandler": "^2.1.1",

--- a/apps/backend/src/modules/streaming/constants.ts
+++ b/apps/backend/src/modules/streaming/constants.ts
@@ -91,3 +91,7 @@ export const IFACE_RESOLVER_MAX_RETRIES = 3;
 
 /** Delay (ms) between iface resolver load attempts. */
 export const IFACE_RESOLVER_RETRY_DELAY_MS = 1_000;
+
+/** Connect/hello timeout (ms) for the srtla_send JSON-RPC control socket before
+ *  the link-telemetry cutover gives up and stays on the --stats-file poll. */
+export const SRTLA_CONTROL_CONNECT_TIMEOUT_MS = 5_000;

--- a/apps/backend/src/modules/streaming/link-telemetry.ts
+++ b/apps/backend/src/modules/streaming/link-telemetry.ts
@@ -43,6 +43,10 @@
 */
 
 import {
+	createControlClient,
+	supportsStatsSubscription,
+} from "@ceralive/srtla-send/control";
+import {
 	senderTelemetryPath,
 	type Telemetry,
 	type WatchTelemetryHandle,
@@ -53,6 +57,7 @@ import { broadcastMsg } from "../ui/websocket-server.ts";
 import {
 	IFACE_RESOLVER_MAX_RETRIES,
 	IFACE_RESOLVER_RETRY_DELAY_MS,
+	SRTLA_CONTROL_CONNECT_TIMEOUT_MS,
 	SRTLA_LISTEN_PORT,
 } from "./constants.ts";
 
@@ -268,6 +273,26 @@ export interface StartLinkTelemetryOptions {
 	intervalMs?: number;
 	/** Test seam: inject a fake watch implementation. */
 	watch?: typeof watchTelemetry;
+	/**
+	 * srtla_send JSON-RPC control-socket path. When set, the telemetry source
+	 * attempts to cut over from the --stats-file poll to the control-socket
+	 * stats subscription; any failure leaves the file-poll running untouched.
+	 */
+	controlSocket?: string;
+}
+
+// Cleanup for the active stats subscription (control-socket cutover). Non-null
+// only while telemetry is sourced from the subscription rather than the poll.
+let subscriptionCleanup: (() => void) | null = null;
+
+type ControlClientFactory = typeof createControlClient;
+let controlClientFactoryOverride: ControlClientFactory | null = null;
+
+/** Test seam: inject a fake control-client factory (null restores the real one). */
+export function setControlClientFactoryForTest(
+	fn: ControlClientFactory | null,
+): void {
+	controlClientFactoryOverride = fn;
 }
 
 /**
@@ -300,6 +325,10 @@ export function startLinkTelemetry(
 	initialIps: Array<string>,
 	opts: StartLinkTelemetryOptions = {},
 ): void {
+	if (subscriptionCleanup) {
+		subscriptionCleanup();
+		subscriptionCleanup = null;
+	}
 	if (handle) {
 		handle.stop();
 		handle = null;
@@ -323,6 +352,23 @@ export function startLinkTelemetry(
 	const watch = opts.watch ?? watchTelemetry;
 	const watchOpts =
 		opts.intervalMs !== undefined ? { intervalMs: opts.intervalMs } : {};
+	// File-poll is the always-on baseline; the subscription cutover (below) only
+	// ever replaces it once the sender confirms the capability, and any failure
+	// leaves this watcher running — the airtight fallback.
+	startFilePollWatcher(watch, statsFile, watchOpts);
+
+	if (opts.controlSocket) {
+		void attemptSubscriptionCutover(opts.controlSocket, watch, statsFile, watchOpts);
+	}
+}
+
+type WatchOpts = { intervalMs?: number };
+
+function startFilePollWatcher(
+	watch: typeof watchTelemetry,
+	statsFile: string,
+	watchOpts: WatchOpts,
+): void {
 	// watchTelemetry's callback gets a TelemetryUpdate ({ data, stale }), not a raw
 	// snapshot — collapse stale ticks to null so ingestTelemetry caches correctly.
 	handle = watch(
@@ -332,8 +378,65 @@ export function startLinkTelemetry(
 	);
 }
 
-/** Stop consuming the stats file and clear the conn_id registry (process reset). */
+/**
+ * Best-effort cutover from file-poll to the control-socket stats subscription.
+ *
+ * Every exit that is not a confirmed, live subscription leaves the file-poll
+ * watcher running (connect failure, hello timeout, capability absent, subscribe
+ * error). Only once the sender advertises `stats-subscription` AND the stream is
+ * open do we stop the poll and source telemetry from pushed `event` frames. A
+ * mid-stream null (parse failure / disconnect) re-arms the file-poll.
+ */
+async function attemptSubscriptionCutover(
+	socketPath: string,
+	watch: typeof watchTelemetry,
+	statsFile: string,
+	watchOpts: WatchOpts,
+): Promise<void> {
+	try {
+		const factory = controlClientFactoryOverride ?? createControlClient;
+		const client = await factory({
+			socketPath,
+			timeoutMs: SRTLA_CONTROL_CONNECT_TIMEOUT_MS,
+		});
+		if (!client) return;
+
+		const hello = await client.hello().catch(() => null);
+		if (!hello || !supportsStatsSubscription(hello)) {
+			client.close();
+			return;
+		}
+
+		subscriptionCleanup = client.subscribeStats((snapshot) => {
+			if (snapshot === null && !handle) {
+				logger.warn(
+					"link-telemetry: subscription disconnected, falling back to file-poll",
+				);
+				startFilePollWatcher(watch, statsFile, watchOpts);
+			}
+			ingestTelemetry(snapshot);
+		});
+
+		// Subscription confirmed live — retire the redundant file-poll.
+		if (handle) {
+			handle.stop();
+			handle = null;
+		}
+		logger.debug("link-telemetry: switched to JSON-RPC subscription path");
+	} catch (err) {
+		logger.debug(
+			"link-telemetry: subscription cutover failed, staying on file-poll",
+			{ err },
+		);
+	}
+}
+
+/** Stop consuming telemetry (poll + subscription) and clear the conn_id registry. */
 export function stopLinkTelemetry(): void {
+	if (subscriptionCleanup) {
+		subscriptionCleanup();
+		subscriptionCleanup = null;
+	}
 	if (handle) {
 		handle.stop();
 		handle = null;
@@ -344,8 +447,14 @@ export function stopLinkTelemetry(): void {
 	resetConnIdRegistry();
 }
 
+// Telemetry is live while EITHER source feeds it: the file-poll watcher or the
+// control-socket subscription (which retires the watcher on cutover).
+function hasActiveTelemetrySource(): boolean {
+	return handle !== null || subscriptionCleanup !== null;
+}
+
 export function isLinkTelemetryActive(): boolean {
-	return handle !== null;
+	return hasActiveTelemetrySource();
 }
 
 /**
@@ -357,7 +466,7 @@ export function isLinkTelemetryActive(): boolean {
  *   - watching, fresh snapshot                    -> live links, stale: false
  */
 export function buildLinkTelemetry(): LinkTelemetryMessage | null {
-	if (!handle) return null;
+	if (!hasActiveTelemetrySource()) return null;
 	if (lastSnapshot === null) return null;
 
 	const stale = !lastTickFresh;

--- a/apps/backend/src/modules/streaming/streamloop/start-stream.ts
+++ b/apps/backend/src/modules/streaming/streamloop/start-stream.ts
@@ -20,7 +20,10 @@
 // wires srtla per-uplink telemetry, then starts the engine session over the
 // StreamingBackend seam.
 
-import { buildSrtlaSendArgs } from "@ceralive/srtla-send/sender";
+import {
+	buildSrtlaSendArgs,
+	controlSocketPath,
+} from "@ceralive/srtla-send/sender";
 import { getConfig } from "../../config.ts";
 import { setup } from "../../setup.ts";
 import { notificationBroadcast } from "../../ui/notifications.ts";
@@ -58,6 +61,9 @@ export async function startStream(
 		}
 	}
 	const statsFile = srtlaStatsFile();
+	// ADR-001 control socket: telemetry rides the JSON-RPC subscription when the
+	// sender advertises it, with --stats-file as the airtight fallback poll.
+	const controlSocket = controlSocketPath(SRTLA_LISTEN_PORT);
 	spawnStreamingLoop(
 		srtlaSendExec,
 		buildSrtlaSendArgs({
@@ -66,8 +72,9 @@ export async function startStream(
 			srtlaPort,
 			ipsFile: setup.ips_file,
 			statsFile,
+			controlSocket,
 			execPath: setup.srtla_path,
-		}).args,
+		}),
 		(err) => {
 			const resolved = resolveProcessError("srtla", err);
 			if (resolved) {
@@ -89,7 +96,7 @@ export async function startStream(
 	const ipsContent = await Bun.file(setup.ips_file)
 		.text()
 		.catch(() => "");
-	startLinkTelemetry(statsFile, ipsContent.split("\n"));
+	startLinkTelemetry(statsFile, ipsContent.split("\n"), { controlSocket });
 
 	// Engine launch (session start over structured IPC) is behind the seam.
 	getStreamingBackend().start(config, {

--- a/apps/backend/src/tests/link-telemetry.test.ts
+++ b/apps/backend/src/tests/link-telemetry.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import type { ControlClient, HelloResult } from "@ceralive/srtla-send/control";
 import type {
 	Telemetry,
 	TelemetryUpdate,
@@ -13,6 +14,7 @@ import {
 	isLinkTelemetryActive,
 	registerSrtlaIpList,
 	resetLinkTelemetryBroadcastState,
+	setControlClientFactoryForTest,
 	setIfaceResolverForTest,
 	setTelemetryClockForTest,
 	startLinkTelemetry,
@@ -63,8 +65,63 @@ function captureWatch() {
 		get path() {
 			return calls.at(-1)?.path;
 		},
+		get count() {
+			return calls.length;
+		},
 	};
 }
+
+// A control-client double: drives the JSON-RPC stats-subscription cutover path.
+// `subscribed` resolves once subscribeStats is invoked (cutover confirmed live),
+// and `emit` pushes an `event` snapshot (or null for disconnect/parse-failure).
+function fakeControlClient(opts: {
+	capabilities: Array<string>;
+	helloThrows?: boolean;
+}) {
+	let onEventCb: ((s: Telemetry | null) => void) | null = null;
+	let closed = false;
+	let resolveSubscribed!: () => void;
+	const subscribed = new Promise<void>((r) => {
+		resolveSubscribed = r;
+	});
+	const client: ControlClient = {
+		hello: async (): Promise<HelloResult> => {
+			if (opts.helloThrows) throw new Error("hello failed");
+			return {
+				schema_version: 1,
+				engine: "srtla_send",
+				capabilities: opts.capabilities,
+			};
+		},
+		rawRequest: async () => null,
+		subscribeStats: (onEvent) => {
+			onEventCb = onEvent;
+			resolveSubscribed();
+			return () => {
+				closed = true;
+				onEventCb = null;
+			};
+		},
+		close: () => {
+			closed = true;
+		},
+	};
+	return {
+		client,
+		emit: (s: Telemetry | null) => onEventCb?.(s),
+		subscribed,
+		get closed() {
+			return closed;
+		},
+	};
+}
+
+// Drain pending microtasks/macrotasks so a fire-and-forget cutover that takes a
+// path with no `subscribed` signal (connect failure, capability absent) settles.
+const flushCutover = async (): Promise<void> => {
+	await Bun.sleep(0);
+	await Bun.sleep(0);
+};
 
 function captureClient(sink: string[]): AppWebSocket {
 	return {
@@ -80,6 +137,7 @@ beforeEach(() => {
 	stopLinkTelemetry();
 	setIfaceResolverForTest(null);
 	setTelemetryClockForTest(null);
+	setControlClientFactoryForTest(null);
 	resetLinkTelemetryBroadcastState();
 });
 
@@ -87,6 +145,7 @@ afterEach(() => {
 	stopLinkTelemetry();
 	setIfaceResolverForTest(null);
 	setTelemetryClockForTest(null);
+	setControlClientFactoryForTest(null);
 	resetLinkTelemetryBroadcastState();
 });
 
@@ -354,5 +413,103 @@ describe("broadcastLinkTelemetryIfChanged — status flow integration", () => {
 		} finally {
 			removeClient(client);
 		}
+	});
+});
+
+describe("control-socket subscription cutover + airtight file-poll fallback", () => {
+	test("subscription path broadcasts the same LinkTelemetryMessage shape as file-poll", async () => {
+		const w = captureWatch();
+		const fake = fakeControlClient({ capabilities: ["stats-subscription"] });
+		setControlClientFactoryForTest(async () => fake.client);
+		setIfaceResolverForTest(() => "usb0");
+
+		startLinkTelemetry("/tmp/stats.json", ["10.0.0.1"], {
+			watch: w.watch,
+			controlSocket: "/tmp/srtla-send-control-9000.sock",
+		});
+		// Cutover confirmed live -> the redundant file-poll watcher is retired.
+		await fake.subscribed;
+		expect(w.stopped).toBe(1);
+		expect(isLinkTelemetryActive()).toBe(true);
+
+		fake.emit(snapshot([{ conn_id: "0", rtt_ms: 7, nak_count: 4 }]));
+		const payload = buildLinkTelemetry();
+		expect(payload?.links).toEqual([
+			{
+				conn_id: "0",
+				iface: "usb0",
+				rtt_ms: 7,
+				nak_count: 4,
+				weight_percent: 100,
+				stale: false,
+			},
+		]);
+		expect(typeof payload?.lastReadMs).toBe("number");
+	});
+
+	test("connect failure (factory returns null) leaves the file-poll running", async () => {
+		const w = captureWatch();
+		setControlClientFactoryForTest(async () => null);
+		setIfaceResolverForTest(() => "usb0");
+
+		startLinkTelemetry("/tmp/stats.json", ["10.0.0.1"], {
+			watch: w.watch,
+			controlSocket: "/tmp/srtla-send-control-9000.sock",
+		});
+		await flushCutover();
+
+		// File-poll never stopped; telemetry still flows from the poll.
+		expect(w.stopped).toBe(0);
+		expect(isLinkTelemetryActive()).toBe(true);
+		w.emit(snapshot([{ conn_id: "0", nak_count: 1 }]));
+		expect(buildLinkTelemetry()?.links[0]?.nak_count).toBe(1);
+	});
+
+	test("capability absent (no stats-subscription) closes the client and stays on file-poll", async () => {
+		const w = captureWatch();
+		const fake = fakeControlClient({ capabilities: ["set-mode"] });
+		setControlClientFactoryForTest(async () => fake.client);
+		setIfaceResolverForTest(() => "usb0");
+
+		startLinkTelemetry("/tmp/stats.json", ["10.0.0.1"], {
+			watch: w.watch,
+			controlSocket: "/tmp/srtla-send-control-9000.sock",
+		});
+		await flushCutover();
+
+		expect(fake.closed).toBe(true);
+		expect(w.stopped).toBe(0);
+		expect(isLinkTelemetryActive()).toBe(true);
+		w.emit(snapshot([{ conn_id: "0", nak_count: 2 }]));
+		expect(buildLinkTelemetry()?.links[0]?.nak_count).toBe(2);
+	});
+
+	test("mid-stream subscription disconnect (onEvent null) re-arms the file-poll", async () => {
+		const w = captureWatch();
+		const fake = fakeControlClient({ capabilities: ["stats-subscription"] });
+		setControlClientFactoryForTest(async () => fake.client);
+		setIfaceResolverForTest(() => "usb0");
+
+		startLinkTelemetry("/tmp/stats.json", ["10.0.0.1"], {
+			watch: w.watch,
+			controlSocket: "/tmp/srtla-send-control-9000.sock",
+		});
+		await fake.subscribed;
+		expect(w.stopped).toBe(1);
+		expect(w.count).toBe(1);
+
+		fake.emit(snapshot([{ conn_id: "0", nak_count: 3 }]));
+		expect(buildLinkTelemetry()?.links[0]?.stale).toBe(false);
+
+		// Subscription drops -> a null event with no live watcher re-starts the poll.
+		fake.emit(null);
+		expect(w.count).toBe(2);
+		expect(buildLinkTelemetry()?.links[0]?.stale).toBe(true);
+
+		// The re-armed file-poll feeds fresh telemetry again.
+		w.emit(snapshot([{ conn_id: "0", nak_count: 5 }]));
+		const link = buildLinkTelemetry()?.links[0];
+		expect(link?.stale).toBe(false);
+		expect(link?.nak_count).toBe(5);
 	});
 });

--- a/apps/backend/src/tests/srtla-send-bindings-skew.test.ts
+++ b/apps/backend/src/tests/srtla-send-bindings-skew.test.ts
@@ -32,6 +32,7 @@ import { describe, expect, test } from "bun:test";
 import * as sender from "@ceralive/srtla-send/sender";
 import {
 	buildSrtlaSendArgs,
+	controlSocketPath,
 	getSrtlaSendExec,
 	isSrtlaSendRunning,
 	type SrtlaSendOptions,
@@ -87,26 +88,39 @@ describe("srtla-send bindings version-skew guard", () => {
 
 	test("buildSrtlaSendArgs honors the positional CLI contract streamloop relies on", () => {
 		// Shape: <listen_port> <srtla_host> <srtla_port> <ips_file> [--verbose]
-		// srtla-send's buildSrtlaSendArgs returns the argv array directly.
+		//        [--control-socket <path>]. The argv array is returned directly.
 		const args = buildSrtlaSendArgs({
 			listenPort: 9000,
 			srtlaHost: "relay.example.com",
 			srtlaPort: 8890,
 			ipsFile: "/tmp/srtla_ips",
 			verbose: true,
+			controlSocket: "/tmp/srtla-send-control-9000.sock",
 		});
 
 		expect(Array.isArray(args)).toBe(true);
 
-		// Positional ordering is load-bearing for srtla_send — a reordering or
-		// flag-shape change in the binding must fail here.
+		// Positional ordering is load-bearing for srtla_send — a reordering or a
+		// flag-shape change (incl. the ADR-001 --control-socket flag) must fail here.
 		expect(args).toEqual([
 			"9000",
 			"relay.example.com",
 			"8890",
 			"/tmp/srtla_ips",
 			"--verbose",
+			"--control-socket",
+			"/tmp/srtla-send-control-9000.sock",
 		]);
+	});
+
+	test("controlSocketPath derives the control-socket path from the listen port", () => {
+		// start-stream.ts pairs CeraUI with srtla_send by deriving the socket path
+		// from the listen port; a drift in this convention breaks the control plane.
+		expect(typeof sender.controlSocketPath).toBe("function");
+		expect(controlSocketPath).toBe(sender.controlSocketPath);
+		expect(controlSocketPath(SRTLA_LISTEN_PORT)).toBe(
+			`/tmp/srtla-send-control-${SRTLA_LISTEN_PORT}.sock`,
+		);
 	});
 
 	test("buildSrtlaSendArgs omits --verbose by default", () => {

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
       "version": "2026.6.2",
       "dependencies": {
         "@ceralive/cerastream": "2026.6.2",
-        "@ceralive/srtla-send": "2026.6.1",
+        "@ceralive/srtla-send": "file:../../../srtla-send-rs/bindings/typescript",
         "@ceraui/rpc": "workspace:*",
         "@orpc/server": "^1.14.6",
         "finalhandler": "^2.1.1",
@@ -344,8 +344,6 @@
     "@ceralive/cerastream": ["@ceralive/cerastream@2026.6.2", "", { "dependencies": { "zod": "^4.3.5" } }, "sha512-JXI7szQS0ieh89LiEO1PJPO0iEFZ8ru0YoFOQ4jcnp7g1TQeLUCX9nF+2uqvJVQofawS+V/Gpa0Hhr3e+b/gOg=="],
 
     "@ceralive/design-tokens": ["@ceralive/design-tokens@2026.6.1", "", {}, "sha512-u0Ja75p7rcJY9anvU+Ke/0PKLWrK6Y8bNO1RnrbNDuQduiKLXK0bgWnsOIMtuv3mxDgp2Kvshpc7cog20znOzw=="],
-
-    "@ceralive/srtla-send": ["@ceralive/srtla-send@2026.6.1", "", { "dependencies": { "zod": "^4.3.5" } }, "sha512-HpYpLsQNwE1MdWdOEuADG7DBuelRdldDETqOMLTXGY149vrHX0jwOKJ7fviR2fV6ee+I6rnCy1MGhwjLkzHvWQ=="],
 
     "@ceraui/i18n": ["@ceraui/i18n@workspace:packages/i18n"],
 
@@ -1689,6 +1687,8 @@
 
     "@vue/compiler-sfc/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
+    "backend/@ceralive/srtla-send": ["@ceralive/srtla-send@file:../srtla-send-rs/bindings/typescript", { "dependencies": { "zod": "^4.3.5" }, "devDependencies": { "@biomejs/biome": "^2.5.0", "@ceralive/biome-config": "^2026.6.1", "@types/bun": "^1.3.5", "typescript": "^5.9.3" } }],
+
     "bits-ui/runed": ["runed@0.35.1", "", { "dependencies": { "dequal": "^2.0.3", "esm-env": "^1.0.0", "lz-string": "^1.5.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "svelte": "^5.7.0" }, "optionalPeers": ["@sveltejs/kit"] }, "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q=="],
 
     "bits-ui/svelte-toolbelt": ["svelte-toolbelt@0.10.6", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.35.1", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.30.2" } }, "sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ=="],
@@ -1750,6 +1750,8 @@
     "workbox-build/pretty-bytes": ["pretty-bytes@5.6.0", "", {}, "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "backend/@ceralive/srtla-send/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "color/color-convert/color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
       "version": "2026.6.2",
       "dependencies": {
         "@ceralive/cerastream": "2026.6.2",
-        "@ceralive/srtla-send": "file:../../../srtla-send-rs/bindings/typescript",
+        "@ceralive/srtla-send": "2026.6.2",
         "@ceraui/rpc": "workspace:*",
         "@orpc/server": "^1.14.6",
         "finalhandler": "^2.1.1",
@@ -344,6 +344,8 @@
     "@ceralive/cerastream": ["@ceralive/cerastream@2026.6.2", "", { "dependencies": { "zod": "^4.3.5" } }, "sha512-JXI7szQS0ieh89LiEO1PJPO0iEFZ8ru0YoFOQ4jcnp7g1TQeLUCX9nF+2uqvJVQofawS+V/Gpa0Hhr3e+b/gOg=="],
 
     "@ceralive/design-tokens": ["@ceralive/design-tokens@2026.6.1", "", {}, "sha512-u0Ja75p7rcJY9anvU+Ke/0PKLWrK6Y8bNO1RnrbNDuQduiKLXK0bgWnsOIMtuv3mxDgp2Kvshpc7cog20znOzw=="],
+
+    "@ceralive/srtla-send": ["@ceralive/srtla-send@2026.6.2", "", { "dependencies": { "zod": "^4.3.5" } }, "sha512-uywRvQaTJvT2lADiwS3702lJsZv9CIG7JnQlLhabANeVPk8s2jXCpc7rTWCKoTjFxEGJd2DwiPJLKpiqiNgagg=="],
 
     "@ceraui/i18n": ["@ceraui/i18n@workspace:packages/i18n"],
 
@@ -1687,8 +1689,6 @@
 
     "@vue/compiler-sfc/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
-    "backend/@ceralive/srtla-send": ["@ceralive/srtla-send@file:../srtla-send-rs/bindings/typescript", { "dependencies": { "zod": "^4.3.5" }, "devDependencies": { "@biomejs/biome": "^2.5.0", "@ceralive/biome-config": "^2026.6.1", "@types/bun": "^1.3.5", "typescript": "^5.9.3" } }],
-
     "bits-ui/runed": ["runed@0.35.1", "", { "dependencies": { "dequal": "^2.0.3", "esm-env": "^1.0.0", "lz-string": "^1.5.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "svelte": "^5.7.0" }, "optionalPeers": ["@sveltejs/kit"] }, "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q=="],
 
     "bits-ui/svelte-toolbelt": ["svelte-toolbelt@0.10.6", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.35.1", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.30.2" } }, "sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ=="],
@@ -1750,8 +1750,6 @@
     "workbox-build/pretty-bytes": ["pretty-bytes@5.6.0", "", {}, "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "backend/@ceralive/srtla-send/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "color/color-convert/color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
 


### PR DESCRIPTION
## What

CeraUI's slice of the srtla-sender-control-protocol-alignment effort. Three atomic commits:

**1. Dep bump + spawn fix**
- `@ceralive/srtla-send` bumped `2026.6.1` → `2026.6.2` (adds the `./control` subpath with the JSON-RPC client)
- `start-stream.ts`: removed a pre-existing `.args` deref bug (`buildSrtlaSendArgs` returns a bare `Array<string>`, not an object with `.args`); derives `controlSocket = controlSocketPath(SRTLA_LISTEN_PORT)` and passes it to both `buildSrtlaSendArgs` (so `srtla_send` opens `--control-socket`) and `startLinkTelemetry` (so the telemetry path can attempt the subscription cutover)

**2. Capability-gated cutover with airtight file-poll fallback**
- `link-telemetry.ts`: file-poll (`watchTelemetry`) **always starts first**. `attemptSubscriptionCutover` runs fire-and-forget (`void`):
  - `createControlClient` returns `null` → stay on file-poll (connect failure)
  - `hello()` throws / no `stats-subscription` capability → `client.close()`, stay on file-poll
  - Capability advertised → `subscribeStats()`, then stop the redundant file-poll
  - `onEvent(null)` after cutover (socket disconnect / parse failure) → **re-arm file-poll**
- Fixed a latent bug: `buildLinkTelemetry()` and `isLinkTelemetryActive()` were gated on `handle !== null` alone — after cutover `handle` is null (subscription took over), so both would have silently reported null/inactive during the subscription happy path. Fixed with `hasActiveTelemetrySource() = (handle !== null || subscriptionCleanup !== null)`.

**3. Tests**
- 4 new cutover/fallback tests in `link-telemetry.test.ts`: subscription path broadcasts same shape as file-poll; connect failure stays on file-poll; capability absent stays on file-poll; mid-stream disconnect re-arms file-poll
- `srtla-send-bindings-skew.test.ts`: positional contract test extended with `--control-socket`; new `controlSocketPath` test

## Why

Engine consistency: cerastream already speaks JSON-RPC 2.0 with `subscribe-events`/`"event"`. This aligns the sender on the same wire contract so CeraUI drives both engines through one client idiom. The fallback ensures no regression for older senders or any failure mode.

## How to verify

```bash
cd apps/backend
bun tsc --noEmit   # exit 0
bun test           # 1225+ pass
```

## Risks

- Medium: coordinated change (depends on `@ceralive/srtla-send@2026.6.2` being published). Mitigated by the airtight file-poll fallback — CeraUI never hard-depends on the new channel.
- The `.args` deref fix is a pre-existing bug fix; it was silently broken before (the spawn was passing `undefined` as the args array).