### PR TITLE
fix(test): make pairing + network-ingest suites order-independent (config.json + network-ingest cache leaks)

### DIFF
--- a/apps/backend/src/tests/network-ingest-control.test.ts
+++ b/apps/backend/src/tests/network-ingest-control.test.ts
@@ -43,6 +43,7 @@ import { getConfig } from "../modules/config.ts";
 import {
 	deriveNetworkIngestInfo,
 	RTMP_GATEWAY_UNIT,
+	resetNetworkIngestState,
 	SRT_GATEWAY_UNIT,
 } from "../modules/network/network-ingest.ts";
 import {
@@ -460,11 +461,15 @@ describe("network.setIngestEnabled handler — mocks (zero spawns)", () => {
 		setStreamingState(false);
 		updateStatus(false);
 		resetMockState();
+		// The real setIngestEnabled RPC writes the module-level network-ingest
+		// cache; clear it so an rtmp-active snapshot never leaks into a later file.
+		resetNetworkIngestState();
 	});
 	afterAll(async () => {
 		stopMockService();
 		setMockHardware("rk3588");
 		await initPipelines();
+		resetNetworkIngestState();
 		if (savedMockMode === undefined) delete process.env.MOCK_MODE;
 		else process.env.MOCK_MODE = savedMockMode;
 	});

--- a/apps/backend/src/tests/pairing-platform-claim.test.ts
+++ b/apps/backend/src/tests/pairing-platform-claim.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { call } from "@orpc/server";
 import { getConfig } from "../modules/config.ts";
 import {
@@ -41,7 +41,11 @@ beforeEach(() => {
 	savedNodeEnv = process.env.NODE_ENV;
 	savedDeviceType = process.env.CERALIVE_DEVICE_TYPE;
 	process.env.PLATFORM_URL = PLATFORM_URL;
-	savedConfigFile = readFileSync("config.json", "utf8");
+	// config.json is gitignored (absent on a fresh CI checkout, and a prior suite
+	// may remove it); an unconditional read throws ENOENT and fails every test.
+	savedConfigFile = existsSync("config.json")
+		? readFileSync("config.json", "utf8")
+		: undefined;
 	getConfig().remote_key = undefined;
 	getConfig().device_id = undefined;
 });
@@ -55,8 +59,8 @@ afterEach(() => {
 	else process.env.NODE_ENV = savedNodeEnv;
 	if (savedDeviceType === undefined) delete process.env.CERALIVE_DEVICE_TYPE;
 	else process.env.CERALIVE_DEVICE_TYPE = savedDeviceType;
-	if (savedConfigFile !== undefined)
-		writeFileSync("config.json", savedConfigFile);
+	if (savedConfigFile === undefined) rmSync("config.json", { force: true });
+	else writeFileSync("config.json", savedConfigFile);
 });
 
 /** Build a fetch stub that records the request and returns a canned Response. */


### PR DESCRIPTION
## What

Follow-up to #153. After that PR fixed the `MOCK_MODE` leak (6 of the original 21 CI failures), 15 tests still failed deterministically in the `BE unit (bun) + exec-guard + biome` job. This PR fixes the two remaining, independent cross-file test-isolation leaks:

- `apps/backend/src/tests/pairing-platform-claim.test.ts` — read `config.json` unconditionally in `beforeEach`.
- `apps/backend/src/tests/network-ingest-control.test.ts` — wrote the module-level network-ingest cache via the real RPC but never reset it in teardown.

13 insertions, 4 deletions, no production code.

## Why

`bun test` runs every file in one shared process, so any global state a file leaves dirty is inherited by whatever file runs next — and the full-suite file order differs between a fresh CI runner and a local box, so both leaks reproduce deterministically in CI but not always locally.

**Leak 1 — config.json (14 failures).** `config.json` is gitignored, so it is absent on a fresh CI checkout. `pairing-platform-claim.test.ts`'s `beforeEach` did `readFileSync("config.json")` unconditionally; when absent that throws `ENOENT`, failing *every* test in the file — including the pure `platformClaimErrorForStatus` and `getPlatformUrl` cases, which is exactly the 14-failure set. The cross-file trigger is `remote-repair-migration.test.ts`, which correctly deletes the `config.json` it created when the file was absent at its start (restoring prior state) — its sibling comment even notes "Reading it unconditionally throws on a fresh CI checkout." The bug is the unconditional read, not the cleanup. Fix: snapshot only when `existsSync`, and in `afterEach` remove it when it was absent at start, else restore the bytes.

**Leak 2 — network-ingest cache (1 C7 failure).** `source-lost-rejection.test.ts`'s "available:false network source (gateway down) → source_unavailable" reads the module-level `cached` snapshot in `network-ingest.ts`. `network-ingest-control.test.ts`'s "mocks" block drives the real `network.setIngestEnabled` RPC (which writes that cache) but never called `resetNetworkIngestState()` in teardown — the only one of the five cache-writers that didn't. Its last test leaves rtmp enabled+active, so a later file sees the rtmp source as `available:true`, and the C7 start returns `network_ingest_gateway_inactive` instead of `source_unavailable`. `streaming-gateway-gate.test.ts` already documents this exact "stale ambient cache leaves service_active:true … under CI test ordering" hazard. Fix: reset the cache in the mocks block's `afterEach` + `afterAll`.

## How to verify

- `pairing-platform-claim.test.ts` alone with `config.json` removed: **14 pass / 0 fail** (was 0/14). `remote-repair-migration` → `pairing-platform-claim` with config.json removed: **30 pass / 0 fail**.
- `network-ingest-control` → `source-lost-rejection` (C7): **27 pass / 0 fail**; a cache probe after the fix reports `rtmp=null` (was `service_active:true`).
- Full suite with `config.json` **present** and **absent**: **1910 pass / 0 fail** both ways.
- `bun tsc --noEmit`, `bunx biome check`: clean. The only other full-suite fails are the pre-existing `qw-e-audio-hotplug.test.ts` `fs.watch` flakes (fail identically on the pristine tree; out of scope).

## Risks

Minimal — test-only changes that restore/reset global state the suites should never have leaked. No production code, no test skipped or weakened (Rule E). With this merged, the four previously-blocked PRs should have a fully green `BE unit` job.
