### PR TITLE
fix(backend): retry engine heal broadcast; precise wifi MAC beats fallback

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -573,7 +573,11 @@ It is the boot `pipelines` init now (main.ts) and owns ONE self-rescheduling loo
 - **Heal broadcast** — on the unavailable→reachable transition it re-broadcasts
   `capabilities` + `pipelines` + `sources` to already-connected clients (the SAME
   trio the `setMockHardware` RPC uses), so the offline banner clears LIVE with no
-  page reload, then SETTLES (stops polling).
+  page reload, then SETTLES (stops polling). Settling is gated on the broadcast
+  actually completing: a reachable engine whose heal broadcast throws (a transient
+  broadcast-collaborator error) does NOT settle — it reschedules under the same
+  backoff — so clients are never stranded on the offline banner while the loop
+  silently gives up.
 
 Reachability = `getLastCapabilities()?.engineUnavailable === false` (a live snapshot).
 It feeds INTO the existing `engine-unavailable`/`engine-starting` capability tier — it

--- a/apps/backend/src/modules/streaming/engine-reconnect.ts
+++ b/apps/backend/src/modules/streaming/engine-reconnect.ts
@@ -204,9 +204,16 @@ function errMessage(err: unknown): string {
  * Run one connection attempt: refresh capabilities, then — when asked — broadcast
  * the healed state if the engine became reachable. `refreshCapabilities` and
  * `broadcastEngineState` are both wrapped so a stray throw can never break the loop.
+ *
+ * Returns whether the loop may SETTLE: `true` only once the engine is reachable AND
+ * (for a heal attempt) the re-broadcast to clients actually completed. A reachable
+ * engine whose heal broadcast THROWS returns `false` so the caller keeps retrying —
+ * otherwise a transient error from any broadcast collaborator would strand
+ * already-connected clients on the offline banner until a manual reload, violating
+ * this module's "clients are updated before the loop settles" invariant.
  */
-async function runAttempt(broadcastOnHeal: boolean): Promise<void> {
-	if (!state) return;
+async function runAttempt(broadcastOnHeal: boolean): Promise<boolean> {
+	if (!state) return false;
 	const { deps } = state;
 	try {
 		await deps.refreshCapabilities();
@@ -217,16 +224,19 @@ async function runAttempt(broadcastOnHeal: boolean): Promise<void> {
 			`engine reconnect: capability refresh threw: ${errMessage(err)}`,
 		);
 	}
-	if (!state || !broadcastOnHeal || !deps.isEngineReachable()) return;
+	if (!state || !deps.isEngineReachable()) return false;
+	if (!broadcastOnHeal) return true;
 	try {
 		await deps.broadcastEngineState();
 		deps.logger.info(
 			"engine reconnect: engine reachable again; re-broadcast capabilities/pipelines/sources to clients",
 		);
+		return true;
 	} catch (err) {
 		deps.logger.warn(
-			`engine reconnect: heal broadcast failed: ${errMessage(err)}`,
+			`engine reconnect: heal broadcast failed, will retry: ${errMessage(err)}`,
 		);
+		return false;
 	}
 }
 
@@ -255,16 +265,19 @@ function scheduleRecheck(): void {
 }
 
 /**
- * One background recheck tick: attempt, then either settle (engine healed) or
- * schedule the next recheck (still down). The heal broadcast fires inside
- * `runAttempt` on the transition, so by the time we settle clients are updated.
+ * One background recheck tick: attempt, then either settle (engine healed AND
+ * clients re-broadcast) or schedule the next recheck (still down, or the heal
+ * broadcast threw). Settling is gated on `runAttempt`'s result — a reachable
+ * engine whose broadcast throws does NOT settle, it reschedules — so clients are
+ * never left on the offline banner while the loop silently gives up.
  */
 async function tickRecheck(): Promise<void> {
 	if (!state || state.stopped) return;
-	await runAttempt(true);
+	const healed = await runAttempt(true);
 	if (!state || state.stopped) return;
-	if (state.deps.isEngineReachable()) {
-		// Healed — the boot race is resolved; settle so we stop polling.
+	if (healed) {
+		// Healed — the boot race is resolved and clients are updated; settle so we
+		// stop polling.
 		state.stopped = true;
 		state.timer = undefined;
 		return;

--- a/apps/backend/src/modules/wifi/wifi.ts
+++ b/apps/backend/src/modules/wifi/wifi.ts
@@ -268,6 +268,11 @@ export function broadcastWifiState() {
   on every adapter, mirroring the scan path where all interfaces see all networks.
   Without this fallback an active-but-unbound connection resolves no UUID and the
   UI shows "Connect" on the network the device is already connected to.
+
+  The fallback registers only where the SSID is not already claimed (`??=`), so a
+  precise MAC binding always wins over a same-SSID fallback profile regardless of
+  nmcli enumeration order — a fallback profile listed after a MAC-bound one for the
+  same SSID must not silently overwrite the precise adapter attribution.
 */
 export function registerSavedWifiConnection(
 	interfaces: Record<MacAddress, WifiInterface>,
@@ -281,7 +286,7 @@ export function registerSavedWifiConnection(
 		return;
 	}
 	for (const wifiInterface of Object.values(interfaces)) {
-		wifiInterface.saved[ssid] = uuid;
+		wifiInterface.saved[ssid] ??= uuid;
 	}
 }
 

--- a/apps/backend/src/tests/engine-reconnect.test.ts
+++ b/apps/backend/src/tests/engine-reconnect.test.ts
@@ -21,12 +21,13 @@ type TimerHandle = ReturnType<typeof setTimeout>;
 // per-attempt reachability outcomes, so the whole loop is driven deterministically
 // with no real time. `fireNextTimer` runs the one pending timer then awaits the
 // background attempt it kicks off (via the settle seam).
-function harness(outcomes: boolean[]) {
+function harness(outcomes: boolean[], broadcastThrowsFirst = 0) {
 	const timers: Array<{ fn: () => void }> = [];
 	let idx = 0;
 	let reachable = false;
 	const refreshCalls: boolean[] = [];
 	let broadcasts = 0;
+	let broadcastAttempts = 0;
 	const delays: number[] = [];
 
 	const deps = {
@@ -37,6 +38,10 @@ function harness(outcomes: boolean[]) {
 		},
 		isEngineReachable: () => reachable,
 		broadcastEngineState: () => {
+			broadcastAttempts += 1;
+			if (broadcastAttempts <= broadcastThrowsFirst) {
+				throw new Error("heal broadcast failed (test)");
+			}
 			broadcasts += 1;
 		},
 		logger: silent,
@@ -61,6 +66,9 @@ function harness(outcomes: boolean[]) {
 		},
 		get broadcasts() {
 			return broadcasts;
+		},
+		get broadcastAttempts() {
+			return broadcastAttempts;
 		},
 		get delays() {
 			return delays;
@@ -149,6 +157,34 @@ describe("initEngineConnection — (b) later out-of-band reconnect", () => {
 		expect(h.delays.slice(0, 6)).toEqual([
 			1_500, 3_000, 6_000, 12_000, 22_500, 22_500,
 		]);
+	});
+});
+
+describe("initEngineConnection — (d) heal broadcast retried until it completes", () => {
+	test("a reachable engine whose first heal broadcast throws keeps retrying, then settles once it succeeds", async () => {
+		// engine is DOWN at boot, then UP on both rechecks; the first heal broadcast
+		// throws (a transient broadcast-collaborator error), the second succeeds.
+		const h = harness([false, true, true], 1);
+		await initEngineConnection(h.deps);
+
+		// boot attempt failed → one recheck scheduled, nothing broadcast yet.
+		expect(h.pendingTimers).toBe(1);
+		expect(h.broadcasts).toBe(0);
+
+		// first recheck: engine reachable, but the heal broadcast THROWS. The loop
+		// must NOT settle on this — it reschedules so clients are not stranded on the
+		// offline banner while the engine is actually healthy.
+		await h.fireNextTimer();
+		expect(h.broadcastAttempts).toBe(1);
+		expect(h.broadcasts).toBe(0);
+		expect(h.pendingTimers).toBe(1);
+
+		// second recheck: the heal broadcast succeeds → clients receive the full
+		// capabilities/pipelines/sources re-broadcast → the loop finally settles.
+		await h.fireNextTimer();
+		expect(h.broadcastAttempts).toBe(2);
+		expect(h.broadcasts).toBe(1);
+		expect(h.pendingTimers).toBe(0);
 	});
 });
 

--- a/apps/backend/src/tests/wifi-saved-connection.test.ts
+++ b/apps/backend/src/tests/wifi-saved-connection.test.ts
@@ -77,4 +77,39 @@ describe("registerSavedWifiConnection", () => {
 		expect(interfaces[ADAPTER_B]?.saved[SSID_NAME]).toBe(UUID);
 		expect(interfaces[ADAPTER_A]?.saved[SSID_NAME]).toBeUndefined();
 	});
+
+	/*
+	 * Duplicate-SSID precedence: two profiles for the SAME ssid — one precisely
+	 * bound to a present adapter, one on the fallback path (unbound / stale MAC).
+	 * The precise binding must win on its adapter regardless of nmcli enumeration
+	 * order; the fallback only fills the adapters the precise profile does not own.
+	 */
+	const UUID_BOUND = "aaaaaaaa-1111-2222-3333-444444444444";
+	const UUID_FALLBACK = "bbbbbbbb-5555-6666-7777-888888888888";
+
+	it("keeps a precise MAC binding when a same-SSID fallback profile is registered after it", () => {
+		const interfaces = {
+			[ADAPTER_A]: makeInterface(0, "wlan0"),
+			[ADAPTER_B]: makeInterface(1, "wlan1"),
+		};
+
+		registerSavedWifiConnection(interfaces, ADAPTER_A, SSID_NAME, UUID_BOUND);
+		registerSavedWifiConnection(interfaces, "", SSID_NAME, UUID_FALLBACK);
+
+		expect(interfaces[ADAPTER_A]?.saved[SSID_NAME]).toBe(UUID_BOUND);
+		expect(interfaces[ADAPTER_B]?.saved[SSID_NAME]).toBe(UUID_FALLBACK);
+	});
+
+	it("lets a precise MAC binding override a same-SSID fallback profile registered before it", () => {
+		const interfaces = {
+			[ADAPTER_A]: makeInterface(0, "wlan0"),
+			[ADAPTER_B]: makeInterface(1, "wlan1"),
+		};
+
+		registerSavedWifiConnection(interfaces, "", SSID_NAME, UUID_FALLBACK);
+		registerSavedWifiConnection(interfaces, ADAPTER_A, SSID_NAME, UUID_BOUND);
+
+		expect(interfaces[ADAPTER_A]?.saved[SSID_NAME]).toBe(UUID_BOUND);
+		expect(interfaces[ADAPTER_B]?.saved[SSID_NAME]).toBe(UUID_FALLBACK);
+	});
 });


### PR DESCRIPTION
## What

Two independent backend correctness fixes surfaced by the verification wave, each with a regression test that fails on the pre-fix code.

**1. Engine reconnect — settle only after the heal broadcast actually completes** (`modules/streaming/engine-reconnect.ts`)

`runAttempt(true)` caught a rejected `broadcastEngineState()`, logged a warning, and returned. `tickRecheck()` then settled the retry loop purely on `isEngineReachable() === true` — so the loop stopped even though the heal broadcast never completed. `runAttempt` now returns whether the loop may settle (engine reachable **and**, for a heal attempt, the re-broadcast completed). A reachable engine whose heal broadcast throws reschedules under the **existing** backoff instead of settling.

**2. WiFi saved-connection — a precise MAC match must beat a same-SSID fallback** (`modules/wifi/wifi.ts`)

`registerSavedWifiConnection`'s fallback registered unbound/stale-MAC profiles on every present adapter with an unconditional assignment. For two profiles targeting the same SSID — one precisely MAC-bound to a present adapter, one on the fallback path — a fallback profile enumerated *after* the precise one silently overwrote the precise adapter attribution, depending on `nmcli` order. The fallback now uses `??=` (set-only-if-absent), so a precise MAC binding wins regardless of enumeration order. The precise branch is unchanged (still assigns to that adapter only).

## Why

- **Engine reconnect:** without the fix, a transient error from any broadcast collaborator on the *first* heal attempt left already-connected clients showing "engine offline" indefinitely (until a manual reload) even though the engine was healthy and the loop had silently given up — violating the module's own invariant that clients receive capabilities/pipelines/sources before the loop settles.
- **WiFi:** the PR #152 fallback introduced a duplicate-SSID precedence risk with no test proving a precise MAC match always wins. A silent overwrite of a precisely-bound profile would misattribute the saved connection to the wrong adapter in multi-adapter setups.

## How to verify

```bash
cd apps/backend
bun test src/tests/engine-reconnect.test.ts src/tests/wifi-saved-connection.test.ts   # new regression tests
bun test          # full backend suite: 1930 pass / 0 fail
bun run check     # tsc --noEmit + exec/spawn guards — clean
```
```bash
# from repo root
bunx biome check apps/backend/src/modules/streaming/engine-reconnect.ts \
  apps/backend/src/modules/wifi/wifi.ts \
  apps/backend/src/tests/engine-reconnect.test.ts \
  apps/backend/src/tests/wifi-saved-connection.test.ts   # clean
```

New regression tests:
- `engine-reconnect.test.ts` — engine reachable, first heal broadcast throws → loop keeps retrying (does not settle) → second heal broadcast succeeds → loop settles and clients receive the full capabilities/pipelines/sources re-broadcast.
- `wifi-saved-connection.test.ts` — two same-SSID profiles (precise MAC + fallback) in both enumeration orders; the precisely-matched adapter keeps the bound UUID and is never overwritten by the fallback, which only fills the other adapter.

## Risks

Low, and scoped to the two fixes:

- Engine reconnect keeps the existing backoff/periodic-recheck policy byte-for-byte — only the *when do we stop retrying* condition changed. The boot path is unchanged (no heal broadcast at boot). No new env vars.
- The WiFi change preserves the exact MAC-match attribution behavior from #152 (a directly matched MAC still assigns to that adapter only); `saved` is reset each `wifiUpdateSavedConns` cycle, so `??=` only guards against a same-cycle earlier registration, never stale cross-cycle state.
- `apps/backend/AGENTS.md` updated in the same PR to document the strengthened settle-on-successful-broadcast invariant.
