### PR TITLE
fix(backend): type SSH WebSocket boundary

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -120,6 +120,10 @@ jobs:
         working-directory: CeraUI
         run: bunx biome check .
 
+      - name: Backend typecheck (socket contract)
+        working-directory: CeraUI
+        run: bun run --filter backend check
+
       - name: RC-pin merge gate (no -rc. pin of @ceralive/{control-protocol,cerastream})
         working-directory: CeraUI
         run: bun run check:rc-pins

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -231,6 +231,10 @@ explicitly are unaffected.
   flips `mockSshActive` and broadcasts `{ssh}` without touching `systemctl` or `passwd`.
   On device, `ceralive` is the default SSH account when `setup.json` has no override;
   start, stop, and reset RPC responses settle only after the privileged action completes.
+- `MessageSocket` (`modules/ui/message-socket.ts`) is exactly
+  `{ readonly data?: { readonly senderId?: string }; send(message: string): void }`;
+  SSH, log, and notification producers accept Bun `AppWebSocket` structurally
+  without casts.
 - Kiosk start/stop RPCs likewise await the cog-display add-on lifecycle before reporting
   their applied status. Background status refresh and software-update scheduling remain
   deliberately asynchronous because their responses acknowledge a refresh/scheduled job,

--- a/apps/backend/src/modules/system/logs.ts
+++ b/apps/backend/src/modules/system/logs.ts
@@ -16,11 +16,10 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import type WebSocket from "ws";
-
 import { getRecentLogLines, logger } from "../../helpers/logger.ts";
 import { run } from "../../helpers/run.ts";
 import { shouldUseMocks } from "../../mocks/mock-service.ts";
+import type { MessageSocket } from "../ui/message-socket.ts";
 
 import { notificationSend } from "../ui/notifications.ts";
 import { buildMsg, getSocketSenderId } from "../ui/websocket-server.ts";
