### PR TITLE
fix(test): restore MOCK_MODE so mock suites do not leak dev mode across the bun suite

### DIFF
--- a/apps/backend/src/tests/mmcli-mode-validation.test.ts
+++ b/apps/backend/src/tests/mmcli-mode-validation.test.ts
@@ -19,9 +19,15 @@ import {
 	validateModeSpec,
 } from "../modules/modems/mmcli.ts";
 
+// The `mmList()` test flips MOCK_MODE on; restore it (bun shares one global
+// across files, so an unrestored env write leaks into every later suite).
+const savedMockMode = process.env.MOCK_MODE;
+
 afterEach(() => {
 	mock.restore();
 	stopMockService();
+	if (savedMockMode === undefined) delete process.env.MOCK_MODE;
+	else process.env.MOCK_MODE = savedMockMode;
 });
 
 describe("validateModeSpec() — mode allowlist", () => {

--- a/apps/backend/src/tests/modem-migration.test.ts
+++ b/apps/backend/src/tests/modem-migration.test.ts
@@ -69,6 +69,8 @@ class FakeMonitor implements IMonitorEmitter {
 const monitor = new FakeMonitor();
 
 describe("modem migration — event-driven presence + retained status poll", () => {
+	const savedMockMode = process.env.MOCK_MODE;
+
 	beforeAll(async () => {
 		// Activate the mock providers so mmcli/nmcli never touch real binaries.
 		process.env.MOCK_MODE = "true";
@@ -92,6 +94,8 @@ describe("modem migration — event-driven presence + retained status poll", () 
 			removeModem(id);
 		}
 		setModemsState({});
+		if (savedMockMode === undefined) delete process.env.MOCK_MODE;
+		else process.env.MOCK_MODE = savedMockMode;
 	});
 
 	beforeEach(() => {


### PR DESCRIPTION
## What

Two backend test files set `process.env.MOCK_MODE = "true"` and never restored it, leaking dev-mock mode into every later test suite in the same `bun test` run:

- `apps/backend/src/tests/mmcli-mode-validation.test.ts` — set in the `mmList()` guard test; `afterEach` did not restore it.
- `apps/backend/src/tests/modem-migration.test.ts` — set in `beforeAll`; `afterAll` did not restore it.

This PR snapshots `MOCK_MODE` once and restores it in each file's teardown, matching the save/restore convention already used by `mock-device-attach.test.ts`. 10 insertions, no production code touched.

## Why

`bun test` (no `--isolate`/`--parallel`, exactly what CI runs) executes all 205 files in one shared global object, sequentially. `shouldUseMocks()` is `isDevelopment() && mockState.initialized`, and `isDevelopment()` is `NODE_ENV === "development" || MOCK_MODE === "true"`.

Because nothing ever clears `MOCK_MODE`, once either file ran, `isDevelopment()` stayed `true` for the rest of the process. Later *real-path* suites — which deliberately never init mocks and inherit whatever global state the run left behind — then took the wrong dev/mock branch:

- `checkConnectivity()` short-circuits to `return true` under `shouldUseMocks()` → `internet-migration.test.ts` saw `true` where it expects `false`.
- Platform-claim accepts loopback HTTP only in dev+emulated → HTTPS-enforcement tests flipped.
- C7 streaming source-availability rejection is `shouldUseMocks()`-gated.
- Add-on install/uninstall is `isRealDevice()`-gated, and `isRealDevice()` short-circuits on `isDevelopment()`.

Whether a given victim failed depended on file execution order (Bun uses filesystem readdir order for the full suite), so it reproduced deterministically on the CI runner but not on a typical local box — and it blocked the `BE unit (bun) + exec-guard + biome` job on every open PR regardless of that PR's contents.

## How to verify

- Per-file state audit before/after: exactly two files left `MOCK_MODE=true` before this change; **zero** after.
- `bun test <both leakers> internet-migration pairing-platform-claim source-lost-rejection` (leakers first): **40 pass, 0 fail** (the victims previously inherited the leak).
- `bun tsc --noEmit`: clean. `bunx biome check` on both files: clean.
- Full suite: the only remaining fails are `qw-e-audio-hotplug.test.ts` `fs.watch`-timing flakes that fail identically in isolation on the pristine pre-fix tree (pre-existing, environment-specific, not in the reported failing set).

## Risks

Minimal — test-only change that restores an env var the files should never have leaked. No production code, no test skipped or weakened (Rule E). Once merged, the four currently-blocked PRs (#149–#152) should go green on their next re-run with no change to them, since the leak lives in files none of them touch.
