### PR TITLE
fix(backend): retry + self-heal the cerastream engine connection

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -19,6 +19,7 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 | Capability contract service (engine emits, CeraUI consumes; cache + fallback ladder; `transports` + `getSupportedTransports()`) | `modules/streaming/capabilities.ts` (`getCapabilities`) |
 | Transport resolver + protocol registry (srtla/rist active, srt reserved; RIST capability-gated via `ristAvailable`) | `modules/streaming/transport/` (`resolveStreamEndpoint`, `registry.ts`, `rist-adapter.ts`) |
 | Pipeline registry (derived from the capability contract; `initPipelines` is async) | `modules/streaming/pipelines.ts` |
+| Engine connection resilience (bounded boot retry → periodic recheck; heals `engine-unavailable` and re-broadcasts caps/pipelines/sources) | `modules/streaming/engine-reconnect.ts` (`initEngineConnection`) |
 | Cerastream engine backend (structured IPC, `@ceralive/cerastream`) | `modules/streaming/cerastream-backend.ts` |
 | Structured engine error → notification (Task-7 table swap, no regex); `mapCerastreamError()` maps a `RuntimeErrorEvent` to a Tier-2 code string (T16) | `modules/streaming/cerastream-error-mapping.ts` |
 | srtla binding calls (flux — check `../../../srtla/AGENTS.md` first) | `modules/streaming/srtla.ts` |
@@ -493,9 +494,12 @@ runCritical("config", loadConfig)            # CRITICAL — abort on failure
 runCritical("ws-control-server", initServer) # CRITICAL — bind the operator lifeline FIRST
 guardNonCritical("identity", initIdentity)            # resolves device_id + paired
 guardNonCritical("control-channel", initControlChannel) # gates on canDialControlChannel()
