### PR TITLE
fix(backend): stop cross-file test-isolation leaks (MOCK_MODE + wifi timer)

### DIFF
--- a/apps/backend/src/tests/mock-feedback-broadcast.test.ts
+++ b/apps/backend/src/tests/mock-feedback-broadcast.test.ts
@@ -84,6 +84,15 @@ function wifiStatuses(sink: Array<Record<string, unknown>>): StatusPayload[] {
 
 const monitor = new FakeMonitor();
 
+// Both blocks below flip MOCK_MODE on; restore it (bun shares one global across
+// files, so an unrestored env write leaks into every later suite).
+const savedMockMode = process.env.MOCK_MODE;
+
+function restoreMockMode(): void {
+	if (savedMockMode === undefined) delete process.env.MOCK_MODE;
+	else process.env.MOCK_MODE = savedMockMode;
+}
+
 describe("mock feedback broadcast — signal fluctuations reach clients on a 5s cadence", () => {
 	beforeAll(async () => {
 		process.env.MOCK_MODE = "true";
@@ -109,6 +118,7 @@ describe("mock feedback broadcast — signal fluctuations reach clients on a 5s 
 		stopMockService();
 		for (const id of getModemIds()) removeModem(id);
 		setModemsState({});
+		restoreMockMode();
 	});
 
 	test("(a) two consecutive feedback ticks broadcast the changed modem signal", async () => {
@@ -229,6 +239,7 @@ describe("mock feedback broadcast — timer lifecycle", () => {
 	});
 	afterAll(() => {
 		stopMockService();
+		restoreMockMode();
 	});
 
 	test("(c) resetMockState clears the feedback broadcast interval (no leaked timer)", () => {

--- a/apps/backend/src/tests/rpc-network.procedure.test.ts
+++ b/apps/backend/src/tests/rpc-network.procedure.test.ts
@@ -8,6 +8,7 @@ import { updateNetif } from "../modules/network/network-interfaces.ts";
 import { withDeviceLock } from "../modules/network/state/device-lock.ts";
 import {
 	addWifiInterface,
+	getWifiInterfaceByMacAddress,
 	removeWifiInterface,
 } from "../modules/wifi/wifi-connections.ts";
 import type { WifiInterface } from "../modules/wifi/wifi-interfaces.ts";
@@ -94,6 +95,12 @@ describe("modems.configure — invalid input", () => {
 });
 
 describe("network.configure — mock immediate netif broadcast (Issue 2)", () => {
+	// The mock ifconfig lists wlan0, so updateNetif() schedules a detached
+	// setTimeout(wifiUpdateDevices, 1000) that registers this adapter into the
+	// process-wide interface registry ~1s later. Drain + evict it in afterAll (see
+	// below) so it can't fire inside a LATER mock suite and leak into every
+	// following file's shared registry.
+	const MOCK_WIFI_MAC = "dc:a6:32:12:34:57";
 	let priorMockMode: string | undefined;
 
 	beforeAll(() => {
@@ -105,7 +112,14 @@ describe("network.configure — mock immediate netif broadcast (Issue 2)", () =>
 		updateNetif();
 	});
 
-	afterAll(() => {
+	afterAll(async () => {
+		// Let the pending wifiUpdateDevices timer fire while mocks are still on,
+		// then evict the adapter it registered before restoring the environment.
+		for (let i = 0; i < 80; i++) {
+			if (getWifiInterfaceByMacAddress(MOCK_WIFI_MAC)) break;
+			await new Promise((resolve) => setTimeout(resolve, 25));
+		}
+		removeWifiInterface(MOCK_WIFI_MAC);
 		stopMockService();
 		if (priorMockMode === undefined) {
 			delete process.env.MOCK_MODE;


### PR DESCRIPTION
## What

Fixes two pre-existing, latent test-isolation leaks that only surface in a
full `bun run --filter backend test` run under a local file-execution order
that differs from CI. On the affected ordering the suite reports **1921 pass /
9 fail**; CI (a different readdir order) is green on the same commit. With this
change the full suite is **1930 pass / 0 fail** in every order.

The 9 failures were: 8 in `kiosk-rpc.test.ts` and 1 in
`wifi.procedure.test.ts`. They trace to two independent leaked-state sources.

## Why

`bun test` runs every file in ONE shared global object, so any file that leaves
`process.env`, a module singleton, or a pending timer dirty poisons every file
that runs after it.

**Leak 1 — `mock-feedback-broadcast.test.ts` leaks `MOCK_MODE` (8 kiosk failures).**
Two `beforeAll` blocks set `process.env.MOCK_MODE = "true"` and never restored
it. `MOCK_MODE=true` makes `isDevelopment()` true; combined with a leaked
`mockState.initialized`, `shouldUseMocks()` becomes true for later files. The
kiosk RPC procedures (`system.procedure.ts`) then take the mock branch —
`resolveActiveKioskDeps()` returns the in-memory mock harness instead of each
test's injected spy deps, and the `!shouldUseMocks() && !isRealDevice()` gate is
bypassed. So the "emulated" tests wrongly succeed, the "real" tests run against
the wrong deps (empty spies), and the "waits for cog-display" test times out.

**Leak 2 — `rpc-network.procedure.test.ts` leaks a wifi-scan timer (1 wifi failure).**
Its `network.configure` block calls `updateNetif()` in mock mode. The mock
`ifconfig` lists `wlan0`, so `processIfconfigOutput` schedules a detached
`setTimeout(wifiUpdateDevices, 1000)`. That timer fires ~1s later — inside a
following mock-mode suite — and registers the mock adapter `dc:a6:32:12:34:57`
(id 0) into the process-wide `wifiInterfacesByMacAddress` registry. In
`wifi.procedure.test.ts`, `macForDeviceId("0")` then resolves to that leaked
adapter instead of the test's own seeded interface, so the held device lock is
missed and the handler returns success instead of `DEVICE_BUSY`.

## How

- `mock-feedback-broadcast.test.ts`: snapshot `MOCK_MODE` once and restore it in
  both teardowns — the same save/restore idiom already used by PR #153 for the
  `mmcli-mode-validation` / `modem-migration` leaks.
- `rpc-network.procedure.test.ts`: in the `network.configure` `afterAll`, drain
  the pending `wifiUpdateDevices` timer (while mocks are still on) and evict the
  registered adapter before restoring the environment, so nothing leaks past the
  file.

No production code changed. No test weakened, skipped, or deleted.

## How to verify

```
bun run --filter backend test    # 1930 pass / 0 fail
```

Run it a few times — the failures were deterministic per file order, so a green
result across runs is the proof. The 8 kiosk + 1 wifi cases all pass; nothing
else changes.

## Risks

Low — test-only. The wifi fix adds a bounded (~1s) drain to one `afterAll`; it
polls for the adapter and exits as soon as it appears, then removes it. If the
timer never fires the loop is capped at 2s and the subsequent `removeWifiInterface`
is a harmless no-op.