@@ -41,7 +40,7 @@ function buildMockJournal(service?: string): string {
 }
 
 export async function getLog(
-	conn: WebSocket,
+	conn: MessageSocket,
 	service?: string,
 ): Promise<LogResult | undefined> {
 	const senderId = getSocketSenderId(conn);

--- a/apps/backend/src/modules/system/ssh.ts
+++ b/apps/backend/src/modules/system/ssh.ts
@@ -16,7 +16,6 @@
 */
 
 /* SSH control */
-import type WebSocket from "ws";
 
 import { randomBase64 } from "../../helpers/crypto.ts";
 import { execFileP } from "../../helpers/exec.ts";
@@ -25,6 +24,7 @@ import { runWithStdin } from "../../helpers/run.ts";
 import { shouldUseMocks } from "../../mocks/mock-service.ts";
 import { getConfig, saveConfig } from "../config.ts";
 import { setup } from "../setup.ts";
+import type { MessageSocket } from "../ui/message-socket.ts";
 import { notificationSend } from "../ui/notifications.ts";
 import { broadcastMsg } from "../ui/websocket-server.ts";
 import { describeCliError } from "./cli-parse.ts";
@@ -223,7 +223,7 @@ export function resetMockSshState(): void {
 }
 
 export async function startStopSsh(
-	conn: WebSocket,
+	conn: MessageSocket,
 	cmd: "start_ssh" | "stop_ssh",
 	statusDeps: Partial<SshStatusDeps> = {},
 ) {
@@ -265,7 +265,7 @@ export async function startStopSsh(
 }
 
 export async function resetSshPassword(
-	conn: WebSocket,
+	conn: MessageSocket,
 ): Promise<string | undefined> {
 	const ssh_user = resolveSshUser();
 

--- a/apps/backend/src/modules/ui/message-socket.ts
+++ b/apps/backend/src/modules/ui/message-socket.ts
@@ -1,0 +1,7 @@
+/** Minimal socket surface used by direct backend message producers. */
+export interface MessageSocket {
+	readonly data?: {
+		readonly senderId?: string;
+	};
+	send(message: string): void;
+}

--- a/apps/backend/src/modules/ui/notifications.ts
+++ b/apps/backend/src/modules/ui/notifications.ts
@@ -28,9 +28,9 @@
   isDismissable - is the user allowed to hide it?
 */
 
-import type WebSocket from "ws";
 import { logger } from "../../helpers/logger.ts";
 import { getms } from "../../helpers/time.ts";
+import type { MessageSocket } from "./message-socket.ts";
 import {
 	broadcastMsg,
 	buildMsg,
@@ -72,7 +72,7 @@ export function buildNotificationMsg(n: Notification, duration: number) {
 }
 
 export function notificationSend(
-	conn: WebSocket | undefined,
+	conn: MessageSocket | undefined,
 	name: Notification["name"],
 	type: Notification["type"],
 	msg: Notification["msg"],
@@ -208,6 +208,9 @@ export function getPersistentNotifications(isAuthed = false) {
 	return { show: notifications };
 }
 
-export function notificationSendPersistent(conn: WebSocket, isAuthed = false) {
+export function notificationSendPersistent(
+	conn: MessageSocket,
+	isAuthed = false,
+) {
 	conn.send(buildMsg("notification", getPersistentNotifications(isAuthed)));
 }

--- a/apps/backend/src/rpc/compat.ts
+++ b/apps/backend/src/rpc/compat.ts
@@ -10,6 +10,7 @@ import {
 	nextRelaySeq,
 	relayStatusToGateway,
 } from "../modules/remote-control/status-relay.ts";
+import type { MessageSocket } from "../modules/ui/message-socket.ts";
 import { broadcast, buildMessage } from "./events.ts";
 import type { AppWebSocket } from "./types.ts";
 
@@ -146,11 +147,8 @@ export function getLastActive(conn: WebSocket | AppWebSocket): number {
  * Get socket sender ID
  * Compatible with old getSocketSenderId function
  */
-export function getSocketSenderId(
-	conn: WebSocket | AppWebSocket,
-): string | undefined {
-	const ws = conn as AppWebSocket;
-	return ws.data?.senderId;
+export function getSocketSenderId(conn: MessageSocket): string | undefined {
+	return conn.data?.senderId;
 }
 
 /**

--- a/apps/backend/src/rpc/procedures/system.procedure.ts
+++ b/apps/backend/src/rpc/procedures/system.procedure.ts
@@ -22,7 +22,6 @@ import {
 	successResponseSchema,
 } from "@ceraui/rpc/schemas";
 import { os } from "@orpc/server";
-import type WebSocket from "ws";
 import { z } from "zod";
 
 import { logger } from "../../helpers/logger.ts";
@@ -93,7 +92,7 @@ export const getLogProcedure = authedProcedure
 	.output(logOutputSchema)
 	.handler(async ({ input, context }) => {
 		const result = await getLog(
-			context.ws as unknown as WebSocket,
+			context.ws,
 			input?.service ?? "ceralive.service",
 		);
 		return { log: result?.contents ?? "" };
@@ -105,7 +104,7 @@ export const getLogProcedure = authedProcedure
 export const getSyslogProcedure = authedProcedure
 	.output(logOutputSchema)
 	.handler(async ({ context }) => {
-		const result = await getLog(context.ws as unknown as WebSocket);
+		const result = await getLog(context.ws);
 		return { log: result?.contents ?? "" };
 	});
 
@@ -194,10 +193,7 @@ export const sshStartProcedure = authedProcedure
 		if (getIsStreaming() || isUpdating()) {
 			return { success: false };
 		}
-		const success = await startStopSsh(
-			context.ws as unknown as WebSocket,
-			"start_ssh",
-		);
+		const success = await startStopSsh(context.ws, "start_ssh");
 		return { success };
 	});
 
@@ -210,10 +206,7 @@ export const sshStopProcedure = authedProcedure
 		if (getIsStreaming() || isUpdating()) {
 			return { success: false };
 		}
-		const success = await startStopSsh(
-			context.ws as unknown as WebSocket,
-			"stop_ssh",
-		);
+		const success = await startStopSsh(context.ws, "stop_ssh");
 		return { success };
 	});
 
@@ -228,7 +221,7 @@ export const sshResetPasswordProcedure = authedProcedure
 		}),
 	)
 	.handler(async ({ context }) => {
-		const password = await resetSshPassword(context.ws as unknown as WebSocket);
+		const password = await resetSshPassword(context.ws);
 		return password === undefined
 			? { success: false }
 			: { success: true, password };

--- a/apps/backend/src/tests/f2-ssh-websocket-contract.test.ts
+++ b/apps/backend/src/tests/f2-ssh-websocket-contract.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test";
+
+import type { MessageSocket } from "../modules/ui/message-socket.ts";
+import { notificationSend } from "../modules/ui/notifications.ts";
+
+test("message socket preserves sender id and notification payload", () => {
+	const sent: string[] = [];
+	const socket: MessageSocket = {
+		data: { senderId: "f2-sender" },
+		send: (message) => {
+			sent.push(message);
+		},
+	};
+
+	notificationSend(
+		socket,
+		"f2-contract",
+		"warning",
+		"structural socket payload",
+		5,
+	);
+
+	const output = sent[0] ?? "";
+	expect(output).toContain('"id":"f2-sender"');
+	expect(output).toContain('"name":"f2-contract"');
+	expect(output).toContain('"msg":"structural socket payload"');
+});

--- a/apps/backend/src/type-tests/f2-ssh-websocket-contract.ts
+++ b/apps/backend/src/type-tests/f2-ssh-websocket-contract.ts
@@ -1,0 +1,8 @@
+import { startStopSsh } from "../modules/system/ssh.ts";
+import type { AppWebSocket } from "../rpc/types.ts";
+
+const startStopSshAcceptsAppWebSocket: (
+	socket: AppWebSocket,
+	command: "start_ssh" | "stop_ssh",
+) => Promise<boolean> = startStopSsh;
+void startStopSshAcceptsAppWebSocket;


### PR DESCRIPTION
## What

- Replace the five SSH/log system-procedure `context.ws as unknown as WebSocket` call-site escapes with a minimal structural `MessageSocket` contract.
- Type SSH, log, notification, and sender-id producers against that contract while preserving their runtime behavior.
- Add a permanent backend compile assertion, a sender-id/notification behavior regression test, backend PR typecheck coverage, and backend documentation.

## Why

Bun's `AppWebSocket` is structurally compatible with the operations these producers use, but it is not the `ws` package's `WebSocket` class. The old boundary hid that mismatch behind double casts and allowed the wrong socket contract to spread.

## How to verify

- `bun run lint`
- `bun run --filter backend check`
- `bun run test:build-check-shape`
- `bun run test:release-package-contracts`
- `bun run check:rc-pins`
- `bun run test:tech-debt && bun run check:tech-debt`
- `bun run test:service-contract`
- `bun run test`
- `BUILD_ARCH=amd64 bun run build`

The local gate passed with 1,598 frontend tests and 1,910 backend tests, zero failures, and a successful amd64 build.

## Risks

The change is type-only at the production boundary. SSH commands, log argv construction, sender-id propagation, notification frames, and RPC response behavior are unchanged. The hosted Build Check remains the final E2E and CI validation surface.
