### PR TITLE
fix(wifi): show Disconnect on a connected saved network without a bound MAC

### DIFF
--- a/apps/backend/src/modules/wifi/wifi.ts
+++ b/apps/backend/src/modules/wifi/wifi.ts
@@ -35,6 +35,7 @@ import {
 import { getMockHotspotConfig } from "../../mocks/providers/wifi.ts";
 import {
 	type ConnectionUUID,
+	type MacAddress,
 	nmConnDelete,
 	nmConnect,
 	nmConnGetFields,
@@ -70,6 +71,7 @@ import {
 	getMacAddressForWifiInterface,
 	getWifiIdToMacAddress,
 	type SSID,
+	type WifiInterface,
 	type WifiInterfaceId,
 } from "./wifi-interfaces.ts";
 
@@ -257,6 +259,32 @@ export function broadcastWifiState() {
 	broadcastMsg("status", { wifi: wifiBuildMsg() });
 }
 
+/*
+  Record one saved infrastructure connection on the interface(s) it can be used
+  from. A profile bound to a MAC that a present adapter reports is attributed to
+  that adapter only. Any other profile — no bound MAC (created outside CeraUI:
+  nmtui, `nmcli device wifi connect`, a baked image profile) or a bound MAC that
+  matches no present adapter (MAC randomization / swapped adapter) — is registered
+  on every adapter, mirroring the scan path where all interfaces see all networks.
+  Without this fallback an active-but-unbound connection resolves no UUID and the
+  UI shows "Connect" on the network the device is already connected to.
+*/
+export function registerSavedWifiConnection(
+	interfaces: Record<MacAddress, WifiInterface>,
+	macAddress: MacAddress,
+	ssid: SSID,
+	uuid: ConnectionUUID,
+): void {
+	const boundInterface = macAddress ? interfaces[macAddress] : undefined;
+	if (boundInterface) {
+		boundInterface.saved[ssid] = uuid;
+		return;
+	}
+	for (const wifiInterface of Object.values(interfaces)) {
+		wifiInterface.saved[ssid] = uuid;
+	}
+}
+
 export async function wifiUpdateSavedConns() {
 	// Retry transient nmcli connection-list failures with exponential backoff (T7).
 	const connections = await pollWithBackoff(() => nmConnsGet("uuid,type"), {
@@ -305,9 +333,12 @@ export async function wifiUpdateSavedConns() {
 			if (mode === "ap") {
 				void handleHotspotConn(macAddress, uuid);
 			} else if (mode === "infrastructure") {
-				if (macAddress && wifiInterfacesByMacAddress[macAddress]) {
-					wifiInterfacesByMacAddress[macAddress].saved[ssid] = uuid;
-				}
+				registerSavedWifiConnection(
+					wifiInterfacesByMacAddress,
+					macAddress,
+					ssid,
+					uuid,
+				);
 			}
 		} catch (err) {
 			if (err instanceof Error) {

--- a/apps/backend/src/tests/wifi-saved-connection.test.ts
+++ b/apps/backend/src/tests/wifi-saved-connection.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Regression: an ACTIVE, connected saved network showed a "Connect" button
+ * instead of "Disconnect" (confirmed on real hardware — SSID "SOMOS - 701").
+ *
+ * Root cause lived in wifiUpdateSavedConns: a saved infrastructure profile was
+ * added to an interface's `saved` map ONLY when its `802-11-wireless.mac-address`
+ * matched a currently-present adapter. A profile with no bound MAC (created
+ * outside CeraUI — nmtui, `nmcli device wifi connect`, a baked image profile) or
+ * a bound MAC that no longer matches the live adapter (MAC randomization / swapped
+ * adapter) was silently dropped. The scan path (wifiUpdateScanResult) has no such
+ * requirement, so the network still rendered `active: true` in `available` while
+ * being absent from `saved` — the frontend `getWifiUUID` then resolved `undefined`
+ * and the UI offered "Connect" on the already-connected network.
+ *
+ * `registerSavedWifiConnection` is the extracted keying step. The "unbound" case
+ * below is the exact reproduction: before the fix the connection was NOT recorded
+ * in `saved`, so the `toBe(UUID)` assertions would have failed (the value was
+ * `undefined`).
+ */
+import { describe, expect, it } from "bun:test";
+import { registerSavedWifiConnection } from "../modules/wifi/wifi.ts";
+import type { SSID, WifiInterface } from "../modules/wifi/wifi-interfaces.ts";
+
+const SSID_NAME: SSID = "SOMOS - 701";
+const UUID = "11112222-3333-4444-5555-666677778888";
+const ADAPTER_A = "aa:bb:cc:dd:ee:01";
+const ADAPTER_B = "aa:bb:cc:dd:ee:02";
+
+function makeInterface(id: number, ifname: string): WifiInterface {
+	return {
+		id,
+		ifname,
+		conn: null,
+		hw: "Test Adapter",
+		available: new Map(),
+		saved: {},
+	};
+}
+
+describe("registerSavedWifiConnection", () => {
+	it("records an unbound profile (empty MAC) so an active network resolves a UUID", () => {
+		const interfaces = { [ADAPTER_A]: makeInterface(0, "wlan0") };
+
+		registerSavedWifiConnection(interfaces, "", SSID_NAME, UUID);
+
+		// Pre-fix this profile was dropped (empty MAC matched no adapter) and the
+		// value here was `undefined` — the "Connect"-on-connected-network bug.
+		expect(interfaces[ADAPTER_A]?.saved[SSID_NAME]).toBe(UUID);
+	});
+
+	it("records a profile whose bound MAC matches no present adapter on every adapter", () => {
+		const interfaces = {
+			[ADAPTER_A]: makeInterface(0, "wlan0"),
+			[ADAPTER_B]: makeInterface(1, "wlan1"),
+		};
+
+		// A stale/randomized bound MAC that matches neither present adapter.
+		registerSavedWifiConnection(
+			interfaces,
+			"de:ad:be:ef:00:99",
+			SSID_NAME,
+			UUID,
+		);
+
+		expect(interfaces[ADAPTER_A]?.saved[SSID_NAME]).toBe(UUID);
+		expect(interfaces[ADAPTER_B]?.saved[SSID_NAME]).toBe(UUID);
+	});
+
+	it("attributes a MAC-bound profile to only its adapter (multi-adapter disambiguation)", () => {
+		const interfaces = {
+			[ADAPTER_A]: makeInterface(0, "wlan0"),
+			[ADAPTER_B]: makeInterface(1, "wlan1"),
+		};
+
+		registerSavedWifiConnection(interfaces, ADAPTER_B, SSID_NAME, UUID);
+
+		expect(interfaces[ADAPTER_B]?.saved[SSID_NAME]).toBe(UUID);
+		expect(interfaces[ADAPTER_A]?.saved[SSID_NAME]).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## What
The currently-connected WiFi network showed a **Connect** button instead of **Disconnect** (confirmed on real hardware — SSID "SOMOS - 701": green checkmark, "Connected" status, yet a yellow "Connect" button).

Backend fix in `wifiUpdateSavedConns` (`apps/backend/src/modules/wifi/wifi.ts`): register a saved WiFi profile in an interface's `saved` map even when its `802-11-wireless.mac-address` is unbound or no longer matches a present adapter. Extracted the keying step into the pure, unit-tested helper `registerSavedWifiConnection`.

## Why
`WifiNetworkList.svelte` only renders the Disconnect/Connect toggle inside `{:else if uuid}`; a falsy `uuid` falls through to the "new/unsaved network" branch that always shows "Connect". `getWifiUUID` (frontend) is a faithful SSID→UUID lookup over `iface.saved` — it returned `undefined` because the backend had dropped the active network from `saved`.

Root cause: a saved profile was added to `saved[ssid]` **only** when its bound MAC matched a currently-present adapter. Profiles created outside CeraUI's own connect flow (nmtui, `nmcli device wifi connect`, baked image profiles) have no bound MAC, and MAC randomization / swapped adapters make a bound MAC stop matching — so those profiles were silently dropped. Meanwhile the scan path (`wifiUpdateScanResult`) marks every scanned SSID `active` from nmcli's `IN-USE` column with no MAC requirement. The asymmetry produced an `active` network that resolved no UUID.

The fix keeps precise per-adapter attribution when the bound MAC matches (multi-adapter disambiguation unchanged), and otherwise registers the profile on every present adapter — mirroring the scan path where all interfaces already see all networks.

## How to verify
- `apps/backend/src/tests/wifi-saved-connection.test.ts` (new, 3 cases):
  - unbound profile (empty MAC) → `saved[ssid]` resolves the UUID (pre-fix this was `undefined` — the exact bug; commented in the test);
  - bound MAC matching no present adapter (stale/randomized) → registered on all adapters;
  - bound MAC matching one adapter → attributed to that adapter only, not the other.
- `cd apps/backend && bun tsc --noEmit` — clean.
- `biome check` on the changed files — clean.
- `bun test` (wifi suites) — `wifi-saved-connection` + `wifi-migration` + `wifi-mock-seam` = 12 pass / 0 fail.

## Risks
- Low, backend-only. On a multi-adapter device an **unbound** profile now shows as saved on every adapter (previously on none). That is the correct semantic — an unbound profile can be used by any adapter — and disconnect/forget already work by UUID across all interfaces. A MAC-bound profile that matches a present adapter is still attributed to that adapter alone, so the common precise case is unchanged.

## Notes
Investigated the related "periodic MAC-randomize-then-scan cycling" report at the same time: it is stock NetworkManager background-scan behaviour (`wifi.scan-rand-mac-address`), the ~35-min idle is NM autoconnect-retry policy, and there is **no** CeraUI boot-time station-connect code path (`nmcli con up` is only called from the explicit `wifi.connect` RPC and hotspot paths) — so the service-restart correlation was coincidental. No change made there; not a defect.