### PR TITLE
fix(backend): detect RK3588 via device-tree compatible marker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,8 +394,13 @@ wraps its read in its own `try/catch` and degrades to `null` on failure — a mi
 Detection contract (fail-safe, defaults to `false`):
 1. `CERALIVE_DEVICE_TYPE==="real"` → true; `==="emulated"` → false (env override wins over everything)
 2. `isDevelopment()` → false (short-circuits before any hardware probe)
-3. `/proc/device-tree/model` contains the RK3588-specific marker `"RK3588"` → true;
-   generic Rockchip, RK3399, and RK356x identities fail closed
+3. `/proc/device-tree/compatible` OR `/proc/device-tree/model` contains the
+   RK3588 marker (`"rk3588"`, matched case-insensitively) → true. `compatible`
+   is the RELIABLE marker (always carries `rockchip,rk3588`, even on boards like
+   the Radxa ROCK 5B+ whose `model` reads just `"Radxa ROCK 5B+"` with no
+   `RK3588` substring); `model` is a belt-and-suspenders fallback for boards
+   whose model string itself names the SoC (e.g. Orange Pi 5+). Generic
+   Rockchip, RK3399, and RK356x identities fail closed
 4. x86 mini-PC path: `/etc/ceralive/release` contains `ID=ceralive` AND DMI
    `/sys/class/dmi/id/{product_name,board_name}` contains a mini-PC marker
    (`N100`, `N200`, `Mini PC`, `MINIPC`) → true

--- a/apps/backend/src/modules/system/device-detection.ts
+++ b/apps/backend/src/modules/system/device-detection.ts
@@ -35,13 +35,24 @@ import { isDevelopment } from "../../mocks/mock-config.ts";
 
 /** Device-tree path Rockchip boards expose their model string on. */
 const DEVICE_TREE_MODEL = "/proc/device-tree/model";
+/**
+ * Device-tree path exposing the board's `compatible` list (NUL-separated on
+ * disk). This is the RELIABLE RK3588 marker: it always carries the SoC
+ * compatible string (e.g. "radxa,rock-5b-plus\0rockchip,rk3588"), even on
+ * boards whose `model` string never names the SoC. The Radxa ROCK 5B+ reads
+ * "Radxa ROCK 5B+" with no "RK3588" substring, so the model check alone
+ * wrongly classifies a real board as emulated — the compatible check fixes it.
+ */
+const DEVICE_TREE_COMPATIBLE = "/proc/device-tree/compatible";
 const CERALIVE_RELEASE_FILE = "/etc/ceralive/release";
 const DMI_PRODUCT_NAME = "/sys/class/dmi/id/product_name";
 const DMI_BOARD_NAME = "/sys/class/dmi/id/board_name";
 
 /**
- * Substrings that positively identify an RK3588 board. On a real Rockchip
- * board `/proc/device-tree/model` reads e.g. "Rockchip RK3588 ...".
+ * Substring that positively identifies an RK3588 board. Matched
+ * case-insensitively against BOTH `/proc/device-tree/compatible` (lowercase
+ * "rockchip,rk3588") and `/proc/device-tree/model` (uppercase "RK3588" on the
+ * boards whose model string names the SoC, e.g. Orange Pi 5+).
  */
 const RK3588_DEVICE_MARKER = "RK3588";
 const X86_MINIPC_DMI_MARKERS = ["N100", "N200", "Mini PC", "MINIPC"] as const;