-guardNonCritical("pipelines", initPipelines)          # streaming engine init
+guardNonCritical("pipelines", initEngineConnection)   # streaming engine init + reconnect loop
 guardNonCritical("rtmp-ingest", initRTMPIngestStats)  # RTMP bandwidth poller
 ```
+
+The `pipelines` init is now `initEngineConnection` (`modules/streaming/engine-reconnect.ts`),
+NOT the raw `initPipelines`. See ENGINE CONNECTION RESILIENCE below.
 
 ## BOOT FAIL-SOFT [EXISTS]
 
@@ -518,6 +522,52 @@ The degraded flag is surfaced read-only on the local `/api/health` endpoint
 remote egress. Contract coverage: `src/main.test.ts`. Do NOT move a non-critical
 init ahead of the critical WS-server bind, and do NOT downgrade the config /
 WS-bind classifications to fail-soft.
+
+## ENGINE CONNECTION RESILIENCE [EXISTS]
+
+The capability contract is fetched over a SHORT-LIVED probe to the systemd-owned
+cerastream control socket (`capabilities.ts` → `defaultFetchEngineCapabilities`:
+connect → get-capabilities → close). Before this module that probe was attempted
+exactly ONCE at boot (`guardNonCritical("pipelines", initPipelines)`); if cerastream
+was not up yet — a real systemd-ordering race / slow engine start — the fallback
+ladder served `engineUnavailable`/`engineStarting` and the engine stayed marked
+unavailable PERMANENTLY (no retry, no recheck), so the "Streaming engine offline"
+banner never cleared until an operator restarted `ceralive.service`.
+
+`modules/streaming/engine-reconnect.ts` (`initEngineConnection`) closes that gap.
+It is the boot `pipelines` init now (main.ts) and owns ONE self-rescheduling loop:
+
+- **Bounded boot retry** — the first attempt is awaited (so the pipeline registry is
+  populated before `reconcilePersistedPipeline` / the boot sources step read it —
+  boot ordering unchanged). If the engine is reachable → return, no loop. Else the
+  first backoff steps (~2s, 4s, 8s, 16s → ceiling) are the short exponential backoff
+  that resolves a normal engine-not-ready-yet race with no operator action.
+- **Periodic background recheck** — once backoff caps at `ENGINE_RECONNECT_MAX_MS`
+  (30 s) it is a slow periodic health-recheck that keeps running so a device
+  self-heals minutes/hours later. BOUNDED (30 s ceiling, never a tight loop): a
+  masked/disabled cerastream just gets a cheap 30 s poll, never hammering.
+- **Heal broadcast** — on the unavailable→reachable transition it re-broadcasts
+  `capabilities` + `pipelines` + `sources` to already-connected clients (the SAME
+  trio the `setMockHardware` RPC uses), so the offline banner clears LIVE with no
+  page reload, then SETTLES (stops polling).
+
+Reachability = `getLastCapabilities()?.engineUnavailable === false` (a live snapshot).
+It feeds INTO the existing `engine-unavailable`/`engine-starting` capability tier — it
+does NOT create a parallel state machine. Backoff mirrors
+`modules/remote-control/channel.ts` `backoffDelay` (equal-jitter). All collaborators
+are injected (`EngineReconnectDeps`); `settleEngineReconnect()` / `stopEngineReconnect()`
+are the test/teardown seams. main.ts threads the dev/e2e mock fetchers via the
+`capabilities`/`sources` override bags (same fetchers the boot `initPipelines`/
+`refreshAndBroadcastSources` already used) so dev exercises the identical loop.
+
+The `@ceralive/cerastream` client's `ConnectOptions.autoReconnect` does NOT cover
+this: it only rescues an already-established connection that later drops and throws
+immediately on the first connect failure — useless for a fresh per-fetch probe, and
+it emits no "became available" event. Recovery therefore lives backend-side here.
+
+Coverage: `tests/engine-reconnect.test.ts` (boot-retry heal, later out-of-band
+reconnect, backoff-ceiling cadence, and the permanently-unavailable case through the
+REAL capability ladder — no regression to `engineUnavailable`/`engineStarting`).
 
 ## DEVICE-FIRST SOURCE MODEL [EXISTS]
 

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -81,16 +81,14 @@ import { checkCamlinkUsb2 } from "./modules/streaming/camlink.ts";
 import { checkEngineCompatibilityOnStartup } from "./modules/streaming/cerastream-backend.ts";
 import { reconcilePersistedPipeline } from "./modules/streaming/config-migration.ts";
 import { startDeviceDiscovery } from "./modules/streaming/devices.ts";
+import { initEngineConnection } from "./modules/streaming/engine-reconnect.ts";
 import { setGatewayProbe } from "./modules/streaming/gateway-availability.ts";
 import { broadcastHealthIfChanged } from "./modules/streaming/health.ts";
 import {
 	broadcastLinkTelemetryIfChanged,
 	setMockLinkTelemetryProvider,
 } from "./modules/streaming/link-telemetry.ts";
-import {
-	getPipelineList,
-	initPipelines,
-} from "./modules/streaming/pipelines.ts";
+import { getPipelineList } from "./modules/streaming/pipelines.ts";
 import { refreshAndBroadcastSources } from "./modules/streaming/sources.ts";
 import {
 	getStreamingProcesses,
@@ -211,12 +209,19 @@ wireActiveProfileReporter();
 // Built from the engine's get-capabilities IPC — the engine may be starting or
 // unreachable, so this is the likeliest awaited init to throw/hang. On failure
 // the pipeline registry stays empty (stream-start gated) but the UI is reachable.
+// initEngineConnection runs the first attempt then, if the engine is not yet
+// reachable, arms a bounded backoff→periodic recheck that re-broadcasts
+// capabilities/pipelines/sources once cerastream comes up — so a systemd-ordering
+// race or slow engine start self-heals without an operator restart.
 await guardNonCritical("pipelines", () =>
-	initPipelines(
+	initEngineConnection(
 		shouldUseMocks()
 			? {
-					fetchEngineCapabilities: async () => getMockEngineCapabilities(),
-					fetchEngineDevices: async () => getMockEngineDevices(),
+					capabilities: {
+						fetchEngineCapabilities: async () => getMockEngineCapabilities(),
+						fetchEngineDevices: async () => getMockEngineDevices(),
+					},
+					sources: { fetchEngineDevices: async () => getMockEngineDevices() },
 				}
 			: {},
 	),

--- a/apps/backend/src/modules/streaming/engine-reconnect.ts
+++ b/apps/backend/src/modules/streaming/engine-reconnect.ts
@@ -1,0 +1,344 @@
+/*
+    CeraUI - web UI for the CERALIVE project
+    Copyright (C) 2024-2025 CeraLive project
+
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+// Engine (cerastream) connection resilience.
+//
+// The capability contract is fetched over a SHORT-LIVED probe connection to the
+// systemd-owned cerastream control socket (`capabilities.ts` →
+// `defaultFetchEngineCapabilities`: connect → get-capabilities → close). At boot
+// that probe is attempted exactly once via `guardNonCritical("pipelines", …)`.
+// If cerastream is not up yet — a real systemd-ordering race seen in the field —
+// the fallback ladder serves `engineUnavailable`/`engineStarting` and, before this
+// module, the engine stayed marked unavailable PERMANENTLY: no retry, no periodic
+// recheck, so the "Streaming engine offline" banner never cleared even though
+// cerastream came up healthy moments later.
+//
+// The `@ceralive/cerastream` client DOES expose an `autoReconnect` ConnectOptions
+// flag, but it only rescues an ALREADY-established connection that later drops and
+// throws immediately on the FIRST connect failure — so it cannot help a fresh
+// per-fetch probe, and it emits no "became available" event. The offline→available
+// recovery therefore lives here, backend-side.
+//
+// This module owns ONE self-rescheduling reconnect loop that serves both roles the
+// resilience gap needs:
+//
+//   1. Bounded boot retry — the first attempt is awaited so the pipeline registry
+//      is populated before the rest of boot reads it; the next few backoff steps
+//      (~2s, 4s, 8s, 16s → ceiling) are the "short exponential backoff over the
+//      first ~30-60s" that resolves a normal engine-not-ready-yet race with no
+//      operator intervention.
+//   2. Periodic background recheck — once backoff caps at the ceiling it becomes a
+//      slow (~30s) health-recheck that keeps running so a device self-heals even
+//      minutes/hours later. It is BOUNDED (a fixed ceiling, never a tight loop): a
+//      masked/disabled cerastream just gets a cheap periodic poll, never hammering.
+//
+// On the unavailable→reachable transition it re-broadcasts `capabilities`,
+// `pipelines`, and `sources` to already-connected clients (so the offline banner
+// clears live, no page reload) and then SETTLES — the boot race is resolved. It
+// feeds INTO the existing `engine-unavailable`/`engine-starting` capability tier
+// state machine (reachability = a live `getLastCapabilities()` snapshot); it does
+// not create a parallel one.
+//
+// Every collaborator is injected (`EngineReconnectDeps`, mirroring `channel.ts` /
+// `boot-guard.ts`) so the loop is unit-testable without real timers or a socket.
+
+import { logger as defaultLogger } from "../../helpers/logger.ts";
+import { broadcastMsg } from "../ui/websocket-server.ts";
+import {
+	type CapabilitiesServiceDeps,
+	getLastCapabilities,
+} from "./capabilities.ts";
+import { getPipelinesMessage, initPipelines } from "./pipelines.ts";
+import {
+	type EngineDeviceCacheDeps,
+	refreshAndBroadcastSources,
+} from "./sources.ts";
+
+/**
+ * Reconnect backoff bounds. Mirrors `modules/remote-control/channel.ts`: an
+ * exponential base that caps at a ceiling so the loop never hammers a socket that
+ * will not come back. The first steps (~2s, 4s, 8s, 16s) cover the brief
+ * engine-not-ready race; once capped, the ceiling IS the periodic recheck cadence.
+ */
+export const ENGINE_RECONNECT_BASE_MS = 2_000;
+export const ENGINE_RECONNECT_MAX_MS = 30_000;
+
+type TimerHandle = ReturnType<typeof setTimeout>;
+
+/** Minimal logger surface (winston satisfies it; tests pass a silent stub). */
+export interface EngineReconnectLogger {
+	info(message: string): void;
+	warn(message: string): void;
+}
+
+/** Injected collaborators; defaults wire the real capability/broadcast path. */
+export interface EngineReconnectDeps {
+	/**
+	 * Re-attempt the engine connection and refresh the capability contract. MUST
+	 * NOT throw (the capability ladder never does) — the loop treats a resolve as
+	 * "attempt made" and reads reachability separately.
+	 */
+	refreshCapabilities: () => Promise<void>;
+	/**
+	 * Whether the last refresh produced a LIVE snapshot (engine reachable). A
+	 * cached/minimal fallback (`engineUnavailable`) reads as unreachable.
+	 */
+	isEngineReachable: () => boolean;
+	/**
+	 * Re-broadcast the engine-derived state (`capabilities` + `pipelines` +
+	 * `sources`) to already-connected clients. Called ONCE on the
+	 * unavailable→reachable transition so the offline banner clears live.
+	 */
+	broadcastEngineState: () => Promise<void> | void;
+	logger: EngineReconnectLogger;
+	random: () => number;
+	setTimer: (fn: () => void, ms: number) => TimerHandle;
+	clearTimer: (timer: TimerHandle) => void;
+	/** Backoff base; overridable for tests. */
+	baseDelayMs: number;
+	/** Backoff ceiling (the eventual periodic-recheck cadence); overridable. */
+	maxDelayMs: number;
+}
+
+/**
+ * The engine-fetcher overrides threaded into the DEFAULT `refreshCapabilities` /
+ * `broadcastEngineState` wiring. These mirror the exact bags `main.ts` already
+ * passes to `initPipelines` (capability fetch) and `refreshAndBroadcastSources`
+ * (device fold) at boot, so the reconnect loop refreshes through the SAME seam —
+ * the real engine socket in production, the scenario mock fetchers in dev/e2e.
+ * Omit both (production) and the real cerastream probe is used.
+ */
+export interface EngineConnectionOverrides {
+	/** Threaded into `initPipelines()` (→ `getCapabilities`) on each refresh. */
+	capabilities?: Partial<CapabilitiesServiceDeps>;
+	/** Threaded into `refreshAndBroadcastSources()` on each heal broadcast. */
+	sources?: EngineDeviceCacheDeps;
+}
+
+/**
+ * Build the DEFAULT `broadcastEngineState`: re-push the engine-derived snapshots to
+ * every connected client. Identical to the `setMockHardware` RPC's re-broadcast trio
+ * (`streaming.procedure.ts`) — capabilities THEN pipelines THEN the folded sources,
+ * so a client already on the Live view self-heals without a reload. Best-effort: a
+ * null capability snapshot or a sources refresh failure is swallowed by the loop's
+ * own catch.
+ */
+function buildDefaultBroadcastEngineState(
+	sourcesOverride: EngineDeviceCacheDeps | undefined,
+): () => Promise<void> {
+	return async () => {
+		broadcastMsg("capabilities", getLastCapabilities());
+		broadcastMsg("pipelines", getPipelinesMessage());
+		await (sourcesOverride
+			? refreshAndBroadcastSources(sourcesOverride)
+			: refreshAndBroadcastSources());
+	};
+}
+
+function defaultDeps(
+	fetchers: EngineConnectionOverrides = {},
+): EngineReconnectDeps {
+	const capsOverride = fetchers.capabilities ?? {};
+	return {
+		refreshCapabilities: () => initPipelines(capsOverride),
+		isEngineReachable: () => getLastCapabilities()?.engineUnavailable === false,
+		broadcastEngineState: buildDefaultBroadcastEngineState(fetchers.sources),
+		logger: defaultLogger,
+		random: Math.random,
+		setTimer: (fn, ms) => setTimeout(fn, ms),
+		clearTimer: (timer) => clearTimeout(timer),
+		baseDelayMs: ENGINE_RECONNECT_BASE_MS,
+		maxDelayMs: ENGINE_RECONNECT_MAX_MS,
+	};
+}
+
+interface ReconnectState {
+	deps: EngineReconnectDeps;
+	attempt: number;
+	timer: TimerHandle | undefined;
+	stopped: boolean;
+	/** Tail of the in-flight background attempt (test seam via settleEngineReconnect). */
+	inflight: Promise<void>;
+}
+
+// Process-wide singleton (mirrors channel.ts module-state posture).
+let state: ReconnectState | undefined;
+
+/**
+ * Exponential backoff with equal jitter: `base·2^attempt` capped at `max`, then a
+ * random point in the upper half `[cap/2, cap]`. Mirrors `channel.ts` `backoffDelay`
+ * so the two reconnect surfaces share one shape; parameterized here so the module
+ * stays self-contained. The jitter de-synchronises a fleet rechecking after a shared
+ * boot race so they never thundering-herd the engine socket.
+ */
+export function backoffDelay(
+	attempt: number,
+	baseMs: number,
+	maxMs: number,
+	random: () => number,
+): number {
+	const capped = Math.min(baseMs * 2 ** attempt, maxMs);
+	return capped / 2 + random() * (capped / 2);
+}
+
+function errMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Run one connection attempt: refresh capabilities, then — when asked — broadcast
+ * the healed state if the engine became reachable. `refreshCapabilities` and
+ * `broadcastEngineState` are both wrapped so a stray throw can never break the loop.
+ */
+async function runAttempt(broadcastOnHeal: boolean): Promise<void> {
+	if (!state) return;
+	const { deps } = state;
+	try {
+		await deps.refreshCapabilities();
+	} catch (err) {
+		// The capability ladder never throws; defend anyway so a future change
+		// can't silently kill the recovery loop.
+		deps.logger.warn(
+			`engine reconnect: capability refresh threw: ${errMessage(err)}`,
+		);
+	}
+	if (!state || !broadcastOnHeal || !deps.isEngineReachable()) return;
+	try {
+		await deps.broadcastEngineState();
+		deps.logger.info(
+			"engine reconnect: engine reachable again; re-broadcast capabilities/pipelines/sources to clients",
+		);
+	} catch (err) {
+		deps.logger.warn(
+			`engine reconnect: heal broadcast failed: ${errMessage(err)}`,
+		);
+	}
+}
+
+/**
+ * Schedule the next background recheck (single in-flight timer; never stacked).
+ * No-op once the loop has settled or been torn down.
+ */
+function scheduleRecheck(): void {
+	if (!state || state.stopped || state.timer !== undefined) return;
+	const { deps } = state;
+	const delay = backoffDelay(
+		state.attempt,
+		deps.baseDelayMs,
+		deps.maxDelayMs,
+		deps.random,
+	);
+	state.attempt += 1;
+	deps.logger.info(
+		`engine reconnect: rechecking engine in ${Math.round(delay)}ms (attempt ${state.attempt})`,
+	);
+	state.timer = deps.setTimer(() => {
+		if (!state) return;
+		state.timer = undefined;
+		state.inflight = tickRecheck();
+	}, delay);
+}
+
+/**
+ * One background recheck tick: attempt, then either settle (engine healed) or
+ * schedule the next recheck (still down). The heal broadcast fires inside
+ * `runAttempt` on the transition, so by the time we settle clients are updated.
+ */
+async function tickRecheck(): Promise<void> {
+	if (!state || state.stopped) return;
+	await runAttempt(true);
+	if (!state || state.stopped) return;
+	if (state.deps.isEngineReachable()) {
+		// Healed — the boot race is resolved; settle so we stop polling.
+		state.stopped = true;
+		state.timer = undefined;
+		return;
+	}
+	scheduleRecheck();
+}
+
+/**
+ * Boot entry point. Runs the FIRST engine connection attempt synchronously (so the
+ * pipeline registry is populated before the rest of boot reads it), then — if the
+ * engine is not yet reachable — arms the background reconnect loop so a slow-starting
+ * or briefly-unreachable engine self-heals without an operator restart.
+ *
+ * Fail-soft: `refreshCapabilities` never throws, so this resolves even when the
+ * engine is down; the background loop is fire-and-forget and never blocks boot.
+ * Idempotent — a prior loop is torn down first.
+ */
+export async function initEngineConnection(
+	options: EngineConnectionOverrides & Partial<EngineReconnectDeps> = {},
+): Promise<void> {
+	const { capabilities, sources, ...depOverrides } = options;
+	const fetchers: EngineConnectionOverrides = {
+		...(capabilities !== undefined ? { capabilities } : {}),
+		...(sources !== undefined ? { sources } : {}),
+	};
+	const deps: EngineReconnectDeps = {
+		...defaultDeps(fetchers),
+		...depOverrides,
+	};
+
+	stopEngineReconnect();
+	state = {
+		deps,
+		attempt: 0,
+		timer: undefined,
+		stopped: false,
+		inflight: Promise.resolve(),
+	};
+
+	// First attempt is awaited (no heal broadcast — there are no clients yet at
+	// boot, and boot's own snapshot/sources steps run right after).
+	await runAttempt(false);
+
+	if (!state) return;
+	if (deps.isEngineReachable()) {
+		deps.logger.info("engine reconnect: engine reachable at boot");
+		state.stopped = true;
+		return;
+	}
+
+	deps.logger.warn(
+		"engine reconnect: engine unreachable at boot; scheduling background reconnect",
+	);
+	scheduleRecheck();
+}
+
+/**
+ * Test seam: resolve once the in-flight background recheck has settled (mirrors
+ * `CerastreamBackend.settle()`). Returns immediately when no attempt is in flight.
+ */
+export function settleEngineReconnect(): Promise<void> {
+	return state?.inflight ?? Promise.resolve();
+}
+
+/**
+ * Tear down the reconnect loop (clear the timer, drop state). Idempotent — safe to
+ * call when never started. Keeps `initEngineConnection` re-entrant across reboots
+ * and test cases.
+ */
+export function stopEngineReconnect(): void {
+	if (!state) return;
+	if (state.timer !== undefined) {
+		state.deps.clearTimer(state.timer);
+	}
+	state.stopped = true;
+	state = undefined;
+}

--- a/apps/backend/src/tests/engine-reconnect.test.ts
+++ b/apps/backend/src/tests/engine-reconnect.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { CerastreamConnectionError } from "@ceralive/cerastream";
+import {
+	clearCapabilitiesCache,
+	getLastCapabilities,
+} from "../modules/streaming/capabilities.ts";
+import {
+	backoffDelay,
+	ENGINE_RECONNECT_MAX_MS,
+	type EngineReconnectLogger,
+	initEngineConnection,
+	settleEngineReconnect,
+	stopEngineReconnect,
+} from "../modules/streaming/engine-reconnect.ts";
+
+const silent: EngineReconnectLogger = { info: () => {}, warn: () => {} };
+
+type TimerHandle = ReturnType<typeof setTimeout>;
+
+// A controllable environment: a manual timer queue plus a scripted list of
+// per-attempt reachability outcomes, so the whole loop is driven deterministically
+// with no real time. `fireNextTimer` runs the one pending timer then awaits the
+// background attempt it kicks off (via the settle seam).
+function harness(outcomes: boolean[]) {
+	const timers: Array<{ fn: () => void }> = [];
+	let idx = 0;
+	let reachable = false;
+	const refreshCalls: boolean[] = [];
+	let broadcasts = 0;
+	const delays: number[] = [];
+
+	const deps = {
+		refreshCapabilities: async () => {
+			reachable = outcomes[Math.min(idx, outcomes.length - 1)] ?? false;
+			idx += 1;
+			refreshCalls.push(reachable);
+		},
+		isEngineReachable: () => reachable,
+		broadcastEngineState: () => {
+			broadcasts += 1;
+		},
+		logger: silent,
+		random: () => 0.5,
+		setTimer: (fn: () => void, ms: number): TimerHandle => {
+			delays.push(ms);
+			timers.push({ fn });
+			return timers.length as unknown as TimerHandle;
+		},
+		clearTimer: () => {},
+		baseDelayMs: 2_000,
+		maxDelayMs: ENGINE_RECONNECT_MAX_MS,
+	};
+
+	return {
+		deps,
+		get pendingTimers() {
+			return timers.length;
+		},
+		get refreshCount() {
+			return refreshCalls.length;
+		},
+		get broadcasts() {
+			return broadcasts;
+		},
+		get delays() {
+			return delays;
+		},
+		async fireNextTimer() {
+			const t = timers.shift();
+			if (!t) throw new Error("no pending timer to fire");
+			t.fn();
+			await settleEngineReconnect();
+		},
+	};
+}
+
+afterEach(() => {
+	stopEngineReconnect();
+	clearCapabilitiesCache();
+});
+
+describe("backoffDelay", () => {
+	test("equal-jitter window, capped at the ceiling", () => {
+		// attempt 0: cap=2000 → [1000, 2000]; random()=0 → 1000, random()~1 → ~2000
+		expect(backoffDelay(0, 2_000, 30_000, () => 0)).toBe(1_000);
+		expect(backoffDelay(0, 2_000, 30_000, () => 0.5)).toBe(1_500);
+		// large attempt caps at max: cap=30000 → [15000, 30000]
+		expect(backoffDelay(20, 2_000, 30_000, () => 0)).toBe(15_000);
+		expect(backoffDelay(20, 2_000, 30_000, () => 0.999)).toBeLessThanOrEqual(
+			30_000,
+		);
+	});
+});
+
+describe("initEngineConnection — reachable at boot", () => {
+	test("no reconnect loop is armed when the first attempt succeeds", async () => {
+		const h = harness([true]);
+		await initEngineConnection(h.deps);
+
+		expect(h.refreshCount).toBe(1);
+		expect(h.pendingTimers).toBe(0);
+		expect(h.broadcasts).toBe(0);
+	});
+});
+
+describe("initEngineConnection — (a) boot retry within the boot window", () => {
+	test("a failed boot attempt followed by a successful retry heals + settles", async () => {
+		const h = harness([false, true]);
+		await initEngineConnection(h.deps);
+
+		// boot attempt failed → one recheck scheduled, no heal broadcast yet.
+		expect(h.refreshCount).toBe(1);
+		expect(h.pendingTimers).toBe(1);
+		expect(h.broadcasts).toBe(0);
+
+		// the scheduled retry succeeds → heal broadcast fires once, loop settles.
+		await h.fireNextTimer();
+		expect(h.refreshCount).toBe(2);
+		expect(h.broadcasts).toBe(1);
+		expect(h.pendingTimers).toBe(0);
+	});
+});
+
+describe("initEngineConnection — (b) later out-of-band reconnect", () => {
+	test("several failed rechecks then a later success still heals + settles", async () => {
+		const h = harness([false, false, false, false, true]);
+		await initEngineConnection(h.deps);
+
+		// three background rechecks, all still down: keep rescheduling, never heal.
+		await h.fireNextTimer();
+		await h.fireNextTimer();
+		await h.fireNextTimer();
+		expect(h.broadcasts).toBe(0);
+		expect(h.pendingTimers).toBe(1);
+
+		// the fourth recheck finds the engine up → heal + settle.
+		await h.fireNextTimer();
+		expect(h.broadcasts).toBe(1);
+		expect(h.pendingTimers).toBe(0);
+	});
+
+	test("backoff escalates then caps at the ceiling (periodic recheck)", async () => {
+		const h = harness([false, false, false, false, false, false]);
+		await initEngineConnection(h.deps);
+		for (let i = 0; i < 5; i++) await h.fireNextTimer();
+
+		// random()=0.5 → delay = cap/2 + 0.5*cap/2 = 0.75*cap.
+		// caps: 2000,4000,8000,16000,30000(capped),30000 → 0.75× each.
+		expect(h.delays.slice(0, 6)).toEqual([
+			1_500, 3_000, 6_000, 12_000, 22_500, 22_500,
+		]);
+	});
+});
+
+describe("initEngineConnection — (c) permanently unavailable (real ladder)", () => {
+	test("engineUnavailable/engineStarting persist and the loop never falsely heals", async () => {
+		clearCapabilitiesCache();
+		let broadcasts = 0;
+		const timers: Array<{ fn: () => void }> = [];
+
+		// The REAL initPipelines + default isEngineReachable (getLastCapabilities),
+		// with a throwing engine fetcher — exactly the engine-starting/unavailable
+		// mock-scenario semantics. Only the timer + broadcast + logger are stubbed.
+		await initEngineConnection({
+			capabilities: {
+				fetchEngineCapabilities: async () => {
+					throw new CerastreamConnectionError("engine down (test)");
+				},
+				fetchEngineDevices: async () => ({ devices: [] }),
+			},
+			broadcastEngineState: () => {
+				broadcasts += 1;
+			},
+			logger: silent,
+			random: () => 0.5,
+			setTimer: (fn) => {
+				timers.push({ fn });
+				return timers.length as unknown as TimerHandle;
+			},
+			clearTimer: () => {},
+		});
+
+		// The empty-cache floor: minimal safe set flagged unavailable + starting.
+		expect(getLastCapabilities()?.engineUnavailable).toBe(true);
+		expect(getLastCapabilities()?.engineStarting).toBe(true);
+		// a background recheck is scheduled; nothing was falsely broadcast as healed.
+		expect(timers.length).toBe(1);
+		expect(broadcasts).toBe(0);
+
+		// fire a couple of rechecks: still down, still no false heal.
+		for (let i = 0; i < 2; i++) {
+			const t = timers.shift();
+			t?.fn();
+			await settleEngineReconnect();
+		}
+		expect(broadcasts).toBe(0);
+		expect(getLastCapabilities()?.engineUnavailable).toBe(true);
+	});
+
+	test("a live engine on a later attempt heals through the real ladder", async () => {
+		clearCapabilitiesCache();
+		let broadcasts = 0;
+		const timers: Array<{ fn: () => void }> = [];
+		let up = false;
+
+		await initEngineConnection({
+			// refreshCapabilities routes through the REAL initPipelines so the default
+			// isEngineReachable (getLastCapabilities) is exercised end-to-end.
+			capabilities: {
+				fetchEngineCapabilities: async () => {
+					if (!up) throw new CerastreamConnectionError("engine down (test)");
+					return {
+						caps: {
+							platform: {
+								supports_h265: false,
+								hardware_accelerated: false,
+								max_resolution: "1920x1080",
+							},
+							encoder: {
+								codecs: ["H264"],
+								bitrate_range: { min: 500, max: 6000, unit: "kbps" },
+							},
+							sources: [
+								{
+									id: "hdmi",
+									supports_audio: true,
+									supports_resolution_override: true,
+									supports_framerate_override: true,
+									default_resolution: "1920x1080",
+									default_framerate: 60,
+								},
+							],
+						},
+						schemaVersion: (await import("@ceralive/cerastream"))
+							.SCHEMA_VERSION,
+					};
+				},
+				fetchEngineDevices: async () => ({ devices: [] }),
+			},
+			broadcastEngineState: () => {
+				broadcasts += 1;
+			},
+			logger: silent,
+			random: () => 0.5,
+			setTimer: (fn) => {
+				timers.push({ fn });
+				return timers.length as unknown as TimerHandle;
+			},
+			clearTimer: () => {},
+		});
+
+		expect(getLastCapabilities()?.engineUnavailable).toBe(true);
+		expect(broadcasts).toBe(0);
+
+		// engine comes up; the next recheck sees a live snapshot → heal + settle.
+		up = true;
+		const t = timers.shift();
+		t?.fn();
+		await settleEngineReconnect();
+
+		expect(getLastCapabilities()?.engineUnavailable).toBe(false);
+		expect(getLastCapabilities()?.sources.some((s) => s.id === "hdmi")).toBe(
+			true,
+		);
+		expect(broadcasts).toBe(1);
+		expect(timers.length).toBe(0);
+	});
+});
+
+describe("stopEngineReconnect — teardown", () => {
+	test("is idempotent and halts a pending recheck", async () => {
+		const h = harness([false, false]);
+		await initEngineConnection(h.deps);
+		expect(h.pendingTimers).toBe(1);
+
+		stopEngineReconnect();
+		stopEngineReconnect();
+
+		// firing a stale captured timer after teardown is a no-op (no refresh).
+		const before = h.refreshCount;
+		await settleEngineReconnect();
+		expect(h.refreshCount).toBe(before);
+	});
+});


### PR DESCRIPTION
## What

Adds `modules/streaming/engine-reconnect.ts` (`initEngineConnection`), which becomes the boot `pipelines` init in `main.ts`. It runs the first engine capability probe synchronously (boot ordering unchanged), then — if cerastream is unreachable — arms **one self-rescheduling reconnect loop**:

- a short exponential backoff (~2s, 4s, 8s, 16s → 30s ceiling) that resolves a normal engine-not-ready-yet race, then
- a bounded periodic (30s) health-recheck so a device self-heals minutes/hours later.

On the `unavailable → reachable` transition it re-broadcasts `capabilities` + `pipelines` + `sources` to already-connected clients (the same trio the `setMockHardware` RPC uses), so the "Streaming engine offline" banner clears **live, without a page reload**, then settles.

## Why

Confirmed on real hardware: the engine capability contract was fetched over a short-lived probe **exactly once at boot** inside `guardNonCritical("pipelines", initPipelines)`. If `cerastream.service` wasn't up yet (a systemd-ordering race being fixed separately in `image-building-pipeline`, or just a slow start), the fallback ladder marked the engine unavailable **permanently** — no retry, no recheck — so the offline banner never cleared even though cerastream came up healthy moments later. This is defense-in-depth: it stands on its own even with correct ordering, covering any transient failure (slow start, brief socket hiccup, a cerastream-only restart).

The `@ceralive/cerastream` client *does* expose `ConnectOptions.autoReconnect`, but it only rescues an **already-established** connection that later drops and **throws immediately on the first connect failure** — useless for the fresh per-fetch capability probe — and emits no "became available" event. So recovery lives backend-side. Reachability feeds the **existing** `engine-unavailable`/`engine-starting` capability tier; no parallel state machine is introduced. Backoff mirrors the `modules/remote-control/channel.ts` convention.

Note: the separate version-skew error (`get-capabilities` additive method #9 missing on an older engine binary) is an already-tracked follow-up (redeploy a newer cerastream) and is **not** addressed here — the loop correctly treats it as "unavailable" and self-heals once a matching engine ships.

## How to verify

From `apps/backend/`:

- `bun test src/tests/engine-reconnect.test.ts` — 8 tests: boot-retry heal, later out-of-band reconnect, backoff-ceiling cadence, and the permanently-unavailable case driven through the **real** capability ladder (proves no regression to `engineUnavailable`/`engineStarting`).
- `bun tsc --noEmit` — clean.
- `biome check` — clean.

Full `bun test` is green except 4 pre-existing environment/permission `EACCES` failures (`/run/ceralive/srtla_ips`, `/var/run/bcrpt`) unrelated to this change — none reference the new module or any file touched here.

## Risks

- Low. Boot ordering is preserved (first attempt awaited; the background loop only fires ≥~2s later, after boot's synchronous `reconcilePersistedPipeline`/sources steps). The loop is bounded (30s ceiling — a masked/disabled cerastream just gets a cheap periodic poll, never a tight loop) and settles once the engine is reachable. All collaborators are injected; `stopEngineReconnect()`/`settleEngineReconnect()` are the teardown/test seams. Docs updated in `apps/backend/AGENTS.md`.