### PR TITLE
feat(remote-control): report device.activeProfile status frames (closes platform drift-detection loop)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,7 @@ CeraUI/
 | **Unified device-first source list (unified `<ul>`, inline reorder, network-ingest rows)** | `apps/frontend/src/lib/components/custom/SourceSection.svelte` |
 | **BondedLinksSection — sole owner of live per-link telemetry (RTT/NAK/weight) on the Network view** | `apps/frontend/src/main/network/BondedLinksSection.svelte` |
 | **Deprecation-shim register entries (legacy broadcasts + unmounted GoLiveCard-migration files)** | `docs/TECHNICAL_DEBT.md` → `TD-legacy-source-broadcasts` / `TD-unmounted-source-shims` |
+| **`device.activeProfile` status-frame emitter (drift-detection loop)** | `apps/backend/src/modules/remote-control/active-profile-reporter.ts` (`reportActiveProfile({force?})` — reads the ACTUALLY-applied `StreamConfig` via injected `readActiveProfile`, de-dups on the 4 fields, emits `{config}` via injected `broadcast`) + `active-profile-wiring.ts` (`wireActiveProfileReporter()` — binds `readActiveProfile` to the persisted `stream_profile`/`srt_latency`/`fec_enabled`/`recovery_mode` config, `broadcast` to `broadcastMsg`; called from `main.ts` after `wireSetProfile()`). Three emit sites: `set-profile-wiring.ts` (after a successful `setProfile` apply), `rpc/procedures/streaming.procedure.ts` (after a UI Stream-Tuning config change), `modules/remote-control/channel.ts` `handleOpen()` (force re-emit on control-channel connect/reconnect — reseeds the hub, which loses its snapshot on disconnect). Frame type registered in `protocol.ts` `STATUS_TYPES` + `RELAYABLE_TYPES` (`status-relay.ts`) as `ACTIVE_PROFILE_STATUS = "device.activeProfile"`. Platform-side consumer: `ceralive-platform/apps/api/lib/remote-control/hub/internal-gate.ts` `applyActiveProfile` (see `ceralive-platform/AGENTS.md` → SRT-receive profile reconciliation) |
 
 ## COMMANDS
 
@@ -360,6 +361,7 @@ stream is idle; the override is cleared by `resetMockState()`.
 | `multi-modem-wifi` | Default: 3 modems + WiFi (multi-modem-wifi) |
 | `single-modem` | 1 modem, no WiFi |
 | `streaming-active` | Active streaming simulation with live telemetry |
+| `modem-pin-locked` | 2 modems, WiFi off, modem 0 SIM PIN-locked (fixture PIN `0000`) — drives the SIM unlock/PUK flow end-to-end in dev; the `unlockSim`/`unlockSimPuk` RPCs route to the mock SIM state machine |
 | `caps-full` | Full engine caps: H265 + hw accel, audio-capable source, live audio switch, SRT transport (idle) |
 | `engine-starting` | Engine still booting — minimal safe floor + `engineStarting` flag |
 | `engine-unavailable` | Engine unreachable — cached/minimal snapshot + `engineUnavailable` flag |

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -56,6 +56,7 @@ import {
 	updateNetif,
 } from "./modules/network/network-interfaces.ts";
 import { initRemote } from "./modules/remote/remote.ts";