@@ -63,6 +74,12 @@ export type DeviceDetectionDeps = {
 	 * {@link isRealDevice} swallows the rejection and resolves false.
 	 */
 	readDeviceTreeModel: () => Promise<string>;
+	/**
+	 * Read the device-tree `compatible` list (NUL-separated on disk). The
+	 * reliable RK3588 marker. MAY reject (file absent/unreadable);
+	 * {@link isRealDevice} swallows the rejection and resolves false.
+	 */
+	readDeviceTreeCompatible: () => Promise<string>;
 	readCeraliveRelease: () => Promise<string>;
 	readDmiProductName: () => Promise<string>;
 	readDmiBoardName: () => Promise<string>;
@@ -72,6 +89,7 @@ export const defaultDeviceDetectionDeps: DeviceDetectionDeps = {
 	getDeviceTypeOverride: () => process.env.CERALIVE_DEVICE_TYPE,
 	isDevelopment,
 	readDeviceTreeModel: () => Bun.file(DEVICE_TREE_MODEL).text(),
+	readDeviceTreeCompatible: () => Bun.file(DEVICE_TREE_COMPATIBLE).text(),
 	readCeraliveRelease: () => Bun.file(CERALIVE_RELEASE_FILE).text(),
 	readDmiProductName: () => Bun.file(DMI_PRODUCT_NAME).text(),
 	readDmiBoardName: () => Bun.file(DMI_BOARD_NAME).text(),
@@ -85,8 +103,8 @@ async function readOptional(probe: () => Promise<string>): Promise<string> {
 	}
 }
 
-function hasRk3588Marker(model: string): boolean {
-	return model.includes(RK3588_DEVICE_MARKER);
+function hasRk3588Marker(identity: string): boolean {
+	return identity.toLowerCase().includes(RK3588_DEVICE_MARKER.toLowerCase());
 }
 
 function hasCeraliveImageIdentity(release: string): boolean {
@@ -102,7 +120,10 @@ function hasX86MiniPcDmiMarker(dmi: string): boolean {
  *
  *  1. `CERALIVE_DEVICE_TYPE` override — "real" → true, "emulated" → false.
  *  2. Dev/mock mode → false (never drive the host OS from a dev box).
- *  3. `/proc/device-tree/model` names an RK3588 board → true.
+ *  3. `/proc/device-tree/compatible` OR `/proc/device-tree/model` names an
+ *     RK3588 board → true. The `compatible` list is the reliable marker (it
+ *     always carries "rockchip,rk3588"); `model` is a belt-and-suspenders
+ *     fallback for boards whose model string itself names the SoC.
  *  4. CeraLive image identity + x86 mini-PC DMI marker → true.
  *  5. Otherwise → false.
  *
@@ -119,6 +140,12 @@ export async function isRealDevice(
 
 	if (deps.isDevelopment()) return false;
 
+	// `compatible` is the reliable RK3588 marker (always carries
+	// "rockchip,rk3588"); `model` is a fallback for boards whose model string
+	// itself names the SoC (e.g. Orange Pi 5+). Either match is a real device.
+	if (hasRk3588Marker(await readOptional(deps.readDeviceTreeCompatible))) {
+		return true;
+	}
 	if (hasRk3588Marker(await readOptional(deps.readDeviceTreeModel))) {
 		return true;
 	}

--- a/apps/backend/src/tests/device-detection.test.ts
+++ b/apps/backend/src/tests/device-detection.test.ts
@@ -22,6 +22,9 @@ function makeDeps(
 		readDeviceTreeModel: async () => {
 			throw new Error("ENOENT: /proc/device-tree/model");
 		},
+		readDeviceTreeCompatible: async () => {
+			throw new Error("ENOENT: /proc/device-tree/compatible");
+		},
 		readCeraliveRelease: async () => {
 			throw new Error("ENOENT: /etc/ceralive/release");
 		},
@@ -66,6 +69,28 @@ describe("isRealDevice", () => {
 		const deps = makeDeps({
 			readDeviceTreeModel: async () =>
 				"Radxa ROCK 5B Plus Board based on Rockchip RK3588",
+		});
+		expect(await isRealDevice(deps)).toBe(true);
+	});
+
+	// Confirmed production bug: on a real Radxa ROCK 5B+ the model string carries
+	// no "RK3588" substring, but /proc/device-tree/compatible (NUL-separated on
+	// disk) reliably contains lowercase "rockchip,rk3588". The compatible check
+	// must classify this real board as a device.
+	test("Radxa ROCK 5B+ compatible marker rescues a model with no RK3588 → true", async () => {
+		const deps = makeDeps({
+			readDeviceTreeModel: async () => "Radxa ROCK 5B+ \n",
+			readDeviceTreeCompatible: async () =>
+				"radxa,rock-5b-plus\u0000rockchip,rk3588\u0000",
+		});
+		expect(await isRealDevice(deps)).toBe(true);
+	});
+
+	test("compatible marker alone identifies an RK3588 board when the model is unhelpful → true", async () => {
+		const deps = makeDeps({
+			readDeviceTreeModel: async () => "Generic Board",
+			readDeviceTreeCompatible: async () =>
+				"vendor,board\u0000rockchip,rk3588\u0000",
 		});
 		expect(await isRealDevice(deps)).toBe(true);
 	});


### PR DESCRIPTION
## What

`isRealDevice()` (`apps/backend/src/modules/system/device-detection.ts`) now
also reads `/proc/device-tree/compatible` (case-insensitively matched for the
`rk3588` marker) in addition to the existing `/proc/device-tree/model` check.
Either match classifies the board as a real device. A new injectable
`readDeviceTreeCompatible` probe is added to `DeviceDetectionDeps` /
`defaultDeviceDetectionDeps`, mirroring `readDeviceTreeModel` exactly.

## Why

On a real, physical Radxa ROCK 5B+ (confirmed live over SSH), `isRealDevice()`
returned `false` and the device was treated as **emulated**. Root cause: the
only RK3588 check read `/proc/device-tree/model`, which on this board reads:

```
Radxa ROCK 5B+
```

No `RK3588` substring anywhere, so the check failed; the x86-DMI fallback path
didn't match either, so detection fell through to `false`. That directly caused:

- Settings → Sources showing *"Network ingest isn't available on this device in
  emulated mode"* on a real device.
- The RTMP/SRT gateway probes (which are `isRealDevice()`-gated in
  `network-ingest.ts`) reporting "Service not running" even though the actual
  `ceralive-rtmp-gateway.service` unit was `active (running)`.

`/proc/device-tree/compatible` is the reliable, standard board-identification
marker. On the same board it reads (NUL-separated on disk):

```
radxa,rock-5b-plus rockchip,rk3588
```

which reliably contains `rk3588`. The `model` check is kept as a
belt-and-suspenders fallback for boards whose model string does name the SoC
(e.g. Orange Pi 5+). The marker match was made case-insensitive so the lowercase
`rockchip,rk3588` (compatible) and uppercase `RK3588` (model) both hit one code
path — this is strictly more permissive, and the fail-closed cases (`RK3399`,
`RK3568`, generic Rockchip) still fail since none contain `rk3588` in any case.

## How to verify

```bash
cd apps/backend
bun test src/tests/device-detection.test.ts src/tests/device-detection-override.test.ts   # 30 pass
bun tsc --noEmit                                                                            # clean
```

A new regression test mirrors the exact field bug: model `"Radxa ROCK 5B+ \n"`
(no RK3588) with compatible `"radxa,rock-5b-plus\u0000rockchip,rk3588\u0000"`
resolves `true`.

## Risks

Low, and additive:

- The override / `isDevelopment` / x86-mini-PC DMI branches are untouched.
- Fail-safe semantics are preserved — the new probe is wrapped in the same
  `readOptional` swallow-on-reject, so any read failure still degrades to `""`
  and never propagates or crashes boot.
- Case-insensitive matching only ever adds matches; every existing fail-closed
  identity still fails closed (covered by the existing `test.each` cases).