### PR TITLE
fix(backend): re-apply persisted SSH password on boot after OTA slot swap

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -241,6 +241,35 @@ explicitly are unaffected.
   deliberately asynchronous because their responses acknowledge a refresh/scheduled job,
   not completion.
 
+### SSH password sync on boot — OTA slot-swap fix [EXISTS]
+
+`ensureSshPasswordSynced()` (`modules/system/ssh.ts`, wired into `main.ts` via
+`guardNonCritical("ssh-password-sync", …)` immediately before the boot
+`getSshStatus()` probe) fixes an operator lockout confirmed on real Rock 5B+
+hardware: an OTA A/B slot swap silently invalidated SSH login. `config.json`
+(`ssh_pass` + `ssh_pass_hash`) is `/data`-persisted and survives the swap, but the
+OS-level `/etc/shadow` entry is **rootfs-local** — baked fresh into each image and
+NOT carried across slots — so a freshly-activated slot holds the build-time
+password while config.json still remembers the operator's real one. Nothing
+re-applied it, so the operator had to click "Reset SSH Password" after every single
+OTA.
+
+The sync mirrors image-building-pipeline's
+`ceralive-ssh-firstboot.sh::ensure_host_keys()` restore pattern for host keys:
+compare the persisted `ssh_pass_hash` (cached via `getSshPasswordHash()`) against
+the live `/etc/shadow` hash (`probeSshUserHash`), and on a mismatch RE-APPLY (never
+regenerate) the EXISTING persisted `ssh_pass` through the same stdin-only
+`runWithStdin("passwd", …)` path `resetSshPassword()` uses. It is additive and does
+NOT touch `resetSshPassword()` (still generates a fresh secret on explicit reset)
+or `startStopSsh()`'s "generate when `ssh_pass` is undefined" branch. Contract:
+never throws (BOOT FAIL-SOFT); a clean no-op under `shouldUseMocks()`, when
+`ssh_pass` is undefined (nothing persisted yet), or when the OS already matches (the
+common same-slot boot). It NEVER generates a new password and NEVER calls
+`saveConfig()` — the credential is unchanged, only the OS shadow entry catches up.
+Effectful surface (`readShadow` / `applyPassword`) is injected via
+`SshPasswordSyncDeps` (mirrors `SshStatusDeps`) so `tests/ssh-password-sync.test.ts`
+drives it without a real `passwd`/`/etc/shadow`.
+
 ## CONVENTIONS
 
 - Runtime: Bun only. No Node-specific APIs (`fs/promises` ok; `node:cluster` not).

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -106,7 +106,7 @@ import {
 	stopDmesgWatchers,
 } from "./modules/system/sensors.ts";
 import { periodicCheckForSoftwareUpdates } from "./modules/system/software-updates.ts";
-import { getSshStatus } from "./modules/system/ssh.ts";
+import { ensureSshPasswordSynced, getSshStatus } from "./modules/system/ssh.ts";
 import { wifiStateInit } from "./modules/wifi/wifi-connections.ts";
 import { handleWifiMonitorEvent as handleHotspotMonitorEvent } from "./modules/wifi/wifi-hotspot-monitor.ts";
 import { onHeartbeatTick, startHeartbeat } from "./rpc/heartbeat.ts";
@@ -258,6 +258,12 @@ initHardwareMonitoring();
 initDeviceStats();
 await guardNonCritical("rtmp-ingest", initRTMPIngestStats);
 await guardNonCritical("srt-ingest", initSRTIngest);
+// Reconcile the OS-level SSH password against the /data-persisted one BEFORE the
+// status probe below reads /etc/shadow: /etc/shadow is rootfs-local and does NOT
+// survive an A/B OTA slot swap, so a fresh slot silently locks the operator out
+// until this re-applies the persisted password (mirrors ceralive-ssh-firstboot.sh's
+// host-key restore). Fail-soft: a sync failure must never brick boot.
+await guardNonCritical("ssh-password-sync", ensureSshPasswordSynced);
 void getSshStatus();
 logger.info(bootTimer.phase("🖥️", "hardware"));
 