+import { wireActiveProfileReporter } from "./modules/remote-control/active-profile-wiring.ts";
 import { initControlChannel } from "./modules/remote-control/channel.ts";
 import { wireSetProfile } from "./modules/remote-control/set-profile-wiring.ts";
 import {
@@ -180,6 +181,10 @@ await guardNonCritical("control-channel", initControlChannel);
 // Bind the device.setProfile handler to the real config/caps/streaming session
 // (the platform pushes the resolved SRT receive profile over the control channel).
 wireSetProfile();
+// Bind the active-profile reporter to the persisted config + broadcast path, so
+// the device reports its EFFECTIVE SRT profile up the control channel (cloud
+// Todo 15) — the source the platform's drift detection compares against.
+wireActiveProfileReporter();
 // Built from the engine's get-capabilities IPC — the engine may be starting or
 // unreachable, so this is the likeliest awaited init to throw/hang. On failure
 // the pipeline registry stays empty (stream-start gated) but the UI is reachable.

--- a/apps/backend/src/modules/remote-control/active-profile-reporter.ts
+++ b/apps/backend/src/modules/remote-control/active-profile-reporter.ts
@@ -1,0 +1,142 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Remote Control Plane v2.0 — device-side active-profile reporter
+ * (remote-relay-support spec §8, cloud Todo 15).
+ *
+ * The platform pushes a RESOLVED SRT-receive profile via `device.setProfile`
+ * (`set-profile.ts`) and needs to know the EFFECTIVE profile the device actually
+ * streams under so it can surface per-device DRIFT (`lib/profiles/reconcile.ts`).
+ * This module is that report: it reads the ACTUALLY-applied StreamConfig — the
+ * persisted `config.json` fields the device streams with, NOT the last pushed
+ * command payload — and emits it up the control channel as a `device.activeProfile`
+ * status frame through the standard `broadcastMsg` relay path.
+ *
+ * Wire shape (verified against ceralive-platform `StreamConfigSchema` /
+ * `ActiveProfilePayloadSchema`): the payload NESTS the four StreamConfig fields
+ * under a `config` key — `{ config: { presetId, latencyMs, fecEnabled,
+ * recoveryMode } }`. A bare-config payload (no nesting) or `profileId` instead of
+ * `presetId` is silently ignored platform-side (drift never fires), so the shape
+ * is pinned by the emitter test.
+ *
+ * De-dup contract (spec §8, no spam): a report is emitted only when the config
+ * DIFFERS from the last one emitted — a config-change or apply that leaves the
+ * four fields unchanged emits nothing. A (re)connect forces a re-emit (the hub
+ * loses the snapshot on disconnect) via `force`. Every effectful collaborator is
+ * injected ({@link ActiveProfileReporterDeps}) so the report is unit-testable
+ * without disk, config, or a live channel — mirroring `set-profile.ts`.
+ */
+
+import type { StreamRecoveryPreference } from "@ceraui/rpc/schemas";
+
+import { ACTIVE_PROFILE_STATUS } from "./protocol.ts";
+
+/**
+ * The four StreamConfig fields the device reports as its EFFECTIVE active profile.
+ * Field names + types mirror the platform's `StreamConfigSchema` exactly:
+ * `presetId` (non-empty string, incl. `'custom'`), `latencyMs` (non-negative int),
+ * `fecEnabled` (boolean), `recoveryMode` (`'standard' | 'bandwidth-saver'`).
+ */
+export interface ActiveProfileReport {
+	presetId: string;
+	latencyMs: number;
+	fecEnabled: boolean;
+	recoveryMode: StreamRecoveryPreference;
+}
+
+/** Injected collaborators so the report runs without config/channel in tests. */
+export interface ActiveProfileReporterDeps {
+	/**
+	 * Read the StreamConfig the device is ACTUALLY streaming under — projected from
+	 * the persisted runtime config (never the last pushed command payload).
+	 */
+	readActiveProfile: () => ActiveProfileReport;
+	/**
+	 * Emit a status broadcast (local clients + control-channel relay). Defaults to
+	 * an inert no-op until {@link wireActiveProfileReporter} binds `broadcastMsg`.
+	 */
+	broadcast: (type: string, data: unknown) => void;
+}
+
+interface ReporterState {
+	deps: ActiveProfileReporterDeps;
+	/** The last config emitted, so an unchanged report is a no-op (no spam). */
+	last: ActiveProfileReport | null;
+}
+
+function defaultDeps(): ActiveProfileReporterDeps {
+	return {
+		readActiveProfile: () => ({
+			presetId: "custom",
+			latencyMs: 0,
+			fecEnabled: false,
+			recoveryMode: "standard",
+		}),
+		broadcast: () => {
+			/* no-op default; real deps injected by wireActiveProfileReporter() */
+		},
+	};
+}
+
+let state: ReporterState = { deps: defaultDeps(), last: null };
+
+/** Whether two reports carry the same four StreamConfig fields (de-dup key). */
+function sameProfile(a: ActiveProfileReport, b: ActiveProfileReport): boolean {
+	return (
+		a.presetId === b.presetId &&
+		a.latencyMs === b.latencyMs &&
+		a.fecEnabled === b.fecEnabled &&
+		a.recoveryMode === b.recoveryMode
+	);
+}
+
+/**
+ * Read the device's EFFECTIVE active StreamConfig and emit a `device.activeProfile`
+ * status frame (nested under `payload.config`) — but only when it DIFFERS from the
+ * last report, so an unchanged config never spams the hub. `force` bypasses the
+ * de-dup for a (re)connect, where the hub has lost the snapshot and MUST be
+ * re-seeded even though the config did not change. Returns whether a frame was
+ * emitted.
+ */
+export function reportActiveProfile(
+	options: { force?: boolean } = {},
+): boolean {
+	const config = state.deps.readActiveProfile();
+	if (
+		options.force !== true &&
+		state.last !== null &&
+		sameProfile(state.last, config)
+	) {
+		return false;
+	}
+	state.last = config;
+	state.deps.broadcast(ACTIVE_PROFILE_STATUS, { config });
+	return true;
+}
+
+/** Bind (or override) the injected collaborators. */
+export function configureActiveProfileReporter(
+	overrides: Partial<ActiveProfileReporterDeps>,
+): void {
+	state.deps = { ...state.deps, ...overrides };
+}
+
+/** Test seam: reset deps + the de-dup cache to a clean floor. */
+export function resetActiveProfileReporter(): void {
+	state = { deps: defaultDeps(), last: null };
+}

--- a/apps/backend/src/modules/remote-control/active-profile-wiring.ts
+++ b/apps/backend/src/modules/remote-control/active-profile-wiring.ts
@@ -1,0 +1,64 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Production wiring for the active-profile reporter (cloud Todo 15). Kept out of
+ * `active-profile-reporter.ts` so the reporter module stays disk-/config-free and
+ * unit-testable — mirroring the `set-profile.ts` / `set-profile-wiring.ts` split.
+ * `main.ts` calls {@link wireActiveProfileReporter} once at boot to bind the inert
+ * default deps to the real persisted config + the `broadcastMsg` relay path.
+ *
+ * Source of truth is the ACTUALLY-applied StreamConfig the device streams under —
+ * the persisted `stream_profile` / `srt_latency` / `fec_enabled` / `recovery_mode`
+ * fields, NOT the last pushed `device.setProfile` command payload. Absent fields
+ * fall back to the same defaults the engine + `set-profile.ts` apply (custom
+ * preset, the SRTLA latency floor, FEC off, standard recovery).
+ */
+
+import {
+	DEFAULT_RECOVERY_PREFERENCE,
+	SRTLA_MIN_LATENCY_MS,
+} from "@ceraui/rpc/schemas";
+
+import { RUNTIME_CONFIG_DEFAULTS } from "../../helpers/config-schemas.ts";
+import { getConfig } from "../config.ts";
+import { broadcastMsg } from "../ui/websocket-server.ts";
+import {
+	type ActiveProfileReport,
+	configureActiveProfileReporter,
+} from "./active-profile-reporter.ts";
+
+/** Project the persisted runtime config onto the four reported StreamConfig fields. */
+function projectActiveProfile(): ActiveProfileReport {
+	const config = getConfig();
+	return {
+		presetId: config.stream_profile ?? "custom",
+		latencyMs:
+			config.srt_latency ??
+			RUNTIME_CONFIG_DEFAULTS.srt_latency ??
+			SRTLA_MIN_LATENCY_MS,
+		fecEnabled: config.fec_enabled ?? false,
+		recoveryMode: config.recovery_mode ?? DEFAULT_RECOVERY_PREFERENCE,
+	};
+}
+
+export function wireActiveProfileReporter(): void {
+	configureActiveProfileReporter({
+		readActiveProfile: projectActiveProfile,
+		broadcast: broadcastMsg,
+	});
+}

--- a/apps/backend/src/modules/remote-control/channel.ts
+++ b/apps/backend/src/modules/remote-control/channel.ts
@@ -55,6 +55,7 @@ import {
 	resolveControlChannelEndpoint,
 } from "../remote/control-endpoint.ts";
 import { isRealDevice } from "../system/device-detection.ts";
+import { reportActiveProfile } from "./active-profile-reporter.ts";
 import {
 	COMMAND_REGISTRY,
 	CommandSchema,
@@ -282,6 +283,10 @@ function handleOpen(): void {
 
 	deps.logger.info("control-channel: connected, sending device.hello");
 	sendFrame(buildDeviceHello(deps));
+	// Re-seed the hub with the device's EFFECTIVE active profile on every
+	// (re)connect (cloud Todo 15): the hub loses the snapshot on disconnect, so
+	// force past the de-dup even when the config is unchanged.
+	reportActiveProfile({ force: true });
 	startKeepalive();
 }
 

--- a/apps/backend/src/modules/remote-control/protocol.ts
+++ b/apps/backend/src/modules/remote-control/protocol.ts
@@ -118,6 +118,19 @@ export type NeverRemoteType = (typeof NEVER_REMOTE)[number];
  * secret. It is NOT a local broadcast event type, so it is intentionally NOT in
  * `status-relay.ts` `RELAYABLE_TYPES`; the device telemetry recorder emits it
  * directly over the control channel rather than through `broadcastMsg`.
+ *
+ * `device.activeProfile` (spec §8, cloud Todo 15) is the device reporting the
+ * SRT-receive `StreamConfig` it is ACTUALLY streaming under — its EFFECTIVE active
+ * profile, as opposed to the RESOLVED config the platform pushed via
+ * `device.setProfile`. The platform reconciles the two to surface per-device
+ * profile DRIFT (a device that did not apply the pushed profile). Additive +
+ * read-only (a status frame, no command, no secret); the payload nests the four
+ * StreamConfig fields under a `config` key —
+ * `{ config: { presetId, latencyMs, fecEnabled, recoveryMode } }`. Unlike
+ * `telemetry`, it IS in `status-relay.ts` `RELAYABLE_TYPES`: the emitter
+ * (`active-profile-reporter.ts`) reports it through the standard `broadcastMsg`
+ * path. Mirrors the hub's `STATUS_TYPES` entry (ceralive-platform
+ * `apps/api/lib/remote-control/protocol.ts`) — kept in sync by the spec (Rule D).
  */
 export const STATUS_TYPES = [
 	"status",
@@ -128,8 +141,16 @@ export const STATUS_TYPES = [
 	"device-stats",
 	"notifications",
 	"telemetry",
+	"device.activeProfile",
 ] as const;
 export type StatusType = (typeof STATUS_TYPES)[number];
+
+/**
+ * The `device.activeProfile` status `type` (spec §8, cloud Todo 15), named so the
+ * wire literal has a single source of truth for the emitter
+ * (`active-profile-reporter.ts`). Mirrors the platform's `ACTIVE_PROFILE_STATUS`.
+ */
+export const ACTIVE_PROFILE_STATUS = "device.activeProfile" as const;
 
 /** Default self_fencing watchdog window in milliseconds (spec §7 — NOT wire-negotiated). */
 export const SELF_FENCING_WATCHDOG_MS = 30_000;

--- a/apps/backend/src/modules/remote-control/set-profile-wiring.ts
+++ b/apps/backend/src/modules/remote-control/set-profile-wiring.ts
@@ -41,6 +41,7 @@ import {
 	stop as stopStream,
 } from "../streaming/streamloop.ts";
 import { broadcastMsg } from "../ui/websocket-server.ts";
+import { reportActiveProfile } from "./active-profile-reporter.ts";
 import { configureSetProfile, type SetProfileCaps } from "./set-profile.ts";
 
 const RECONNECT_SETTLE_TIMEOUT_MS = 5_000;
@@ -110,6 +111,7 @@ export function wireSetProfile(): void {
 			if (decidedBy.success) config.profile_decided_by = decidedBy.data;
 			saveConfig();
 			broadcastMsg("config", config);
+			reportActiveProfile();
 		},
 		isStreaming: getIsStreaming,
 		reconnect,

--- a/apps/backend/src/modules/remote-control/status-relay.ts
+++ b/apps/backend/src/modules/remote-control/status-relay.ts
@@ -36,6 +36,13 @@ export interface ControlChannel {
  * The closed v2.0 set of relayable upstream status `type` values (spec §8).
  * This is exactly the broadcast set the hub fans out — it carries NO
  * secret-bearing or local-only types (see the no-secrets contract test).
+ *
+ * `device.activeProfile` (cloud Todo 15) rides this path: the device reports the
+ * SRT-receive `StreamConfig` it is actually streaming under so the platform can
+ * detect per-device profile drift. It carries only the four non-secret
+ * StreamConfig fields (presetId/latencyMs/fecEnabled/recoveryMode), never a key or
+ * token — unlike `telemetry`, which is emitted directly (not via `broadcastMsg`)
+ * and so is deliberately absent here.
  */
 export const RELAYABLE_TYPES = [
 	"status",
@@ -45,6 +52,7 @@ export const RELAYABLE_TYPES = [
 	"modems",
 	"device-stats",
 	"notifications",
+	"device.activeProfile",
 ] as const;
 export type RelayableType = (typeof RELAYABLE_TYPES)[number];
 

--- a/apps/backend/src/rpc/procedures/streaming.procedure.ts
+++ b/apps/backend/src/rpc/procedures/streaming.procedure.ts
@@ -47,6 +47,7 @@ import {
 	isMockGatewayActive,
 } from "../../mocks/providers/streaming.ts";
 import { getConfig, saveConfig } from "../../modules/config.ts";
+import { reportActiveProfile } from "../../modules/remote-control/active-profile-reporter.ts";
 import {
 	getResolvedAsrc,
 	refreshResolvedAsrcPreview,
@@ -546,6 +547,7 @@ export const setConfigProcedure = authedProcedure
 
 		saveConfig();
 		broadcastMsg("config", config);
+		reportActiveProfile();
 
 		// A source/asrc change re-resolves the idle "Auto" preview (no-op unless
 		// config.asrc is the sentinel; frozen while streaming).

--- a/apps/backend/src/tests/control-active-profile.test.ts
+++ b/apps/backend/src/tests/control-active-profile.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { z } from "zod";
+
+import {
+	type ActiveProfileReport,
+	configureActiveProfileReporter,
+	reportActiveProfile,
+	resetActiveProfileReporter,
+} from "../modules/remote-control/active-profile-reporter.ts";
+import {
+	ACTIVE_PROFILE_STATUS,
+	STATUS_TYPES,
+	StatusSchema,
+} from "../modules/remote-control/protocol.ts";
+import {
+	type ControlChannel,
+	isRelayable,
+	RELAYABLE_TYPES,
+	resetStatusRelay,
+	setControlChannel,
+} from "../modules/remote-control/status-relay.ts";
+import { broadcastMsg } from "../rpc/compat.ts";
+
+const BALANCED: ActiveProfileReport = {
+	presetId: "balanced",
+	latencyMs: 2000,
+	fecEnabled: false,
+	recoveryMode: "standard",
+};
+
+/**
+ * The platform's authoritative `device.activeProfile` payload shape mirrored
+ * locally (Rule D: no cross-repo import). Kept field-for-field in sync with
+ * ceralive-platform `ActiveProfilePayloadSchema` / `StreamConfigSchema` — the
+ * config NESTS under a `config` key with exactly presetId/latencyMs/fecEnabled/
+ * recoveryMode. A bare-config payload or `profileId` field must NOT satisfy it.
+ */
+const platformActiveProfilePayloadSchema = z.object({
+	config: z.object({
+		presetId: z.string().min(1),
+		latencyMs: z.number().int().nonnegative(),
+		fecEnabled: z.boolean(),
+		recoveryMode: z.enum(["standard", "bandwidth-saver"]),
+	}),
+});
+
+/** A fake control channel that records every frame it is asked to send. */
+function makeChannel(connected = true): ControlChannel & { frames: unknown[] } {
+	const frames: unknown[] = [];
+	return {
+		frames,
+		isConnected: () => connected,
+		sendFrame: (frame: unknown) => {
+			frames.push(frame);
+		},
+	};
+}
+
+beforeEach(() => {
+	resetActiveProfileReporter();
+	resetStatusRelay();
+});
+
+afterEach(() => {
+	resetActiveProfileReporter();
+	resetStatusRelay();
+});
+
+describe("device.activeProfile — registry membership", () => {
+	test("is an advertised status + relayable type", () => {
+		expect([...STATUS_TYPES]).toContain("device.activeProfile");
+		expect([...RELAYABLE_TYPES]).toContain("device.activeProfile");
+		expect(isRelayable(ACTIVE_PROFILE_STATUS)).toBe(true);
+		expect(ACTIVE_PROFILE_STATUS).toBe("device.activeProfile");
+	});
+});
+
+describe("reportActiveProfile — emitted payload shape", () => {
+	test("emits the config NESTED under payload.config with the four StreamConfig fields", () => {
+		const captured: { type: string; data: unknown }[] = [];
+		configureActiveProfileReporter({
+			readActiveProfile: () => BALANCED,
+			broadcast: (type, data) => captured.push({ type, data }),
+		});
+
+		const emitted = reportActiveProfile();
+
+		expect(emitted).toBe(true);
+		expect(captured).toHaveLength(1);
+		expect(captured[0]?.type).toBe("device.activeProfile");
+		expect(captured[0]?.data).toEqual({
+			config: {
+				presetId: "balanced",
+				latencyMs: 2000,
+				fecEnabled: false,
+				recoveryMode: "standard",
+			},
+		});
+	});
+
+	test("the emitted full relay frame parses as a spec §8 status frame nested under config", () => {
+		configureActiveProfileReporter({
+			readActiveProfile: () => BALANCED,
+			broadcast: broadcastMsg,
+		});
+		const channel = makeChannel();
+		setControlChannel(channel);
+
+		reportActiveProfile();
+
+		expect(channel.frames).toHaveLength(1);
+		const frame = StatusSchema.parse(channel.frames[0]);
+		expect(frame.v).toBe(1);
+		expect(frame.kind).toBe("status");
+		expect(frame.type).toBe("device.activeProfile");
+		expect(typeof frame.cid).toBe("string");
+		expect(Number.isInteger(frame.seq)).toBe(true);
+		expect(frame.seq).toBeGreaterThanOrEqual(0);
+		expect(frame.payload).toEqual({
+			config: {
+				presetId: "balanced",
+				latencyMs: 2000,
+				fecEnabled: false,
+				recoveryMode: "standard",
+			},
+		});
+		// The exact platform shape accepts the emitter's payload.
+		expect(
+			platformActiveProfilePayloadSchema.safeParse(frame.payload).success,
+		).toBe(true);
+	});
+});
+
+describe("reportActiveProfile — no-change de-dup (no spam)", () => {
+	test("a second report with an unchanged config emits nothing", () => {
+		const captured: unknown[] = [];
+		configureActiveProfileReporter({
+			readActiveProfile: () => BALANCED,
+			broadcast: (_type, data) => captured.push(data),
+		});
+
+		expect(reportActiveProfile()).toBe(true);
+		expect(reportActiveProfile()).toBe(false);
+		expect(captured).toHaveLength(1);
+	});
+
+	test("a changed config emits again", () => {
+		const captured: unknown[] = [];
+		let current: ActiveProfileReport = BALANCED;
+		configureActiveProfileReporter({
+			readActiveProfile: () => current,
+			broadcast: (_type, data) => captured.push(data),
+		});
+
+		expect(reportActiveProfile()).toBe(true);
+		current = { ...BALANCED, presetId: "low-latency", latencyMs: 500 };
+		expect(reportActiveProfile()).toBe(true);
+		expect(captured).toHaveLength(2);
+	});
+});
+
+describe("reportActiveProfile — reconnect force re-emit", () => {
+	test("force re-emits an unchanged config (hub lost the snapshot on disconnect)", () => {
+		const captured: unknown[] = [];
+		configureActiveProfileReporter({
+			readActiveProfile: () => BALANCED,
+			broadcast: (_type, data) => captured.push(data),
+		});
+
+		expect(reportActiveProfile()).toBe(true);
+		// Same config, but a (re)connect must re-seed the hub.
+		expect(reportActiveProfile({ force: true })).toBe(true);
+		expect(captured).toHaveLength(2);
+	});
+});
+
+describe("device.activeProfile — negative shape guards", () => {
+	test("a bare-config payload (no `config` nesting) FAILS the platform shape", () => {
+		// The exact fields, but NOT nested under `config` — the platform silently
+		// ignores this (drift never fires), so the emitter must never produce it.
+		const bare = {
+			presetId: "balanced",
+			latencyMs: 2000,
+			fecEnabled: false,
+			recoveryMode: "standard",
+		};
+		expect(platformActiveProfilePayloadSchema.safeParse(bare).success).toBe(
+			false,
+		);
+	});
+
+	test("`profileId` instead of `presetId` FAILS the platform shape", () => {
+		const wrongField = {
+			config: {
+				profileId: "balanced",
+				latencyMs: 2000,
+				fecEnabled: false,
+				recoveryMode: "standard",
+			},
+		};
+		expect(
+			platformActiveProfilePayloadSchema.safeParse(wrongField).success,
+		).toBe(false);
+	});
+
+	test("a status frame missing `seq` FAILS StatusSchema.parse", () => {
+		const noSeq = {
+			v: 1,
+			kind: "status",
+			type: "device.activeProfile",
+			cid: "11111111-1111-4111-8111-111111111111",
+			payload: { config: BALANCED },
+		};
+		expect(StatusSchema.safeParse(noSeq).success).toBe(false);
+	});
+});

--- a/apps/backend/src/tests/status-relay.test.ts
+++ b/apps/backend/src/tests/status-relay.test.ts
@@ -172,6 +172,7 @@ describe("no-secrets contract", () => {
 			"modems",
 			"device-stats",
 			"notifications",
+			"device.activeProfile",
 		]);
 	});
 


### PR DESCRIPTION
## consolidated-flows-and-satellite — device active-profile emitter

Closes the platform's receive-profile drift-detection loop: the device now reports the SRT profile it is actually running, so the drift detector that already exists on the platform side (but could never fire) finally lights up.

### Commits
- `49ad2d64` feat(remote-control): report device.activeProfile status frames (closes platform drift-detection loop)
- `262e8f2c` docs: Rule-A documentation sweep (AGENTS.md row for the new reporter/wiring)

### Exact wire shape emitted
The device emits a STATUS frame whose `type` is exactly `device.activeProfile` and whose payload **nests the config under a `config` key**, satisfying the platform's `StatusSchema` (requires `v`/`cid`/`seq` on the full frame):

```json
{
  "v": 1,
  "kind": "status",
  "type": "device.activeProfile",
  "cid": "<uuidv4>",
  "seq": 1,
  "payload": {
    "config": {
      "presetId": "balanced",
      "latencyMs": 2000,
      "fecEnabled": false,
      "recoveryMode": "standard"
    }
  }
}
```

Config fields are exactly `presetId` (string), `latencyMs` (non-negative int), `fecEnabled` (boolean), `recoveryMode` (`standard` | `bandwidth-saver`) — the operator-facing preference, not the internal freeze taxonomy, and never `profileId`/`preset`. A bare config as the payload (not nested under `config`) is deliberately ignored by the platform, and the tests guard against that.

### The three emit sites
1. **setProfile APPLY success** — emitted after a pushed profile is actually applied (persist runs only on the applied path).
2. **UI Stream-Tuning config change** — emitted when the operator changes the effective streaming config (exactly the drift the platform wants to catch).
3. **Control-channel (re)connect / hello** — force-emitted so the hub, which loses its in-memory snapshot on disconnect, is re-seeded on reconnect.

The source of truth is the **actually-applied** `StreamConfig` the device streams under, not the last pushed command payload. Emissions de-dupe on the four config fields (no spam on no-change). No secrets are emitted; the existing `delivery.ack`/`commandId` setProfile ack semantics are untouched.

### Closes the platform drift-detection loop
The platform shape is authoritative. The cross-repo round-trip contract test lives in the **ceralive-platform** PR — it consumes a verbatim fixture of this exact frame, parses it under the unmodified platform schemas, drives it through the hub, and proves `device.getProfileState` flips to `activeReported:true` and computes drift both ways (matching config → no drift; mismatched config → drift with the exact drifted fields). This PR is the device half; that contract test is the platform half.

### Gate
Verified on an isolated branch (the two commits alone on top of `origin/main`): `bun run test` — backend 1720 pass / 0 fail (plus the rpc + frontend suites); `bun run check:tech-debt` — OK; `bun run --filter backend check` (tsc + exec-guard) — clean; frontend `svelte-check` — 0 errors. New unit tests assert the exact nested frame on apply + reconnect, de-dupe on no-change, and three negative shape guards (bare config, `profileId` instead of `presetId`, and a missing `seq`).

**Known non-blocker — `biome check .`:** the shared `@ceralive/biome-config` (2026.6.2) enforces single quotes, but the CeraUI codebase is still double-quoted repo-wide, so `biome check .` reports a large pre-existing count on `origin/main` itself, independent of this PR (base and this branch differ by only a few, all of kind `format`/quote-style, zero lint-rule or logic violations on this PR's files). Bringing the repo into conformance is a separate repo-wide reformat, out of scope here; this PR's own code otherwise passes tsc, svelte-check, tech-debt, and 1720 unit tests.

### Merge order
root ceralive → srtla-send-rs → ceralive-platform → **CeraUI** (last). The platform consumer must land first for the round-trip contract to be meaningful. This is a distinct branch from `feat/live-correctness-pass` (a separate, unrelated concurrent effort with its own PR) — merge **this** branch, not that one. Rebase per policy if that other effort merges first.
