### PR TITLE
fix(e2e): resolve notification-count failures in notifications-panel & relay-notifications specs

### DIFF
--- a/apps/frontend/tests/e2e/notifications-panel.spec.ts
+++ b/apps/frontend/tests/e2e/notifications-panel.spec.ts
@@ -126,12 +126,14 @@ function clearStore(page: Page): Promise<void> {
 	});
 }
 
-/** Inject a persistent notification through the real `notifications` broadcast. */
+// Wire type is SINGULAR `notification` — the type the backend actually
+// broadcasts and the only one subscriptions.svelte.ts folds into the store.
+// (Plural `notifications` lands nowhere since fa7f0277 renamed the handler.)
 function emitPersistent(page: Page, notification: Record<string, unknown>): Promise<void> {
 	return page.evaluate(async (n) => {
 		const specPath = '/src/lib/rpc/client.ts';
 		const mod = await import(/* @vite-ignore */ specPath);
-		await mod.rpc.dev.emit({ type: 'notifications', payload: { show: [n] } });
+		await mod.rpc.dev.emit({ type: 'notification', payload: { show: [n] } });
 	}, notification);
 }
 

--- a/apps/frontend/tests/e2e/relay-notifications.spec.ts
+++ b/apps/frontend/tests/e2e/relay-notifications.spec.ts
@@ -182,12 +182,15 @@ function readActiveNotifications(page: Page): Promise<ActiveLite[]> {
 	});
 }
 
-/** Inject a backend `notifications` broadcast via the dev-only `dev.emit`. */
-async function emitNotification(page: Page, notification: Record<string, unknown>): Promise<void> {
-	await page.evaluate(async (n) => {
+// Inject a backend `notification` broadcast via the dev-only `dev.emit`. Wire
+// type is SINGULAR `notification` — the type the backend actually broadcasts and
+// the only one subscriptions.svelte.ts folds into the store; plural `notifications`
+// lands nowhere since fa7f0277 renamed the handler to the singular case.
+function emitNotification(page: Page, notification: Record<string, unknown>): Promise<void> {
+	return page.evaluate(async (n) => {
 		const specPath = '/src/lib/rpc/client.ts';
 		const mod = await import(/* @vite-ignore */ specPath);
-		await mod.rpc.dev.emit({ type: 'notifications', payload: { show: [n] } });
+		await mod.rpc.dev.emit({ type: 'notification', payload: { show: [n] } });
 	}, notification);
 }
 


### PR DESCRIPTION
## Problem

Two E2E tests fail deterministically in **E2E (shard 1/2)** on `main` — the only hard failures in that job:

- `notifications-panel.spec.ts:158` — `Error: both persistent notifications should land in the store`
- `relay-notifications.spec.ts:306` — `expect(locator).toHaveCount(expected) failed`

Confirmed pre-existing (not a regression from any recent PR):
- Base commit `fa7f0277` CI run [28456290185](https://github.com/CERALIVE/CeraUI/actions/runs/28456290185) — E2E shard 1/2 **failure**.
- PR #132 CI run [28541468560](https://github.com/CERALIVE/CeraUI/actions/runs/28541468560) — shard-1 summary: **145 passed, 1 flaky, 2 failed**, and the 2 failed are exactly these two tests. `notifications-panel:158` failed on **all 3 attempts** (initial + 2 retries) — i.e. deterministic, not a timing flake.

## Root cause (a deterministic wire-type mismatch)

Commit `fa7f0277` renamed the frontend notification broadcast handler in `apps/frontend/src/lib/rpc/subscriptions.svelte.ts` from the plural `case "notifications"` to the **singular** `case "notification"`, correctly matching what the real backend broadcasts (`broadcastMsg("notification", …)` in `apps/backend/src/modules/ui/notifications.ts`). The singular case is the only path that folds a notification into the store that `getPersistent()` / `getActive()` read.

But both specs still inject notifications via `rpc.dev.emit` using the **plural** type:

```ts
await mod.rpc.dev.emit({ type: 'notifications', payload: { show: [n] } });  // no handler consumes this
```

`dev.emit` forwards the type verbatim, so the frontend gets a `{ notifications: … }` frame that no handler in `subscriptions.svelte.ts` consumes — nothing lands in the store. Test 1 sees `Received: 0`; test 2's toast count stays `0`.

Reproduced locally: `notifications-panel.spec.ts:158` failed **5/5** with `Expected: 2 / Received: 0`.

## Fix (in the tests — match the real backend wire contract)

Two single-token changes, one per shared inject helper (`emitPersistent`, `emitNotification`), so `dev.emit` faithfully reproduces the real backend by emitting the singular `notification` type:

```diff
- await mod.rpc.dev.emit({ type: 'notifications', payload: { show: [n] } });
+ await mod.rpc.dev.emit({ type: 'notification',  payload: { show: [n] } });
```

**No assertion is loosened** — `toBe(2)` and `toHaveCount(1)` are unchanged. A regression-guard comment on each helper cites `fa7f0277` so the type is not reverted. The fix belongs in the tests: the real backend and the frontend handler already agree on the singular type; only the test injection had diverged.

## Verification

- `notifications-panel.spec.ts` target test — **10/10** pass under `--repeat-each=10`.
- Both specs run together (`--workers=1`) — all relevant tests pass (notifications-panel target + empty-state, relay tests 1–4 including the target).
- `bun run check:tech-debt` — pass; diff has no guardrail violations (no screenshot / `waitForTimeout` / `#nav-tab-`).
- Diff scope: 2 e2e spec files only (11 insertions, 6 deletions).