### PR TITLE
fix(backend): stop mock modem re-broadcast clobbering merged client state (fixes flaky shard-2 E2E)

### DIFF
--- a/apps/backend/src/modules/modems/modem-update-loop.ts
+++ b/apps/backend/src/modules/modems/modem-update-loop.ts
@@ -47,7 +47,6 @@
 */
 
 import { logger } from "../../helpers/logger.ts";
-import { shouldUseMocks } from "../../mocks/mock-service.ts";
 import { createMonitorManager } from "../network/monitor/monitor-manager.ts";
 import { withModemUpdateLock } from "../network/state/device-lock.ts";
 import type {
@@ -101,16 +100,21 @@ function publishModemsSnapshot(): void {
 /**
  * Broadcast the `modems` message in response to a reconcile diff.
  *
- * Shape is preserved exactly from the legacy loop: in mock mode the FULL state
- * is sent (the mock frontend wholesale-replaces modemsState per `status`
- * message), otherwise only newly-added modems carry their full descriptor and
- * everything else is a status-only partial.
+ * Only newly-added modems carry their full descriptor; every other modem sends
+ * a status-only partial. This holds in mock mode too: the frontend merges each
+ * `status.modems` frame field-by-field per modem id (subscriptions
+ * `mergeModemList`), so a periodic status refresh MUST NOT re-send full state —
+ * `buildModemMessage` ALWAYS includes `available_networks` (and `config`) in a
+ * full descriptor, so re-sending it on every tick clobbers an operator-scan
+ * list or config the client already holds (e.g. a pending modem scan would
+ * false-confirm when its `available_networks` is overwritten with `{}`). This
+ * mirrors the real device: a status poll refreshes signal/registration only,
+ * never the operator scan list. The initial full snapshot still reaches every
+ * client via the post-login `buildModemsMessage()` push and the discovery
+ * diff's `added` entries. (Formerly mock mode wholesale-replaced full state on
+ * every tick, a stale assumption from before the frontend merged per-field.)
  */
 function broadcastFromDiff(diff: StateDiff<ModemDiffEntry>): void {
-	if (shouldUseMocks()) {
-		broadcastModems(undefined);
-		return;
-	}
 	const fullState: Record<number, true> = {};
 	for (const entry of diff.added) {
 		fullState[entry.id] = true;


### PR DESCRIPTION
## What

In mock mode, `broadcastFromDiff` (`apps/backend/src/modules/modems/modem-update-loop.ts`) re-broadcast the **full** modem descriptor for every modem on every reconcile diff (`broadcastModems(undefined)`). This change makes mock mode use the **same** path as a real device: a full descriptor only for newly-`added` modems, a status-only partial for every `changed` modem. One file, +13/-9.

## Why

The desktop **shard-2 E2E job** (`modem-config-surface.spec.ts:100 — "a modem scan holds pending across same-list re-broadcasts…"`) failed **byte-identically on every PR**:

```
expect(locator).toBeDisabled() failed
Locator: getByRole('dialog').getByTestId('modem-scan-button')
Expected: disabled   Received: enabled
```

Root cause (a timing race, **not** a cross-file leak):

- The spec injects `available_networks` over the page socket via `dev.emit`, which is **page-scoped and never persisted** in the backend `modemsState` — so the backend's real `available_networks` for that modem stays empty (`{}`).
- The mock feedback tick (`runMockFeedbackBroadcast`, ~5s) re-sent the **full** modem state on every signal fluctuation, and `buildModemMessage` **always** includes `available_networks` (and `config`) in a full descriptor.
- The frontend merges each `status.modems` frame field-by-field (`subscriptions.svelte.ts` `mergeModemList`, shallow), so an incoming `available_networks:{}` **overwrote** the injected set.
- That flipped the scan signature and **false-confirmed** the pending scan, re-enabling the button.

The race only lands inside the 5s assertion window on slower/contended CI runners (backend up for minutes across ~25 prior shard-2 specs), so it passed locally but failed deterministically in CI. `sim_lock` is only serialized when present, which is why the sibling `sim-unlock-surface.spec.ts` survives the same tick; `available_networks`/`config` are always serialized, so they get clobbered.

A **real device** already sends status-only for a `changed` modem (the `!shouldUseMocks()` branch), so it never clobbers the scan list. The mock's full re-send was a stale artifact from before the frontend merged per-field. This aligns the two; **real-device behavior is unchanged**.

## How to verify

- Repro: temporarily set `MOCK_FEEDBACK_BROADCAST_INTERVAL_MS=250` and run `modem-config-surface.spec.ts` — it fails at the `toBeDisabled` assertion (byte-identical to CI). With this fix, `-g "holds pending" --repeat-each=8` → 8/8 pass.
- Backend `bun test`: `mock-feedback-broadcast`, `modem-available-networks-contract`, `modems-state-cache`, `modems-configure-applied`, `mock-modems-output`, `mock-monitor`, `monitor-manager`, `modem-migration`, sim-state suites → 75 pass, 0 fail.
- E2E `--project=desktop --workers=4` (grep-invert `@visual|@a11y|@gallery`): full suite → **226 pass / 3 skipped / 0 fail**; modem/network/sim blast-radius subset → 25 pass.
- `bun tsc --noEmit` exit 0; `biome check` clean.

## Risks

- Low. The change only affects the mock-gated broadcast shape; the real-device path is untouched. The initial full snapshot still reaches every client via the post-login `buildModemsMessage()` push and the discovery diff's `added` entries. The mock-feedback unit test asserts only `.status.signal`/`.status.connection` + dedupe counts, all preserved by a status-only partial.