### PR TITLE
fix(backend): repair automatic apt update-check + add manual re-check

### DIFF
--- a/apps/backend/src/modules/system/software-updates.ts
+++ b/apps/backend/src/modules/system/software-updates.ts
@@ -475,6 +475,20 @@ export function periodicCheckForSoftwareUpdates() {
 	}
 }
 
+// Reuses the periodic discovery + skip guard but never touches its timer.
+// Returns false when skipped (streaming/updating/apt busy).
+export function triggerManualUpdateCheck(): boolean {
+	if (shouldUseMocks()) {
+		if (getIsStreaming() || isUpdating() || aptGetUpdating) return false;
+		availableUpdates = { package_count: 0 };
+		broadcastMsg("status", { available_updates: availableUpdates });
+		return true;
+	}
+	return checkForSoftwareUpdates(async (err_) => {
+		if (err_ === null) await getSoftwareUpdateSize();
+	});
+}
+
 // apt spawn seam (T8): the default kicks off the real `apt-get update` →
 // dist-upgrade pipeline. The dev/mock path NEVER calls it (it simulates the
 // progress sequence instead); tests spy it to assert the real path fired (prod)

--- a/apps/backend/src/modules/system/software-updates.ts
+++ b/apps/backend/src/modules/system/software-updates.ts
@@ -369,10 +369,12 @@ export function classifyAptUpdateResult(
 	return null;
 }
 