--- a/apps/backend/src/modules/system/ssh.ts
+++ b/apps/backend/src/modules/system/ssh.ts
@@ -25,7 +25,10 @@ import { shouldUseMocks } from "../../mocks/mock-service.ts";
 import { getConfig, saveConfig } from "../config.ts";
 import { setup } from "../setup.ts";
 import type { MessageSocket } from "../ui/message-socket.ts";
-import { notificationSend } from "../ui/notifications.ts";
+import {
+	notificationBroadcast,
+	notificationSend,
+} from "../ui/notifications.ts";
 import { broadcastMsg } from "../ui/websocket-server.ts";
 import { describeCliError } from "./cli-parse.ts";
 
@@ -297,4 +300,102 @@ export async function resetSshPassword(
 	broadcastMsg("config", config);
 	await getSshStatus();
 	return password;
+}
+
+/**
+ * Injectable surface for {@link ensureSshPasswordSynced}. Mirrors the
+ * {@link SshStatusDeps} DI pattern so tests drive the sync without a real
+ * `/etc/shadow` read or a real `passwd` spawn. `readShadow` is fed to the shared
+ * {@link probeSshUserHash}; `applyPassword` runs the same stdin-only `passwd`
+ * path {@link resetSshPassword} uses.
+ */
+export type SshPasswordSyncDeps = {
+	/** Read the raw /etc/shadow document (JS, no `grep` subprocess). */
+	readShadow: () => string | Promise<string>;
+	/** Apply `password` to `user`'s OS account via `passwd` (stdin only). */
+	applyPassword: (user: string, password: string) => Promise<void>;
+};
+
+const defaultSshPasswordSyncDeps: SshPasswordSyncDeps = {
+	readShadow: () => Bun.file("/etc/shadow").text(),
+	applyPassword: async (user, password) => {
+		// `passwd` reads the new password twice from stdin. The secret is fed via
+		// stdin ONLY — never on argv (parity with resetSshPassword).
+		await runWithStdin("passwd", [user], `${password}\n${password}\n`);
+	},
+};
+
+/**
+ * Boot-time reconciliation of the persisted SSH password against the live OS.
+ *
+ * `config.json` (which stores `ssh_pass` + `ssh_pass_hash`) is `/data`-persisted
+ * and survives an A/B OTA slot swap, but the OS-level `/etc/shadow` entry is
+ * rootfs-local — baked fresh into each image and NOT carried across a slot swap.
+ * So after an OTA the fresh slot's shadow holds a build-time password while
+ * config.json still remembers the operator's real one, locking the operator out
+ * until they manually reset. This mirrors the host-key restore in
+ * image-building-pipeline's `ceralive-ssh-firstboot.sh::ensure_host_keys()`:
+ * compare the persisted identity against the live one and RE-APPLY (never
+ * regenerate) the persisted one on a mismatch.
+ *
+ * Contract: never throws (BOOT FAIL-SOFT); a clean no-op under mocks, when
+ * nothing is persisted yet (`ssh_pass === undefined`), or when the OS already
+ * matches (the common same-slot boot). It re-applies the EXISTING persisted
+ * password — it NEVER generates a new one and NEVER writes config (the credential
+ * is unchanged; only the OS-level shadow entry must catch up).
+ */
+export async function ensureSshPasswordSynced(
+	deps: Partial<SshPasswordSyncDeps> = {},
+): Promise<void> {
+	// Dev/mock seam: never spawn passwd or read the real /etc/shadow on a dev box
+	// (mirrors startStopSsh's shouldUseMocks() gate).
+	if (shouldUseMocks()) return;
+
+	let ssh_user: string;
+	try {
+		ssh_user = resolveSshUser();
+	} catch (err) {
+		logger.error(`Skipping SSH password sync: ${err}`);
+		return;
+	}
+
+	// Nothing persisted yet → nothing to sync. Leaves the existing "generate on
+	// first startStopSsh when ssh_pass is undefined" contract untouched.
+	const password = getConfig().ssh_pass;
+	if (password === undefined) return;
+
+	const { readShadow, applyPassword } = {
+		...defaultSshPasswordSyncDeps,
+		...deps,
+	};
+
+	// The live OS hash vs the cached hash loadConfig() set from the persisted
+	// ssh_pass_hash. Equal → this slot already matches (the common same-slot
+	// boot); a fast, harmless no-op.
+	const liveHash = await probeSshUserHash(readShadow, ssh_user);
+	if (liveHash === sshPasswordHash) return;
+
+	try {
+		// Mismatch (a fresh OTA slot still carrying the build-time password):
+		// re-apply the EXISTING persisted password so the operator's credential
+		// stays stable across the update. A RESTORE, not a reset — no new random
+		// password, no saveConfig().
+		await applyPassword(ssh_user, password);
+	} catch (err) {
+		logger.error(`Failed to sync the SSH password for ${ssh_user}: ${err}`);
+		notificationBroadcast(
+			"ssh_pass_sync",
+			"error",
+			`Failed to sync the SSH password for ${ssh_user}`,
+			0,
+			true,
+		);
+		return;
+	}
+
+	// Re-probe so the cached hash (and the SSH status tile it feeds) reflects the
+	// OS we just wrote — the crypt salt on this slot differs from the persisted
+	// hash's, so read back the authoritative value rather than assume it.
+	sshPasswordHash = await probeSshUserHash(readShadow, ssh_user);
+	logger.info(`Re-applied the persisted SSH password for ${ssh_user}`);
 }