+// Returns false when skipped (streaming/updating/apt busy) so the periodic
+// caller can still reschedule — a skipped check never runs its callback.
 function checkForSoftwareUpdates(
 	callback: (err: SoftwareUpdateError, aptGetUpdateFailures: number) => unknown,
-) {
-	if (getIsStreaming() || isUpdating() || aptGetUpdating) return;
+): boolean {
+	if (getIsStreaming() || isUpdating() || aptGetUpdating) return false;
 
 	aptGetUpdating = true;
 	void (async () => {
@@ -401,10 +403,50 @@ function checkForSoftwareUpdates(
 
 		if (callback) callback(errOrStderr, aptGetUpdateFailures);
 	})();
+	return true;
+}
+
+// 10 SECONDS, not a bare `10` (10ms) which hammered apt every 10ms.
+export const RETRY_DELAY_SHORT_MS = 10 * 1000;
+export const RETRY_FAILURE_THRESHOLD = 12;
+export const SKIP_RETRY_DELAY_MS = oneMinute;
+
+export function computeNextCheckDelay(
+	err: SoftwareUpdateError,
+	failures: number,
+): number {
+	if (err === null) return oneHour;
+	if (failures < RETRY_FAILURE_THRESHOLD) return RETRY_DELAY_SHORT_MS;
+	return oneMinute;
+}
+
+type SoftwareUpdateCheckRunner = (
+	callback: (err: SoftwareUpdateError, failures: number) => unknown,
+) => boolean;
+
+let softwareUpdateCheckRunner: SoftwareUpdateCheckRunner =
+	checkForSoftwareUpdates;
+
+export function setSoftwareUpdateCheckRunner(
+	runner: SoftwareUpdateCheckRunner,
+): void {
+	softwareUpdateCheckRunner = runner;
+}
+
+export function resetSoftwareUpdateCheckRunner(): void {
+	softwareUpdateCheckRunner = checkForSoftwareUpdates;
 }
 
 let nextCheckForSoftwareUpdates = getms();
 let nextCheckForSoftwareUpdatesTimer: ReturnType<typeof setTimeout> | undefined;
+
+function scheduleNextSoftwareUpdateCheck(delay: number): void {
+	nextCheckForSoftwareUpdates = getms() + delay;
+	nextCheckForSoftwareUpdatesTimer = setTimeout(
+		periodicCheckForSoftwareUpdates,
+		delay,
+	);
+}
 
 export function periodicCheckForSoftwareUpdates() {
 	if (nextCheckForSoftwareUpdatesTimer) {
@@ -421,27 +463,16 @@ export function periodicCheckForSoftwareUpdates() {
 		return;
 	}
 
-	checkForSoftwareUpdates(async (err_, failures) => {
+	const started = softwareUpdateCheckRunner(async (err_, failures) => {
 		const err = err_ === null ? await getSoftwareUpdateSize() : err_;
-
-		// one hour delay after a succesful check
-		let delay = oneHour;
-		// otherwise, increasing delay depending on the number of failures
-		if (err !== null) {
-			// try after 10s for the first ~2 minutes
-			if (failures < 12) {
-				delay = 10;
-				// back off to a minute delay
-			} else {
-				delay = oneMinute;
-			}
-		}
-		nextCheckForSoftwareUpdates = getms() + delay;
-		nextCheckForSoftwareUpdatesTimer = setTimeout(
-			periodicCheckForSoftwareUpdates,
-			delay,
-		);
+		scheduleNextSoftwareUpdateCheck(computeNextCheckDelay(err, failures));
 	});
+
+	// Skip path runs no callback; reschedule here so the loop survives a
+	// stream/update window instead of dying until the next backend restart.
+	if (!started) {
+		scheduleNextSoftwareUpdateCheck(SKIP_RETRY_DELAY_MS);
+	}
 }
 
 // apt spawn seam (T8): the default kicks off the real `apt-get update` →

--- a/apps/backend/src/rpc/procedures/system.procedure.ts
+++ b/apps/backend/src/rpc/procedures/system.procedure.ts
@@ -48,6 +48,7 @@ import { getSensors } from "../../modules/system/sensors.ts";
 import {
 	isUpdating,
 	startSoftwareUpdate,
+	triggerManualUpdateCheck,
 } from "../../modules/system/software-updates.ts";
 import { resetSshPassword, startStopSsh } from "../../modules/system/ssh.ts";
 import { mintPreviewToken } from "../../modules/ui/preview-token.ts";
@@ -182,6 +183,18 @@ export const startUpdateProcedure = authedProcedure
 		logger.info("System: software update started");
 		startSoftwareUpdate();
 		return { success: true };
+	});
+
+/**
+ * Manual "check for updates now". Runs the same discovery the periodic loop
+ * uses; success:false when skipped (streaming/updating/apt busy).
+ */
+export const checkForUpdatesProcedure = authedProcedure
+	.output(successResponseSchema)
+	.handler(() => {
+		const started = triggerManualUpdateCheck();
+		if (started) logger.info("System: manual software update check started");
+		return { success: started };
 	});
 
 /**

--- a/apps/backend/src/rpc/router.ts
+++ b/apps/backend/src/rpc/router.ts
@@ -62,6 +62,7 @@ import {
 	switchInputProcedure,
 } from "./procedures/streaming.procedure.ts";
 import {
+	checkForUpdatesProcedure,
 	getCloudProvidersProcedure,
 	getLogProcedure,
 	getRevisionsProcedure,
@@ -166,6 +167,7 @@ const stableRoutes = {
 		poweroff: poweroffProcedure,
 		reboot: rebootProcedure,
 		startUpdate: startUpdateProcedure,
+		checkForUpdates: checkForUpdatesProcedure,
 		sshStart: sshStartProcedure,
 		sshStop: sshStopProcedure,
 		sshResetPassword: sshResetPasswordProcedure,

--- a/apps/backend/src/tests/software-updates-schedule.test.ts
+++ b/apps/backend/src/tests/software-updates-schedule.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Regression coverage for the automatic apt-update-check scheduler:
+ *
+ *   Bug 1 — the first-failures retry used a bare `10` (10ms), hammering apt every
+ *           10ms instead of the intended 10 seconds.
+ *   Bug 2 — a check skipped while streaming/updating never ran its callback, so
+ *           the periodic loop stopped rescheduling and died until backend restart.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import { oneHour, oneMinute } from "../helpers/time.ts";
+import {
+	computeNextCheckDelay,
+	periodicCheckForSoftwareUpdates,
+	RETRY_DELAY_SHORT_MS,
+	resetSoftwareUpdateCheckRunner,
+	SKIP_RETRY_DELAY_MS,
+	setSoftwareUpdateCheckRunner,
+} from "../modules/system/software-updates.ts";
+
+describe("computeNextCheckDelay() — retry backoff", () => {
+	const err = new Error("apt-get update failed");
+
+	it("retries after a full 10 SECONDS on the first failures (not 10ms)", () => {
+		expect(computeNextCheckDelay(err, 0)).toBe(10_000);
+		expect(computeNextCheckDelay(err, 11)).toBe(RETRY_DELAY_SHORT_MS);
+		expect(RETRY_DELAY_SHORT_MS).toBe(10_000);
+	});
+
+	it("backs off to one minute once failures reach the threshold", () => {
+		expect(computeNextCheckDelay(err, 12)).toBe(oneMinute);
+		expect(computeNextCheckDelay(err, 99)).toBe(oneMinute);
+	});
+
+	it("waits one hour after a successful check (err === null)", () => {
+		expect(computeNextCheckDelay(null, 0)).toBe(oneHour);
+		expect(computeNextCheckDelay(null, 50)).toBe(oneHour);
+	});
+});
+
+describe("periodicCheckForSoftwareUpdates() — reschedule after a skip", () => {
+	afterEach(() => resetSoftwareUpdateCheckRunner());
+
+	it("still schedules the next check when the current one is skipped", () => {
+		// Force the skip path: the runner declines (streaming/updating/apt busy)
+		// and, like the real code, never invokes the reschedule callback.
+		setSoftwareUpdateCheckRunner(() => false);
+
+		const realSetTimeout = globalThis.setTimeout;
+		const scheduledDelays: number[] = [];
+		globalThis.setTimeout = ((_fn: () => void, ms?: number) => {
+			scheduledDelays.push(ms ?? 0);
+			return 0 as unknown as ReturnType<typeof setTimeout>;
+		}) as typeof globalThis.setTimeout;
+
+		try {
+			periodicCheckForSoftwareUpdates();
+		} finally {
+			globalThis.setTimeout = realSetTimeout;
+		}
+
+		// Pre-fix the skip path scheduled nothing, so this array was empty and the
+		// loop was dead until the next backend restart.
+		expect(scheduledDelays).toContain(SKIP_RETRY_DELAY_MS);
+	});
+});

--- a/apps/frontend/src/lib/rpc/client.ts
+++ b/apps/frontend/src/lib/rpc/client.ts
@@ -594,6 +594,7 @@ export interface TypedRPC {
 		poweroff: () => Promise<SuccessResponse>;
 		reboot: () => Promise<SuccessResponse>;
 		startUpdate: () => Promise<SuccessResponse>;
+		checkForUpdates: () => Promise<SuccessResponse>;
 		sshStart: () => Promise<SuccessResponse>;
 		sshStop: () => Promise<SuccessResponse>;
 		sshResetPassword: () => Promise<{ success: boolean; password?: string }>;

--- a/apps/frontend/src/main/dialogs/UpdatesDialog.svelte
+++ b/apps/frontend/src/main/dialogs/UpdatesDialog.svelte
@@ -71,6 +71,35 @@ async function doInstall() {
 	});
 }
 
+let checking = $state(false);
+let checkTimeout: ReturnType<typeof setTimeout> | undefined;
+let checkBaseline: typeof updates = undefined;
+
+async function doCheck() {
+	if (checking || isUpdating) return;
+	checking = true;
+	checkBaseline = updates;
+	clearTimeout(checkTimeout);
+	checkTimeout = setTimeout(() => {
+		checking = false;
+	}, 30_000);
+	const res = await rpc.system.checkForUpdates();
+	if (!res.success) {
+		checking = false;
+		clearTimeout(checkTimeout);
+	}
+}
+
+// A fresh available_updates broadcast (new object ref) confirms the check ran.
+$effect(() => {
+	if (checking && updates !== checkBaseline) {
+		checking = false;
+		clearTimeout(checkTimeout);
+	}
+});
+
+$effect(() => () => clearTimeout(checkTimeout));
+
 // Confirm the start-dispatch op once the first `updating` broadcast lands.
 $effect(() => {
 	if (getOperationPhase('update') !== 'pending') return;
@@ -121,6 +150,20 @@ $effect(() => {
 			<Button class="w-full gap-2" onclick={() => (confirmOpen = true)}>
 				<Download class="size-4" />
 				{$LL.general.updateButton()}
+			</Button>
+		{/if}
+
+		{#if !isUpdating && !starting}
+			<!-- Manual re-check: re-runs the discovery pipeline on the device -->
+			<Button
+				aria-busy={checking}
+				class="w-full gap-2"
+				disabled={checking}
+				onclick={doCheck}
+				variant="outline"
+			>
+				<RefreshCw class="size-4 {checking ? 'motion-safe:animate-spin' : ''}" />
+				{checking ? $LL.general.checkingForUpdates() : $LL.general.checkForUpdates()}
 			</Button>
 		{/if}
 	</div>

--- a/packages/i18n/src/ar/index.ts
+++ b/packages/i18n/src/ar/index.ts
@@ -179,6 +179,8 @@ const ar = {
 		liveMetrics: "المقاييس المباشرة",
 		noSensorData: "لا توجد بيانات حساسات متاحة",
 		noUpdatesAvailable: "النظام محدث",
+		checkForUpdates: "التحقق من وجود تحديثات",
+		checkingForUpdates: "جارٍ التحقق…",
 		notAvailable: "غير متوفر",
 		notConfigured: "غير مُكوّن",
 		unknownSource: "Unknown source",

--- a/packages/i18n/src/de/index.ts
+++ b/packages/i18n/src/de/index.ts
@@ -197,6 +197,8 @@ const de = {
 		pleaseConfigureServer:
 			"Bitte konfigurieren Sie einen Relay-Server, um mit dem Streaming zu beginnen",
 		noUpdatesAvailable: "System ist aktuell",
+		checkForUpdates: "Nach Updates suchen",
+		checkingForUpdates: "Wird geprüft…",
 		serverSettings: "Server-Einstellungen",
 		audioSettings: "Audio-Einstellungen",
 		hardwareSensors: "Hardware-Sensoren",

--- a/packages/i18n/src/en/index.ts
+++ b/packages/i18n/src/en/index.ts
@@ -189,6 +189,8 @@ const en = {
 		configurationNotComplete: "Configuration pending",
 		pleaseConfigureServer: "Please configure a relay server to begin streaming",
 		noUpdatesAvailable: "System is up to date",
+		checkForUpdates: "Check for updates",
+		checkingForUpdates: "Checking…",
 		serverSettings: "Server Settings",
 		audioSettings: "Audio Settings",
 		hardwareSensors: "Hardware Sensors",

--- a/packages/i18n/src/es/index.ts
+++ b/packages/i18n/src/es/index.ts
@@ -197,6 +197,8 @@ const es = {
 		pleaseConfigureServer:
 			"Por favor configure un servidor de retransmisión para comenzar la transmisión",
 		noUpdatesAvailable: "El sistema está actualizado",
+		checkForUpdates: "Buscar actualizaciones",
+		checkingForUpdates: "Comprobando…",
 		serverSettings: "Configuración del Servidor",
 		audioSettings: "Configuración de Audio",
 		hardwareSensors: "Sensores de Hardware",

--- a/packages/i18n/src/fr/index.ts
+++ b/packages/i18n/src/fr/index.ts
@@ -195,6 +195,8 @@ const fr = {
 		streamingMessage:
 			"Votre transmission utilise {usingNetworksCount} réseaux avec une latence de {srtLatency} ms",
 		noUpdatesAvailable: "Le système est à jour",
+		checkForUpdates: "Rechercher des mises à jour",
+		checkingForUpdates: "Vérification…",
 		serverSettings: "Paramètres du Serveur",
 		audioSettings: "Paramètres Audio",
 		hardwareSensors: "Capteurs Matériels",

--- a/packages/i18n/src/hi/index.ts
+++ b/packages/i18n/src/hi/index.ts
@@ -41,6 +41,8 @@ const hi = {
 		liveMetrics: "लाइव मेट्रिक्स",
 		noSensorData: "कोई सेंसर डेटा उपलब्ध नहीं",
 		noUpdatesAvailable: "सिस्टम अद्यतित है",
+		checkForUpdates: "अपडेट जांचें",
+		checkingForUpdates: "जांच हो रही है…",
 		notAvailable: "उपलब्ध नहीं",
 		notConfigured: "कॉन्फ़िगर नहीं किया गया",
 		unknownSource: "Unknown source",

--- a/packages/i18n/src/ja/index.ts
+++ b/packages/i18n/src/ja/index.ts
@@ -41,6 +41,8 @@ const ja = {
 		liveMetrics: "ライブメトリクス",
 		noSensorData: "センサーデータが利用できません",
 		noUpdatesAvailable: "システムは最新です",
+		checkForUpdates: "アップデートを確認",
+		checkingForUpdates: "確認中…",
 		notAvailable: "利用不可",
 		notConfigured: "未設定",
 		unknownSource: "Unknown source",

--- a/packages/i18n/src/ko/index.ts
+++ b/packages/i18n/src/ko/index.ts
@@ -41,6 +41,8 @@ const ko = {
 		liveMetrics: "실시간 지표",
 		noSensorData: "센서 데이터 사용 불가",
 		noUpdatesAvailable: "시스템이 최신 상태입니다",
+		checkForUpdates: "업데이트 확인",
+		checkingForUpdates: "확인 중…",
 		notAvailable: "사용 불가",
 		notConfigured: "구성되지 않음",
 		unknownSource: "Unknown source",

--- a/packages/i18n/src/pt-BR/index.ts
+++ b/packages/i18n/src/pt-BR/index.ts
@@ -200,6 +200,8 @@ const ptBR = {
 		streamingMessage:
 			"Sua transmissão está usando {usingNetworksCount} redes com uma latência de {srtLatency} ms",
 		noUpdatesAvailable: "Sistema atualizado",
+		checkForUpdates: "Verificar atualizações",
+		checkingForUpdates: "Verificando…",
 		serverSettings: "Configurações do Servidor",
 		audioSettings: "Configurações de Áudio",
 		hardwareSensors: "Sensores de Hardware",

--- a/packages/i18n/src/zh/index.ts
+++ b/packages/i18n/src/zh/index.ts
@@ -40,6 +40,8 @@ const zh = {
 		liveMetrics: "实时指标",
 		noSensorData: "无传感器数据可用",
 		noUpdatesAvailable: "系统已是最新版本",
+		checkForUpdates: "检查更新",
+		checkingForUpdates: "正在检查…",
 		notAvailable: "不可用",
 		notConfigured: "未配置",
 		unknownSource: "Unknown source",


### PR DESCRIPTION
## What

Fixes two real bugs in the automatic apt update-check loop and adds an operator-triggered "check for updates now" path.

**Bug fixes (`software-updates.ts`)**
- **Retry delay was 10ms, not 10s.** The first-failures retry passed a bare `10` to `setTimeout` — 10 milliseconds — so a failing check re-ran `apt-get update` every 10ms. The `failures < 12` window only makes sense at 10 seconds (~2 minutes of fast retries). Fixed to `10_000` behind a named `RETRY_DELAY_SHORT_MS`.
- **A skipped check killed the loop.** `checkForSoftwareUpdates` returns early when a stream is live, an update is running, or another apt op is in flight — but it returned *without* invoking its callback, and the callback was the only thing that scheduled the next check. So one skip stopped all future automatic checks until the backend restarted. The check now reports whether it started, and `periodicCheckForSoftwareUpdates` reschedules on the skip path so the loop always survives a stream/update window.

**New feature — manual re-check**
- `system.checkForUpdates` RPC → `triggerManualUpdateCheck()` reuses the exact same `apt-get update` → `dist-upgrade --assume-no` discovery the periodic loop runs, honors the same skip guard, and deliberately does **not** touch the periodic loop's own timer (a manual check never resets the hourly cadence).
- A "Check for updates" button in `UpdatesDialog`, disabled with a spinner while a check is in flight (clears on the next `available_updates` broadcast or a 30s fallback). New param-free i18n keys in all 10 locales.

## Why

The automatic updater could silently stop working: any check that happened to fire while streaming would permanently disable update discovery until a reboot, and a transient apt failure would hammer the package manager every 10ms. Operators also had no way to force a fresh check — the only "Update" button installs, it doesn't check.

## How to verify

- `bun run --filter backend test` — new `software-updates-schedule.test.ts` covers both bugs (retry delay = 10s; skip path still reschedules). Backend suite green (1945 tests).
- Manual: open Settings → Updates, click **Check for updates** — the button spins, then the availability summary refreshes. Verify starting a stream and letting an auto-check fire no longer stops later checks.
- `bun run lint`, `bun run check:tech-debt` — green.

## Risks

Low. The scheduler change is additive (a boolean return + a reschedule on the previously-dead skip path); the 1-hour interval and skip conditions are unchanged. The manual RPC reuses existing, tested discovery logic and never mutates the auto-loop timer. Frontend button is purely additive to the existing dialog.