--- a/apps/backend/src/tests/ssh-password-sync.test.ts
+++ b/apps/backend/src/tests/ssh-password-sync.test.ts
@@ -1,0 +1,216 @@
+/*
+ * ssh-password-sync.test.ts — boot-time SSH password reconciliation.
+ *
+ * `ensureSshPasswordSynced()` re-applies the /data-persisted `ssh_pass` to the
+ * rootfs-local /etc/shadow after an A/B OTA slot swap (the swap keeps config.json
+ * but bakes a fresh, non-matching shadow entry, silently locking the operator
+ * out). It mirrors ceralive-ssh-firstboot.sh's host-key restore: compare the
+ * persisted hash against the live one and RE-APPLY (never regenerate) the existing
+ * password on a mismatch.
+ *
+ * Like update-ssh-mock-seams.test.ts, every OS effect (the /etc/shadow read and
+ * the `passwd` spawn) is injected through the SshPasswordSyncDeps seam, so the
+ * suite asserts on whether `passwd` FIRED and with what stdin — never spawning
+ * passwd or reading the real shadow file.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { initMockService, shouldUseMocks } from "../mocks/mock-service.ts";
+import { getConfig } from "../modules/config.ts";
+import { setup } from "../modules/setup.ts";
+import {
+	ensureSshPasswordSynced,
+	getSshPasswordHash,
+	type SshPasswordSyncDeps,
+	setSshPasswordHash,
+} from "../modules/system/ssh.ts";
+
+// A well-formed /etc/shadow document carrying `hash` as `user`'s crypt field.
+function shadowLine(user: string, hash: string): string {
+	return `root:!:19000:0:99999:7:::\n${user}:${hash}:19000:0:99999:7:::\n`;
+}
+
+// Capture every passwd apply as a {user, password} record so a test can prove
+// WHICH plaintext was applied (never a freshly-generated one).
+function captureApply(
+	calls: Array<{ user: string; password: string }>,
+): SshPasswordSyncDeps["applyPassword"] {
+	return async (user, password) => {
+		calls.push({ user, password });
+	};
+}
+
+let savedNodeEnv: string | undefined;
+let savedMockMode: string | undefined;
+let savedDeviceType: string | undefined;
+let savedSshUser: string | undefined;
+let savedSshPass: string | undefined;
+let savedSshPasswordHash: string | undefined;
+
+beforeEach(() => {
+	savedNodeEnv = process.env.NODE_ENV;
+	savedMockMode = process.env.MOCK_MODE;
+	savedDeviceType = process.env.CERALIVE_DEVICE_TYPE;
+	savedSshUser = setup.ssh_user;
+	savedSshPass = getConfig().ssh_pass;
+	savedSshPasswordHash = getSshPasswordHash();
+});
+
+afterEach(() => {
+	const restore = (key: string, value: string | undefined) => {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	};
+	restore("NODE_ENV", savedNodeEnv);
+	restore("MOCK_MODE", savedMockMode);
+	restore("CERALIVE_DEVICE_TYPE", savedDeviceType);
+	setup.ssh_user = savedSshUser;
+	getConfig().ssh_pass = savedSshPass;
+	setSshPasswordHash(savedSshPasswordHash);
+});
+
+/** Enter production (real) mode so the sync path actually runs. */
+function enterProd(): void {
+	process.env.NODE_ENV = "production";
+	delete process.env.MOCK_MODE;
+	delete process.env.CERALIVE_DEVICE_TYPE;
+}
+
+describe("ensureSshPasswordSynced — same-slot boot (hashes match)", () => {
+	test("(prod) makes NO passwd call when the OS already matches", async () => {
+		enterProd();
+		setup.ssh_user = "produser";
+		getConfig().ssh_pass = "persisted-secret";
+		setSshPasswordHash("$6$abc$hashvalue");
+		expect(shouldUseMocks()).toBe(false);
+
+		const calls: Array<{ user: string; password: string }> = [];
+		await ensureSshPasswordSynced({
+			readShadow: () => shadowLine("produser", "$6$abc$hashvalue"),
+			applyPassword: captureApply(calls),
+		});
+
+		// Common case: same slot, live shadow hash == cached persisted hash → no-op.
+		expect(calls).toHaveLength(0);
+	});
+});
+
+describe("ensureSshPasswordSynced — fresh OTA slot (hashes differ)", () => {
+	test("(prod) re-applies the EXISTING persisted password, never a new one", async () => {
+		enterProd();
+		setup.ssh_user = "produser";
+		getConfig().ssh_pass = "persisted-secret";
+		// Cached hash from config.json's ssh_pass_hash (the slot where reset ran)...
+		setSshPasswordHash("$6$old$persistedhash");
+		expect(shouldUseMocks()).toBe(false);
+
+		const calls: Array<{ user: string; password: string }> = [];
+		// ...while THIS freshly-activated slot's shadow still holds the build-time
+		// baked hash before the apply, and the re-applied hash after.
+		let applied = false;
+		await ensureSshPasswordSynced({
+			readShadow: () =>
+				shadowLine(
+					"produser",
+					applied ? "$6$new$reappliedhash" : "$6$baked$buildhash",
+				),
+			applyPassword: async (user, password) => {
+				calls.push({ user, password });
+				applied = true;
+			},
+		});
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.user).toBe("produser");
+		// CRITICAL: the EXISTING persisted plaintext — proving no random password
+		// was generated on the sync path.
+		expect(calls[0]?.password).toBe("persisted-secret");
+		// The cache is re-probed to the post-apply OS hash (consistent with state).
+		expect(getSshPasswordHash()).toBe("$6$new$reappliedhash");
+	});
+});
+
+describe("ensureSshPasswordSynced — nothing to sync", () => {
+	test("(prod) no-op (no shadow read, no passwd) when ssh_pass is unset", async () => {
+		enterProd();
+		setup.ssh_user = "produser";
+		getConfig().ssh_pass = undefined;
+		setSshPasswordHash("$6$abc$hashvalue");
+		expect(shouldUseMocks()).toBe(false);
+
+		const calls: Array<{ user: string; password: string }> = [];
+		let shadowReads = 0;
+		await ensureSshPasswordSynced({
+			readShadow: () => {
+				shadowReads++;
+				return shadowLine("produser", "$6$def$otherhash");
+			},
+			applyPassword: captureApply(calls),
+		});
+
+		// Bails before comparing — matches the "generate on first startStopSsh"
+		// contract for a genuinely fresh device that never had SSH reset.
+		expect(shadowReads).toBe(0);
+		expect(calls).toHaveLength(0);
+	});
+});
+
+describe("ensureSshPasswordSynced — boot-safety (never propagates)", () => {
+	test("(prod) a passwd failure is swallowed, not thrown", async () => {
+		enterProd();
+		setup.ssh_user = "produser";
+		getConfig().ssh_pass = "persisted-secret";
+		setSshPasswordHash("$6$old$persistedhash");
+
+		await expect(
+			ensureSshPasswordSynced({
+				readShadow: () => shadowLine("produser", "$6$baked$buildhash"),
+				applyPassword: async () => {
+					throw new Error("passwd exited with code 1");
+				},
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	test("(prod) a shadow-read failure is swallowed, not thrown", async () => {
+		enterProd();
+		setup.ssh_user = "produser";
+		getConfig().ssh_pass = "persisted-secret";
+		setSshPasswordHash("$6$old$persistedhash");
+
+		await expect(
+			ensureSshPasswordSynced({
+				readShadow: () => {
+					throw new Error("EACCES: /etc/shadow");
+				},
+				applyPassword: captureApply([]),
+			}),
+		).resolves.toBeUndefined();
+	});
+});
+
+describe("ensureSshPasswordSynced — dev mock seam", () => {
+	test("(dev) no shadow read and no passwd apply under mocks", async () => {
+		process.env.NODE_ENV = "development";
+		delete process.env.MOCK_MODE;
+		delete process.env.CERALIVE_DEVICE_TYPE;
+		initMockService("multi-modem-wifi");
+		setup.ssh_user = "devuser";
+		getConfig().ssh_pass = "persisted-secret";
+		setSshPasswordHash("$6$old$persistedhash");
+		expect(shouldUseMocks()).toBe(true);
+
+		const calls: Array<{ user: string; password: string }> = [];
+		let shadowReads = 0;
+		await ensureSshPasswordSynced({
+			readShadow: () => {
+				shadowReads++;
+				return shadowLine("devuser", "$6$baked$buildhash");
+			},
+			applyPassword: captureApply(calls),
+		});
+
+		expect(shadowReads).toBe(0);
+		expect(calls).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## What

Adds `ensureSshPasswordSynced()` to the backend and wires it into the boot sequence
(`main.ts`, via `guardNonCritical("ssh-password-sync", …)`) immediately before the
boot `getSshStatus()` probe. On boot it compares the persisted `ssh_pass_hash`
(from `config.json`) against the live `/etc/shadow` hash and, on a mismatch,
re-applies the **existing** persisted `ssh_pass` through the same stdin-only `passwd`
path `resetSshPassword()` already uses.

Touches four files, backend-only: `apps/backend/src/modules/system/ssh.ts`,
`apps/backend/src/main.ts`, a new `apps/backend/src/tests/ssh-password-sync.test.ts`,
and the backend `AGENTS.md`.

## Why

An OTA A/B slot swap silently reverts the operator's SSH password to the
factory-baked default — confirmed on real Rock 5B+ hardware. `config.json`
(`ssh_pass` + `ssh_pass_hash`) is `/data`-persisted and survives the swap, but the
OS-level `/etc/shadow` entry is **rootfs-local**: baked fresh into each image and not
carried across slots. After an OTA the freshly-activated slot holds the build-time
password while `config.json` still remembers the operator's real one, locking SSH
until a manual UI reset — on **every** update. Nothing re-applied it.

This mirrors the host-key restore the image already does in
`ceralive-ssh-firstboot.sh::ensure_host_keys()`: compare the persisted identity
against the live one and re-apply (never regenerate) on a mismatch.

## How to verify

- `cd apps/backend && bun test src/tests/ssh-password-sync.test.ts` — covers
  same-slot no-op, fresh-slot re-apply (proves the **existing** plaintext is applied,
  not a new one), unset-password no-op, boot-safety (never throws on `passwd` or
  shadow-read failure), and the dev-mock seam.
- `cd apps/backend && bun test` — full backend suite green (1936 pass / 0 fail).
- `cd apps/backend && bunx tsc --noEmit` and `bunx biome check` — both clean.

## Risks

Low, and contained to a boot-time reconciliation:

- **Boot fail-soft**: `ensureSshPasswordSynced()` never throws (wrapped in
  `guardNonCritical`); a sync failure logs + broadcasts a notification and returns —
  it can never brick boot.
- **No-op on the common path**: a clean no-op under mocks, when `ssh_pass` is unset
  (nothing persisted yet), and on the same-slot boot where the OS already matches.
- **No credential change**: it re-applies the *existing* persisted password and never
  generates a new one or writes config — only the OS `/etc/shadow` entry catches up.
  `resetSshPassword()` and `startStopSsh()`'s generate-if-missing branch are untouched.
- Effectful surface (`readShadow` / `applyPassword`) is injected via
  `SshPasswordSyncDeps`, so the test suite drives it without a real `passwd`/`/etc/shadow`.
