### PR TITLE
feat(modems): Phase-B cellular modem-stack integration

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -25,6 +25,7 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 | srtla binding calls (flux — check `../../../srtla/AGENTS.md` first) | `modules/streaming/srtla.ts` |
 | srtla per-link telemetry → `status.linkTelemetry` | `modules/streaming/link-telemetry.ts` |
 | Stream lifecycle (spawn supervision, start/stop, autostart, exec paths) | `modules/streaming/streamloop/` (barrel: `modules/streaming/streamloop.ts`) |
+| **Streaming ↔ modem-lifecycle interlock (mutual exclusion between stream admission and USB-mode switch / recovery)** | `modules/streaming/lifecycle-admission.ts` (`tryAcquireLifecycle`, `withLifecycleLock`) |
 | WebSocket server wiring | `modules/ui/websocket-server.ts` + `rpc/server.ts` |
 | Auth token logic | `modules/ui/auth.ts` + `rpc/middleware/auth.middleware.ts` |
 | PASETO device-token verification (relay-config + device-control, ADR-0006) | `modules/pairing/device-token.ts` — `verifyDeviceControlToken`, `resolveControlChannelEndpoint` |
@@ -47,6 +48,13 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 | Preview single-use token store (in-memory, TTL 30s) + `system.mintPreviewToken` | `modules/ui/preview-token.ts` + `rpc/procedures/system.procedure.ts` |
 | SIM PIN secrets store (opt-in "remember PIN", chmod-600 tmpfs) | `modules/modems/sim-secrets.ts` |
 | Boot SIM PIN auto-unlock hook (bounded, single attempt) | `modules/modems/sim-autounlock.ts` |
+| Cellular-control composition root (`getCellularStack`/`initCellularStack`, `modem_backend` seam, `CELLULAR_STACK_INITIALIZING`) | `modules/cellular/cellular-stack.ts` |
+| Production dbus backend (`@ceralive/modem-control` ModemManager observer; lazy-imported) | `modules/cellular/dbus-backend.ts` |
+| **`modem_shadow` fail-closed D-Bus audit transport (refuses every non-read call incl. `Signal.Setup`; call/refusal log seam)** | `modules/cellular/dbus-audit-transport.ts` |
+| **`modem_shadow` divergence classifier (mmcli-vs-observer diff; `logRedact` reuse; secret-dropping state mappers)** | `modules/cellular/shadow-divergence.ts` |
+| **`modem_shadow` orchestration (read-only observer beside mmcli; DI) + lazy production wiring** | `modules/cellular/shadow.ts` + `modules/cellular/shadow-wiring.ts` |
+| **Legacy numeric wire projection (byte-compatible; autoconfig/`auto` seam; ≥1000 collision-checked replug-stable synthetic ids)** | `modules/modems/modem-wire-projection.ts` (`projectModemWire`, `resolveWireConfig`, `allocateSyntheticIds`) |
+| **Wire-projection backend adapters (mmcli `Modem` + dbus observation view → one normalized source; RAT→display)** | `modules/modems/modem-wire-adapters.ts` (`fromMmcliModem`, `fromDbusView`, `fromRouterView`, `ratsToNetworkTypeDisplay`) |
 | Kiosk DC-2 state machine (toggle runs the `cog-display` add-on via the manager) | `modules/system/kiosk.ts` |
 | Observable logs (getLog/getSyslog → `log` push → LogsDialog download) | `modules/system/logs.ts` + `rpc/procedures/system.procedure.ts` |
 | In-memory log ring buffer (dev/CI journal substitute) | `helpers/logger.ts` — `getRecentLogLines` |
@@ -102,6 +110,192 @@ boot never resubmits a known-wrong PIN. The unlock flow is the intended caller
 (store on a successful unlock when the user chooses "remember"). Coverage:
 `tests/sim-autounlock.test.ts` (mode-600 + config-untouched, boot unlock, bounded
 wrong-PIN, and the no-op gates).
+
+## CELLULAR CONTROL COMPOSITION ROOT [EXISTS]
+
+`modules/cellular/cellular-stack.ts` is the cellular-control seam — the modem
+equivalent of the `getStreamingBackend()` precedent. It selects which control
+backend is live and gates the modem RPC layer while that backend initializes.
+
+- **`modem_backend: 'mmcli' | 'dbus'`** (config-schemas.ts, additive-optional, no
+  default injected → an absent key echoes byte-identical). `mmcli` is the DEFAULT
+  and the legacy one-shot-CLI path; `dbus` selects the `@ceralive/modem-control`
+  ModemManager backend (`dbus-backend.ts`, lazily imported so the D-Bus transport
+  never loads on the default path).
+- **`initCellularStack(deps?)`** — awaited at boot
+  (`guardNonCritical("cellular-stack", …)`, before `initModemUpdateLoop`). mmcli is
+  ready immediately (NO init window — this is what keeps the default path
+  byte-identical). A dbus backend is **committed only after its first authoritative
+  snapshot**; until then the stack is `ready:false`. An init failure, a
+  non-authoritative snapshot, or a hang past the bounded init window (default 15s)
+  **falls back to mmcli** and flips an OBSERVABLE `degraded` flag — both on
+  `getCellularStack()` and on the boot-readiness surface (`markBootDegraded` →
+  `/api/health`).
+- **`assertCellularStackReady()`** — the shared gate. Every modem procedure runs it
+  via the `cellularStackMiddleware` in `modems.procedure.ts`; while a dbus backend
+  is initializing it throws the typed **`CELLULAR_STACK_INITIALIZING`** oRPC error
+  (never a raw throw, never a hang — the init window has bounded behaviour). It is a
+  no-op on the ready mmcli default, so the gate never fires on the default path and
+  the modem outputs are unchanged. The gate + error code are exported for later
+  Phase-B consumers (e.g. the `modem.reconfig` control-channel command, which is a
+  `modules/remote-control` self-fencing op, NOT yet an oRPC procedure).
+- **`getCellularStack()`** returns the observable `{ backend, ready, degraded,
+  degradedReason? }` snapshot; **`stopCellularStack()`** releases a committed dbus
+  backend's transport.
+
+Phase B foundation only: the modem procedures still drive the existing mmcli code
+directly. Later Phase-B todos consume the committed dbus backend. Coverage:
+`tests/cellular-stack.test.ts` (commit-after-snapshot, init-fail/hang/ok:false
+fallback, gate, teardown) + `tests/modems-cellular-gate.test.ts` (procedure gate).
+
+## MODEM SHADOW MODE [EXISTS]
+
+`modem_shadow` (config-schemas.ts, additive-optional, no default) runs the
+`@ceralive/modem-control` READ-ONLY observer BESIDE the live mmcli path, for
+pre-cutover parity comparison. It is orthogonal to `modem_backend`: mmcli stays the
+ACTIVE, authoritative control path; the shadow observer only WATCHES and logs
+redacted divergences. It never becomes the control path and never mutates the bus.
+Wired at boot via `guardNonCritical("cellular-shadow", startModemShadowIfEnabled)`
+(after `initCellularStack`); a no-op unless `modem_shadow === true`, so the default
+path never loads the D-Bus transport.
+
+- **Mutation-free by guard — `dbus-audit-transport.ts`.** `createAuditingTransport`
+  wraps the observer's transport and FAILS CLOSED: a method call is forwarded ONLY
+  when its `interface.member` is in `SHADOW_READ_ONLY_MEMBERS`
+  (`GetNameOwner` / `GetManagedObjects` / `GetCellInfo`). Every mutation
+  (`SetCurrentModes`, `SetPrimarySimSlot`, `Modem3gpp.Scan`, `InhibitDevice`,
+  `SendPin`, `SendPuk`, and the annex-called-out **`Signal.Setup`**) AND any
+  unknown/future member is refused with a `ShadowMutationError` and NEVER reaches
+  the bus ("in doubt → treat as a write"). `Signal.Setup` LOOKS like a passive
+  signal-watch subscription but is a MUTATING call; it is in the deny set. Signal
+  SUBSCRIPTIONS pass through (observational). The wrapper records an ordered
+  call/refusal log so the transport-level audit test spies on the ACTUAL dispatch.
+  The read-only observer (`createMmDbusObserver`, the narrow `ModemObservationPort`)
+  is already mutation-free by construction — `Signal.Setup` lives only in the FULL
+  `createMmDbusBackend`, which shadow mode never uses; the auditing transport is the
+  belt-and-braces guard proving it.
+- **Redacted divergence classifier — `shadow-divergence.ts`.** Compares mmcli-
+  reported vs observer-reported state normalized to `ShadowModemState` — a
+  NON-secret shape (no ICCID/EID/PIN/PUK/APN/password by construction; the mappers
+  copy a non-secret allowlist and the observation mapper keys on the logical-slot /
+  equipment id, NEVER the subscription id/ICCID). `classifyShadowDivergences` yields
+  `only-in-mmcli` / `only-in-dbus` / `field-mismatch` diffs; `logShadowDivergences`
+  scrubs the payload through the SHARED `logRedact` helper (`helpers/logger.ts`)
+  before logging — field-mismatches are keyed by field name so a sensitive-keyed
+  field is scrubbed wholesale and any token/PASETO/bearer value is scrubbed by shape.
+  Reuses CeraUI's ONE redaction mechanism — never a parallel one.
+- **Orchestration — `shadow.ts` / `shadow-wiring.ts`.** `startModemShadow(deps)`
+  (DI; idempotent) wraps the transport in the auditing guard, starts the read-only
+  observer, and on every snapshot maps both sides + logs redacted divergences.
+  Production deps (`shadow-wiring.ts`) are lazily imported so the package graph never
+  loads on the default path (mirrors `dbus-backend.ts`).
+
+Coverage: `tests/cellular-shadow-audit.test.ts` (drives the REAL observer through the
+auditing transport — asserts only read-only calls, zero mutations, `Signal.Setup`
+never in the log; fail-closed refusal of every mutation incl. `Signal.Setup`) +
+`tests/cellular-shadow-divergence.test.ts` (classifier, `logRedact` redaction of
+secret-shaped/keyed values, secret-dropping mappers, and the injected fake-divergence
+redacted-only QA scenario).
+
+### mmcli backend retirement gate
+
+`modem_shadow` exists to earn the mmcli→dbus cutover. Retiring the legacy mmcli
+backend is gated by an explicit, dated criteria set recorded in the machine-checkable
+tech-debt register (`docs/TECHNICAL_DEBT.md` → `TD-mmcli-retirement`, enforced by
+`scripts/check-tech-debt.mjs`): **≥14 days shadow on ≥2 devices, zero unexplained
+divergences, HIL parity, rollback drill, one dbus-default release** (the criteria
+settled in the modem-control-package Phase-B annex). Until every criterion is met,
+mmcli stays the DEFAULT `modem_backend` and the authoritative control path; only then
+does the default flip to `dbus`, the mmcli backend + `fromMmcliModem` wire adapter +
+the shadow-parity harness get deleted, and the register entry flips to `resolved`. Do
+NOT flip the `modem_backend` default or delete the mmcli path ahead of that register
+gate — this note is the pointer that binds the composition root, shadow mode, wire
+projection, and the streaming interlock above to their single retirement authority.
+
+## LEGACY NUMERIC WIRE PROJECTION [EXISTS]
+
+The seam that projects a modem snapshot from EITHER control backend into the
+EXISTING numeric-id `status.modems` wire shape the frontend already consumes
+(`modem-status.ts::buildModemsMessage` — `Record<numericModemId, entry>`). Both
+backends feed ONE projector, so the frontend can never tell which is live (the
+byte-compatible claim). This is Phase-B capability only: the live mmcli broadcast
+path (`broadcastModems`) is UNCHANGED — it still calls `buildModemsMessage`
+verbatim; the projector merely reproduces that exact shape (regression-locked
+byte-for-byte) and the dbus path consumes it later.
+
+- **`modules/modems/modem-wire-projection.ts`** — the pure projector.
+  `projectModemWire(sources, {hasGsmAutoconfig, previousSyntheticIds?})` builds the
+  wire message from the backend-agnostic `ProjectedModemSource[]`. Three
+  legacy-compat invariants live HERE, at the seam:
+  - **`autoconfig` mapped once** in `resolveWireConfig` — the wire value is
+    `hasGsmAutoconfig && config.autoconfig` (mirrors `modem-status.ts:114`).
+  - **`"auto"` NEVER echoed** — an auto-config APN (or a raw `AUTO_APN_SENTINEL`)
+    resolves to the concrete legacy value, empty string, exactly as the mmcli path
+    clears it (`modem-registration.ts::applyAutoconfigToModemConfig`).
+  - **Router/unmanaged rows** (`runtimeId: null`) take synthetic ids from the
+    reserved ≥`SYNTHETIC_ID_BASE` (1000) namespace via `allocateSyntheticIds`:
+    collision-checked against the live MM runtime ids (an MM id ≥1000 is skipped —
+    "≥1000 is always safe" is NOT assumed) and REPLUG-STABLE (allocation walks
+    `stableKey` order, reuses a device's prior id from `previousSyntheticIds` — never
+    array/insertion order, which does not survive replug).
+- **`modules/modems/modem-wire-adapters.ts`** — the two backend adapters.
+  `fromMmcliModem(id, modem)` normalizes a legacy `Modem` (its output projects
+  byte-identically to `buildModemsMessage` — the reference the dbus side matches).
+  `fromDbusView(view)` maps a `@ceralive/modem-control` observation view
+  (`CellularSnapshot` state dims + MM-interface descriptor + NM-owned config) into
+  the SAME normalized source: `status.connection` from `mmState` (same MM grammar,
+  `scanning` override), `roaming` from `registration.status`, `status.network_type`
+  DISPLAY from the active-RAT set via `ratsToNetworkTypeDisplay` (matches
+  `mmcli.ts::mmConvertAccessTech` — NOT the mode label), `no_sim` from the absence of
+  an NM profile. `fromRouterView(view)` normalizes a non-MM router/unmanaged device
+  (`runtimeId: null`, hardware-stable `stableKey`). The dbus config comes from the NM
+  readback the descriptor carries — the MM snapshot omits secrets (ICCID/APN) by
+  construction.
+
+Coverage: `tests/modem-wire-projection.test.ts` — the golden-fixture test (same
+fake-harness scenario set under mmcli AND dbus projects to a byte-identical payload),
+the regression lock (mmcli projection == `buildModemsMessage`), the autoconfig/`auto`
+seam, the ≥1000 collision test, and the replug-stability + array-order-independence
+tests.
+
+## STREAMING ↔ MODEM-LIFECYCLE INTERLOCK [EXISTS]
+
+`modules/streaming/lifecycle-admission.ts` is the LifecycleInterlock (Phase B,
+T5.5): the single mutual-exclusion guard between STREAMING ADMISSION and MODEM
+LIFECYCLE mutations. A modem USB-composition switch (`modems.setUsbMode`) or a
+future, DEFAULT-DISABLED autonomous cellular recovery / USB-reset re-enumerates a
+modem and tears its bond link down; a stream admission mid-transition (or a
+transition mid-admission) breaks the bond math. The two are therefore mutually
+exclusive in BOTH race orders.
+
+- **Primitive** — modeled on `network/state/device-lock.ts`: a single global
+  holder (`"streaming" | "modem-transition"`), FAIL-FAST (a contended acquire is
+  refused immediately, never queued), no deps beyond `logger`.
+  `tryAcquireLifecycle(who)` returns a `LifecycleLease | null`;
+  `withLifecycleLock(who, fn)` runs `fn` under the lock and releases in a `finally`
+  on ANY exit (return OR throw) — the no-deadlock guarantee. `lease.release()` is
+  idempotent, so a `finally` may release after the body already did and a stale
+  lease never frees a later holder.
+- **Streaming side** (`rpc/procedures/streaming.procedure.ts`): `streaming.start`
+  acquires `tryAcquireLifecycle("streaming")` at the top of the pre-engine
+  admission window (right after the `startInFlight` guard) and releases it in the
+  SAME `finally` as `startInFlight`. A modem transition already holding the
+  interlock refuses the admission pre-engine with the stable `MODEM_TRANSITION_ACTIVE`
+  error. The interlock is held ONLY across admission; the LIVE window is guarded
+  separately by `getIsStreaming()`.
+- **Modem side** (`rpc/procedures/modems.procedure.ts`): `setUsbMode`, AFTER its
+  `modem_provisioning` + `isRealDevice()` gates, refuses with the existing
+  `streaming_active` code when `getIsStreaming()` is true (LIVE) OR when it cannot
+  acquire `withLifecycleLock("modem-transition", …)` (ADMISSION-window race —
+  "admitted-start, not just is_streaming"). Holding the lock across the transition
+  blocks a concurrent stream admission in turn.
+
+This ships the interlock plumbing only — NO autonomous recovery loop is wired
+anywhere; cellular recovery stays default-disabled. Coverage:
+`tests/cellular-lifecycle-interlock.test.ts` (both race orders via genuine async
+coordination + finally-release/no-deadlock + idempotent release) and
+`tests/modems-streaming-interlock.test.ts` (the real-procedure wiring on both sides,
+plus the release-on-failure and release-on-success handoff to the live guard).
 
 ## PREVIEW WEBSOCKET PROXY — single-origin (Task 20) [EXISTS]
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -11,6 +11,7 @@
 	"dependencies": {
 		"@ceralive/cerastream": "2026.7.1",
 		"@ceralive/control-protocol": "2026.7.0",
+		"@ceralive/modem-control": "0.2.0",
 		"@ceralive/srtla-send": "2026.6.2",
 		"@ceraui/rpc": "workspace:*",
 		"@orpc/server": "^1.14.7",

--- a/apps/backend/src/helpers/config-schemas.ts
+++ b/apps/backend/src/helpers/config-schemas.ts
@@ -149,6 +149,14 @@ export const balancerSchema = z.enum(["adaptive", "fixed", "aimd"]);
 
 export type Balancer = z.infer<typeof balancerSchema>;
 
+// Per-boot cellular-control backend selection. `mmcli` (default) is the legacy
+// one-shot-CLI path; `dbus` selects the @ceralive/modem-control ModemManager
+// backend, committed only after its first snapshot — see the commit/fallback
+// contract in modules/cellular/cellular-stack.ts.
+export const modemBackendSchema = z.enum(["mmcli", "dbus"]);
+
+export type ModemBackend = z.infer<typeof modemBackendSchema>;
+
 // One persisted last-seen capture-device snapshot (C7 lost-device retention),
 // carrying exactly the fields `captureSourceSchema` needs to synthesize a `lost`
 // row: `devicePath` is REQUIRED there, and `pipelineId` is the
@@ -283,6 +291,26 @@ export const runtimeConfigSchema = z.object({
 	// every source visible via the inner default; kept `.optional()` so
 	// `let config: RuntimeConfig = {}` still parses (E3 additive pattern).
 	sources_visibility: sourcesVisibilitySchema.optional(),
+
+	// Per-boot cellular-control backend selection. Absent (old config) resolves to
+	// the mmcli default in the composition root — no default is injected here so an
+	// existing config's echo stays byte-identical (additive-optional).
+	modem_backend: modemBackendSchema.optional(),
+
+	// Opt-in `modem_shadow` observation (Phase B). When true, the read-only
+	// @ceralive/modem-control observer runs BESIDE the active (mmcli) backend and
+	// logs redacted divergences — it never becomes the control path and never
+	// mutates the bus. Additive-optional with no injected default: an absent key
+	// (old config) echoes byte-identical and shadow mode stays off.
+	modem_shadow: z.boolean().optional(),
+
+	// Opt-in `modem_provisioning` gate (Phase B, T5.4). DEFAULT-ABSENT: while this
+	// key is absent (every existing device that hasn't opted in) the guarded
+	// USB-composition-mode mutation is UNREACHABLE — the setUsbMode RPC refuses
+	// with a typed error at entry, not merely hidden in the UI. No default is
+	// injected here so an absent key echoes byte-identical (additive-optional);
+	// the mutation stays off until an operator explicitly provisions it.
+	modem_provisioning: z.boolean().optional(),
 });
 
 export type RuntimeConfig = z.infer<typeof runtimeConfigSchema>;

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -43,6 +43,8 @@ import {
 	getMockEngineDevices,
 } from "./mocks/providers/streaming.ts";
 import { runAddonReconciler } from "./modules/addons/reconciler.ts";
+import { initCellularStack } from "./modules/cellular/cellular-stack.ts";
+import { startModemShadowIfEnabled } from "./modules/cellular/shadow.ts";
 import { getConfig, loadConfig } from "./modules/config.ts";
 import { initIdentity } from "./modules/identity/index.ts";
 import { initRTMPIngestStats } from "./modules/ingest/rtmp.ts";
@@ -286,6 +288,15 @@ wifiStateInit(networkMonitor);
 
 // Hotspot NM-confirmation: flips station↔hotspot once NM reports the switch
 networkMonitor.on("monitor-event", handleHotspotMonitorEvent);
+
+// Cellular-control composition root: select + init the modem backend. Awaited
+// before the modem loop so the init gate is settled before any modem procedure
+// runs (mmcli default is an instant no-op; dbus opt-in commits or falls back).
+await guardNonCritical("cellular-stack", initCellularStack);
+
+// Opt-in read-only observer beside mmcli. A no-op unless `modem_shadow` is set, so
+// the default path never loads the D-Bus transport. Never mutates the bus.
+await guardNonCritical("cellular-shadow", startModemShadowIfEnabled);
 
 // Event-driven modems share the SAME monitor (one nmcli monitor for all)
 void initModemUpdateLoop({ monitor: networkMonitor });

--- a/apps/backend/src/modules/cellular/cellular-stack.ts
+++ b/apps/backend/src/modules/cellular/cellular-stack.ts
@@ -1,0 +1,230 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Cellular-control composition root (Phase B seam).
+ *
+ * Mirrors the `getStreamingBackend()` seam precedent: one selection point so the
+ * modem RPC layer never hard-codes which control backend is live. `mmcli` (the
+ * default) is the legacy one-shot-CLI path and is synchronously ready — it has no
+ * init window, so the default backend behaves exactly as it did before this seam
+ * existed. `dbus` selects the `@ceralive/modem-control` ModemManager backend.
+ *
+ * Two invariants make the dbus path safe:
+ *   1. COMMIT-AFTER-FIRST-SNAPSHOT — a dbus backend is only committed once it
+ *      confirms its first authoritative snapshot. Until then the stack is
+ *      "initializing" and every modem procedure returns the typed
+ *      {@link CELLULAR_STACK_INITIALIZING} error (never a raw throw, never a hang).
+ *   2. FALLBACK-ON-FAILURE — an init failure, a non-authoritative snapshot, or a
+ *      hang past the bounded init window falls back to mmcli and flips an
+ *      OBSERVABLE degraded-readiness flag (both on this stack and on the boot
+ *      readiness surface at `/api/health`).
+ *
+ * Phase B foundation only: the modem procedures still drive the existing mmcli
+ * code directly. Later Phase-B todos consume the committed dbus backend (shadow
+ * mode, wire projection). The reusable {@link assertCellularStackReady} gate is
+ * exported for those todos (e.g. the `modem.reconfig` control-channel command,
+ * which is not yet an oRPC procedure).
+ */
+
+import { ORPCError } from "@orpc/server";
+import type { ModemBackend } from "../../helpers/config-schemas.ts";
+import { logger } from "../../helpers/logger.ts";
+import { getConfig } from "../config.ts";
+import { markBootDegraded } from "../system/readiness.ts";
+
+export type ModemBackendKind = ModemBackend;
+
+export const DEFAULT_MODEM_BACKEND: ModemBackendKind = "mmcli";
+
+/** oRPC error code returned by every modem procedure while dbus init is in flight. */
+export const CELLULAR_STACK_INITIALIZING = "CELLULAR_STACK_INITIALIZING";
+
+/** Subsystem name recorded on the boot-readiness surface on a dbus fallback. */
+const CELLULAR_SUBSYSTEM = "cellular-stack";
+
+/** Reason surfaced on the stack when a dbus init falls back to mmcli. */
+const DBUS_FALLBACK_REASON = "cellular_dbus_init_failed";
+
+/** Bounded init window; a dbus backend that does not snapshot within it falls back. */
+const DEFAULT_INIT_TIMEOUT_MS = 15_000;
+
+/** The outcome of a backend's awaited init — `ok` only on an authoritative snapshot. */
+export interface CellularStartResult {
+	readonly ok: boolean;
+}
+
+/**
+ * A cellular-control backend. `start()` performs the awaited init and resolves
+ * the first snapshot; `stop()` releases the source and is idempotent.
+ */
+export interface CellularBackend {
+	start(): Promise<CellularStartResult>;
+	stop(): Promise<void>;
+}
+
+export type CellularBackendFactory = () => CellularBackend;
+
+/** Observable readiness snapshot of the committed cellular-control backend. */
+export interface CellularStack {
+	readonly backend: ModemBackendKind;
+	readonly ready: boolean;
+	readonly degraded: boolean;
+	readonly degradedReason?: string;
+}
+
+export interface InitCellularStackDeps {
+	/** Force the backend (tests). Default: `config.modem_backend ?? "mmcli"`. */
+	backend?: ModemBackendKind;
+	/** Inject the dbus backend factory (tests). Default: lazy production factory. */
+	createDbusBackend?: CellularBackendFactory;
+	/** Bounded init window before falling back to mmcli (default 15s). */
+	initTimeoutMs?: number;
+}
+
+const READY_MMCLI: CellularStack = {
+	backend: "mmcli",
+	ready: true,
+	degraded: false,
+};
+
+// Process-wide singleton (same posture as the identity / readiness singletons).
+// DEFAULT is mmcli-ready with no init window, so the default backend — and every
+// existing modem test that never calls init — sees a ready stack byte-identically.
+let stack: CellularStack = READY_MMCLI;
+let activeBackend: CellularBackend | null = null;
+
+/** The committed cellular-control backend readiness snapshot. */
+export function getCellularStack(): CellularStack {
+	return stack;
+}
+
+/**
+ * Throw the typed {@link CELLULAR_STACK_INITIALIZING} error while a dbus backend
+ * is still initializing. A no-op on the ready mmcli default, so it never fires on
+ * the default path. Shared by every modem procedure and (later) `modem.reconfig`.
+ */
+export function assertCellularStackReady(): void {
+	if (!stack.ready) {
+		throw new ORPCError(CELLULAR_STACK_INITIALIZING, {
+			message: "Cellular stack is initializing",
+		});
+	}
+}
+
+/**
+ * Select and initialize the cellular-control backend. Awaited at boot. mmcli is
+ * ready immediately; dbus is gated until its first snapshot commits or it falls
+ * back to mmcli + degraded. Never throws — a failure resolves as a degraded
+ * fallback, so boot continues.
+ */
+export async function initCellularStack(
+	deps: InitCellularStackDeps = {},
+): Promise<void> {
+	const selected =
+		deps.backend ?? getConfig().modem_backend ?? DEFAULT_MODEM_BACKEND;
+
+	if (selected === "mmcli") {
+		stack = READY_MMCLI;
+		return;
+	}
+
+	// dbus: gate every modem procedure until the first authoritative snapshot.
+	stack = { backend: "dbus", ready: false, degraded: false };
+	const factory = deps.createDbusBackend ?? (await loadProductionDbusFactory());
+	const backend = factory();
+	activeBackend = backend;
+
+	try {
+		const result = await withTimeout(
+			backend.start(),
+			deps.initTimeoutMs ?? DEFAULT_INIT_TIMEOUT_MS,
+		);
+		if (!result.ok) {
+			throw new Error("dbus backend produced no authoritative snapshot");
+		}
+		stack = { backend: "dbus", ready: true, degraded: false };
+	} catch (err) {
+		logger.warn(
+			`cellular stack: dbus backend init failed — falling back to mmcli (${errorMessage(
+				err,
+			)})`,
+		);
+		await safeStop(backend);
+		activeBackend = null;
+		markBootDegraded(CELLULAR_SUBSYSTEM);
+		stack = {
+			backend: "mmcli",
+			ready: true,
+			degraded: true,
+			degradedReason: DBUS_FALLBACK_REASON,
+		};
+	}
+}
+
+/**
+ * Stop the committed dbus backend and release its transport, then reset to the
+ * mmcli default. Idempotent — a no-op on the mmcli path (no active backend).
+ */
+export async function stopCellularStack(): Promise<void> {
+	const backend = activeBackend;
+	activeBackend = null;
+	stack = READY_MMCLI;
+	if (backend) {
+		await safeStop(backend);
+	}
+}
+
+/** Test seam: synchronously reset to the ready mmcli default. */
+export function resetCellularStack(): void {
+	stack = READY_MMCLI;
+	activeBackend = null;
+}
+
+async function loadProductionDbusFactory(): Promise<CellularBackendFactory> {
+	const { createDbusCellularBackend } = await import("./dbus-backend.ts");
+	return createDbusCellularBackend;
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const timeout = new Promise<never>((_resolve, reject) => {
+		timer = setTimeout(
+			() => reject(new Error(`cellular init exceeded ${ms}ms`)),
+			ms,
+		);
+	});
+	try {
+		return await Promise.race([promise, timeout]);
+	} finally {
+		if (timer !== undefined) {
+			clearTimeout(timer);
+		}
+	}
+}
+
+async function safeStop(backend: CellularBackend): Promise<void> {
+	try {
+		await backend.stop();
+	} catch (err) {
+		logger.debug(`cellular stack: stop() after fallback failed: ${err}`);
+	}
+}
+
+function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}

--- a/apps/backend/src/modules/cellular/dbus-audit-transport.ts
+++ b/apps/backend/src/modules/cellular/dbus-audit-transport.ts
@@ -1,0 +1,186 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Fail-closed D-Bus transport audit for `modem_shadow` (Phase B).
+ *
+ * Shadow mode observes the SAME modem hardware mmcli is actively driving, but must
+ * be MUTATION-FREE — the binding-ledger invariant is "zero `Signal.Setup` calls"
+ * (`.omo/plans/modem-control-package.md` §annex). `Signal.Setup` LOOKS like a
+ * passive signal-watch subscription, but it is a MUTATING ModemManager call that
+ * turns on periodic extended signal reporting, so it is in the deny set below.
+ *
+ * This wraps any `@ceralive/modem-control` {@link DbusTransport} and enforces a
+ * FAIL-CLOSED allowlist: a method call is forwarded to the bus ONLY when its
+ * fully-qualified `interface.member` is in {@link SHADOW_READ_ONLY_MEMBERS}. Every
+ * other member — the known mutations AND any unknown/future member — is refused
+ * with a {@link ShadowMutationError} and NEVER reaches the inner transport
+ * ("in doubt → treat as a write"). Signal SUBSCRIPTIONS are observational reads and
+ * pass through unchanged.
+ *
+ * The wrapper also records an ordered call log + refusal log, so the safety-critical
+ * audit test can spy on the ACTUAL dispatch of the real observer rather than assert
+ * by code review.
+ *
+ * The member classification is derived from the package dispatch sites
+ * (`@ceralive/modem-control` `src/backend/*`): the read-only observer calls only
+ * `GetNameOwner` + `GetManagedObjects`; `GetCellInfo` is the one further read the
+ * full backend can make; the mutations live in `mm-mutations.ts` / `sim-unlock.ts` /
+ * `signal-setup.ts`.
+ */
+
+import type {
+	DbusTransport,
+	MethodCall,
+	MethodReply,
+	SignalListener,
+	SignalSpec,
+	Subscription,
+	TransportEvent,
+} from "@ceralive/modem-control/transport";
+
+/** `interface.member` key for a call or signal spec. */
+export function memberKey(call: {
+	readonly interface: string;
+	readonly member: string;
+}): string {
+	return `${call.interface}.${call.member}`;
+}
+
+/**
+ * The ONLY D-Bus method members shadow mode may dispatch. Everything else is
+ * refused. `GetNameOwner` + `GetManagedObjects` are the read-only observer's two
+ * calls; `GetCellInfo` is the additional read the full backend can make — included
+ * so a future read-only cell-info observation is not spuriously refused.
+ */
+export const SHADOW_READ_ONLY_MEMBERS: ReadonlySet<string> = new Set<string>([
+	"org.freedesktop.DBus.GetNameOwner",
+	"org.freedesktop.DBus.ObjectManager.GetManagedObjects",
+	"org.freedesktop.ModemManager1.Modem.GetCellInfo",
+]);
+
+/** One mutating ModemManager member, split into its interface + member. */
+export interface MutatingMemberCall {
+	readonly interface: string;
+	readonly member: string;
+}
+
+/**
+ * Every mutating member the `@ceralive/modem-control` package can dispatch. This is
+ * documentation + the explicit deny surface the audit test iterates; the runtime
+ * guard is the fail-closed allowlist above, which refuses these AND anything not
+ * enumerated as a read.
+ */
+export const MUTATING_DBUS_MEMBER_CALLS: readonly MutatingMemberCall[] = [
+	{
+		interface: "org.freedesktop.ModemManager1.Modem",
+		member: "SetCurrentModes",
+	},
+	{
+		interface: "org.freedesktop.ModemManager1.Modem",
+		member: "SetPrimarySimSlot",
+	},
+	{
+		interface: "org.freedesktop.ModemManager1.Modem.Modem3gpp",
+		member: "Scan",
+	},
+	{ interface: "org.freedesktop.ModemManager1", member: "InhibitDevice" },
+	{ interface: "org.freedesktop.ModemManager1.Sim", member: "SendPin" },
+	{ interface: "org.freedesktop.ModemManager1.Sim", member: "SendPuk" },
+	// LOOKS passive, is a mutation — the annex-called-out invariant.
+	{ interface: "org.freedesktop.ModemManager1.Modem.Signal", member: "Setup" },
+];
+
+/** The mutating members as fully-qualified `interface.member` keys. */
+export const MUTATING_DBUS_MEMBERS: ReadonlySet<string> = new Set(
+	MUTATING_DBUS_MEMBER_CALLS.map(memberKey),
+);
+
+/** Thrown when shadow mode attempts (or a bug attempts) a non-read D-Bus call. */
+export class ShadowMutationError extends Error {
+	readonly member: string;
+	constructor(member: string) {
+		super(
+			`modem shadow refused a non-read D-Bus call: ${member} (shadow mode is mutation-free)`,
+		);
+		this.name = "ShadowMutationError";
+		this.member = member;
+	}
+}
+
+/** A {@link DbusTransport} that records its call log and refusal log for auditing. */
+export interface AuditingTransport extends DbusTransport {
+	/** Every method member the guard admitted and forwarded, in dispatch order. */
+	getCallLog(): readonly string[];
+	/** Every method member the guard refused, in attempt order. */
+	getRefusedCalls(): readonly string[];
+}
+
+export interface AuditingTransportDeps {
+	/** Notified (member key) whenever a non-read call is refused. */
+	readonly onRefusal?: (member: string) => void;
+}
+
+/**
+ * Wrap a transport so shadow mode can dispatch ONLY read-only members. A refused
+ * call throws {@link ShadowMutationError} and is never forwarded to `inner`; signal
+ * subscriptions and lifecycle passthroughs are untouched.
+ */
+export function createAuditingTransport(
+	inner: DbusTransport,
+	deps: AuditingTransportDeps = {},
+): AuditingTransport {
+	const callLog: string[] = [];
+	const refusedCalls: string[] = [];
+
+	return {
+		connect: () => inner.connect(),
+		disconnect: () => inner.disconnect(),
+		isConnected: () => inner.isConnected(),
+
+		async callMethod(call: MethodCall): Promise<MethodReply> {
+			const key = memberKey(call);
+			if (!SHADOW_READ_ONLY_MEMBERS.has(key)) {
+				// Fail closed: known mutation OR unknown member → refuse, never forward.
+				refusedCalls.push(key);
+				deps.onRefusal?.(key);
+				throw new ShadowMutationError(key);
+			}
+			callLog.push(key);
+			return inner.callMethod(call);
+		},
+
+		subscribeSignal(
+			spec: SignalSpec,
+			listener: SignalListener,
+		): Promise<Subscription> {
+			// Signal subscriptions are observational reads — they never mutate the modem.
+			return inner.subscribeSignal(spec, listener);
+		},
+
+		on(event: TransportEvent, handler: (payload?: unknown) => void): void {
+			inner.on(event, handler);
+		},
+		off(event: TransportEvent, handler: (payload?: unknown) => void): void {
+			inner.off(event, handler);
+		},
+		subscriptionCount: () => inner.subscriptionCount(),
+
+		getCallLog: () => [...callLog],
+		getRefusedCalls: () => [...refusedCalls],
+	};
+}

--- a/apps/backend/src/modules/cellular/dbus-backend.ts
+++ b/apps/backend/src/modules/cellular/dbus-backend.ts
@@ -1,0 +1,53 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Production dbus cellular backend — a thin adapter over the
+ * `@ceralive/modem-control` epoch-scoped ModemManager D-Bus observer.
+ *
+ * `start()` connects the system bus and resolves the first authoritative
+ * snapshot (the composition root's commit point). With no reachable bus
+ * (dev / CI / no hardware) `start()` rejects, so the composition root falls back
+ * to mmcli with degraded readiness. Lazily imported by `cellular-stack.ts` only
+ * when the dbus backend is selected, so the D-Bus transport never loads on the
+ * default mmcli path.
+ *
+ * Phase B foundation only: the observer's ongoing snapshot stream is consumed by
+ * a later todo (shadow mode). This wave commits the seam + the registry dep.
+ */
+
+import { createMmDbusObserver } from "@ceralive/modem-control";
+import { createDbusTransport } from "@ceralive/modem-control/transport";
+
+import type { CellularBackend, CellularStartResult } from "./cellular-stack.ts";
+
+const SYSTEM_BUS_ADDRESS = "unix:path=/var/run/dbus/system_bus_socket";
+
+export function createDbusCellularBackend(): CellularBackend {
+	const transport = createDbusTransport({
+		busAddress: process.env.DBUS_SYSTEM_BUS_ADDRESS ?? SYSTEM_BUS_ADDRESS,
+	});
+	const observer = createMmDbusObserver({ transport });
+
+	return {
+		async start(): Promise<CellularStartResult> {
+			const list = await observer.start();
+			return { ok: list.ok };
+		},
+		stop: () => observer.stop(),
+	};
+}

--- a/apps/backend/src/modules/cellular/shadow-divergence.ts
+++ b/apps/backend/src/modules/cellular/shadow-divergence.ts
@@ -1,0 +1,246 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * `modem_shadow` divergence classifier (Phase B).
+ *
+ * Compares what mmcli reports against what the read-only dbus observer reports for
+ * the SAME modem hardware and logs the differences — REDACTED. Two layers keep
+ * secrets out of the log ("no ICCID/PIN/secrets" — annex):
+ *
+ *   1. EXCLUSION — the normalized {@link ShadowModemState} carries only non-secret
+ *      observables. The state mappers ({@link mmcliModemToShadowState},
+ *      {@link observationRowToShadowState}) copy an allowlist of fields and drop
+ *      ICCID/EID (subscription id), PIN/PUK, APN, and password by construction.
+ *   2. REDACTION — the log payload is scrubbed through the shared
+ *      {@link logRedact} helper before it reaches any transport, so a secret-shaped
+ *      value or a sensitive-keyed field that ever slipped into a comparable field is
+ *      still scrubbed. This reuses CeraUI's ONE redaction mechanism — never a
+ *      parallel one.
+ *
+ * The classifier is pure; the log function's sink is injectable for tests.
+ */
+
+import { logger, logRedact } from "../../helpers/logger.ts";
+
+/**
+ * Normalized, NON-SECRET modem state used for shadow comparison. There is no
+ * ICCID/EID/PIN/PUK/APN/password field here — secrets never enter the comparison.
+ * `id` is a non-secret stable join key (ifname / logical slot / equipment id).
+ */
+export interface ShadowModemState {
+	readonly id: string;
+	readonly present: boolean;
+	readonly registration?: string;
+	readonly signalBucket?: string;
+	readonly operatorName?: string;
+	readonly simPresent?: boolean;
+	readonly networkType?: string;
+}
+
+/** The comparable dimensions (everything on {@link ShadowModemState} except `id`). */
+const COMPARABLE_FIELDS = [
+	"present",
+	"registration",
+	"signalBucket",
+	"operatorName",
+	"simPresent",
+	"networkType",
+] as const satisfies ReadonlyArray<Exclude<keyof ShadowModemState, "id">>;
+
+export interface ShadowFieldDivergence {
+	readonly field: string;
+	readonly mmcli: unknown;
+	readonly dbus: unknown;
+}
+
+export type ShadowDivergenceKind =
+	| "only-in-mmcli"
+	| "only-in-dbus"
+	| "field-mismatch";
+
+export interface ShadowModemDivergence {
+	readonly id: string;
+	readonly kind: ShadowDivergenceKind;
+	readonly fields?: readonly ShadowFieldDivergence[];
+}
+
+/** The log message shadow divergences are emitted under. */
+export const SHADOW_DIVERGENCE_MSG = "modem shadow divergence";
+
+/**
+ * Compare mmcli-reported vs dbus-observed states. A modem present in only one side
+ * is `only-in-*`; a shared modem with differing comparable fields yields a
+ * `field-mismatch` with the per-field pairs. Identical states → `[]`.
+ */
+export function classifyShadowDivergences(
+	mmcli: readonly ShadowModemState[],
+	dbus: readonly ShadowModemState[],
+): ShadowModemDivergence[] {
+	const mmcliById = new Map(mmcli.map((s) => [s.id, s]));
+	const dbusById = new Map(dbus.map((s) => [s.id, s]));
+	const divergences: ShadowModemDivergence[] = [];
+
+	for (const [id, mmcliState] of mmcliById) {
+		const dbusState = dbusById.get(id);
+		if (dbusState === undefined) {
+			divergences.push({ id, kind: "only-in-mmcli" });
+			continue;
+		}
+		const fields = diffFields(mmcliState, dbusState);
+		if (fields.length > 0) {
+			divergences.push({ id, kind: "field-mismatch", fields });
+		}
+	}
+	for (const [id] of dbusById) {
+		if (!mmcliById.has(id)) {
+			divergences.push({ id, kind: "only-in-dbus" });
+		}
+	}
+	return divergences;
+}
+
+function diffFields(
+	mmcli: ShadowModemState,
+	dbus: ShadowModemState,
+): ShadowFieldDivergence[] {
+	const fields: ShadowFieldDivergence[] = [];
+	for (const field of COMPARABLE_FIELDS) {
+		if (mmcli[field] !== dbus[field]) {
+			fields.push({ field, mmcli: mmcli[field], dbus: dbus[field] });
+		}
+	}
+	return fields;
+}
+
+/**
+ * Build the redacted log payload. Each field-mismatch is reshaped to key the diff BY
+ * the field name, so {@link logRedact}'s sensitive-key rule scrubs a `simPin`-style
+ * field wholesale, while its value-shape rule scrubs any token/PASETO/bearer value.
+ */
+export function redactShadowDivergences(
+	divergences: readonly ShadowModemDivergence[],
+): unknown {
+	const shaped = divergences.map((divergence) => {
+		if (divergence.kind === "field-mismatch" && divergence.fields) {
+			const fields: Record<string, { mmcli: unknown; dbus: unknown }> = {};
+			for (const field of divergence.fields) {
+				fields[field.field] = { mmcli: field.mmcli, dbus: field.dbus };
+			}
+			return { id: divergence.id, kind: divergence.kind, fields };
+		}
+		return { id: divergence.id, kind: divergence.kind };
+	});
+	return logRedact({ count: divergences.length, divergences: shaped });
+}
+
+export interface ShadowDivergenceLogDeps {
+	/** Sink for the redacted divergence record. Defaults to `logger.warn`. */
+	readonly log?: ((msg: string, meta: unknown) => void) | undefined;
+}
+
+/** Log the redacted divergences. A no-op when there are none. */
+export function logShadowDivergences(
+	divergences: readonly ShadowModemDivergence[],
+	deps: ShadowDivergenceLogDeps = {},
+): void {
+	if (divergences.length === 0) {
+		return;
+	}
+	const sink = deps.log ?? ((msg, meta) => logger.warn(msg, meta));
+	sink(SHADOW_DIVERGENCE_MSG, redactShadowDivergences(divergences));
+}
+
+// ── secret-dropping state mappers ────────────────────────────────────────────
+
+/** Loose mmcli-side modem shape — extra (secret) fields are tolerated and DROPPED. */
+export interface MmcliModemLike {
+	readonly id: string;
+	readonly present?: boolean | undefined;
+	readonly registration?: string | undefined;
+	readonly signalBucket?: string | undefined;
+	readonly operatorName?: string | undefined;
+	readonly simPresent?: boolean | undefined;
+	readonly networkType?: string | undefined;
+	readonly [extra: string]: unknown;
+}
+
+/**
+ * Map an mmcli modem to the normalized state, copying ONLY the non-secret allowlist.
+ * ICCID/PIN/APN/password (or any other extra field) are dropped by construction.
+ */
+export function mmcliModemToShadowState(raw: MmcliModemLike): ShadowModemState {
+	const state: {
+		-readonly [K in keyof ShadowModemState]?: ShadowModemState[K];
+	} = {
+		id: raw.id,
+		present: raw.present ?? false,
+	};
+	if (raw.registration !== undefined) state.registration = raw.registration;
+	if (raw.signalBucket !== undefined) state.signalBucket = raw.signalBucket;
+	if (raw.operatorName !== undefined) state.operatorName = raw.operatorName;
+	if (raw.simPresent !== undefined) state.simPresent = raw.simPresent;
+	if (raw.networkType !== undefined) state.networkType = raw.networkType;
+	return state as ShadowModemState;
+}
+
+function asString(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === "object" && value !== null
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+/**
+ * Map an observer row (a package `CellularSnapshot`, read structurally) to the
+ * normalized state. The join key is the non-secret logical-slot / equipment id —
+ * NEVER the subscription id (ICCID/EID). Read via safe narrowing so the strict
+ * package type assigns without a cast and no secret field is ever reached.
+ */
+export function observationRowToShadowState(row: unknown): ShadowModemState {
+	const record = asRecord(row) ?? {};
+	const identity = asRecord(record.identity);
+	const equipmentId = asRecord(identity?.equipmentId);
+	const id =
+		asString(identity?.logicalSlotId) ??
+		asString(equipmentId?.value) ??
+		asString(identity?.runtimePath) ??
+		"unknown";
+
+	const registration = asRecord(record.registration);
+	const simSlots = Array.isArray(record.simSlots) ? record.simSlots : undefined;
+
+	const state: {
+		-readonly [K in keyof ShadowModemState]?: ShadowModemState[K];
+	} = {
+		id,
+		present: record.presence === "present",
+	};
+	const registrationStatus = asString(registration?.status);
+	if (registrationStatus !== undefined) {
+		state.registration = registrationStatus;
+	}
+	if (simSlots !== undefined) {
+		state.simPresent = simSlots.some(
+			(slot) => asRecord(slot)?.occupied === true,
+		);
+	}
+	return state as ShadowModemState;
+}

--- a/apps/backend/src/modules/cellular/shadow-wiring.ts
+++ b/apps/backend/src/modules/cellular/shadow-wiring.ts
@@ -1,0 +1,83 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Production dependency wiring for `modem_shadow` (Phase B).
+ *
+ * Mirrors `dbus-backend.ts`: the ONLY place that touches `@ceralive/modem-control`
+ * (the read-only observer + the D-Bus transport). Lazily imported by
+ * `startModemShadowIfEnabled()` so neither the transport nor the observer graph ever
+ * loads on the default mmcli path.
+ *
+ * Both mappers are secret-dropping: the mmcli mapper copies a non-secret allowlist
+ * (never APN/username/password/PIN), and the observation mapper keys on the
+ * equipment/slot id — never the subscription id (ICCID/EID).
+ */
+
+import { createMmDbusObserver } from "@ceralive/modem-control";
+import { createDbusTransport } from "@ceralive/modem-control/transport";
+
+import { getModems } from "../modems/modems-state.ts";
+import type { ShadowModeDeps } from "./shadow.ts";
+import {
+	mmcliModemToShadowState,
+	observationRowToShadowState,
+	type ShadowModemState,
+} from "./shadow-divergence.ts";
+
+const SYSTEM_BUS_ADDRESS = "unix:path=/var/run/dbus/system_bus_socket";
+
+/** Coarse, non-secret signal bucket from mmcli's 0–100 quality. */
+function signalBucket(signal: number | undefined): string | undefined {
+	if (signal === undefined || Number.isNaN(signal)) return undefined;
+	if (signal <= 0) return "none";
+	if (signal < 34) return "low";
+	if (signal < 67) return "mid";
+	return "high";
+}
+
+/** Snapshot the live mmcli-reported modems as normalized, non-secret states. */
+function readMmcliStates(): readonly ShadowModemState[] {
+	const modems = getModems();
+	return Object.values(modems).map((modem) =>
+		mmcliModemToShadowState({
+			id: modem.ifname,
+			present: modem.removed !== true,
+			registration: modem.status?.connection,
+			signalBucket: signalBucket(modem.status?.signal),
+			operatorName: modem.status?.network ?? modem.sim_network,
+			networkType:
+				modem.status?.network_type ?? modem.network_type.active ?? undefined,
+			simPresent:
+				modem.sim_lock !== undefined || (modem.sim_network?.length ?? 0) > 0,
+		}),
+	);
+}
+
+/** Build the production shadow deps (system-bus observer + live mmcli snapshot). */
+export function buildProductionShadowDeps(): ShadowModeDeps {
+	return {
+		createTransport: () =>
+			createDbusTransport({
+				busAddress: process.env.DBUS_SYSTEM_BUS_ADDRESS ?? SYSTEM_BUS_ADDRESS,
+			}),
+		createObserver: (transport) => createMmDbusObserver({ transport }),
+		readMmcliStates,
+		mapObservation: (list) =>
+			list.rows.map((row) => observationRowToShadowState(row)),
+	};
+}

--- a/apps/backend/src/modules/cellular/shadow.ts
+++ b/apps/backend/src/modules/cellular/shadow.ts
@@ -1,0 +1,154 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * `modem_shadow` orchestration (Phase B).
+ *
+ * Runs the `@ceralive/modem-control` READ-ONLY observer BESIDE the live mmcli path.
+ * mmcli stays authoritative for actual modem control — shadow only WATCHES: on every
+ * observer snapshot it maps both sides to the normalized {@link ShadowModemState} and
+ * logs redacted divergences.
+ *
+ * MUTATION-FREE by construction and by guard: the observer is the narrow
+ * `ModemObservationPort` (no mutation verb), and its transport is additionally
+ * wrapped in {@link createAuditingTransport}, which FAILS CLOSED — any non-read call
+ * (including `Signal.Setup`) is refused and never reaches the bus. See
+ * `dbus-audit-transport.ts`.
+ *
+ * The composition root (`cellular-stack.ts`) is untouched: `modem_backend` still
+ * selects the ACTIVE backend (default mmcli). `modem_shadow` is orthogonal — a
+ * parallel observer that never becomes the control path. Production deps are built
+ * lazily (`shadow-wiring.ts`) so the D-Bus transport never loads on the default path.
+ */
+
+import type {
+	ModemObservationPort,
+	ObservationList,
+} from "@ceralive/modem-control";
+import type { DbusTransport } from "@ceralive/modem-control/transport";
+
+import { logger } from "../../helpers/logger.ts";
+import { getConfig } from "../config.ts";
+import { createAuditingTransport } from "./dbus-audit-transport.ts";
+import {
+	classifyShadowDivergences,
+	logShadowDivergences,
+	type ShadowModemState,
+} from "./shadow-divergence.ts";
+
+export interface ShadowModeDeps {
+	/** Build the raw D-Bus transport (production: the package's system-bus transport). */
+	readonly createTransport: () => DbusTransport;
+	/** Build the read-only observer over a transport (production: `createMmDbusObserver`). */
+	readonly createObserver: (transport: DbusTransport) => ModemObservationPort;
+	/** Read the current mmcli-reported modem states (the authoritative live side). */
+	readonly readMmcliStates: () => readonly ShadowModemState[];
+	/** Map an observer snapshot to normalized states (secret-dropping). */
+	readonly mapObservation: (
+		list: ObservationList,
+	) => readonly ShadowModemState[];
+	/** Divergence log sink (tests). Defaults to the redacted `logger.warn`. */
+	readonly log?: (msg: string, meta: unknown) => void;
+	/** Notified (member key) when the audit guard refuses a non-read call. */
+	readonly onRefusal?: (member: string) => void;
+}
+
+interface RunningShadow {
+	readonly observer: ModemObservationPort;
+	readonly unobserve: () => void;
+}
+
+// Process-wide singleton, mirroring the composition-root singleton posture.
+let running: RunningShadow | null = null;
+
+/** Whether the shadow observer is currently running. */
+export function isModemShadowRunning(): boolean {
+	return running !== null;
+}
+
+/**
+ * Start the read-only shadow observer beside mmcli. Idempotent: a second call while
+ * one is running is a no-op. Never mutates the bus — the auditing transport refuses
+ * every non-read call. A refused call flips an OBSERVABLE default warning unless the
+ * caller supplies its own `onRefusal`.
+ */
+export async function startModemShadow(deps: ShadowModeDeps): Promise<void> {
+	if (running !== null) {
+		return;
+	}
+
+	const onRefusal =
+		deps.onRefusal ??
+		((member: string) =>
+			logger.warn(
+				`modem shadow refused a non-read D-Bus call (mutation-free invariant): ${member}`,
+			));
+	const audit = createAuditingTransport(deps.createTransport(), { onRefusal });
+	const observer = deps.createObserver(audit);
+
+	const compare = (list: ObservationList): void => {
+		try {
+			const dbusStates = deps.mapObservation(list);
+			const mmcliStates = deps.readMmcliStates();
+			const divergences = classifyShadowDivergences(mmcliStates, dbusStates);
+			logShadowDivergences(divergences, { log: deps.log });
+		} catch (err) {
+			// Shadow must never destabilize the live path — swallow after logging.
+			logger.debug(`modem shadow: divergence pass failed: ${err}`);
+		}
+	};
+
+	const unobserve = observer.observe(compare);
+	running = { observer, unobserve };
+
+	const first = await observer.start();
+	compare(first);
+}
+
+/** Stop the shadow observer and release its transport. Idempotent. */
+export async function stopModemShadow(): Promise<void> {
+	const current = running;
+	running = null;
+	if (current === null) {
+		return;
+	}
+	current.unobserve();
+	try {
+		await current.observer.stop();
+	} catch (err) {
+		logger.debug(`modem shadow: stop() failed: ${err}`);
+	}
+}
+
+/** Test seam: synchronously drop the running reference without awaiting teardown. */
+export function resetModemShadow(): void {
+	running?.unobserve();
+	running = null;
+}
+
+/**
+ * Start shadow mode iff `config.modem_shadow` is enabled. A no-op otherwise — so an
+ * absent key (old config) and the default path never load the D-Bus transport.
+ * Production deps are lazily imported so the package graph stays off the default path.
+ */
+export async function startModemShadowIfEnabled(): Promise<void> {
+	if (getConfig().modem_shadow !== true) {
+		return;
+	}
+	const { buildProductionShadowDeps } = await import("./shadow-wiring.ts");
+	await startModemShadow(buildProductionShadowDeps());
+}

--- a/apps/backend/src/modules/modems/modem-wire-adapters.ts
+++ b/apps/backend/src/modules/modems/modem-wire-adapters.ts
@@ -1,0 +1,313 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Backend adapters for the legacy numeric wire projection (Phase B, T5.3).
+ *
+ * Each control backend normalizes its native modem view into the ONE
+ * backend-agnostic {@link ProjectedModemSource} the projector
+ * (`modem-wire-projection.ts`) consumes:
+ *
+ *   - {@link fromMmcliModem}   — the legacy mmcli `Modem` (`modems-state.ts`). Its
+ *     output projects BYTE-IDENTICALLY to `modem-status.ts::buildModemsMessage`
+ *     (the regression lock proves it). This is the reference the dbus side must
+ *     match.
+ *   - {@link fromDbusView}     — a `@ceralive/modem-control` observation view:
+ *     the epoch-scoped `CellularSnapshot` (state dimensions + identity) plus the
+ *     slow MM-interface descriptor (model/manufacturer/signal/operator/ports) and
+ *     the NM-owned connection profile. mmcli-native tokens and dbus-native enums
+ *     map to the SAME legacy wire, so the frontend cannot tell them apart.
+ *
+ * The dbus snapshot deliberately omits secrets (ICCID/EID/APN/PIN — see the
+ * package's `domain/identity.ts` and the shadow mapper); the config block therefore
+ * comes from the NM readback the descriptor carries, never from the MM snapshot.
+ */
+
+import type {
+	ProjectedModemConfig,
+	ProjectedModemSource,
+	WireModemStatus,
+} from "./modem-wire-projection.ts";
+import { getAvailableNetworksForModem, type Modem } from "./modems-state.ts";
+
+// ── mmcli adapter ────────────────────────────────────────────────────────────
+
+/**
+ * Normalize a legacy mmcli `Modem` (already in `modemsState`) into a projection
+ * source. Mirrors `modem-status.ts::buildModemMessage` field-for-field so the
+ * projected entry is byte-identical to the live broadcast — `status` verbatim,
+ * `network_type.supported` = `Object.keys(...)`, `available_networks` via the same
+ * `getAvailableNetworksForModem` helper. The MM runtime id keys the wire row.
+ *
+ * `modem.status` MUST be present (the live builder skips modems without status);
+ * callers filter on that before adapting.
+ */
+export function fromMmcliModem(id: number, modem: Modem): ProjectedModemSource {
+	if (modem.status === undefined) {
+		throw new Error(`fromMmcliModem: modem ${id} has no status`);
+	}
+
+	const status: WireModemStatus = {
+		connection: modem.status.connection,
+		...(modem.status.network !== undefined
+			? { network: modem.status.network }
+			: {}),
+		network_type: modem.status.network_type,
+		signal: modem.status.signal,
+		roaming: modem.status.roaming,
+	};
+
+	const source: {
+		-readonly [K in keyof ProjectedModemSource]: ProjectedModemSource[K];
+	} = {
+		kind: "mm-managed",
+		runtimeId: id,
+		stableKey: `mm:${id}`,
+		ifname: modem.ifname,
+		name: modem.name,
+		networkType: {
+			supported: Object.keys(modem.network_type.supported),
+			active: modem.network_type.active,
+		},
+		status,
+		availableNetworks: getAvailableNetworksForModem(modem),
+	};
+	if (modem.model !== undefined) source.model = modem.model;
+	if (modem.manufacturer !== undefined)
+		source.manufacturer = modem.manufacturer;
+	if (modem.config) {
+		source.config = {
+			apn: modem.config.apn,
+			username: modem.config.username,
+			password: modem.config.password,
+			roaming: modem.config.roaming,
+			network: modem.config.network,
+			autoconfig: modem.config.autoconfig,
+		};
+	}
+	if (modem.sim_lock) source.simLock = modem.sim_lock;
+
+	return source;
+}
+
+// ── dbus adapter ─────────────────────────────────────────────────────────────
+
+/** MM `MMModemAccessTechnology` families → the legacy generation display string. */
+const RAT_TO_GENERATION: Record<string, string> = {
+	gsm: "2G",
+	umts: "3G",
+	lte: "4G",
+	"5gnr": "5G",
+};
+
+const GENERATION_ORDER: Record<string, number> = {
+	"2G": 1,
+	"3G": 2,
+	"3G+": 3,
+	"4G": 4,
+	"5G": 5,
+};
+
+/**
+ * Map the SET of active RATs to the single legacy `network_type` display string
+ * (highest generation wins, e.g. `lte + 5gnr` → "5G"), matching
+ * `mmcli.ts::mmConvertAccessTech`. Empty set → "" (mmcli's empty-tech value).
+ */
+export function ratsToNetworkTypeDisplay(
+	activeRats: ReadonlySet<string>,
+): string {
+	let best = "";
+	for (const rat of activeRats) {
+		const gen = RAT_TO_GENERATION[rat];
+		if (gen === undefined) {
+			continue;
+		}
+		if (
+			best === "" ||
+			(GENERATION_ORDER[gen] ?? 0) > (GENERATION_ORDER[best] ?? 0)
+		) {
+			best = gen;
+		}
+	}
+	return best;
+}
+
+/** The dbus-native SIM-slot shape (a `CellularSnapshot.simSlots[]` element). */
+export interface DbusSimSlotView {
+	readonly occupied: boolean;
+	readonly active: boolean;
+	readonly lock: string;
+}
+
+/** The MM 3gpp registration dimension of a `CellularSnapshot`. */
+export interface DbusRegistrationView {
+	readonly status: string;
+	readonly activeRats: ReadonlySet<string>;
+}
+
+/**
+ * A `@ceralive/modem-control` observation view: the epoch-scoped state snapshot
+ * plus the slow MM-interface descriptor and the NM-owned config. This is the
+ * "richer snapshot" the dbus backend projects FROM. Every field here has a legacy
+ * wire counterpart; the adapter maps dbus-native enums to the mmcli-native tokens.
+ */
+export interface DbusModemView {
+	/** MM runtime id parsed from the runtime object path (`…/Modem/<n>`). */
+	readonly runtimeId: number;
+	readonly ifname: string;
+	/** MM `Modem.Model` (descriptor). */
+	readonly model?: string;
+	/** MM `Modem.Manufacturer` (descriptor). */
+	readonly manufacturer?: string;
+	/** MM `Modem.EquipmentIdentifier` — last-5 form the legacy `name` suffix. */
+	readonly equipmentId?: string;
+	/** MM `MMModemState` token — identical grammar to mmcli `modem.generic.state`. */
+	readonly mmState: string;
+	/** MM 3gpp registration + active-RAT set. */
+	readonly registration: DbusRegistrationView;
+	/** MM `Modem.SignalQuality` value (0-100). */
+	readonly signal: number;
+	/** MM `Modem3gpp.OperatorName` (descriptor). */
+	readonly operatorName?: string;
+	/** Whether the modem is scanning (drives the `scanning` connection override). */
+	readonly scanning?: boolean;
+	/** Legacy supported-mode labels (from MM `Modem.SupportedModes`, mmcli-normalized). */
+	readonly supportedNetworkTypes: readonly string[];
+	/** Legacy active-mode label, or null. */
+	readonly activeNetworkType: string | null;
+	readonly simSlots: readonly DbusSimSlotView[];
+	/** SIM lock the modem currently requires (MM `Modem.UnlockRequired`), or none. */
+	readonly simLockRequired?: string;
+	readonly simLockRemainingAttempts?: number;
+	/** NM-owned connection profile; absent ⇒ no SIM/profile ⇒ wire `no_sim`. */
+	readonly config?: ProjectedModemConfig;
+	readonly availableNetworks?: ProjectedModemSource["availableNetworks"];
+}
+
+/**
+ * Map a dbus observation view to the SAME normalized projection source the mmcli
+ * adapter produces. The legacy `connection` token comes from `mmState` (same MM
+ * grammar), `scanning` overriding it; `roaming` from the registration status;
+ * `network_type` display from the active-RAT set; `no_sim` from the absence of an
+ * NM profile. mm-managed ⇒ the MM runtime id keys the wire row.
+ */
+export function fromDbusView(view: DbusModemView): ProjectedModemSource {
+	const connection = view.scanning ? "scanning" : view.mmState;
+	const roaming = view.registration.status === "roaming";
+	// `status.network_type` is the legacy GENERATION display ("5G"/"4G"), derived
+	// from the active RAT set exactly as mmcli's `mmConvertAccessTech` does — NOT
+	// the mode label (`activeNetworkType`, e.g. "5g4g"), which is a separate field.
+	const networkTypeDisplay = ratsToNetworkTypeDisplay(
+		view.registration.activeRats,
+	);
+
+	const status: WireModemStatus = {
+		connection,
+		...(view.operatorName !== undefined ? { network: view.operatorName } : {}),
+		network_type: networkTypeDisplay,
+		signal: view.signal,
+		roaming,
+	};
+
+	const source: {
+		-readonly [K in keyof ProjectedModemSource]: ProjectedModemSource[K];
+	} = {
+		kind: "mm-managed",
+		runtimeId: view.runtimeId,
+		stableKey: `mm:${view.runtimeId}`,
+		ifname: view.ifname,
+		name: buildDbusName(view),
+		networkType: {
+			supported: [...view.supportedNetworkTypes],
+			active: view.activeNetworkType,
+		},
+		status,
+	};
+	if (view.model !== undefined) source.model = view.model;
+	if (view.manufacturer !== undefined) source.manufacturer = view.manufacturer;
+	if (view.config) source.config = view.config;
+	if (view.availableNetworks) source.availableNetworks = view.availableNetworks;
+	if (view.simLockRequired !== undefined && view.simLockRequired !== "none") {
+		source.simLock =
+			view.simLockRemainingAttempts !== undefined
+				? {
+						required: view.simLockRequired,
+						remainingAttempts: view.simLockRemainingAttempts,
+					}
+				: { required: view.simLockRequired };
+	}
+
+	return source;
+}
+
+/**
+ * Compose the legacy hardware name `"<model> - <last5-imei>"` exactly as
+ * `modem-registration.ts` does (`${model} - ${partialImei}`), so the dbus and
+ * mmcli names match byte-for-byte.
+ */
+function buildDbusName(view: DbusModemView): string {
+	const model = view.model ?? "";
+	const imei = view.equipmentId ?? "";
+	const partial = imei.length > 5 ? imei.substring(imei.length - 5) : imei;
+	return `${model} - ${partial}`;
+}
+
+// ── router / unmanaged adapter ───────────────────────────────────────────────
+
+/**
+ * A device ModemManager cannot control (HiLink/RNDIS/NCM router-mode, or an
+ * unmanaged stick surfaced disabled-with-reason). It has NO MM runtime id, so the
+ * projector assigns it a synthetic id from the reserved ≥1000 namespace, keyed by
+ * a hardware-stable identity (`stableKey`) so the id survives replug.
+ */
+export interface RouterDeviceView {
+	readonly kind: "router" | "unmanaged";
+	/** Hardware-stable identity (USB port path / sysfs handle) — never array order. */
+	readonly stableKey: string;
+	readonly ifname: string;
+	readonly name: string;
+	readonly model?: string;
+	readonly manufacturer?: string;
+	readonly status: WireModemStatus;
+	readonly networkType?: {
+		readonly supported: readonly string[];
+		readonly active: string | null;
+	};
+}
+
+/**
+ * Normalize a router/unmanaged device into a projection source. `runtimeId` is
+ * `null` (no MM id); the projector allocates its ≥1000 synthetic id. The legacy
+ * wire entry carries only the existing fields — no additive Phase-B fields (T5.4).
+ */
+export function fromRouterView(view: RouterDeviceView): ProjectedModemSource {
+	const source: {
+		-readonly [K in keyof ProjectedModemSource]: ProjectedModemSource[K];
+	} = {
+		kind: view.kind,
+		runtimeId: null,
+		stableKey: view.stableKey,
+		ifname: view.ifname,
+		name: view.name,
+		networkType: view.networkType ?? { supported: [], active: null },
+		status: view.status,
+		availableNetworks: {},
+	};
+	if (view.model !== undefined) source.model = view.model;
+	if (view.manufacturer !== undefined) source.manufacturer = view.manufacturer;
+	return source;
+}

--- a/apps/backend/src/modules/modems/modem-wire-projection.ts
+++ b/apps/backend/src/modules/modems/modem-wire-projection.ts
@@ -1,0 +1,327 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Legacy numeric wire projection (Phase B, T5.3).
+ *
+ * The single seam that projects a backend-agnostic {@link ProjectedModemSource}
+ * set into the EXISTING numeric-id modem wire shape the frontend already consumes
+ * (`status.modems` — `Record<numericModemId, entry>`, built today by
+ * `modem-status.ts::buildModemsMessage`). Both control backends feed this ONE
+ * projector:
+ *
+ *   - mmcli   → `modem-wire-adapters.ts::fromMmcliModem`
+ *   - dbus    → `modem-wire-adapters.ts::fromDbusView` (over `@ceralive/modem-control`)
+ *
+ * so the frontend can never tell which backend is live (the "byte-compatible"
+ * claim, proven by the golden-fixture test). This module changes NOTHING on the
+ * live mmcli broadcast path — `broadcastModems` still calls `buildModemsMessage`
+ * verbatim; the projector reproduces that exact shape and the regression test
+ * locks it byte-for-byte.
+ *
+ * Three legacy-compat invariants live HERE, at the adapter seam, not scattered:
+ *
+ *   1. `autoconfig` is mapped once, in {@link resolveWireConfig}: the wire value is
+ *      `has_gsm_autoconfig && config.autoconfig` (mirrors `modem-status.ts:114`).
+ *   2. The literal `"auto"` is NEVER echoed. An auto-config APN resolves to its
+ *      concrete legacy value — an empty string — exactly as the mmcli path already
+ *      clears it (`modem-registration.ts::applyAutoconfigToModemConfig`).
+ *   3. Router / unmanaged rows (devices ModemManager cannot manage) take synthetic
+ *      numeric ids from the reserved ≥1000 namespace ({@link SYNTHETIC_ID_BASE}),
+ *      collision-checked against the live MM runtime ids and stable across replug
+ *      (keyed by a hardware-stable identity), via {@link allocateSyntheticIds}.
+ */
+
+import type { AvailableNetwork } from "./modems-state.ts";
+
+/** Wire status block — identical shape to `modem-status.ts::ModemsResponseModemStatus`. */
+export interface WireModemStatus {
+	readonly connection: string;
+	readonly network?: string;
+	readonly network_type: string;
+	readonly signal: number;
+	readonly roaming: boolean;
+}
+
+/** Wire SIM-lock block — mirrors `modems-state.ts::SimLock`. */
+export interface WireSimLock {
+	readonly required: string;
+	readonly remainingAttempts?: number;
+}
+
+/**
+ * The NM-owned connection profile as seen by the projection seam. `apn` MAY be the
+ * `"auto"` policy sentinel here (the Auto-APN arm maps `apn:"auto"` → NM
+ * `gsm.auto-config yes`); {@link resolveWireConfig} is the single place that
+ * reconciles it — the sentinel never reaches the wire.
+ */
+export interface ProjectedModemConfig {
+	readonly apn: string;
+	readonly username: string;
+	readonly password: string;
+	readonly roaming: boolean;
+	readonly network: string;
+	readonly autoconfig: boolean;
+}
+
+/** Which control class a device belongs to. `router`/`unmanaged` are non-MM. */
+export type ProjectedDeviceKind = "mm-managed" | "router" | "unmanaged";
+
+/**
+ * A backend-agnostic, normalized view of ONE device. The mmcli and dbus adapters
+ * both produce this; the projector consumes only this. It carries exactly the
+ * information the legacy wire needs — no additive Phase-B fields (those are T5.4).
+ */
+export interface ProjectedModemSource {
+	readonly kind: ProjectedDeviceKind;
+	/**
+	 * The ModemManager runtime id for an `mm-managed` device — the wire key. `null`
+	 * for router/unmanaged devices, which have no MM id and get a synthetic id.
+	 */
+	readonly runtimeId: number | null;
+	/**
+	 * A hardware-stable identity (e.g. USB port path / logical slot) used to keep a
+	 * router/unmanaged device's synthetic id STABLE across unplug→replug. Never the
+	 * MM runtime path (which MM reassigns) and never a secret (ICCID/EID).
+	 */
+	readonly stableKey: string;
+	readonly ifname: string;
+	readonly name: string;
+	readonly model?: string;
+	readonly manufacturer?: string;
+	readonly networkType: {
+		readonly supported: readonly string[];
+		readonly active: string | null;
+	};
+	readonly status: WireModemStatus;
+	/** Present when a SIM/profile exists; absent ⇒ the wire carries `no_sim: true`. */
+	readonly config?: ProjectedModemConfig;
+	readonly simLock?: WireSimLock;
+	readonly availableNetworks?: Record<string, AvailableNetwork>;
+}
+
+/** The projected wire config block (post autoconfig / "auto" resolution). */
+export interface WireModemConfig {
+	readonly apn: string;
+	readonly username: string;
+	readonly password: string;
+	readonly roaming: boolean;
+	readonly network: string;
+	readonly autoconfig: boolean;
+}
+
+/** One projected wire entry — same field set + key ORDER as `buildModemMessage`. */
+export type WireModemEntry = {
+	status: WireModemStatus;
+	ifname?: string;
+	name?: string;
+	model?: string;
+	manufacturer?: string;
+	network_type?: { supported: string[]; active: string | null };
+	config?: WireModemConfig;
+	no_sim?: true;
+	sim_lock?: WireSimLock;
+	available_networks?: Record<string, AvailableNetwork>;
+};
+
+/** The projected wire message — `Record<numericId(string), entry>`. */
+export type WireModemsMessage = Record<string, WireModemEntry>;
+
+/** First reserved synthetic id. Router/unmanaged rows allocate at or above this. */
+export const SYNTHETIC_ID_BASE = 1000;
+
+/** The Auto-APN policy sentinel — a wire value NEVER echoes it. */
+export const AUTO_APN_SENTINEL = "auto";
+
+export interface ProjectModemWireDeps {
+	/** `setup.has_gsm_autoconfig` — gates the wire `autoconfig` value. */
+	readonly hasGsmAutoconfig: boolean;
+	/**
+	 * Prior `stableKey → synthetic id` allocations, retained across snapshots so a
+	 * replugged device gets its OLD id back. Optional; a fresh `Map` when omitted.
+	 */
+	readonly previousSyntheticIds?: ReadonlyMap<string, number>;
+}
+
+export interface ProjectModemWireResult {
+	readonly message: WireModemsMessage;
+	/**
+	 * The `stableKey → synthetic id` map to retain for the NEXT projection so
+	 * replug stability holds. Carries only router/unmanaged allocations.
+	 */
+	readonly syntheticIds: ReadonlyMap<string, number>;
+}
+
+/**
+ * Map a device's NM-owned config to the legacy wire config. This is THE seam for
+ * `autoconfig` + the `"auto"` sentinel:
+ *
+ *   - `autoconfig` = `hasGsmAutoconfig && config.autoconfig` (mirrors the mmcli
+ *     gate at `modem-status.ts:114`).
+ *   - when auto-config resolves ON, or the raw APN is the `"auto"` sentinel, the
+ *     wire APN is the concrete legacy value — empty — exactly as the mmcli path
+ *     clears it. The literal `"auto"` is never echoed to any client.
+ *
+ * `username`/`password`/`roaming`/`network` pass through verbatim (the mmcli path
+ * echoes them unchanged), so an mmcli-derived config projects byte-identically.
+ */
+export function resolveWireConfig(
+	config: ProjectedModemConfig,
+	hasGsmAutoconfig: boolean,
+): WireModemConfig {
+	const autoconfig = hasGsmAutoconfig && config.autoconfig;
+	const apn = autoconfig || config.apn === AUTO_APN_SENTINEL ? "" : config.apn;
+	return {
+		apn,
+		username: config.username,
+		password: config.password,
+		roaming: config.roaming,
+		network: config.network,
+		autoconfig,
+	};
+}
+
+/**
+ * Allocate a stable synthetic wire id (≥ {@link SYNTHETIC_ID_BASE}) for every
+ * router/unmanaged source, collision-checked against the live MM runtime ids.
+ *
+ * Guarantees:
+ *   - NEVER collides with a live MM id (MM ids are monotonic and could in principle
+ *     exceed 1000, so a raw "≥1000 is always safe" assumption is wrong — every
+ *     candidate is checked against `usedMmIds` AND ids claimed earlier this pass).
+ *   - REPLUG-STABLE: allocation walks sources in `stableKey` order (never array /
+ *     insertion order, which does not survive replug) and reuses a source's prior
+ *     id from `previous` when it is still free — so the same physical device gets
+ *     the same id across unplug→replug.
+ */
+export function allocateSyntheticIds(
+	sources: readonly ProjectedModemSource[],
+	usedMmIds: ReadonlySet<number>,
+	previous: ReadonlyMap<string, number> = new Map(),
+): Map<string, number> {
+	const synthetic = sources
+		.filter((s) => s.kind !== "mm-managed")
+		.slice()
+		.sort((a, b) => a.stableKey.localeCompare(b.stableKey));
+
+	const result = new Map<string, number>();
+	const claimed = new Set<number>();
+
+	// Pass 1: reinstate a prior id when it is still collision-free (replug stability).
+	for (const source of synthetic) {
+		const prior = previous.get(source.stableKey);
+		if (
+			prior !== undefined &&
+			prior >= SYNTHETIC_ID_BASE &&
+			!usedMmIds.has(prior) &&
+			!claimed.has(prior)
+		) {
+			result.set(source.stableKey, prior);
+			claimed.add(prior);
+		}
+	}
+
+	// Pass 2: assign the lowest free id ≥ base to any source still unallocated.
+	for (const source of synthetic) {
+		if (result.has(source.stableKey)) {
+			continue;
+		}
+		let id = SYNTHETIC_ID_BASE;
+		while (usedMmIds.has(id) || claimed.has(id)) {
+			id++;
+		}
+		result.set(source.stableKey, id);
+		claimed.add(id);
+	}
+
+	return result;
+}
+
+/**
+ * Build ONE wire entry with the EXACT field set and key ORDER of
+ * `modem-status.ts::buildModemMessage` (full-status form): `status` first, then
+ * `ifname, name, model?, manufacturer?, network_type, config?/no_sim, sim_lock?,
+ * available_networks`. Key order is load-bearing — the byte-compat claim is a
+ * `JSON.stringify` equality, so this order is asserted, not incidental.
+ */
+function buildWireEntry(
+	source: ProjectedModemSource,
+	hasGsmAutoconfig: boolean,
+): WireModemEntry {
+	const entry: WireModemEntry = { status: source.status };
+
+	entry.ifname = source.ifname;
+	entry.name = source.name;
+	if (source.model !== undefined) {
+		entry.model = source.model;
+	}
+	if (source.manufacturer !== undefined) {
+		entry.manufacturer = source.manufacturer;
+	}
+	entry.network_type = {
+		supported: [...source.networkType.supported],
+		active: source.networkType.active,
+	};
+	if (source.config) {
+		entry.config = resolveWireConfig(source.config, hasGsmAutoconfig);
+	} else {
+		entry.no_sim = true;
+	}
+	if (source.simLock) {
+		entry.sim_lock = source.simLock;
+	}
+	entry.available_networks = source.availableNetworks ?? {};
+
+	return entry;
+}
+
+/**
+ * Project a normalized source set into the legacy numeric wire message. mm-managed
+ * devices key by their MM runtime id; router/unmanaged devices key by a
+ * collision-checked, replug-stable synthetic id (≥ {@link SYNTHETIC_ID_BASE}).
+ */
+export function projectModemWire(
+	sources: readonly ProjectedModemSource[],
+	deps: ProjectModemWireDeps,
+): ProjectModemWireResult {
+	const usedMmIds = new Set<number>();
+	for (const source of sources) {
+		if (source.kind === "mm-managed" && source.runtimeId !== null) {
+			usedMmIds.add(source.runtimeId);
+		}
+	}
+
+	const syntheticIds = allocateSyntheticIds(
+		sources,
+		usedMmIds,
+		deps.previousSyntheticIds,
+	);
+
+	const message: WireModemsMessage = {};
+	for (const source of sources) {
+		const id =
+			source.kind === "mm-managed" && source.runtimeId !== null
+				? source.runtimeId
+				: syntheticIds.get(source.stableKey);
+		if (id === undefined) {
+			continue;
+		}
+		message[String(id)] = buildWireEntry(source, deps.hasGsmAutoconfig);
+	}
+
+	return { message, syntheticIds };
+}

--- a/apps/backend/src/modules/streaming/lifecycle-admission.ts
+++ b/apps/backend/src/modules/streaming/lifecycle-admission.ts
@@ -1,0 +1,111 @@
+import { logger } from "../../helpers/logger.ts";
+
+/**
+ * LifecycleInterlock (Phase B, T5.5) — the single mutual-exclusion guard between
+ * STREAMING ADMISSION and MODEM LIFECYCLE mutations.
+ *
+ * Two operations must never run concurrently against a bonded modem link:
+ *
+ *  - `"streaming"` — a stream is being ADMITTED (the pre-engine window in
+ *    `streaming.start`, before `getIsStreaming()` flips true). The interlock is
+ *    held only across that admission window; once the stream is live, the live
+ *    guard (`getIsStreaming()`) takes over — so a crash mid-admission can never
+ *    strand the interlock (it is released in the admission `finally`).
+ *  - `"modem-transition"` — a USB-composition-mode switch (`modems.setUsbMode`)
+ *    or a future, DEFAULT-DISABLED autonomous cellular recovery / USB-reset
+ *    action. Both re-enumerate a modem, tearing its bond link down mid-flight.
+ *
+ * Letting either start while the other is mid-flight breaks the bond math (a link
+ * vanishing during admission, or an admitted stream losing a link to a reset), so
+ * the two are mutually exclusive in BOTH race orders. This is the real interlock
+ * the plan calls "LifecycleInterlock".
+ *
+ * Design mirrors `network/state/device-lock.ts`: a minimal in-flight guard, no
+ * queue, no scheduler, no dependencies. Acquisition is FAIL-FAST — a caller that
+ * cannot acquire is refused immediately (it maps that to its own typed refusal),
+ * never blocked/queued. Release is guaranteed via `finally` and idempotent, so a
+ * throwing guarded operation can never leave the interlock permanently held.
+ *
+ * NOTE: this ships the interlock plumbing only. No autonomous recovery loop is
+ * wired here or anywhere by this todo — cellular recovery stays default-disabled.
+ */
+export type LifecycleHolder = "streaming" | "modem-transition";
+
+/** A held interlock. `release()` is idempotent — safe to call from a `finally`. */
+export interface LifecycleLease {
+	readonly holder: LifecycleHolder;
+	release(): void;
+}
+
+/** Result of a `withLifecycleLock` run: the guarded value, or a contention miss. */
+export type LifecycleOutcome<T> =
+	| { acquired: true; result: T }
+	| { acquired: false };
+
+/** The single interlock holder, or `undefined` when free. */
+let holder: LifecycleHolder | undefined;
+
+/**
+ * Try to acquire the interlock for `who`. Returns a lease when the interlock is
+ * free, or `null` when the OTHER lifecycle operation currently holds it. Never
+ * blocks; the caller converts a `null` into its own typed refusal.
+ */
+export function tryAcquireLifecycle(
+	who: LifecycleHolder,
+): LifecycleLease | null {
+	if (holder !== undefined) {
+		logger.debug(
+			`LifecycleInterlock held by ${holder}; refusing concurrent ${who}`,
+		);
+		return null;
+	}
+
+	holder = who;
+	let released = false;
+	return {
+		holder: who,
+		release() {
+			// Idempotent so an outer `finally` may release after the body already
+			// did, and so a double-release is a no-op — never frees another holder.
+			if (released) return;
+			released = true;
+			if (holder === who) holder = undefined;
+		},
+	};
+}
+
+/**
+ * Run `fn` while holding the interlock for `who`, releasing in a `finally` on ANY
+ * exit (return OR throw). Returns `{ acquired: false }` WITHOUT running `fn` when
+ * the other lifecycle operation holds the interlock. A throw from `fn` propagates
+ * to the caller AFTER the interlock is released — the core no-deadlock guarantee.
+ */
+export async function withLifecycleLock<T>(
+	who: LifecycleHolder,
+	fn: () => Promise<T>,
+): Promise<LifecycleOutcome<T>> {
+	const lease = tryAcquireLifecycle(who);
+	if (lease === null) {
+		return { acquired: false };
+	}
+	try {
+		return { acquired: true, result: await fn() };
+	} finally {
+		lease.release();
+	}
+}
+
+/** True while either lifecycle operation holds the interlock. */
+export function isLifecycleHeld(): boolean {
+	return holder !== undefined;
+}
+
+/** The current holder, or `undefined` when the interlock is free (diagnostics). */
+export function currentLifecycleHolder(): LifecycleHolder | undefined {
+	return holder;
+}
+
+/** Test-only: force-release the interlock so a suite starts from a free state. */
+export function resetLifecycleInterlock(): void {
+	holder = undefined;
+}

--- a/apps/backend/src/rpc/procedures/modems.procedure.ts
+++ b/apps/backend/src/rpc/procedures/modems.procedure.ts
@@ -9,13 +9,14 @@ import {
 	modemListSchema,
 	modemScanInputSchema,
 	modemScanOutputSchema,
+	setUsbModeInputSchema,
+	setUsbModeOutputSchema,
 	simPukUnlockInputSchema,
 	simPukUnlockOutputSchema,
 	simUnlockInputSchema,
 	simUnlockOutputSchema,
 } from "@ceraui/rpc/schemas";
 import { os } from "@orpc/server";
-
 import { logger } from "../../helpers/logger.ts";
 import { setMockModemConfig } from "../../mocks/mock-service.ts";
 import {
@@ -23,6 +24,8 @@ import {
 	mockAttemptSimUnlock,
 	shouldMockModems,
 } from "../../mocks/providers/modems.ts";
+import { assertCellularStackReady } from "../../modules/cellular/cellular-stack.ts";
+import { getConfig } from "../../modules/config.ts";
 import {
 	type SimPukUnlockResult,
 	type SimUnlockResult,
@@ -37,6 +40,9 @@ import { handleModems } from "../../modules/modems/modems.ts";
 import { getModem } from "../../modules/modems/modems-state.ts";
 import { clearSimPin, storeSimPin } from "../../modules/modems/sim-secrets.ts";
 import { withModemUpdateLock } from "../../modules/network/state/device-lock.ts";
+import { withLifecycleLock } from "../../modules/streaming/lifecycle-admission.ts";
+import { getIsStreaming } from "../../modules/streaming/streaming.ts";
+import { isRealDevice } from "../../modules/system/device-detection.ts";
 import { authMiddleware } from "../middleware/auth.middleware.ts";
 import type { RPCContext } from "../types.ts";
 
@@ -46,10 +52,21 @@ const baseProcedure = os.$context<RPCContext>();
 // Authenticated procedure
 const authedProcedure = baseProcedure.use(authMiddleware);
 
+// Gate every modem procedure on the cellular-stack composition root: while a
+// dbus backend is still initializing, `assertCellularStackReady` throws the
+// shared typed `CELLULAR_STACK_INITIALIZING` oRPC error. A no-op on the ready
+// mmcli default, so the default path is unaffected.
+const cellularStackMiddleware = baseProcedure.middleware(async ({ next }) => {
+	assertCellularStackReady();
+	return next();
+});
+
+const modemProcedure = authedProcedure.use(cellularStackMiddleware);
+
 /**
  * Get all modems procedure
  */
-export const getAllModemsProcedure = authedProcedure
+export const getAllModemsProcedure = modemProcedure
 	.output(modemListSchema)
 	.handler(() => {
 		return modemListSchema.parse(buildModemsMessage());
@@ -58,7 +75,7 @@ export const getAllModemsProcedure = authedProcedure
 /**
  * Configure modem procedure
  */
-export const configureModemProcedure = authedProcedure
+export const configureModemProcedure = modemProcedure
 	.input(modemConfigInputSchema)
 	.output(modemConfigOutputSchema)
 	.handler(async ({ input, context }) => {
@@ -123,7 +140,7 @@ export const configureModemProcedure = authedProcedure
 /**
  * Scan modem networks procedure
  */
-export const scanModemProcedure = authedProcedure
+export const scanModemProcedure = modemProcedure
 	.input(modemScanInputSchema)
 	.output(modemScanOutputSchema)
 	.handler(async ({ input, context }) => {
@@ -148,7 +165,7 @@ export const scanModemProcedure = authedProcedure
  * branch is real-device only — it never runs under mocks (no `/run/ceralive`
  * writes on a dev host).
  */
-export const unlockSimProcedure = authedProcedure
+export const unlockSimProcedure = modemProcedure
 	.input(simUnlockInputSchema)
 	.output(simUnlockOutputSchema)
 	.handler(async ({ input }) => {
@@ -195,7 +212,7 @@ export const unlockSimProcedure = authedProcedure
  * `modem-pin-locked` scenario trips the SIM to PUK-locked, and the fixture PUK
  * "12345678" recovers it, so the full PUK flow works end-to-end in dev.
  */
-export const unlockSimPukProcedure = authedProcedure
+export const unlockSimPukProcedure = modemProcedure
 	.input(simPukUnlockInputSchema)
 	.output(simPukUnlockOutputSchema)
 	.handler(async ({ input }) => {
@@ -208,4 +225,54 @@ export const unlockSimPukProcedure = authedProcedure
 			result = await unlockSimPuk(input.modemPath, input.puk, input.newPin);
 		});
 		return result;
+	});
+
+/**
+ * Switch a modem's USB composition mode (Phase B, T5.4).
+ *
+ * DEFAULT-ABSENT GATE: the guarded mutation is UNREACHABLE unless the operator has
+ * provisioned it. The FIRST guard reads the `modem_provisioning` config key and
+ * refuses with the typed `provisioning_disabled` error whenever it is absent/false
+ * — a hard RPC-layer refusal, not a hidden UI control, so a direct RPC call is
+ * refused too. The full re-enumeration transaction (cached-UID inhibit, port-drop,
+ * re-enumeration wait, postcondition verify) is a later wave; the streaming
+ * LifecycleInterlock is Todo 27. This wave ships only the gate + the emulated-mode
+ * refusal, so any code path past the gate stays a typed refusal for now.
+ */
+export const setUsbModeProcedure = modemProcedure
+	.input(setUsbModeInputSchema)
+	.output(setUsbModeOutputSchema)
+	.handler(async () => {
+		if (getConfig().modem_provisioning !== true) {
+			return { success: false, error: "provisioning_disabled" };
+		}
+
+		if (!(await isRealDevice())) {
+			return { success: false, error: "unavailable_in_emulated_mode" };
+		}
+
+		// LifecycleInterlock (Phase B, T5.5): a USB-composition switch re-enumerates
+		// the modem, tearing its bond link down mid-transition. Refuse while a stream
+		// is LIVE or being ADMITTED. getIsStreaming() covers the live window; the
+		// interlock closes the admission-window race a bare is_streaming check would
+		// miss (admitted-start, not just is_streaming). Holding the interlock across
+		// the transition blocks a concurrent stream admission in turn (both race
+		// orders); withLifecycleLock releases it in a finally on ANY exit.
+		if (getIsStreaming()) {
+			return { success: false, error: "streaming_active" };
+		}
+		const outcome = await withLifecycleLock("modem-transition", async () => {
+			// The full re-enumeration transaction (cached-UID inhibit, port-drop,
+			// re-enumeration wait, postcondition verify) is a later wave; autonomous
+			// cellular recovery stays default-disabled. This wave ships the interlock
+			// + gate, so any path past the gate stays a typed refusal for now.
+			logger.warn(
+				"modems.setUsbMode reached past the provisioning + streaming gates but the transition transaction is not yet implemented (Phase-B later wave)",
+			);
+			return { success: false, error: "error" } as const;
+		});
+		if (!outcome.acquired) {
+			return { success: false, error: "streaming_active" };
+		}
+		return outcome.result;
 	});

--- a/apps/backend/src/rpc/procedures/streaming.procedure.ts
+++ b/apps/backend/src/rpc/procedures/streaming.procedure.ts
@@ -399,6 +399,7 @@ export const getConfigProcedure = authedProcedure
 			relay_protocol: config.relay_protocol,
 			selected_ingest_endpoint: config.selected_ingest_endpoint,
 			detectionMethod: config.detectionMethod,
+			modem_provisioning: config.modem_provisioning,
 		};
 	});
 

--- a/apps/backend/src/rpc/procedures/streaming.procedure.ts
+++ b/apps/backend/src/rpc/procedures/streaming.procedure.ts
@@ -67,6 +67,7 @@ import { deviceRegistry } from "../../modules/streaming/devices.ts";
 import { clampBitrate } from "../../modules/streaming/encoder.ts";
 import { isGatewayActive } from "../../modules/streaming/gateway-availability.ts";
 import { getStreamHealth } from "../../modules/streaming/health.ts";
+import { tryAcquireLifecycle } from "../../modules/streaming/lifecycle-admission.ts";
 import { AUDIO_CODECS } from "../../modules/streaming/pipeline-sources.ts";
 import {
 	getEffectiveHardware,
@@ -114,6 +115,13 @@ const authedProcedure = baseProcedure.use(authMiddleware);
 // double-spawn the sender and double-start the engine.
 const START_IN_PROGRESS = "START_IN_PROGRESS";
 
+// A stream cannot be admitted while a modem USB-composition switch (or a future,
+// default-disabled cellular recovery action) is re-enumerating a modem: the
+// transition tears a bond link down mid-flight. The LifecycleInterlock refuses the
+// admission pre-engine with this stable code; the operator retries once the
+// transition releases (Phase B, T5.5).
+const MODEM_TRANSITION_ACTIVE = "MODEM_TRANSITION_ACTIVE";
+
 let startInFlight = false;
 
 /**
@@ -128,6 +136,19 @@ export const streamingStartProcedure = authedProcedure
 				success: false,
 				is_streaming: getIsStreaming(),
 				error: START_IN_PROGRESS,
+			};
+		}
+		// Hold the LifecycleInterlock across the whole pre-engine admission window
+		// so a concurrent modem USB-mode switch / recovery action can't re-enumerate
+		// a modem mid-admission — and refuse admission outright when such a
+		// transition already holds it (both race orders). Released in the finally
+		// below alongside startInFlight, so a crash/throw never deadlocks it.
+		const lifecycleLease = tryAcquireLifecycle("streaming");
+		if (lifecycleLease === null) {
+			return {
+				success: false,
+				is_streaming: getIsStreaming(),
+				error: MODEM_TRANSITION_ACTIVE,
 			};
 		}
 		startInFlight = true;
@@ -272,6 +293,7 @@ export const streamingStartProcedure = authedProcedure
 			}
 		} finally {
 			startInFlight = false;
+			lifecycleLease.release();
 		}
 	});
 

--- a/apps/backend/src/rpc/router.ts
+++ b/apps/backend/src/rpc/router.ts
@@ -21,6 +21,7 @@ import {
 	configureModemProcedure,
 	getAllModemsProcedure,
 	scanModemProcedure,
+	setUsbModeProcedure,
 	unlockSimProcedure,
 	unlockSimPukProcedure,
 } from "./procedures/modems.procedure.ts";
@@ -138,6 +139,7 @@ const stableRoutes = {
 		scan: scanModemProcedure,
 		unlockSim: unlockSimProcedure,
 		unlockSimPuk: unlockSimPukProcedure,
+		setUsbMode: setUsbModeProcedure,
 	}),
 
 	wifi: base.router({

--- a/apps/backend/src/tests/cellular-lifecycle-interlock.test.ts
+++ b/apps/backend/src/tests/cellular-lifecycle-interlock.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Phase B, T5.5 — LifecycleInterlock primitive: the streaming-admission ↔
+ * modem-lifecycle mutual-exclusion gate, tested at the primitive level.
+ *
+ * Acceptance: BOTH race orders protect the bond (a streaming admission blocks a
+ * concurrent USB-mode switch / recovery, and a switch/recovery blocks a concurrent
+ * streaming admission); the interlock releases in a `finally` even when the guarded
+ * operation THROWS, so it can never deadlock. Real-procedure wiring is covered by
+ * `modems-streaming-interlock.test.ts`.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	currentLifecycleHolder,
+	isLifecycleHeld,
+	resetLifecycleInterlock,
+	tryAcquireLifecycle,
+	withLifecycleLock,
+} from "../modules/streaming/lifecycle-admission.ts";
+
+function deferred<T>(): {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+} {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+describe("LifecycleInterlock primitive — both race orders + finally-release", () => {
+	beforeEach(() => resetLifecycleInterlock());
+	afterEach(() => resetLifecycleInterlock());
+
+	test("race order 1: streaming admission in-flight blocks a concurrent modem transition until it releases", async () => {
+		const admissionAcquired = deferred<void>();
+		const releaseAdmission = deferred<void>();
+		const order: string[] = [];
+
+		const streamingOp = (async () => {
+			const lease = tryAcquireLifecycle("streaming");
+			expect(lease).not.toBeNull();
+			order.push("streaming-acquired");
+			admissionAcquired.resolve();
+			try {
+				await releaseAdmission.promise;
+			} finally {
+				lease?.release();
+				order.push("streaming-released");
+			}
+		})();
+
+		await admissionAcquired.promise;
+		expect(tryAcquireLifecycle("modem-transition")).toBeNull();
+		expect(currentLifecycleHolder()).toBe("streaming");
+		order.push("transition-blocked");
+
+		releaseAdmission.resolve();
+		await streamingOp;
+
+		const txLease = tryAcquireLifecycle("modem-transition");
+		expect(txLease).not.toBeNull();
+		txLease?.release();
+		expect(order).toEqual([
+			"streaming-acquired",
+			"transition-blocked",
+			"streaming-released",
+		]);
+	});
+
+	test("race order 2: modem transition in-flight blocks a concurrent streaming admission until it releases", async () => {
+		const transitionAcquired = deferred<void>();
+		const releaseTransition = deferred<void>();
+		const order: string[] = [];
+
+		const transitionOp = (async () => {
+			const lease = tryAcquireLifecycle("modem-transition");
+			expect(lease).not.toBeNull();
+			order.push("transition-acquired");
+			transitionAcquired.resolve();
+			try {
+				await releaseTransition.promise;
+			} finally {
+				lease?.release();
+				order.push("transition-released");
+			}
+		})();
+
+		await transitionAcquired.promise;
+		expect(tryAcquireLifecycle("streaming")).toBeNull();
+		expect(currentLifecycleHolder()).toBe("modem-transition");
+		order.push("streaming-blocked");
+
+		releaseTransition.resolve();
+		await transitionOp;
+
+		const streamLease = tryAcquireLifecycle("streaming");
+		expect(streamLease).not.toBeNull();
+		streamLease?.release();
+		expect(order).toEqual([
+			"transition-acquired",
+			"streaming-blocked",
+			"transition-released",
+		]);
+	});
+
+	test("finally-release: a guarded streaming op that THROWS after acquiring still frees the interlock (no deadlock)", async () => {
+		let caught: unknown;
+		try {
+			await withLifecycleLock("streaming", async () => {
+				throw new Error("engine start blew up after admission");
+			});
+		} catch (err) {
+			caught = err;
+		}
+
+		expect((caught as Error | undefined)?.message).toBe(
+			"engine start blew up after admission",
+		);
+		expect(isLifecycleHeld()).toBe(false);
+		const after = tryAcquireLifecycle("modem-transition");
+		expect(after).not.toBeNull();
+		after?.release();
+	});
+
+	test("withLifecycleLock refuses (acquired:false) WITHOUT running fn when the other lifecycle op holds it", async () => {
+		const held = tryAcquireLifecycle("streaming");
+		expect(held).not.toBeNull();
+		let ran = false;
+		try {
+			const outcome = await withLifecycleLock("modem-transition", async () => {
+				ran = true;
+				return "should-not-run";
+			});
+			expect(outcome).toEqual({ acquired: false });
+			expect(ran).toBe(false);
+		} finally {
+			held?.release();
+		}
+	});
+
+	test("release() is idempotent — a stale double-release never frees a later holder", () => {
+		const lease = tryAcquireLifecycle("streaming");
+		expect(lease).not.toBeNull();
+		lease?.release();
+		lease?.release();
+		expect(isLifecycleHeld()).toBe(false);
+
+		const other = tryAcquireLifecycle("modem-transition");
+		expect(other).not.toBeNull();
+		lease?.release();
+		expect(currentLifecycleHolder()).toBe("modem-transition");
+		other?.release();
+	});
+});

--- a/apps/backend/src/tests/cellular-shadow-audit.test.ts
+++ b/apps/backend/src/tests/cellular-shadow-audit.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test";
+
+import { createMmDbusObserver } from "@ceralive/modem-control";
+import type {
+	DbusTransport,
+	MethodCall,
+	MethodReply,
+	SignalListener,
+	SignalSpec,
+	Subscription,
+	TransportEvent,
+} from "@ceralive/modem-control/transport";
+
+import {
+	createAuditingTransport,
+	MUTATING_DBUS_MEMBER_CALLS,
+	MUTATING_DBUS_MEMBERS,
+	memberKey,
+	SHADOW_READ_ONLY_MEMBERS,
+	ShadowMutationError,
+} from "../modules/cellular/dbus-audit-transport.ts";
+import {
+	startModemShadow,
+	stopModemShadow,
+} from "../modules/cellular/shadow.ts";
+import type { ShadowModemState } from "../modules/cellular/shadow-divergence.ts";
+
+const SIGNAL_SETUP = "org.freedesktop.ModemManager1.Modem.Signal.Setup";
+
+/**
+ * An in-memory `DbusTransport` that records every dispatched member call and signal
+ * subscription. It answers the two reads the read-only observer makes so
+ * `observer.start()` completes with an authoritative (empty) snapshot, letting the
+ * audit run the REAL package observer over a spy rather than a code-review assertion.
+ */
+class RecordingTransport implements DbusTransport {
+	readonly calls: string[] = [];
+	readonly subscriptions: string[] = [];
+	#connected = false;
+
+	async connect(): Promise<void> {
+		this.#connected = true;
+	}
+	async disconnect(): Promise<void> {
+		this.#connected = false;
+	}
+	isConnected(): boolean {
+		return this.#connected;
+	}
+	async callMethod(call: MethodCall): Promise<MethodReply> {
+		this.calls.push(memberKey(call));
+		if (call.member === "GetNameOwner") {
+			return { signature: "s", body: [":1.42"] };
+		}
+		if (call.member === "GetManagedObjects") {
+			// a{oa{sa{sv}}} with an empty tree → an authoritative empty snapshot.
+			return { signature: "a{oa{sa{sv}}}", body: [[]] };
+		}
+		return { signature: "", body: [] };
+	}
+	async subscribeSignal(
+		spec: SignalSpec,
+		_listener: SignalListener,
+	): Promise<Subscription> {
+		this.subscriptions.push(memberKey(spec));
+		return { unsubscribe: async () => {} };
+	}
+	on(_event: TransportEvent, _handler: (payload?: unknown) => void): void {}
+	off(_event: TransportEvent, _handler: (payload?: unknown) => void): void {}
+	subscriptionCount(): number {
+		return this.subscriptions.length;
+	}
+}
+
+describe("modem shadow — transport-level mutation audit", () => {
+	test("the REAL observer over the auditing transport issues only read-only calls — never Signal.Setup", async () => {
+		const inner = new RecordingTransport();
+		const audit = createAuditingTransport(inner);
+		const observer = createMmDbusObserver({ transport: audit });
+
+		const first = await observer.start();
+		expect(first.ok).toBe(true);
+
+		// Every forwarded call is in the read-only allowlist (fail-closed).
+		for (const member of audit.getCallLog()) {
+			expect(SHADOW_READ_ONLY_MEMBERS.has(member)).toBe(true);
+		}
+		// Signal.Setup — the annex-called-out mutation — NEVER appears.
+		expect(audit.getCallLog()).not.toContain(SIGNAL_SETUP);
+		// No mutation member appears at all.
+		for (const mutation of MUTATING_DBUS_MEMBERS) {
+			expect(audit.getCallLog()).not.toContain(mutation);
+		}
+		// The guard never tripped — the observer is genuinely read-only.
+		expect(audit.getRefusedCalls()).toEqual([]);
+		// The two authoritative reads actually reached the bus.
+		expect(inner.calls).toContain("org.freedesktop.DBus.GetNameOwner");
+		expect(inner.calls).toContain(
+			"org.freedesktop.DBus.ObjectManager.GetManagedObjects",
+		);
+
+		await observer.stop();
+	});
+
+	test("the auditing transport fails closed: every mutating member is refused and never forwarded", async () => {
+		const inner = new RecordingTransport();
+		const audit = createAuditingTransport(inner);
+
+		for (const call of MUTATING_DBUS_MEMBER_CALLS) {
+			await expect(
+				audit.callMethod({
+					destination: "org.freedesktop.ModemManager1",
+					path: "/org/freedesktop/ModemManager1/Modem/0",
+					interface: call.interface,
+					member: call.member,
+				}),
+			).rejects.toBeInstanceOf(ShadowMutationError);
+		}
+
+		// Not one mutating call was forwarded to the underlying bus.
+		expect(inner.calls).toEqual([]);
+		// Every mutation attempt was recorded as a refusal.
+		expect(audit.getRefusedCalls().sort()).toEqual(
+			[...MUTATING_DBUS_MEMBERS].sort(),
+		);
+	});
+
+	test("Signal.Setup specifically is refused and reported to the onRefusal hook", async () => {
+		const inner = new RecordingTransport();
+		const refused: string[] = [];
+		const audit = createAuditingTransport(inner, {
+			onRefusal: (member) => refused.push(member),
+		});
+
+		await expect(
+			audit.callMethod({
+				destination: "org.freedesktop.ModemManager1",
+				path: "/org/freedesktop/ModemManager1/Modem/0",
+				interface: "org.freedesktop.ModemManager1.Modem.Signal",
+				member: "Setup",
+				signature: "u",
+				args: [5],
+			}),
+		).rejects.toThrow(ShadowMutationError);
+
+		expect(refused).toEqual([SIGNAL_SETUP]);
+		expect(inner.calls).toEqual([]);
+	});
+
+	test("read-only members are forwarded unchanged", async () => {
+		const inner = new RecordingTransport();
+		const audit = createAuditingTransport(inner);
+
+		const reply = await audit.callMethod({
+			destination: "org.freedesktop.ModemManager1",
+			path: "/org/freedesktop/ModemManager1",
+			interface: "org.freedesktop.DBus.ObjectManager",
+			member: "GetManagedObjects",
+		});
+
+		expect(reply.body).toEqual([[]]);
+		expect(inner.calls).toEqual([
+			"org.freedesktop.DBus.ObjectManager.GetManagedObjects",
+		]);
+		expect(audit.getRefusedCalls()).toEqual([]);
+	});
+
+	test("an unknown/future member is refused by default (in-doubt-is-a-write)", async () => {
+		const inner = new RecordingTransport();
+		const audit = createAuditingTransport(inner);
+
+		await expect(
+			audit.callMethod({
+				destination: "org.freedesktop.ModemManager1",
+				path: "/org/freedesktop/ModemManager1/Modem/0",
+				interface: "org.freedesktop.ModemManager1.Modem",
+				member: "SomeFutureMethod",
+			}),
+		).rejects.toBeInstanceOf(ShadowMutationError);
+		expect(inner.calls).toEqual([]);
+	});
+
+	test("startModemShadow drives the observer read-only and never mutates the bus", async () => {
+		const inner = new RecordingTransport();
+		const observed: ShadowModemState[][] = [];
+
+		await startModemShadow({
+			createTransport: () => inner,
+			createObserver: (transport) => createMmDbusObserver({ transport }),
+			readMmcliStates: () => [],
+			mapObservation: (list) => {
+				observed.push([...(list.rows as ShadowModemState[])]);
+				return [];
+			},
+			log: () => {},
+		});
+
+		// The observer completed its first authoritative snapshot via reads only.
+		expect(inner.calls).toContain("org.freedesktop.DBus.GetNameOwner");
+		expect(inner.calls).toContain(
+			"org.freedesktop.DBus.ObjectManager.GetManagedObjects",
+		);
+		expect(inner.calls).not.toContain(SIGNAL_SETUP);
+		for (const mutation of MUTATING_DBUS_MEMBERS) {
+			expect(inner.calls).not.toContain(mutation);
+		}
+
+		await stopModemShadow();
+	});
+});

--- a/apps/backend/src/tests/cellular-shadow-divergence.test.ts
+++ b/apps/backend/src/tests/cellular-shadow-divergence.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	classifyShadowDivergences,
+	logShadowDivergences,
+	mmcliModemToShadowState,
+	observationRowToShadowState,
+	redactShadowDivergences,
+	SHADOW_DIVERGENCE_MSG,
+	type ShadowModemState,
+} from "../modules/cellular/shadow-divergence.ts";
+
+function state(
+	overrides: Partial<ShadowModemState> & { id: string },
+): ShadowModemState {
+	return { present: true, ...overrides };
+}
+
+function capture(): {
+	lines: Array<{ msg: string; meta: unknown }>;
+	log: (msg: string, meta: unknown) => void;
+} {
+	const lines: Array<{ msg: string; meta: unknown }> = [];
+	return { lines, log: (msg, meta) => lines.push({ msg, meta }) };
+}
+
+describe("modem shadow — divergence classifier", () => {
+	test("identical states produce zero divergences", () => {
+		const mmcli = [
+			state({
+				id: "wwan0",
+				registration: "registered",
+				operatorName: "Carrier",
+			}),
+		];
+		const dbus = [
+			state({
+				id: "wwan0",
+				registration: "registered",
+				operatorName: "Carrier",
+			}),
+		];
+		expect(classifyShadowDivergences(mmcli, dbus)).toEqual([]);
+	});
+
+	test("a modem only mmcli sees is reported as only-in-mmcli", () => {
+		const divs = classifyShadowDivergences([state({ id: "wwan0" })], []);
+		expect(divs).toEqual([{ id: "wwan0", kind: "only-in-mmcli" }]);
+	});
+
+	test("a modem only the shadow observer sees is reported as only-in-dbus", () => {
+		const divs = classifyShadowDivergences([], [state({ id: "wwan1" })]);
+		expect(divs).toEqual([{ id: "wwan1", kind: "only-in-dbus" }]);
+	});
+
+	test("field mismatches on a shared modem are enumerated field-by-field", () => {
+		const divs = classifyShadowDivergences(
+			[state({ id: "wwan0", registration: "registered", networkType: "5g" })],
+			[state({ id: "wwan0", registration: "searching", networkType: "5g" })],
+		);
+		expect(divs).toEqual([
+			{
+				id: "wwan0",
+				kind: "field-mismatch",
+				fields: [
+					{ field: "registration", mmcli: "registered", dbus: "searching" },
+				],
+			},
+		]);
+	});
+});
+
+describe("modem shadow — redacted divergence logging (reuses logRedact)", () => {
+	test("secret-shaped values in a divergence are redacted in the logged output", () => {
+		// A divergence carrying secret-SHAPED and secret-KEYED values. logRedact must
+		// scrub each before it reaches any transport.
+		const divs = classifyShadowDivergences(
+			[
+				state({
+					id: "wwan0",
+					operatorName: "v4.public.LEAKED-paseto-token-abc",
+				}),
+			],
+			[
+				state({
+					id: "wwan0",
+					operatorName: "Bearer sk_live_SECRET_credential_value",
+				}),
+			],
+		);
+		const { lines, log } = capture();
+		logShadowDivergences(divs, { log });
+
+		expect(lines).toHaveLength(1);
+		expect(lines[0]?.msg).toBe(SHADOW_DIVERGENCE_MSG);
+		const serialized = JSON.stringify(lines[0]?.meta);
+		expect(serialized).toContain("[REDACTED]");
+		expect(serialized).not.toContain("LEAKED-paseto-token-abc");
+		expect(serialized).not.toContain("sk_live_SECRET_credential_value");
+	});
+
+	test("a value under a sensitive key (pin) is redacted", () => {
+		// redactShadowDivergences must scrub a pin-keyed value via the shared helper.
+		const redacted = redactShadowDivergences([
+			{
+				id: "wwan0",
+				kind: "field-mismatch",
+				fields: [{ field: "simPin", mmcli: "1234", dbus: "9999" }],
+			},
+		]);
+		const serialized = JSON.stringify(redacted);
+		expect(serialized).toContain("[REDACTED]");
+		expect(serialized).not.toContain("1234");
+		expect(serialized).not.toContain("9999");
+	});
+
+	test("empty divergences never emit a log line", () => {
+		const { lines, log } = capture();
+		logShadowDivergences([], { log });
+		expect(lines).toEqual([]);
+	});
+});
+
+describe("modem shadow — secret-dropping state mappers", () => {
+	test("mmcli mapper copies only non-secret fields and drops ICCID/PIN/APN/password", () => {
+		const mapped = mmcliModemToShadowState({
+			id: "wwan0",
+			present: true,
+			registration: "registered",
+			operatorName: "Carrier",
+			networkType: "5g",
+			simPresent: true,
+			// secrets that MUST NOT survive the mapping:
+			iccid: "8934071100003141592",
+			pin: "1234",
+			apn: "secret.apn.example",
+			password: "hunter2",
+		});
+
+		expect(mapped).toEqual({
+			id: "wwan0",
+			present: true,
+			registration: "registered",
+			operatorName: "Carrier",
+			networkType: "5g",
+			simPresent: true,
+		});
+		const serialized = JSON.stringify(mapped);
+		expect(serialized).not.toContain("8934071100003141592");
+		expect(serialized).not.toContain("1234");
+		expect(serialized).not.toContain("secret.apn.example");
+		expect(serialized).not.toContain("hunter2");
+	});
+
+	test("observation mapper keys on the equipment/slot id, never the subscription id (ICCID/EID)", () => {
+		const mapped = observationRowToShadowState({
+			identity: {
+				logicalSlotId: "slot-usb-1-2",
+				equipmentId: {
+					provenance: "imei",
+					value: "356938035643809",
+					confidence: "high",
+				},
+				subscriptionId: "8934071100003141592", // ICCID — SENSITIVE, must be dropped
+			},
+			presence: "present",
+			registration: { status: "registered" },
+			simSlots: [{ index: 1, occupied: true, active: true, lock: "none" }],
+		});
+
+		expect(mapped.id).toBe("slot-usb-1-2");
+		expect(mapped.present).toBe(true);
+		expect(mapped.simPresent).toBe(true);
+		const serialized = JSON.stringify(mapped);
+		expect(serialized).not.toContain("8934071100003141592");
+	});
+});
+
+describe("modem shadow — QA failure scenario (injected fake divergence, redacted-only)", () => {
+	test("an injected mmcli-vs-dbus divergence is logged, and the log line leaks no secret", () => {
+		// Fake harness: mmcli reports one thing, the shadow observer another — including
+		// a secret-shaped value in the diverging field. The divergence MUST be logged,
+		// but the logged content MUST be redacted-only.
+		const mmcliStates = [
+			mmcliModemToShadowState({
+				id: "wwan0",
+				present: true,
+				registration: "registered",
+				operatorName: "Carrier",
+				iccid: "8934071100003141592",
+				pin: "4321",
+			}),
+		];
+		const dbusStates: ShadowModemState[] = [
+			{
+				id: "wwan0",
+				present: true,
+				registration: "searching",
+				operatorName: "v4.public.another-leaked-token",
+			},
+		];
+
+		const divs = classifyShadowDivergences(mmcliStates, dbusStates);
+		expect(divs.length).toBeGreaterThan(0);
+
+		const { lines, log } = capture();
+		logShadowDivergences(divs, { log });
+
+		expect(lines).toHaveLength(1);
+		const serialized = JSON.stringify(lines[0]?.meta);
+		// The divergence WAS logged...
+		expect(serialized).toContain("wwan0");
+		expect(serialized).toContain("registration");
+		// ...but no secret survived — neither the ICCID/PIN (dropped by the mapper) nor
+		// the token-shaped value (scrubbed by logRedact).
+		expect(serialized).not.toContain("8934071100003141592");
+		expect(serialized).not.toContain("4321");
+		expect(serialized).not.toContain("another-leaked-token");
+		expect(serialized).toContain("[REDACTED]");
+	});
+});

--- a/apps/backend/src/tests/cellular-stack.test.ts
+++ b/apps/backend/src/tests/cellular-stack.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { ORPCError } from "@orpc/server";
+
+import {
+	assertCellularStackReady,
+	CELLULAR_STACK_INITIALIZING,
+	type CellularBackend,
+	type CellularStartResult,
+	getCellularStack,
+	initCellularStack,
+	resetCellularStack,
+	stopCellularStack,
+} from "../modules/cellular/cellular-stack.ts";
+import { getConfig } from "../modules/config.ts";
+import {
+	getBootReadiness,
+	resetBootReadiness,
+} from "../modules/system/readiness.ts";
+
+function deferred<T>(): {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+	reject: (err: unknown) => void;
+} {
+	let resolve!: (value: T) => void;
+	let reject!: (err: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+function fakeBackend(
+	start: () => Promise<CellularStartResult>,
+	onStop?: () => void,
+): CellularBackend {
+	return {
+		start,
+		stop: async () => {
+			onStop?.();
+		},
+	};
+}
+
+function gateError(): unknown {
+	try {
+		assertCellularStackReady();
+	} catch (err) {
+		return err;
+	}
+	return undefined;
+}
+
+describe("cellular stack composition root", () => {
+	beforeEach(() => {
+		resetCellularStack();
+		resetBootReadiness();
+		getConfig().modem_backend = undefined;
+	});
+
+	afterEach(() => {
+		resetCellularStack();
+		resetBootReadiness();
+		getConfig().modem_backend = undefined;
+	});
+
+	test("default state is mmcli-ready with no init window", () => {
+		// Given a fresh process where init has never run
+		// When reading the stack and the readiness gate
+		// Then mmcli is committed, ready, and the gate never fires
+		expect(getCellularStack()).toEqual({
+			backend: "mmcli",
+			ready: true,
+			degraded: false,
+		});
+		expect(gateError()).toBeUndefined();
+	});
+
+	test("initCellularStack with mmcli commits mmcli ready synchronously", async () => {
+		// Given the default mmcli backend
+		// When init runs
+		await initCellularStack({ backend: "mmcli" });
+		// Then the stack is ready with no init window
+		expect(getCellularStack()).toEqual({
+			backend: "mmcli",
+			ready: true,
+			degraded: false,
+		});
+		expect(gateError()).toBeUndefined();
+	});
+
+	test("dbus commits only after its first successful snapshot", async () => {
+		// Given a dbus backend whose first snapshot has not resolved yet
+		const gate = deferred<CellularStartResult>();
+		const initPromise = initCellularStack({
+			backend: "dbus",
+			createDbusBackend: () => fakeBackend(() => gate.promise),
+		});
+
+		// Then the stack is still initializing and the gate throws the typed error
+		expect(getCellularStack().ready).toBe(false);
+		expect(getCellularStack().backend).toBe("dbus");
+		const err = gateError();
+		expect(err).toBeInstanceOf(ORPCError);
+		expect((err as ORPCError<string, unknown>).code).toBe(
+			CELLULAR_STACK_INITIALIZING,
+		);
+
+		// When the first authoritative snapshot resolves
+		gate.resolve({ ok: true });
+		await initPromise;
+
+		// Then dbus is committed, ready, and undegraded
+		expect(getCellularStack()).toEqual({
+			backend: "dbus",
+			ready: true,
+			degraded: false,
+		});
+		expect(gateError()).toBeUndefined();
+		expect(getBootReadiness().degraded).toBe(false);
+	});
+
+	test("dbus init failure falls back to mmcli with degraded readiness", async () => {
+		// Given a dbus backend whose snapshot rejects (no reachable bus)
+		await initCellularStack({
+			backend: "dbus",
+			createDbusBackend: () =>
+				fakeBackend(() => Promise.reject(new Error("no system bus"))),
+		});
+
+		// Then the stack falls back to mmcli, stays ready, and reports degraded
+		const stack = getCellularStack();
+		expect(stack.backend).toBe("mmcli");
+		expect(stack.ready).toBe(true);
+		expect(stack.degraded).toBe(true);
+		expect(stack.degradedReason).toBeDefined();
+		expect(getBootReadiness().degradedSubsystems).toContain("cellular-stack");
+		expect(gateError()).toBeUndefined();
+	});
+
+	test("a non-authoritative first snapshot (ok:false) is not committed", async () => {
+		// Given a dbus backend that starts but yields no authoritative snapshot
+		await initCellularStack({
+			backend: "dbus",
+			createDbusBackend: () =>
+				fakeBackend(() => Promise.resolve({ ok: false })),
+		});
+
+		// Then the backend is NOT committed — it falls back + degrades
+		const stack = getCellularStack();
+		expect(stack.backend).toBe("mmcli");
+		expect(stack.degraded).toBe(true);
+		expect(getBootReadiness().degradedSubsystems).toContain("cellular-stack");
+	});
+
+	test("a hung dbus init falls back within the bounded init window", async () => {
+		// Given a dbus backend whose snapshot never resolves
+		await initCellularStack({
+			backend: "dbus",
+			createDbusBackend: () =>
+				fakeBackend(() => new Promise<CellularStartResult>(() => {})),
+			initTimeoutMs: 20,
+		});
+
+		// Then the bounded window elapses and the stack falls back rather than hang
+		const stack = getCellularStack();
+		expect(stack.backend).toBe("mmcli");
+		expect(stack.degraded).toBe(true);
+		expect(getBootReadiness().degradedSubsystems).toContain("cellular-stack");
+	});
+
+	test("selects the backend from config.modem_backend when unset in deps", async () => {
+		// Given config opting into the dbus backend
+		getConfig().modem_backend = "dbus";
+		// When init runs without an explicit backend override
+		await initCellularStack({
+			createDbusBackend: () => fakeBackend(() => Promise.resolve({ ok: true })),
+		});
+		// Then the config-selected dbus backend is committed
+		expect(getCellularStack().backend).toBe("dbus");
+		expect(getCellularStack().ready).toBe(true);
+	});
+
+	test("stops the failed dbus backend on fallback", async () => {
+		// Given a dbus backend that rejects init
+		let stopped = false;
+		await initCellularStack({
+			backend: "dbus",
+			createDbusBackend: () =>
+				fakeBackend(
+					() => Promise.reject(new Error("boom")),
+					() => {
+						stopped = true;
+					},
+				),
+		});
+		// Then its transport is released on fallback
+		expect(stopped).toBe(true);
+	});
+
+	test("stopCellularStack releases the committed dbus backend and resets", async () => {
+		// Given a committed dbus backend
+		let stopped = false;
+		await initCellularStack({
+			backend: "dbus",
+			createDbusBackend: () =>
+				fakeBackend(
+					() => Promise.resolve({ ok: true }),
+					() => {
+						stopped = true;
+					},
+				),
+		});
+		expect(getCellularStack().backend).toBe("dbus");
+
+		// When the stack is torn down
+		await stopCellularStack();
+
+		// Then the backend is stopped and the stack resets to the mmcli default
+		expect(stopped).toBe(true);
+		expect(getCellularStack()).toEqual({
+			backend: "mmcli",
+			ready: true,
+			degraded: false,
+		});
+	});
+});

--- a/apps/backend/src/tests/modem-additive-fields-contract.test.ts
+++ b/apps/backend/src/tests/modem-additive-fields-contract.test.ts
@@ -1,0 +1,160 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Phase B, T5.4 — additive-optional schema contract.
+ *
+ * The ten Phase-B modem detail fields (`device_class`, `availability_reason`,
+ * `slot_label`, `recovery_state`, `usb_mode`, `recommended_usb_mode`,
+ * `data_usage`, `firmware_revision`, `esim`, `cell_info`) are additive-only. This
+ * suite is the acceptance gate for "old payloads still parse": a modem entry that
+ * omits EVERY new field must parse, and a payload that carries them must round-trip
+ * losslessly — proving an old backend/frontend pair never breaks on the new wire.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { modemListSchema, modemSchema } from "@ceraui/rpc/schemas";
+
+const OLD_MODEM_ENTRY = {
+	ifname: "wwan0",
+	name: "Quectel EM120R-GL",
+	model: "EM120R-GL",
+	manufacturer: "Quectel",
+	network_type: { supported: ["4g", "5g"], active: "5g" },
+	config: {
+		apn: "internet",
+		username: "",
+		password: "",
+		roaming: false,
+		network: "",
+	},
+	status: {
+		connection: "connected" as const,
+		network_type: "5G",
+		signal: 72,
+		roaming: false,
+	},
+} as const;
+
+describe("modem additive-optional field contract (T5.4)", () => {
+	test("an old modem entry (zero Phase-B fields) still parses", () => {
+		const parsed = modemSchema.parse(OLD_MODEM_ENTRY);
+		expect(parsed.device_class).toBeUndefined();
+		expect(parsed.availability_reason).toBeUndefined();
+		expect(parsed.slot_label).toBeUndefined();
+		expect(parsed.recovery_state).toBeUndefined();
+		expect(parsed.usb_mode).toBeUndefined();
+		expect(parsed.recommended_usb_mode).toBeUndefined();
+		expect(parsed.data_usage).toBeUndefined();
+		expect(parsed.firmware_revision).toBeUndefined();
+		expect(parsed.esim).toBeUndefined();
+		expect(parsed.cell_info).toBeUndefined();
+	});
+
+	test("an old modem entry round-trips byte-identically through the schema", () => {
+		const parsed = modemSchema.parse(OLD_MODEM_ENTRY);
+		expect(JSON.stringify(parsed)).toBe(JSON.stringify(OLD_MODEM_ENTRY));
+	});
+
+	test("an old modem LIST payload (record) still parses", () => {
+		const list = {
+			"0": OLD_MODEM_ENTRY,
+			"1": { ...OLD_MODEM_ENTRY, ifname: "wwan1" },
+		};
+		const parsed = modemListSchema.parse(list);
+		expect(Object.keys(parsed)).toEqual(["0", "1"]);
+	});
+
+	test("a new payload carrying every Phase-B field round-trips losslessly", () => {
+		const enriched = {
+			...OLD_MODEM_ENTRY,
+			device_class: "usb" as const,
+			availability_reason: "SIM slot empty",
+			slot_label: "SIM 1",
+			recovery_state: "online" as const,
+			usb_mode: "mbim" as const,
+			recommended_usb_mode: "qmi" as const,
+			data_usage: {
+				session_bytes: 1024,
+				monthly_bytes: 4096,
+				cycle_day: 1,
+				threshold_bytes: 5_000_000,
+			},
+			firmware_revision: "EM120RGLAR03A03M4G",
+			esim: {
+				sim_type: "physical" as const,
+				esim_status: "unknown" as const,
+			},
+			cell_info: {
+				tech: "nr" as const,
+				cell_id: "0x1A2B",
+				band: "n78",
+				rsrp: -85,
+				rsrq: -11,
+				sinr: 18,
+				provenance: { source: "mmcli", observed_at: 1_700_000_000 },
+			},
+		};
+		const parsed = modemSchema.parse(enriched);
+		expect(JSON.stringify(parsed)).toBe(JSON.stringify(enriched));
+	});
+
+	test("every Phase-B field is INDEPENDENTLY optional (omit-one still parses)", () => {
+		const keys = [
+			"device_class",
+			"availability_reason",
+			"slot_label",
+			"recovery_state",
+			"usb_mode",
+			"recommended_usb_mode",
+			"data_usage",
+			"firmware_revision",
+			"esim",
+			"cell_info",
+		] as const;
+		for (const omit of keys) {
+			const full: Record<string, unknown> = {
+				...OLD_MODEM_ENTRY,
+				device_class: "pcie-mhi",
+				availability_reason: "recovering",
+				slot_label: "SIM 2",
+				recovery_state: "recovering",
+				usb_mode: "qmi",
+				recommended_usb_mode: "mbim",
+				data_usage: { session_bytes: 1 },
+				firmware_revision: "rev",
+				esim: { sim_type: "esim" },
+				cell_info: { tech: "lte", rsrp: -90 },
+			};
+			delete full[omit];
+			expect(() => modemSchema.parse(full)).not.toThrow();
+		}
+	});
+
+	test("cell_info accepts LTE snr and NR sinr separately (ledger sinr-not-snr)", () => {
+		const lte = modemSchema.parse({
+			...OLD_MODEM_ENTRY,
+			cell_info: { tech: "lte", snr: 12 },
+		});
+		expect(lte.cell_info?.snr).toBe(12);
+		const nr = modemSchema.parse({
+			...OLD_MODEM_ENTRY,
+			cell_info: { tech: "nr", sinr: 20 },
+		});
+		expect(nr.cell_info?.sinr).toBe(20);
+	});
+});

--- a/apps/backend/src/tests/modem-wire-projection.test.ts
+++ b/apps/backend/src/tests/modem-wire-projection.test.ts
@@ -1,0 +1,526 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Phase B, T5.3 — legacy numeric wire projection (byte-compatible).
+ *
+ * The core proof is the GOLDEN-FIXTURE test: the same fake-harness scenario set
+ * expressed in BOTH backends (mmcli `Modem` and dbus observation view) projects to
+ * a BYTE-IDENTICAL frontend payload — so the frontend can never tell which backend
+ * is live. Plus:
+ *   - a regression lock proving the mmcli projection reproduces the live
+ *     `buildModemsMessage` output byte-for-byte (the existing wire is unchanged);
+ *   - the `"auto"` / `autoconfig` seam behaviour;
+ *   - the ≥1000 synthetic-id collision test;
+ *   - the replug-stability test.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { getGsmOperatorName } from "../modules/modems/gsm-operators-cache.ts";
+import { buildModemsMessage } from "../modules/modems/modem-status.ts";
+import type { DbusModemView } from "../modules/modems/modem-wire-adapters.ts";
+import {
+	fromDbusView,
+	fromMmcliModem,
+	fromRouterView,
+	ratsToNetworkTypeDisplay,
+} from "../modules/modems/modem-wire-adapters.ts";
+import {
+	AUTO_APN_SENTINEL,
+	type ProjectedModemSource,
+	projectModemWire,
+	resolveWireConfig,
+	SYNTHETIC_ID_BASE,
+} from "../modules/modems/modem-wire-projection.ts";
+import {
+	getModemIds,
+	type Modem,
+	removeModem,
+	setModem,
+} from "../modules/modems/modems-state.ts";
+import { setup } from "../modules/setup.ts";
+
+const OPERATOR_CODE = "310260";
+
+// The dbus adapter must resolve an available-networks name via the SAME
+// gsm-operators-cache lookup the mmcli path uses (`getAvailableNetworksForModem`
+// → `getGsmOperatorName(config.network) || "Operator ID <code>"`). This test
+// derives BOTH sides' fixture value from that ONE resolver at module load, so the
+// two paths agree regardless of the (empty-by-default, test-order-dependent)
+// operator cache — never a hardcoded name that silently diverges when the cache
+// is unseeded.
+function operatorDisplayName(code: string): string {
+	return getGsmOperatorName(code) ?? `Operator ID ${code}`;
+}
+
+const OPERATOR_NAME = operatorDisplayName(OPERATOR_CODE);
+
+function clearModems(): void {
+	for (const id of getModemIds()) {
+		removeModem(id);
+	}
+}
+
+/** A `setup.has_gsm_autoconfig` scope that always restores the prior value. */
+function withGsmAutoconfig<T>(value: boolean | undefined, fn: () => T): T {
+	const prior = setup.has_gsm_autoconfig;
+	setup.has_gsm_autoconfig = value;
+	try {
+		return fn();
+	} finally {
+		setup.has_gsm_autoconfig = prior;
+	}
+}
+
+const stableStringify = (v: unknown): string => JSON.stringify(v);
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Fake-harness scenario set — the SAME logical modems in both backend shapes.
+// Each scenario yields an mmcli `Modem` and the equivalent dbus observation view;
+// projecting either must produce the identical wire entry.
+// ──────────────────────────────────────────────────────────────────────────────
+
+interface Scenario {
+	readonly name: string;
+	readonly runtimeId: number;
+	readonly hasGsmAutoconfig: boolean;
+	readonly mmcli: Modem;
+	readonly dbus: DbusModemView;
+}
+
+const SCENARIOS: readonly Scenario[] = [
+	{
+		name: "5G online modem with manual APN",
+		runtimeId: 0,
+		hasGsmAutoconfig: false,
+		mmcli: {
+			ifname: "wwan0",
+			name: "RM520N-GL - 45678",
+			sim_network: "T-Mobile",
+			model: "RM520N-GL",
+			manufacturer: "Quectel",
+			network_type: {
+				supported: {
+					"4g": { allowed: "4g", preferred: "none" },
+					"5g4g": { allowed: "4g|5g", preferred: "5g" },
+				},
+				active: "5g4g",
+			},
+			status: {
+				connection: "connected",
+				network: "T-Mobile",
+				network_type: "5G",
+				signal: 82,
+				roaming: false,
+			},
+			config: {
+				autoconfig: false,
+				apn: "fast.t-mobile.com",
+				username: "user",
+				password: "secret",
+				roaming: true,
+				network: OPERATOR_CODE,
+			},
+		},
+		dbus: {
+			runtimeId: 0,
+			ifname: "wwan0",
+			model: "RM520N-GL",
+			manufacturer: "Quectel",
+			equipmentId: "123456789045678",
+			mmState: "connected",
+			registration: { status: "home", activeRats: new Set(["lte", "5gnr"]) },
+			signal: 82,
+			operatorName: "T-Mobile",
+			supportedNetworkTypes: ["4g", "5g4g"],
+			activeNetworkType: "5g4g",
+			simSlots: [{ occupied: true, active: true, lock: "none" }],
+			config: {
+				autoconfig: false,
+				apn: "fast.t-mobile.com",
+				username: "user",
+				password: "secret",
+				roaming: true,
+				network: OPERATOR_CODE,
+			},
+			// The dbus backend resolves the saved operator (config.network) to the
+			// same synthesized available-networks entry the mmcli path derives via
+			// getAvailableNetworksForModem — through the SAME operator-cache resolver,
+			// so the name matches byte-for-byte whether or not the cache is seeded.
+			availableNetworks: { [OPERATOR_CODE]: { name: OPERATOR_NAME } },
+		},
+	},
+	{
+		name: "4G roaming modem, auto-config ON (auto never echoed)",
+		runtimeId: 3,
+		hasGsmAutoconfig: true,
+		mmcli: {
+			ifname: "wwan1",
+			name: "EM7455 - 99887",
+			sim_network: "Vodafone",
+			model: "EM7455",
+			manufacturer: "Sierra",
+			network_type: {
+				supported: { "4g": { allowed: "4g", preferred: "none" } },
+				active: "4g",
+			},
+			status: {
+				connection: "registered",
+				network: "Vodafone",
+				network_type: "4G",
+				signal: 55,
+				roaming: true,
+			},
+			// auto-config ON: the mmcli path clears apn/user/pass to "" already.
+			config: {
+				autoconfig: true,
+				apn: "",
+				username: "",
+				password: "",
+				roaming: false,
+				network: "",
+			},
+		},
+		dbus: {
+			runtimeId: 3,
+			ifname: "wwan1",
+			model: "EM7455",
+			manufacturer: "Sierra",
+			equipmentId: "35291099887",
+			mmState: "registered",
+			registration: { status: "roaming", activeRats: new Set(["lte"]) },
+			signal: 55,
+			operatorName: "Vodafone",
+			supportedNetworkTypes: ["4g"],
+			activeNetworkType: "4g",
+			simSlots: [{ occupied: true, active: true, lock: "none" }],
+			// dbus side carries the raw Auto-APN sentinel — MUST resolve to "".
+			config: {
+				autoconfig: true,
+				apn: AUTO_APN_SENTINEL,
+				username: "",
+				password: "",
+				roaming: false,
+				network: "",
+			},
+		},
+	},
+	{
+		name: "SIM-PIN-locked modem, no profile (no_sim)",
+		runtimeId: 7,
+		hasGsmAutoconfig: false,
+		mmcli: {
+			ifname: "wwan2",
+			name: "RM500Q-GL - 11223",
+			sim_network: "<NO SIM>",
+			model: "RM500Q-GL",
+			manufacturer: "Quectel",
+			network_type: {
+				supported: { "4g": { allowed: "4g", preferred: "none" } },
+				active: null,
+			},
+			status: {
+				connection: "locked",
+				network_type: "",
+				signal: 0,
+				roaming: false,
+			},
+			sim_lock: { required: "sim-pin", remainingAttempts: 3 },
+		},
+		dbus: {
+			runtimeId: 7,
+			ifname: "wwan2",
+			model: "RM500Q-GL",
+			manufacturer: "Quectel",
+			equipmentId: "86000000011223",
+			mmState: "locked",
+			registration: { status: "idle", activeRats: new Set() },
+			signal: 0,
+			supportedNetworkTypes: ["4g"],
+			activeNetworkType: null,
+			simSlots: [{ occupied: true, active: true, lock: "sim-pin" }],
+			simLockRequired: "sim-pin",
+			simLockRemainingAttempts: 3,
+			// no NM profile ⇒ no_sim on the wire.
+		},
+	},
+];
+
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe("T5.3 golden fixture — mmcli vs dbus byte-identical projection", () => {
+	afterEach(clearModems);
+
+	test("each scenario projects identically under both backends", () => {
+		for (const scenario of SCENARIOS) {
+			const mmcliWire = withGsmAutoconfig(scenario.hasGsmAutoconfig, () =>
+				projectModemWire([fromMmcliModem(scenario.runtimeId, scenario.mmcli)], {
+					hasGsmAutoconfig: scenario.hasGsmAutoconfig,
+				}),
+			);
+			const dbusWire = projectModemWire([fromDbusView(scenario.dbus)], {
+				hasGsmAutoconfig: scenario.hasGsmAutoconfig,
+			});
+
+			expect(stableStringify(dbusWire.message)).toBe(
+				stableStringify(mmcliWire.message),
+			);
+		}
+	});
+
+	test("the whole scenario set projects identically as one payload", () => {
+		// Every scenario shares hasGsmAutoconfig=... independently; drive the mixed
+		// set through the shared true/false split the wire uses per-broadcast.
+		for (const hasGsm of [true, false]) {
+			const mmcliSources = SCENARIOS.map((s) =>
+				withGsmAutoconfig(hasGsm, () => fromMmcliModem(s.runtimeId, s.mmcli)),
+			);
+			const dbusSources = SCENARIOS.map((s) => fromDbusView(s.dbus));
+
+			const mmcliWire = projectModemWire(mmcliSources, {
+				hasGsmAutoconfig: hasGsm,
+			});
+			const dbusWire = projectModemWire(dbusSources, {
+				hasGsmAutoconfig: hasGsm,
+			});
+
+			expect(stableStringify(dbusWire.message)).toBe(
+				stableStringify(mmcliWire.message),
+			);
+		}
+	});
+
+	test("`auto` sentinel is never echoed on the wire (either backend)", () => {
+		const scenario = SCENARIOS[1]; // auto-config ON scenario
+		if (scenario === undefined) throw new Error("missing scenario");
+
+		const dbusWire = projectModemWire([fromDbusView(scenario.dbus)], {
+			hasGsmAutoconfig: true,
+		});
+		const raw = stableStringify(dbusWire.message);
+		expect(raw).not.toContain(`"apn":"${AUTO_APN_SENTINEL}"`);
+		const entry = dbusWire.message["3"];
+		expect(entry?.config?.apn).toBe("");
+		expect(entry?.config?.autoconfig).toBe(true);
+	});
+});
+
+describe("T5.3 regression lock — mmcli projection == buildModemsMessage", () => {
+	afterEach(clearModems);
+
+	test("projected mmcli wire byte-matches the live broadcast builder", () => {
+		for (const hasGsm of [true, false]) {
+			withGsmAutoconfig(hasGsm, () => {
+				clearModems();
+				for (const scenario of SCENARIOS) {
+					setModem(scenario.runtimeId, scenario.mmcli);
+				}
+
+				const live = buildModemsMessage();
+
+				// Build from the SAME modemsState the live builder read.
+				const projectedSources: ProjectedModemSource[] = getModemIds()
+					.map((id) => {
+						const m = SCENARIOS.find((s) => s.runtimeId === id)?.mmcli;
+						return m ? fromMmcliModem(id, m) : undefined;
+					})
+					.filter((s): s is ProjectedModemSource => s !== undefined);
+
+				const projected = projectModemWire(projectedSources, {
+					hasGsmAutoconfig: hasGsm,
+				});
+
+				expect(stableStringify(projected.message)).toBe(stableStringify(live));
+			});
+		}
+	});
+});
+
+describe("T5.3 autoconfig seam + auto resolution", () => {
+	test("autoconfig gate = hasGsmAutoconfig && config.autoconfig", () => {
+		const base = {
+			apn: "internet",
+			username: "u",
+			password: "p",
+			roaming: true,
+			network: "310260",
+		};
+
+		// setup off ⇒ autoconfig false even when config wants it, apn echoed.
+		expect(resolveWireConfig({ ...base, autoconfig: true }, false)).toEqual({
+			...base,
+			autoconfig: false,
+		});
+
+		// setup on + config on ⇒ autoconfig true, apn cleared.
+		expect(resolveWireConfig({ ...base, autoconfig: true }, true)).toEqual({
+			apn: "",
+			username: "u",
+			password: "p",
+			roaming: true,
+			network: "310260",
+			autoconfig: true,
+		});
+
+		// setup on + config off ⇒ autoconfig false, apn echoed.
+		expect(resolveWireConfig({ ...base, autoconfig: false }, true)).toEqual({
+			...base,
+			autoconfig: false,
+		});
+	});
+
+	test("a raw `auto` apn is coerced to empty even with autoconfig gated off", () => {
+		const resolved = resolveWireConfig(
+			{
+				apn: AUTO_APN_SENTINEL,
+				username: "",
+				password: "",
+				roaming: false,
+				network: "",
+				autoconfig: false,
+			},
+			false,
+		);
+		expect(resolved.apn).toBe("");
+		expect(resolved.autoconfig).toBe(false);
+	});
+});
+
+describe("T5.3 RAT → legacy network_type display", () => {
+	test("highest generation wins; unknowns ignored; empty → ''", () => {
+		expect(ratsToNetworkTypeDisplay(new Set(["lte", "5gnr"]))).toBe("5G");
+		expect(ratsToNetworkTypeDisplay(new Set(["lte"]))).toBe("4G");
+		expect(ratsToNetworkTypeDisplay(new Set(["umts"]))).toBe("3G");
+		expect(ratsToNetworkTypeDisplay(new Set(["gsm"]))).toBe("2G");
+		expect(ratsToNetworkTypeDisplay(new Set(["gsm", "lte"]))).toBe("4G");
+		expect(ratsToNetworkTypeDisplay(new Set())).toBe("");
+		expect(ratsToNetworkTypeDisplay(new Set(["unknown-tech"]))).toBe("");
+	});
+});
+
+describe("T5.3 router/unmanaged ≥1000 synthetic-id allocation", () => {
+	function routerSource(
+		stableKey: string,
+		ifname: string,
+	): ProjectedModemSource {
+		return fromRouterView({
+			kind: "router",
+			stableKey,
+			ifname,
+			name: `HiLink ${ifname}`,
+			status: {
+				connection: "connected",
+				network_type: "4G",
+				signal: 0,
+				roaming: false,
+			},
+		});
+	}
+
+	test("router/unmanaged rows key from the reserved ≥1000 namespace", () => {
+		const mm = fromMmcliModem(0, SCENARIOS[0]?.mmcli as Modem);
+		const router = routerSource("usb-1-2", "eth1");
+
+		const { message } = projectModemWire([mm, router], {
+			hasGsmAutoconfig: false,
+		});
+
+		expect(Object.keys(message)).toContain("0");
+		const syntheticKey = Object.keys(message).find(
+			(k) => Number(k) >= SYNTHETIC_ID_BASE,
+		);
+		expect(syntheticKey).toBe(String(SYNTHETIC_ID_BASE));
+		expect(message[String(SYNTHETIC_ID_BASE)]?.ifname).toBe("eth1");
+	});
+
+	test("collision: a synthetic id NEVER equals a live MM id at/above 1000", () => {
+		// A pathological run where MM handed out runtime id 1000 and 1001.
+		const mmHigh1 = fromMmcliModem(
+			SYNTHETIC_ID_BASE,
+			SCENARIOS[0]?.mmcli as Modem,
+		);
+		const mmHigh2 = fromMmcliModem(
+			SYNTHETIC_ID_BASE + 1,
+			SCENARIOS[2]?.mmcli as Modem,
+		);
+		const routerA = routerSource("usb-1-1", "eth1");
+		const routerB = routerSource("usb-1-2", "eth2");
+
+		const { message, syntheticIds } = projectModemWire(
+			[mmHigh1, mmHigh2, routerA, routerB],
+			{ hasGsmAutoconfig: false },
+		);
+
+		const mmKeys = new Set([
+			String(SYNTHETIC_ID_BASE),
+			String(SYNTHETIC_ID_BASE + 1),
+		]);
+		// Both routers must have been pushed ABOVE the two live MM ids at 1000/1001.
+		for (const [, id] of syntheticIds) {
+			expect(id).toBeGreaterThanOrEqual(SYNTHETIC_ID_BASE);
+			expect(mmKeys.has(String(id))).toBe(false);
+		}
+		// Distinct ids, and none clobbered a live MM entry.
+		const ids = [...syntheticIds.values()];
+		expect(new Set(ids).size).toBe(ids.length);
+		expect(message[String(SYNTHETIC_ID_BASE)]?.ifname).toBeDefined();
+		// The two live MM entries survived at their own ids.
+		expect(Object.keys(message)).toContain(String(SYNTHETIC_ID_BASE));
+		expect(Object.keys(message)).toContain(String(SYNTHETIC_ID_BASE + 1));
+	});
+
+	test("replug stability: same hardware key ⇒ same synthetic id across replug", () => {
+		const router = () => routerSource("usb-1-2", "eth1");
+
+		// Plug in.
+		const first = projectModemWire([router()], { hasGsmAutoconfig: false });
+		const firstId = first.syntheticIds.get("usb-1-2");
+		expect(firstId).toBe(SYNTHETIC_ID_BASE);
+
+		// Unplug (device absent from the snapshot). Its id is retained.
+		const gap = projectModemWire([], {
+			hasGsmAutoconfig: false,
+			previousSyntheticIds: first.syntheticIds,
+		});
+
+		// Replug the SAME hardware ⇒ same id.
+		const second = projectModemWire([router()], {
+			hasGsmAutoconfig: false,
+			previousSyntheticIds: gap.syntheticIds.size
+				? gap.syntheticIds
+				: first.syntheticIds,
+		});
+		expect(second.syntheticIds.get("usb-1-2")).toBe(firstId);
+		expect(second.message[String(firstId)]?.ifname).toBe("eth1");
+	});
+
+	test("allocation is independent of source array order (replug-safe)", () => {
+		const a = routerSource("usb-aaa", "eth1");
+		const b = routerSource("usb-bbb", "eth2");
+
+		const forward = projectModemWire([a, b], { hasGsmAutoconfig: false });
+		const reversed = projectModemWire([b, a], { hasGsmAutoconfig: false });
+
+		// Same stableKey ⇒ same id regardless of insertion order.
+		expect(forward.syntheticIds.get("usb-aaa")).toBe(
+			reversed.syntheticIds.get("usb-aaa"),
+		);
+		expect(forward.syntheticIds.get("usb-bbb")).toBe(
+			reversed.syntheticIds.get("usb-bbb"),
+		);
+	});
+});

--- a/apps/backend/src/tests/modems-cellular-gate.test.ts
+++ b/apps/backend/src/tests/modems-cellular-gate.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { call, ORPCError } from "@orpc/server";
+
+import {
+	CELLULAR_STACK_INITIALIZING,
+	type CellularStartResult,
+	initCellularStack,
+	resetCellularStack,
+} from "../modules/cellular/cellular-stack.ts";
+import { getConfig } from "../modules/config.ts";
+import { resetBootReadiness } from "../modules/system/readiness.ts";
+import { getAllModemsProcedure } from "../rpc/procedures/modems.procedure.ts";
+import type { AppWebSocket, RPCContext } from "../rpc/types.ts";
+
+function makeContext(): RPCContext {
+	const ws = {
+		send: () => {},
+		data: { isAuthenticated: true, lastActive: Date.now() },
+	} as unknown as AppWebSocket;
+	return {
+		ws,
+		isAuthenticated: () => true,
+		authenticate: () => {},
+		deauthenticate: () => {},
+		markActive: () => {},
+		getLastActive: () => 0,
+		setSenderId: () => {},
+		getSenderId: () => undefined,
+		clearSenderId: () => {},
+	};
+}
+
+function deferred<T>(): {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+} {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+async function callGetAll(): Promise<unknown> {
+	return call(getAllModemsProcedure, undefined, { context: makeContext() });
+}
+
+describe("modem procedures — cellular stack init gate", () => {
+	beforeEach(() => {
+		resetCellularStack();
+		resetBootReadiness();
+		getConfig().modem_backend = undefined;
+	});
+
+	afterEach(() => {
+		resetCellularStack();
+		resetBootReadiness();
+		getConfig().modem_backend = undefined;
+	});
+
+	test("default (mmcli ready) — getAll resolves without the gate firing", async () => {
+		// Given the default mmcli-ready stack (no init run)
+		// When a modem procedure is called
+		const result = await callGetAll();
+		// Then it resolves normally (byte-identical to the pre-seam path)
+		expect(result).toBeDefined();
+	});
+
+	test("during the dbus init window — getAll returns CELLULAR_STACK_INITIALIZING", async () => {
+		// Given a dbus backend whose first snapshot has not resolved yet
+		const gate = deferred<CellularStartResult>();
+		const initPromise = initCellularStack({
+			backend: "dbus",
+			createDbusBackend: () => ({
+				start: () => gate.promise,
+				stop: async () => {},
+			}),
+		});
+
+		// When a modem procedure is called during the init window
+		let err: unknown;
+		try {
+			await callGetAll();
+		} catch (e) {
+			err = e;
+		}
+
+		// Then it returns the typed error — never a crash, never a hang
+		expect(err).toBeInstanceOf(ORPCError);
+		expect((err as ORPCError<string, unknown>).code).toBe(
+			CELLULAR_STACK_INITIALIZING,
+		);
+
+		gate.resolve({ ok: true });
+		await initPromise;
+	});
+
+	test("after the dbus backend commits — getAll resolves again", async () => {
+		// Given a dbus backend that committed its first snapshot
+		await initCellularStack({
+			backend: "dbus",
+			createDbusBackend: () => ({
+				start: () => Promise.resolve({ ok: true }),
+				stop: async () => {},
+			}),
+		});
+
+		// When a modem procedure is called
+		const result = await callGetAll();
+
+		// Then it resolves normally
+		expect(result).toBeDefined();
+	});
+
+	test("after a dbus init failure — the mmcli fallback keeps procedures working", async () => {
+		// Given a dbus backend that failed to initialize (fell back to mmcli)
+		await initCellularStack({
+			backend: "dbus",
+			createDbusBackend: () => ({
+				start: () => Promise.reject(new Error("no system bus")),
+				stop: async () => {},
+			}),
+		});
+
+		// When a modem procedure is called after fallback
+		const result = await callGetAll();
+
+		// Then it resolves normally on the mmcli fallback path
+		expect(result).toBeDefined();
+	});
+});

--- a/apps/backend/src/tests/modems-set-usb-mode-gate.test.ts
+++ b/apps/backend/src/tests/modems-set-usb-mode-gate.test.ts
@@ -1,0 +1,124 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Phase B, T5.4 — the `modem_provisioning` default-absent USB-mode gate.
+ *
+ * Acceptance: while `modem_provisioning` is absent (the default state) the guarded
+ * `modems.setUsbMode` mutation is UNREACHABLE — a direct RPC call is refused with
+ * the typed `provisioning_disabled` error, never a crash and never a silent
+ * success. Setting the key to `true` lifts the gate (the mutation then reaches the
+ * still-unimplemented transition transaction, which is a later wave, so the
+ * emulated-mode refusal is expected here).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { SetUsbModeInput } from "@ceraui/rpc/schemas";
+import { call } from "@orpc/server";
+import { resetCellularStack } from "../modules/cellular/cellular-stack.ts";
+import { getConfig } from "../modules/config.ts";
+import { resetBootReadiness } from "../modules/system/readiness.ts";
+import { setUsbModeProcedure } from "../rpc/procedures/modems.procedure.ts";
+import type { AppWebSocket, RPCContext } from "../rpc/types.ts";
+
+function makeContext(): RPCContext {
+	const ws = {
+		send: () => {},
+		data: { isAuthenticated: true, lastActive: Date.now() },
+	} as unknown as AppWebSocket;
+	return {
+		ws,
+		isAuthenticated: () => true,
+		authenticate: () => {},
+		deauthenticate: () => {},
+		markActive: () => {},
+		getLastActive: () => 0,
+		setSenderId: () => {},
+		getSenderId: () => undefined,
+		clearSenderId: () => {},
+	};
+}
+
+const VALID_INPUT: SetUsbModeInput = {
+	device: "0",
+	mode: "mbim",
+	confirm: true,
+};
+
+async function callSetUsbMode(input: unknown): Promise<unknown> {
+	return call(setUsbModeProcedure, input as SetUsbModeInput, {
+		context: makeContext(),
+	});
+}
+
+describe("modems.setUsbMode — modem_provisioning default-absent gate", () => {
+	beforeEach(() => {
+		resetCellularStack();
+		resetBootReadiness();
+		getConfig().modem_provisioning = undefined;
+	});
+
+	afterEach(() => {
+		resetCellularStack();
+		resetBootReadiness();
+		getConfig().modem_provisioning = undefined;
+	});
+
+	test("modem_provisioning ABSENT → typed provisioning_disabled refusal (not a crash)", async () => {
+		// Given no modem_provisioning key (the default for every existing device)
+		expect(getConfig().modem_provisioning).toBeUndefined();
+		// When setUsbMode is called directly over RPC
+		const result = await callSetUsbMode(VALID_INPUT);
+		// Then it is a typed refusal — the mutation is unreachable
+		expect(result).toEqual({ success: false, error: "provisioning_disabled" });
+	});
+
+	test("modem_provisioning === false → still provisioning_disabled", async () => {
+		getConfig().modem_provisioning = false;
+		const result = await callSetUsbMode(VALID_INPUT);
+		expect(result).toEqual({ success: false, error: "provisioning_disabled" });
+	});
+
+	test("modem_provisioning === true (emulated host) → past the gate, emulated refusal", async () => {
+		// Given the operator opted in but this is an emulated/dev host
+		getConfig().modem_provisioning = true;
+		// When setUsbMode is called
+		const result = await callSetUsbMode(VALID_INPUT);
+		// Then it clears the provisioning gate and hits the emulated-mode refusal —
+		// proving the gate is the ONLY thing that returns provisioning_disabled.
+		expect(result).toEqual({
+			success: false,
+			error: "unavailable_in_emulated_mode",
+		});
+	});
+
+	test("missing confirm:true is rejected at the input boundary (strict schema)", async () => {
+		getConfig().modem_provisioning = true;
+		await expect(
+			// biome-ignore lint/suspicious/noExplicitAny: exercising an invalid payload
+			callSetUsbMode({ device: "0", mode: "mbim" } as any),
+		).rejects.toThrow();
+	});
+
+	test("an unknown extra field is rejected (.strict input)", async () => {
+		getConfig().modem_provisioning = true;
+		await expect(
+			// biome-ignore lint/suspicious/noExplicitAny: exercising an invalid payload
+			callSetUsbMode({ ...VALID_INPUT, rogue: 1 } as any),
+		).rejects.toThrow();
+	});
+});

--- a/apps/backend/src/tests/modems-streaming-interlock.test.ts
+++ b/apps/backend/src/tests/modems-streaming-interlock.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Phase B, T5.5 — LifecycleInterlock wiring across the REAL procedures.
+ *
+ * Proves the interlock is consulted end-to-end: `modems.setUsbMode` refuses with
+ * `streaming_active` while a stream is being ADMITTED (interlock held) OR is LIVE
+ * (`getIsStreaming()`), and `streaming.start` refuses pre-engine with
+ * `MODEM_TRANSITION_ACTIVE` while a modem transition holds the interlock — and the
+ * admission `finally` releases the interlock on both its failure and success paths.
+ * The primitive's race-order + no-deadlock proofs live in
+ * `cellular-lifecycle-interlock.test.ts`.
+ */
+
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from "bun:test";
+import type { SetUsbModeInput } from "@ceraui/rpc/schemas";
+import { call } from "@orpc/server";
+import {
+	initMockService,
+	resetMockState,
+	setStreamingState,
+	stopMockService,
+} from "../mocks/mock-service.ts";
+import { injectMockStreamError } from "../mocks/providers/streaming.ts";
+import { resetCellularStack } from "../modules/cellular/cellular-stack.ts";
+import { getConfig } from "../modules/config.ts";
+import {
+	isLifecycleHeld,
+	resetLifecycleInterlock,
+	tryAcquireLifecycle,
+} from "../modules/streaming/lifecycle-admission.ts";
+import {
+	getIsStreaming,
+	updateStatus,
+} from "../modules/streaming/streaming.ts";
+import { withDeviceType } from "../modules/system/device-detection.ts";
+import { resetBootReadiness } from "../modules/system/readiness.ts";
+import { setUsbModeProcedure } from "../rpc/procedures/modems.procedure.ts";
+import { streamingStartProcedure } from "../rpc/procedures/streaming.procedure.ts";
+import type { AppWebSocket, RPCContext } from "../rpc/types.ts";
+
+function makeContext(): RPCContext {
+	const ws = {
+		send: () => {},
+		data: { isAuthenticated: true, lastActive: Date.now() },
+	} as unknown as AppWebSocket;
+	return {
+		ws,
+		isAuthenticated: () => true,
+		authenticate: () => {},
+		deauthenticate: () => {},
+		markActive: () => {},
+		getLastActive: () => 0,
+		setSenderId: () => {},
+		getSenderId: () => undefined,
+		clearSenderId: () => {},
+	};
+}
+
+const VALID_USB_MODE: SetUsbModeInput = {
+	device: "0",
+	mode: "mbim",
+	confirm: true,
+};
+
+describe("streaming ↔ modem-transition interlock (real procedures)", () => {
+	let priorPipeline: string | undefined;
+	const savedMockMode = process.env.MOCK_MODE;
+	const savedNodeEnv = process.env.NODE_ENV;
+
+	beforeAll(() => {
+		process.env.MOCK_MODE = "true";
+		initMockService("multi-modem-wifi");
+	});
+	beforeEach(() => {
+		resetLifecycleInterlock();
+		resetCellularStack();
+		resetBootReadiness();
+		priorPipeline = getConfig().pipeline;
+		getConfig().pipeline = undefined;
+		getConfig().modem_provisioning = undefined;
+		setStreamingState(false);
+		updateStatus(false);
+	});
+	afterEach(() => {
+		resetLifecycleInterlock();
+		resetCellularStack();
+		resetBootReadiness();
+		getConfig().pipeline = priorPipeline;
+		getConfig().modem_provisioning = undefined;
+		setStreamingState(false);
+		updateStatus(false);
+		resetMockState();
+	});
+	afterAll(() => {
+		stopMockService();
+		if (savedMockMode === undefined) delete process.env.MOCK_MODE;
+		else process.env.MOCK_MODE = savedMockMode;
+		if (savedNodeEnv === undefined) delete process.env.NODE_ENV;
+		else process.env.NODE_ENV = savedNodeEnv;
+	});
+
+	test("setUsbMode is refused (streaming_active) while a streaming admission holds the interlock", async () => {
+		getConfig().modem_provisioning = true;
+		const admission = tryAcquireLifecycle("streaming");
+		expect(admission).not.toBeNull();
+		try {
+			let result: unknown;
+			await withDeviceType("real", async () => {
+				result = await call(setUsbModeProcedure, VALID_USB_MODE, {
+					context: makeContext(),
+				});
+			});
+			expect(result).toEqual({ success: false, error: "streaming_active" });
+		} finally {
+			admission?.release();
+		}
+	});
+
+	test("setUsbMode is refused (streaming_active) while a stream is LIVE — admitted-start covers is_streaming too", async () => {
+		getConfig().modem_provisioning = true;
+		updateStatus(true);
+		expect(isLifecycleHeld()).toBe(false);
+		let result: unknown;
+		await withDeviceType("real", async () => {
+			result = await call(setUsbModeProcedure, VALID_USB_MODE, {
+				context: makeContext(),
+			});
+		});
+		expect(result).toEqual({ success: false, error: "streaming_active" });
+	});
+
+	test("streaming.start is refused pre-engine (MODEM_TRANSITION_ACTIVE) while a modem transition holds the interlock", async () => {
+		const transition = tryAcquireLifecycle("modem-transition");
+		expect(transition).not.toBeNull();
+		try {
+			const result = await call(
+				streamingStartProcedure,
+				{},
+				{ context: makeContext() },
+			);
+			expect(result).toEqual({
+				success: false,
+				is_streaming: false,
+				error: "MODEM_TRANSITION_ACTIVE",
+			});
+			expect(getIsStreaming()).toBe(false);
+		} finally {
+			transition?.release();
+		}
+	});
+
+	test("streaming.start releases the interlock on its failure path — a subsequent transition can acquire", async () => {
+		injectMockStreamError("srt_connect_failed");
+		const result = await call(
+			streamingStartProcedure,
+			{},
+			{ context: makeContext() },
+		);
+		expect(result.success).toBe(false);
+		expect(isLifecycleHeld()).toBe(false);
+		const after = tryAcquireLifecycle("modem-transition");
+		expect(after).not.toBeNull();
+		after?.release();
+	});
+
+	test("streaming.start releases the interlock on success, then the LIVE guard blocks a transition (no gap)", async () => {
+		const result = await call(
+			streamingStartProcedure,
+			{},
+			{ context: makeContext() },
+		);
+		expect(result.success).toBe(true);
+		expect(isLifecycleHeld()).toBe(false);
+		expect(getIsStreaming()).toBe(true);
+
+		getConfig().modem_provisioning = true;
+		let usbResult: unknown;
+		await withDeviceType("real", async () => {
+			usbResult = await call(setUsbModeProcedure, VALID_USB_MODE, {
+				context: makeContext(),
+			});
+		});
+		expect(usbResult).toEqual({ success: false, error: "streaming_active" });
+	});
+});

--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -121,7 +121,7 @@ via `bun run build:federation` from the CeraUI root (delegates to the frontend
   the typed host adapter. Shared graph code is split into sibling chunks
   co-located at the same versioned path.
 - **`<ceraui-version>`** is read at build time from the workspace-root `package.json` `version`
-  (CalVer, `2026.7.1` at time of writing) — the single source of truth, matching the platform's
+  (CalVer, `2026.7.2` at time of writing) — the single source of truth, matching the platform's
   `ceraui-version` claim.
 - **Isolation**: this build NEVER touches the SPA `dist/public` output, runs no
   PWA/service-worker plugin, and emits no `index.html`. The SPA `vite.config.ts` is unmodified.

--- a/apps/frontend/src/lib/rpc/client.ts
+++ b/apps/frontend/src/lib/rpc/client.ts
@@ -43,6 +43,8 @@ import type {
 	SetPasswordInput,
 	SetSourceVisibilityInput,
 	SetSourceVisibilityOutput,
+	SetUsbModeInput,
+	SetUsbModeOutput,
 	SimPukUnlockInput,
 	SimPukUnlockOutput,
 	SimUnlockInput,
@@ -566,6 +568,7 @@ export interface TypedRPC {
 		scan: (input: ModemScanInput) => Promise<ModemScanOutput>;
 		unlockSim: (input: SimUnlockInput) => Promise<SimUnlockOutput>;
 		unlockSimPuk: (input: SimPukUnlockInput) => Promise<SimPukUnlockOutput>;
+		setUsbMode: (input: SetUsbModeInput) => Promise<SetUsbModeOutput>;
 	};
 	wifi: {
 		getStatus: () => Promise<unknown>;

--- a/apps/frontend/src/main/dialogs/ModemConfigDialog.svelte
+++ b/apps/frontend/src/main/dialogs/ModemConfigDialog.svelte
@@ -19,11 +19,15 @@
   the primary (Save) action is disabled.
 -->
 <script lang="ts">
-import { LL } from '@ceraui/i18n/svelte';
+import { formatBytes } from '@ceraui/i18n/formatters';
+import { LL, locale } from '@ceraui/i18n/svelte';
 import type { Modem } from '@ceraui/rpc/schemas';
 import {
+	Cable,
+	Gauge,
 	Globe,
 	Loader2,
+	Lock,
 	Network as NetworkIcon,
 	Radio,
 	RefreshCw,
@@ -53,6 +57,7 @@ import {
 	modemConfigEchoMatches,
 } from '$lib/rpc/modem-config-echo';
 import { modemScanSignature } from '$lib/rpc/modem-scan-signature';
+import { getConfig } from '$lib/rpc/subscriptions.svelte';
 import { cn } from '$lib/utils';
 
 interface Props {
@@ -77,11 +82,27 @@ const signalValue = $derived(modemSignal(modem));
 const operatorName = $derived(modem.status?.network || modem.sim_network || modem.name);
 const activeNetworkType = $derived(modem.status?.network_type ?? '');
 
+// ── Phase-B additive-optional detail surfaces (T5.4) ─────────────────────────
+const loc = $derived($locale);
+const dataUsage = $derived(modem.data_usage);
+const hasDataUsage = $derived(
+	dataUsage?.session_bytes != null || dataUsage?.monthly_bytes != null,
+);
+const usbMode = $derived(modem.usb_mode);
+const recommendedUsbMode = $derived(modem.recommended_usb_mode);
+// USB-mode switching is gated on the DEFAULT-ABSENT `modem_provisioning` config
+// key — the frontend mirror of the backend RPC refusal. Absent (the default)
+// ⇒ the switch control is disabled-with-reason, never a fake-interactive button.
+const usbModeSwitchingEnabled = $derived(getConfig()?.modem_provisioning === true);
+
 // ── Form state ────────────────────────────────────────────────────────────────
 function readModemConfig() {
 	return {
 		selectedNetwork: modem.network_type?.active ?? modem.network_type?.supported?.[0] ?? '',
-		autoconfig: modem.config?.autoconfig ?? false,
+		// Auto-APN "Automatic (recommended)" default (Phase B, W6.6): a modem with
+		// no persisted config yet defaults to Automatic; an explicit stored value
+		// is honoured. `?? undefined` distinguishes "never configured" from "off".
+		autoconfig: modem.config?.autoconfig ?? modem.config === undefined,
 		apn: modem.config?.apn ?? '',
 		username: modem.config?.username ?? '',
 		password: modem.config?.password ?? '',
@@ -428,14 +449,14 @@ const selectedNetworkLabel = $derived(
 						aria-hidden="true"
 					/>
 					<div class="min-w-0">
-						<p class="text-sm font-medium">{$LL.network.modem.autoapn()}</p>
+						<p class="text-sm font-medium">{$LL.network.modem.autoapnRecommended()}</p>
 						<p class="text-muted-foreground text-xs">{$LL.network.modem.autoApnDescription()}</p>
 					</div>
 				</div>
 				<LabeledSwitch
 					checked={formData.autoconfig}
 					disabled={noSim}
-					label={$LL.network.modem.autoapn()}
+					label={$LL.network.modem.autoapnRecommended()}
 					onCheckedChange={(checked) => (formData.autoconfig = checked)}
 				/>
 			</div>
@@ -481,6 +502,83 @@ const selectedNetworkLabel = $derived(
 							/>
 						</div>
 					</div>
+				</div>
+			{/if}
+
+			<!-- ── Data usage (Phase B, read-only; only when the modem reports it) ── -->
+			{#if hasDataUsage}
+				<div class="space-y-2 rounded-lg border p-3" data-testid="modem-data-usage">
+					<div class="flex items-center gap-2.5">
+						<Gauge class="text-muted-foreground size-4 shrink-0" aria-hidden="true" />
+						<p class="text-sm font-medium">{$LL.network.modem.dataUsage.title()}</p>
+					</div>
+					<dl class="grid grid-cols-2 gap-2 text-sm">
+						{#if dataUsage?.session_bytes != null}
+							<div class="space-y-0.5">
+								<dt class="text-muted-foreground text-xs">{$LL.network.modem.dataUsage.session()}</dt>
+								<dd class="font-mono tabular-nums" data-testid="modem-data-usage-session">
+									{formatBytes(loc)(dataUsage.session_bytes)}
+								</dd>
+							</div>
+						{/if}
+						{#if dataUsage?.monthly_bytes != null}
+							<div class="space-y-0.5">
+								<dt class="text-muted-foreground text-xs">{$LL.network.modem.dataUsage.monthly()}</dt>
+								<dd class="font-mono tabular-nums" data-testid="modem-data-usage-monthly">
+									{formatBytes(loc)(dataUsage.monthly_bytes)}
+								</dd>
+							</div>
+						{/if}
+					</dl>
+					{#if dataUsage?.threshold_bytes != null && dataUsage.monthly_bytes != null && dataUsage.monthly_bytes >= dataUsage.threshold_bytes}
+						<p class="text-status-warning text-xs" role="status" data-testid="modem-data-threshold">
+							{$LL.network.modem.dataUsage.thresholdReached()}
+						</p>
+					{/if}
+				</div>
+			{/if}
+
+			<!-- ── USB composition mode (Phase B; switching gated by modem_provisioning) ── -->
+			{#if usbMode}
+				<div class="space-y-2 rounded-lg border p-3" data-testid="modem-usb-mode">
+					<div class="flex items-center gap-2.5">
+						<Cable class="text-muted-foreground size-4 shrink-0" aria-hidden="true" />
+						<p class="text-sm font-medium">{$LL.network.modem.usbMode.title()}</p>
+					</div>
+					<div class="flex flex-wrap items-center justify-between gap-2">
+						<div class="min-w-0 space-y-0.5">
+							<p class="text-sm" data-testid="modem-usb-mode-active">
+								{$LL.network.modem.usbMode.active()}: <span class="font-mono uppercase">{usbMode}</span>
+							</p>
+							{#if recommendedUsbMode && recommendedUsbMode !== usbMode}
+								<p class="text-muted-foreground text-xs" data-testid="modem-usb-mode-recommended">
+									{$LL.network.modem.usbMode.recommended({ mode: recommendedUsbMode.toUpperCase() })}
+								</p>
+							{/if}
+						</div>
+						<Button
+							class="h-8 gap-1 px-2.5"
+							data-testid="modem-usb-mode-switch"
+							disabled={!usbModeSwitchingEnabled}
+							size="sm"
+							variant="outline"
+							title={usbModeSwitchingEnabled ? undefined : $LL.network.modem.usbMode.locked()}
+						>
+							{#if !usbModeSwitchingEnabled}
+								<Lock class="size-3.5" aria-hidden="true" />
+							{/if}
+							{$LL.network.modem.usbMode.switchAction()}
+						</Button>
+					</div>
+					{#if !usbModeSwitchingEnabled}
+						<p
+							class="text-muted-foreground text-xs"
+							role="note"
+							data-testid="modem-usb-mode-locked-reason"
+						>
+							{$LL.network.modem.usbMode.locked()}
+						</p>
+					{/if}
 				</div>
 			{/if}
 		</fieldset>

--- a/apps/frontend/src/main/network/CellularSection.svelte
+++ b/apps/frontend/src/main/network/CellularSection.svelte
@@ -42,38 +42,66 @@ const { modemEntries, netif, isFullyStale, staleInterfaces, onConfigure }: Props
 				{@const entry = netif?.[modem.ifname]}
 				{@const ifaceStale = staleInterfaces.has(modem.ifname) || isFullyStale}
 				{@const showStale = ifaceStale && !noSim}
+				{@const unavailableReason = modem.availability_reason}
 				<!-- Single-line row: identity (dot · name · status) left; bond + configure right. -->
-				<div class="flex flex-wrap items-center gap-3 px-4 py-2.5">
+				<div
+					class={cn(
+						'flex flex-wrap items-center gap-3 px-4 py-2.5',
+						unavailableReason && 'opacity-60',
+					)}
+					data-testid="cellular-modem-row"
+					data-unavailable={unavailableReason ? '' : undefined}
+				>
 					<span
 						class={cn('size-2 shrink-0 rounded-full', connected ? 'bg-primary' : 'bg-muted-foreground/40')}
 						aria-hidden="true"
 					></span>
 					<div class="min-w-0 flex-1">
-						<p class="truncate text-sm font-medium">{modem.name}</p>
-						<p
-							class={cn(
-								'text-muted-foreground truncate text-xs transition-opacity',
-								ifaceStale && 'opacity-50',
-							)}
-						>
-							{#if noSim}
-								{$LL.network.view.noModems()}
-							{:else}
-								{operator}{#if modem.status?.network_type}
-									· {modem.status.network_type}{/if} ·
-								{#if scanning}
-									{$LL.network.modem.scanning()}
-								{:else}
-									{connected ? $LL.network.view.connected() : $LL.network.view.disconnected()}
-								{/if}
+						<p class="truncate text-sm font-medium">
+							{modem.name}{#if modem.slot_label}
+								<span class="text-muted-foreground ms-1 text-xs font-normal">· {modem.slot_label}</span>
 							{/if}
 						</p>
+						{#if unavailableReason}
+							<p
+								class="text-status-warning truncate text-xs"
+								role="note"
+								data-testid="cellular-modem-unavailable-reason"
+							>
+								{$LL.network.modem.unavailable.title()} · {unavailableReason}
+							</p>
+						{:else}
+							<p
+								class={cn(
+									'text-muted-foreground truncate text-xs transition-opacity',
+									ifaceStale && 'opacity-50',
+								)}
+							>
+								{#if noSim}
+									{$LL.network.view.noModems()}
+								{:else}
+									{operator}{#if modem.status?.network_type}
+										· {modem.status.network_type}{/if} ·
+									{#if scanning}
+										{$LL.network.modem.scanning()}
+									{:else}
+										{connected ? $LL.network.view.connected() : $LL.network.view.disconnected()}
+									{/if}
+								{/if}
+							</p>
+						{/if}
 					</div>
 					<div class="ms-auto flex shrink-0 items-center gap-2">
 						{#if showStale}
 							<Badge variant="stale" data-stale-interface={modem.ifname} />
 						{/if}
-						{#if noSim}
+						{#if unavailableReason}
+							<BondToggle
+								name={modem.ifname}
+								enabled={false}
+								disabledReason={unavailableReason}
+							/>
+						{:else if noSim}
 							<BondToggle
 								name={modem.ifname}
 								enabled={false}

--- a/apps/frontend/tests/e2e/modem-config-surface-fixture.ts
+++ b/apps/frontend/tests/e2e/modem-config-surface-fixture.ts
@@ -4,6 +4,8 @@ type ModemPatch = Record<string, unknown>;
 
 type CeraHarnessState = {
 	sendThrough: WebSocket["send"] | null;
+	/** The live hooked socket instance — lets a test add its own inbound listener. */
+	socket: WebSocket | null;
 	lastModems: Record<string, unknown> | null;
 	rpcFake: Record<string, unknown>;
 	seq: number;
@@ -37,6 +39,7 @@ export function installWsHarness(): void {
 
 	window.__ceraModemConfigSurface = {
 		sendThrough: null,
+		socket: null,
 		lastModems: null,
 		rpcFake: {},
 		seq: 0,
@@ -62,6 +65,7 @@ export function installWsHarness(): void {
 			const state = window.__ceraModemConfigSurface;
 			if (state) {
 				state.sendThrough = this.sendThrough;
+				state.socket = this;
 			}
 			this.addEventListener("message", (event: MessageEvent) => {
 				const parsed = parseFrame(event.data);
@@ -107,6 +111,68 @@ export function installWsHarness(): void {
 	}
 
 	window.WebSocket = HookedWebSocket;
+}
+
+export type DirectRpcResult =
+	| { ok: true; value: unknown }
+	| { ok: false; error: string };
+
+/**
+ * Send ONE oRPC frame over the live authenticated socket and resolve with the REAL
+ * backend reply (never a client-side fake). Used to prove a server-side RPC refusal
+ * survives even when the UI control is bypassed.
+ */
+export function directRpc(
+	page: Page,
+	path: string[],
+	input: unknown,
+	timeoutMs = 5000,
+): Promise<DirectRpcResult> {
+	return page.evaluate(
+		({ rpcPath, rpcInput, timeout }) => {
+			const state = window.__ceraModemConfigSurface;
+			const socket = state?.socket;
+			const send = state?.sendThrough;
+			if (!socket || !send) {
+				return { ok: false, error: "no-socket" } as DirectRpcResult;
+			}
+			const id = `direct-rpc-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+			return new Promise<DirectRpcResult>((resolve) => {
+				let settled = false;
+				const done = (r: DirectRpcResult) => {
+					if (settled) return;
+					settled = true;
+					socket.removeEventListener("message", handler as EventListener);
+					resolve(r);
+				};
+				const handler = (event: MessageEvent) => {
+					let frame: unknown;
+					try {
+						frame = JSON.parse(String(event.data));
+					} catch {
+						return;
+					}
+					if (
+						typeof frame !== "object" ||
+						frame === null ||
+						(frame as { id?: unknown }).id !== id
+					) {
+						return;
+					}
+					const f = frame as { result?: unknown; error?: unknown };
+					if (f.error !== undefined) {
+						done({ ok: false, error: JSON.stringify(f.error) });
+					} else {
+						done({ ok: true, value: f.result });
+					}
+				};
+				socket.addEventListener("message", handler as EventListener);
+				send(JSON.stringify({ id, path: rpcPath, input: rpcInput }));
+				setTimeout(() => done({ ok: false, error: "timeout-no-reply" }), timeout);
+			});
+		},
+		{ rpcPath: path, rpcInput: input, timeout: timeoutMs },
+	);
 }
 
 export function armFake(

--- a/apps/frontend/tests/e2e/modem-usb-mode-gate.spec.ts
+++ b/apps/frontend/tests/e2e/modem-usb-mode-gate.spec.ts
@@ -1,0 +1,145 @@
+import fs from "node:fs";
+
+import { expect, test } from "./fixtures/index.js";
+
+import { ensureAuthenticated, evidencePath, navigateTo } from "./helpers";
+import {
+	directRpc,
+	installWsHarness,
+	openTargetModemDialog,
+	patchModem,
+	targetModemKey,
+} from "./modem-config-surface-fixture";
+
+/**
+ * T5.4 — modem_provisioning default-absent USB-mode gate (@functional).
+ *
+ * Proves the Phase-B gate end-to-end against the REAL dev backend + ModemConfigDialog:
+ *
+ *   1. UI gate — a modem that reports `usb_mode` renders the USB-mode block with the
+ *      "Switch mode" control DISABLED and a disabled-with-reason line, because the
+ *      dev backend config carries no `modem_provisioning` key (the default).
+ *   2. Server-side refusal — calling `modems.setUsbMode` DIRECTLY over the same
+ *      authenticated socket (bypassing the disabled button) is refused server-side
+ *      with the typed `provisioning_disabled` error — the gate is a real RPC-layer
+ *      refusal, not merely a hidden UI control.
+ *
+ * The USB-mode block is driven by the injected `usb_mode`/`recommended_usb_mode`
+ * fields (multi-modem-wifi does not advertise them); the RPC refusal is served by
+ * the real per-worker backend, whose config has no modem_provisioning key.
+ *
+ * PLAYBOOK.md compliance: role/testid/web-first assertions only — no screenshots,
+ * no fixed-delay waits.
+ */
+
+const MODEM_INDEX = 1;
+
+test.describe(
+	"modem USB-mode gate — modem_provisioning default-absent",
+	{ tag: "@functional" },
+	() => {
+		test.skip(
+			({ browserName }) => browserName !== "chromium",
+			"single-browser integration proof",
+		);
+
+		const evidence: string[] = [];
+		const record = (line: string) => evidence.push(line);
+
+		test.beforeEach(async ({ page }, testInfo) => {
+			test.skip(
+				testInfo.project.name !== "desktop",
+				"desktop layout drives the modem config dialog",
+			);
+			await page.addInitScript(installWsHarness);
+			await page.goto("/");
+			await ensureAuthenticated(page);
+			await navigateTo(page, "network");
+			await expect
+				.poll(
+					() =>
+						page.evaluate(() => {
+							const m = window.__ceraModemConfigSurface?.lastModems;
+							return m ? Object.keys(m).length : 0;
+						}),
+					{ timeout: 15000, message: "modem snapshot should arrive" },
+				)
+				.toBeGreaterThan(0);
+		});
+
+		test.afterAll(async () => {
+			fs.writeFileSync(
+				evidencePath("t5-4-modem-usb-mode-gate.txt"),
+				[
+					"T5.4 — modem_provisioning default-absent USB-mode gate: functional E2E evidence",
+					"Driver: real ModemConfigDialog + real per-worker backend; usb_mode injected",
+					"        via dev.emit; setUsbMode called directly over the authed socket.",
+					`Generated: ${new Date().toISOString()}`,
+					"",
+					...evidence,
+					"",
+				].join("\n"),
+				"utf8",
+			);
+		});
+
+		test("a modem reporting usb_mode shows the switch DISABLED with a reason when modem_provisioning is absent", async ({
+			page,
+		}) => {
+			record("── USB-mode UI gate (modem_provisioning absent) ──");
+			const key = await targetModemKey(page, MODEM_INDEX);
+
+			await patchModem(page, key, {
+				usb_mode: "rndis",
+				recommended_usb_mode: "mbim",
+			});
+
+			await openTargetModemDialog(page, MODEM_INDEX);
+			const dialog = page.getByRole("dialog");
+			await expect(dialog).toBeVisible();
+
+			const block = dialog.getByTestId("modem-usb-mode");
+			await expect(block).toBeVisible();
+			await expect(dialog.getByTestId("modem-usb-mode-active")).toContainText(
+				"rndis",
+				{ ignoreCase: true },
+			);
+			await expect(
+				dialog.getByTestId("modem-usb-mode-recommended"),
+			).toBeVisible();
+
+			// The switch control is disabled-with-reason — not a fake-interactive button.
+			const switchBtn = dialog.getByTestId("modem-usb-mode-switch");
+			await expect(switchBtn).toBeVisible();
+			await expect(switchBtn).toBeDisabled();
+			await expect(switchBtn).toHaveAttribute("title", /.+/);
+			await expect(
+				dialog.getByTestId("modem-usb-mode-locked-reason"),
+			).toBeVisible();
+			record(
+				"usb_mode row renders; Switch mode DISABLED with reason (modem_provisioning absent) ✓",
+			);
+		});
+
+		test("calling modems.setUsbMode DIRECTLY over the socket is refused server-side with provisioning_disabled", async ({
+			page,
+		}) => {
+			record("── USB-mode server-side refusal (direct RPC) ──");
+			const result = await directRpc(page, ["modems", "setUsbMode"], {
+				device: "0",
+				mode: "mbim",
+				confirm: true,
+			});
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toEqual({
+					success: false,
+					error: "provisioning_disabled",
+				});
+			}
+			record(
+				"direct modems.setUsbMode → { success:false, error:'provisioning_disabled' } server-side ✓",
+			);
+		});
+	},
+);

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
       "dependencies": {
         "@ceralive/cerastream": "2026.7.1",
         "@ceralive/control-protocol": "2026.7.0",
+        "@ceralive/modem-control": "0.2.0",
         "@ceralive/srtla-send": "2026.6.2",
         "@ceraui/rpc": "workspace:*",
         "@orpc/server": "^1.14.7",
@@ -348,6 +349,8 @@
 
     "@ceralive/design-tokens": ["@ceralive/design-tokens@2026.6.1", "", {}, "sha512-u0Ja75p7rcJY9anvU+Ke/0PKLWrK6Y8bNO1RnrbNDuQduiKLXK0bgWnsOIMtuv3mxDgp2Kvshpc7cog20znOzw=="],
 
+    "@ceralive/modem-control": ["@ceralive/modem-control@0.2.0", "", { "dependencies": { "@httptoolkit/dbus-native": "0.1.5", "zod": "4.4.3" } }, "sha512-q9ntogeDDMhAvodLKm8tI6xKDPmzg3L1+OxHXLYKTEKE03o+iXF2YGxgi0kTwOFl5OyNJAx65Ow4pYRGEzdB8w=="],
+
     "@ceralive/srtla-send": ["@ceralive/srtla-send@2026.6.2", "", { "dependencies": { "zod": "^4.3.5" } }, "sha512-uywRvQaTJvT2lADiwS3702lJsZv9CIG7JnQlLhabANeVPk8s2jXCpc7rTWCKoTjFxEGJd2DwiPJLKpiqiNgagg=="],
 
     "@ceraui/i18n": ["@ceraui/i18n@workspace:packages/i18n"],
@@ -396,6 +399,8 @@
 
     "@fontsource-variable/space-grotesk": ["@fontsource-variable/space-grotesk@5.2.10", "", {}, "sha512-yJQO/o35/hAP3CFnpdFTwQku2yzJOae2HIpBmqkOVoxhhXJaQP3g+b6Jrz7u+eI7A5ZdCIf88uMWpBJdFiGr5w=="],
 
+    "@httptoolkit/dbus-native": ["@httptoolkit/dbus-native@0.1.5", "", { "dependencies": { "event-stream": "^4.0.0", "fast-xml-parser": "^5.3.6", "long": "^4.0.0", "safe-buffer": "^5.1.1" } }, "sha512-ygpvPvzb6yyhop/wEDouGvIHzXrLvArIAdyPqy87l3YllS8scyeu6a61I75kgp1QK7QZSRT26wpq6+/egiQwcA=="],
+
     "@internationalized/date": ["@internationalized/date@3.12.2", "", { "dependencies": { "@swc/helpers": "^0.5.0" } }, "sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@9.0.0", "", {}, "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg=="],
@@ -417,6 +422,8 @@
     "@macfja/serializer": ["@macfja/serializer@1.1.4", "", {}, "sha512-bUKIyLdSTyPfTgOvRqH8MkSDQhSaEGjUSvQlvnjA6tbeZDuY9u0WKieZNyqYwq3mPxytNd6Z5Lq2n4A3dA9HMA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
 
     "@orpc/client": ["@orpc/client@1.14.7", "", { "dependencies": { "@orpc/shared": "1.14.7", "@orpc/standard-server": "1.14.7", "@orpc/standard-server-fetch": "1.14.7", "@orpc/standard-server-peer": "1.14.7" } }, "sha512-/yloM96/6Z3qlmEgW4/VMYUnhxXbCr6lIJiKSHmsvhgKcwrUPOPJrL3p0ZpItz5SKVtQSwXIhT5KcT/3va/Aew=="],
 
@@ -688,6 +695,8 @@
 
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
+    "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
+
     "app-module-path": ["app-module-path@2.2.0", "", {}, "sha512-gkco+qxENJV+8vFcDiiFhuoSvRXb2a/QPqpSoWhVz829VNJfOTnELbBmPmNKFxf3xdNnw4DWCkzkDaavcX/1YQ=="],
 
     "arg": ["arg@4.1.3", "", {}, "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="],
@@ -870,6 +879,8 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
+    "duplexer": ["duplexer@0.1.2", "", {}, "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="],
+
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
@@ -928,6 +939,8 @@
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
+    "event-stream": ["event-stream@4.0.1", "", { "dependencies": { "duplexer": "^0.1.1", "from": "^0.1.7", "map-stream": "0.0.7", "pause-stream": "^0.0.11", "split": "^1.0.1", "stream-combiner": "^0.2.2", "through": "^2.3.8" } }, "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA=="],
+
     "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
@@ -937,6 +950,10 @@
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
+    "fast-xml-builder": ["fast-xml-builder@1.3.0", "", { "dependencies": { "path-expression-matcher": "^1.6.2", "xml-naming": "^0.3.0" } }, "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.10.1", "", { "dependencies": { "@nodable/entities": "^3.0.0", "fast-xml-builder": "^1.2.0", "is-unsafe": "^2.0.0", "path-expression-matcher": "^1.6.2", "strnum": "^2.4.1", "xml-naming": "^0.3.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -959,6 +976,8 @@
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "from": ["from@0.1.7", "", {}, "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g=="],
 
     "frontend": ["frontend@workspace:apps/frontend"],
 
@@ -1092,6 +1111,8 @@
 
     "is-unicode-supported": ["is-unicode-supported@0.1.0", "", {}, "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="],
 
+    "is-unsafe": ["is-unsafe@2.0.0", "", {}, "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA=="],
+
     "is-url-superb": ["is-url-superb@4.0.0", "", {}, "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA=="],
 
     "is-weakmap": ["is-weakmap@2.0.2", "", {}, "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w=="],
@@ -1168,6 +1189,8 @@
 
     "logform": ["logform@2.7.0", "", { "dependencies": { "@colors/colors": "1.6.0", "@types/triple-beam": "^1.3.2", "fecha": "^4.2.0", "ms": "^2.1.1", "safe-stable-stringify": "^2.3.1", "triple-beam": "^1.3.0" } }, "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ=="],
 
+    "long": ["long@4.0.0", "", {}, "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="],
+
     "lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
@@ -1177,6 +1200,8 @@
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "make-error": ["make-error@1.3.6", "", {}, "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="],
+
+    "map-stream": ["map-stream@0.0.7", "", {}, "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -1256,6 +1281,8 @@
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
+    "path-expression-matcher": ["path-expression-matcher@1.6.2", "", {}, "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ=="],
+
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
@@ -1263,6 +1290,8 @@
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pause-stream": ["pause-stream@0.0.11", "", { "dependencies": { "through": "~2.3" } }, "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A=="],
 
     "php-serialize": ["php-serialize@5.1.3", "", {}, "sha512-p7zXX8xjGgddgP6byN+KmGKM0x6uoMZBRZteBa9LonqgrDV3LyMxUeGVX7RTFYwWaUAnTEsUWJfHI3N7eKvJgw=="],
 
@@ -1422,6 +1451,8 @@
 
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
+    "split": ["split@1.0.1", "", { "dependencies": { "through": "2" } }, "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg=="],
+
     "stack-trace": ["stack-trace@0.0.10", "", {}, "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
@@ -1431,6 +1462,8 @@
     "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
+
+    "stream-combiner": ["stream-combiner@0.2.2", "", { "dependencies": { "duplexer": "~0.1.1", "through": "~2.3.4" } }, "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ=="],
 
     "stream-to-array": ["stream-to-array@2.3.0", "", { "dependencies": { "any-promise": "^1.1.0" } }, "sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA=="],
 
@@ -1455,6 +1488,8 @@
     "strip-comments": ["strip-comments@2.0.1", "", {}, "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw=="],
 
     "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
+    "strnum": ["strnum@2.4.1", "", { "dependencies": { "anynum": "^1.0.1" } }, "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
@@ -1499,6 +1534,8 @@
     "terser": ["terser@5.48.0", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.15.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": { "terser": "bin/terser" } }, "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q=="],
 
     "text-hex": ["text-hex@1.0.0", "", {}, "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="],
+
+    "through": ["through@2.3.8", "", {}, "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
@@ -1645,6 +1682,8 @@
     "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xml-naming": ["xml-naming@0.3.0", "", {}, "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ=="],
 
     "xml2js": ["xml2js@0.6.2", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA=="],
 

--- a/docs/TECHNICAL_DEBT.md
+++ b/docs/TECHNICAL_DEBT.md
@@ -309,6 +309,27 @@ The audit script (`scripts/audit-contract-parity.mjs`) classifies
 not fail the parity gate; this register entry is the durable record that the
 device-side fan-out is a known, benign mismatch pending an explicit no-op consumer.
 
+```debt
+id: TD-mmcli-retirement
+title: Retire the legacy mmcli modem backend once the dbus backend is proven safe
+track: 1
+status: open
+exit_criteria: `bun run --filter backend test -- cellular-stack.test.ts`
+owner: ceraui-team
+registered_at: 2026-07-18
+resolved_at: null
+unblock: The Phase-B cellular-control composition root (modules/cellular/cellular-stack.ts) ships mmcli as the DEFAULT modem_backend, with the @ceralive/modem-control dbus backend selectable and a read-only modem_shadow parity observer running beside it. mmcli stays the authoritative control path until the dbus backend has cleared the annex retirement criteria (.omo/plans/modem-control-package.md Phase-B annex; .omo/drafts/modem-control-package.md D6): ≥14 days shadow on ≥2 devices, zero unexplained divergences, HIL parity, rollback drill, one dbus-default release. Only after every one of those criteria is met: flip the modem_backend default from mmcli to dbus, delete the mmcli one-shot-CLI backend + its wire adapter (modules/modems/modem-wire-adapters.ts fromMmcliModem) and the shadow-parity harness (modules/cellular/shadow.ts + shadow-divergence.ts + dbus-audit-transport.ts), update cellular-stack.test.ts to lock dbus as the sole backend, then flip this entry to resolved. Do NOT flip the default or delete the mmcli path ahead of this gate. This entry carries no source data-debt-id marker — the retirement is a backend modem-control-backend decision, not a UI affordance.
+```
+
+This entry carries no source `data-debt-id` marker — the retirement of the mmcli
+modem backend is a backend control-plane decision, not a UI affordance, so there is
+no live element to bind a marker to. The register entry is the durable, dated record
+of the mmcli→dbus cutover criteria settled in the modem-control-package Phase-B annex
+(reviewed across 11 dual-review rounds) — the single machine-checkable home for the
+"≥14 days shadow on ≥2 devices, zero unexplained divergences, HIL parity, rollback
+drill, one dbus-default release" gate, so a future agent finds it instead of
+re-litigating when it is safe to drop mmcli.
+
 ## Resolved Debt
 
 ```debt

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ceralive-workspace",
 	"private": true,
-	"version": "2026.7.1",
+	"version": "2026.7.2",
 	"description": "Monorepo workspace containing CeraUI frontend and CeraLive backend",
 	"type": "module",
 	"repository": {

--- a/packages/i18n/src/ar/index.ts
+++ b/packages/i18n/src/ar/index.ts
@@ -669,6 +669,7 @@ const ar = {
 			scanningForNetworks: "جارٍ البحث عن المشغّلين…",
 			save: "حفظ",
 			autoapn: "APN تلقائي",
+			autoapnRecommended: "تلقائي (موصى به)",
 			apn: "APN",
 			apnPlaceholder: "internet.provider.com",
 			username: "اسم المستخدم",
@@ -729,6 +730,23 @@ const ar = {
 				connecting: "جاري الاتصال",
 				scanning: "جارٍ المسح",
 				searching: "البحث",
+			},
+			dataUsage: {
+				title: "استهلاك البيانات",
+				session: "هذه الجلسة",
+				monthly: "هذا الشهر",
+				thresholdReached: "تم بلوغ حد البيانات",
+			},
+			usbMode: {
+				title: "وضع USB",
+				active: "الوضع النشط",
+				recommended: "موصى به: {mode}",
+				switchAction: "تبديل الوضع",
+				lockedTitle: "تبديل الوضع مقفل",
+				locked: "تبديل وضع USB معطّل على هذا الجهاز. فعّل تهيئة المودم لتغييره.",
+			},
+			unavailable: {
+				title: "المودم غير متاح",
 			},
 		},
 		dialog: {

--- a/packages/i18n/src/de/index.ts
+++ b/packages/i18n/src/de/index.ts
@@ -1216,6 +1216,7 @@ const de = {
 			scanningForNetworks: "Suche nach Anbietern…",
 			save: "Speichern",
 			autoapn: "Automatischer APN",
+			autoapnRecommended: "Automatisch (empfohlen)",
 			apn: "APN",
 			apnPlaceholder: "internet.provider.com",
 			username: "Benutzername",
@@ -1281,6 +1282,24 @@ const de = {
 				connecting: "Verbinde",
 				scanning: "Wird gescannt",
 				searching: "Suchen",
+			},
+			dataUsage: {
+				title: "Datennutzung",
+				session: "Diese Sitzung",
+				monthly: "Diesen Monat",
+				thresholdReached: "Datenschwelle erreicht",
+			},
+			usbMode: {
+				title: "USB-Modus",
+				active: "Aktiver Modus",
+				recommended: "Empfohlen: {mode}",
+				switchAction: "Modus wechseln",
+				lockedTitle: "Moduswechsel gesperrt",
+				locked:
+					"Der USB-Moduswechsel ist auf diesem Gerät deaktiviert. Aktiviere die Modem-Bereitstellung, um ihn zu ändern.",
+			},
+			unavailable: {
+				title: "Modem nicht verfügbar",
 			},
 		},
 		dialog: {

--- a/packages/i18n/src/en/index.ts
+++ b/packages/i18n/src/en/index.ts
@@ -1206,6 +1206,7 @@ const en = {
 			scanningForNetworks: "Searching for operators…",
 			save: "Save",
 			autoapn: "Automatic APN",
+			autoapnRecommended: "Automatic (recommended)",
 			apn: "APN",
 			apnPlaceholder: "internet.provider.com",
 			username: "Username",
@@ -1268,6 +1269,24 @@ const en = {
 				connecting: "Connecting",
 				scanning: "Scanning",
 				searching: "Searching",
+			},
+			dataUsage: {
+				title: "Data usage",
+				session: "This session",
+				monthly: "This month",
+				thresholdReached: "Data threshold reached",
+			},
+			usbMode: {
+				title: "USB mode",
+				active: "Active mode",
+				recommended: "Recommended: {mode}",
+				switchAction: "Switch mode",
+				lockedTitle: "Mode switching is locked",
+				locked:
+					"USB mode switching is disabled on this device. Enable modem provisioning to change it.",
+			},
+			unavailable: {
+				title: "Modem unavailable",
 			},
 		},
 		dialog: {

--- a/packages/i18n/src/es/index.ts
+++ b/packages/i18n/src/es/index.ts
@@ -1233,6 +1233,7 @@ const es = {
 			scanningForNetworks: "Buscando operadores…",
 			save: "Guardar",
 			autoapn: "APN Automático",
+			autoapnRecommended: "Automático (recomendado)",
 			apn: "APN",
 			apnPlaceholder: "internet.provider.com",
 			username: "Nombre de usuario",
@@ -1297,6 +1298,24 @@ const es = {
 				connecting: "Conectando",
 				scanning: "Buscando",
 				searching: "Buscando",
+			},
+			dataUsage: {
+				title: "Uso de datos",
+				session: "Esta sesión",
+				monthly: "Este mes",
+				thresholdReached: "Límite de datos alcanzado",
+			},
+			usbMode: {
+				title: "Modo USB",
+				active: "Modo activo",
+				recommended: "Recomendado: {mode}",
+				switchAction: "Cambiar modo",
+				lockedTitle: "Cambio de modo bloqueado",
+				locked:
+					"El cambio de modo USB está desactivado en este dispositivo. Activa el aprovisionamiento del módem para cambiarlo.",
+			},
+			unavailable: {
+				title: "Módem no disponible",
 			},
 		},
 		dialog: {

--- a/packages/i18n/src/fr/index.ts
+++ b/packages/i18n/src/fr/index.ts
@@ -718,6 +718,7 @@ const fr = {
 			scanningForNetworks: "Recherche d'opérateurs…",
 			save: "Enregistrer",
 			autoapn: "APN Automatique",
+			autoapnRecommended: "Automatique (recommandé)",
 			apn: "APN",
 			apnPlaceholder: "internet.provider.com",
 			username: "Nom d'utilisateur",
@@ -781,6 +782,24 @@ const fr = {
 				scanning: "Scan en cours",
 				searching: "Recherche",
 				enabled: "Activé",
+			},
+			dataUsage: {
+				title: "Consommation de données",
+				session: "Cette session",
+				monthly: "Ce mois-ci",
+				thresholdReached: "Seuil de données atteint",
+			},
+			usbMode: {
+				title: "Mode USB",
+				active: "Mode actif",
+				recommended: "Recommandé : {mode}",
+				switchAction: "Changer de mode",
+				lockedTitle: "Changement de mode verrouillé",
+				locked:
+					"Le changement de mode USB est désactivé sur cet appareil. Activez le provisionnement du modem pour le modifier.",
+			},
+			unavailable: {
+				title: "Modem indisponible",
 			},
 		},
 		dialog: {

--- a/packages/i18n/src/hi/index.ts
+++ b/packages/i18n/src/hi/index.ts
@@ -530,6 +530,7 @@ const hi = {
 			scanningForNetworks: "ऑपरेटर खोजे जा रहे हैं…",
 			save: "सहेजें",
 			autoapn: "स्वचालित APN",
+			autoapnRecommended: "स्वचालित (अनुशंसित)",
 			apn: "APN",
 			apnPlaceholder: "internet.provider.com",
 			username: "उपयोगकर्ता नाम",
@@ -591,6 +592,24 @@ const hi = {
 				connecting: "कनेक्ट हो रहा है",
 				scanning: "स्कैनिंग",
 				searching: "खोज रहे हैं",
+			},
+			dataUsage: {
+				title: "डेटा उपयोग",
+				session: "यह सत्र",
+				monthly: "इस माह",
+				thresholdReached: "डेटा सीमा तक पहुँच गई",
+			},
+			usbMode: {
+				title: "USB मोड",
+				active: "सक्रिय मोड",
+				recommended: "अनुशंसित: {mode}",
+				switchAction: "मोड बदलें",
+				lockedTitle: "मोड स्विचिंग लॉक है",
+				locked:
+					"इस डिवाइस पर USB मोड स्विचिंग अक्षम है। इसे बदलने के लिए मॉडेम प्रोविज़निंग सक्षम करें।",
+			},
+			unavailable: {
+				title: "मॉडेम अनुपलब्ध",
 			},
 		},
 		dialog: {

--- a/packages/i18n/src/ja/index.ts
+++ b/packages/i18n/src/ja/index.ts
@@ -551,6 +551,7 @@ const ja = {
 			scanningForNetworks: "事業者を検索中…",
 			save: "保存",
 			autoapn: "自動APN",
+			autoapnRecommended: "自動（推奨）",
 			apn: "APN",
 			apnPlaceholder: "internet.provider.com",
 			username: "ユーザー名",
@@ -614,6 +615,24 @@ const ja = {
 				connecting: "接続中",
 				scanning: "スキャン中",
 				searching: "検索中",
+			},
+			dataUsage: {
+				title: "データ使用量",
+				session: "今回のセッション",
+				monthly: "今月",
+				thresholdReached: "データのしきい値に達しました",
+			},
+			usbMode: {
+				title: "USBモード",
+				active: "アクティブモード",
+				recommended: "推奨: {mode}",
+				switchAction: "モードを切り替え",
+				lockedTitle: "モード切り替えはロックされています",
+				locked:
+					"このデバイスではUSBモードの切り替えが無効です。変更するにはモデムのプロビジョニングを有効にしてください。",
+			},
+			unavailable: {
+				title: "モデムを利用できません",
 			},
 		},
 		dialog: {

--- a/packages/i18n/src/ko/index.ts
+++ b/packages/i18n/src/ko/index.ts
@@ -538,6 +538,7 @@ const ko = {
 			scanningForNetworks: "사업자 검색 중…",
 			save: "저장",
 			autoapn: "자동 APN",
+			autoapnRecommended: "자동(권장)",
 			apn: "APN",
 			apnPlaceholder: "internet.provider.com",
 			username: "사용자 이름",
@@ -600,6 +601,24 @@ const ko = {
 				connecting: "연결 중",
 				scanning: "스캔 중",
 				searching: "검색 중",
+			},
+			dataUsage: {
+				title: "데이터 사용량",
+				session: "이번 세션",
+				monthly: "이번 달",
+				thresholdReached: "데이터 임계값 도달",
+			},
+			usbMode: {
+				title: "USB 모드",
+				active: "활성 모드",
+				recommended: "권장: {mode}",
+				switchAction: "모드 전환",
+				lockedTitle: "모드 전환이 잠김",
+				locked:
+					"이 장치에서는 USB 모드 전환이 비활성화되어 있습니다. 변경하려면 모뎀 프로비저닝을 활성화하세요.",
+			},
+			unavailable: {
+				title: "모뎀을 사용할 수 없음",
 			},
 		},
 		dialog: {

--- a/packages/i18n/src/pt-BR/index.ts
+++ b/packages/i18n/src/pt-BR/index.ts
@@ -711,6 +711,7 @@ const ptBR = {
 			scanningForNetworks: "Procurando operadoras…",
 			save: "Salvar",
 			autoapn: "APN Automático",
+			autoapnRecommended: "Automático (recomendado)",
 			apn: "APN",
 			apnPlaceholder: "internet.provider.com",
 			username: "Nome de usuário",
@@ -775,6 +776,24 @@ const ptBR = {
 				scanning: "Escaneando",
 				searching: "Procurando",
 				enabled: "Habilitado",
+			},
+			dataUsage: {
+				title: "Uso de dados",
+				session: "Esta sessão",
+				monthly: "Este mês",
+				thresholdReached: "Limite de dados atingido",
+			},
+			usbMode: {
+				title: "Modo USB",
+				active: "Modo ativo",
+				recommended: "Recomendado: {mode}",
+				switchAction: "Trocar modo",
+				lockedTitle: "Troca de modo bloqueada",
+				locked:
+					"A troca de modo USB está desativada neste dispositivo. Ative o provisionamento do modem para alterá-la.",
+			},
+			unavailable: {
+				title: "Modem indisponível",
 			},
 		},
 		dialog: {

--- a/packages/i18n/src/zh/index.ts
+++ b/packages/i18n/src/zh/index.ts
@@ -518,6 +518,7 @@ const zh = {
 			scanningForNetworks: "正在搜索运营商…",
 			save: "保存",
 			autoapn: "自动 APN",
+			autoapnRecommended: "自动（推荐）",
 			apn: "APN",
 			apnPlaceholder: "internet.provider.com",
 			username: "用户名",
@@ -578,6 +579,24 @@ const zh = {
 				connecting: "连接中",
 				scanning: "扫描中",
 				searching: "搜索中",
+			},
+			dataUsage: {
+				title: "数据用量",
+				session: "本次会话",
+				monthly: "本月",
+				thresholdReached: "已达到数据阈值",
+			},
+			usbMode: {
+				title: "USB 模式",
+				active: "当前模式",
+				recommended: "推荐：{mode}",
+				switchAction: "切换模式",
+				lockedTitle: "模式切换已锁定",
+				locked:
+					"此设备上的 USB 模式切换已禁用。请启用调制解调器配置以进行更改。",
+			},
+			unavailable: {
+				title: "调制解调器不可用",
 			},
 		},
 		dialog: {

--- a/packages/rpc/src/contracts/modems.contract.ts
+++ b/packages/rpc/src/contracts/modems.contract.ts
@@ -9,6 +9,8 @@ import {
 	modemListSchema,
 	modemScanInputSchema,
 	modemScanOutputSchema,
+	setUsbModeInputSchema,
+	setUsbModeOutputSchema,
 	simPukUnlockInputSchema,
 	simPukUnlockOutputSchema,
 	simUnlockInputSchema,
@@ -40,6 +42,13 @@ export const modemsContract = oc.router({
 	 * Submit a SIM PUK + new PIN to recover a PUK-locked modem
 	 */
 	unlockSimPuk: oc.input(simPukUnlockInputSchema).output(simPukUnlockOutputSchema),
+
+	/**
+	 * Switch a modem's USB composition mode. Guarded by the default-absent
+	 * `modem_provisioning` config key: refuses with `provisioning_disabled` while
+	 * that key is absent (Phase B, T5.4).
+	 */
+	setUsbMode: oc.input(setUsbModeInputSchema).output(setUsbModeOutputSchema),
 
 	/**
 	 * Subscribe to modem status changes

--- a/packages/rpc/src/schemas/modems.schema.ts
+++ b/packages/rpc/src/schemas/modems.schema.ts
@@ -78,6 +78,92 @@ export const SIM_PIN_MAX_LENGTH = 8;
 // A carrier-issued SIM PUK is always exactly 8 digits.
 export const SIM_PUK_LENGTH = 8;
 
+// ── Phase-B additive-optional detail fields (T5.4) ───────────────────────────
+// Every schema below is ADDITIVE-OPTIONAL: a modem entry that omits them all
+// parses byte-identically to the pre-Phase-B wire shape, so an old backend or an
+// old frontend still round-trips. The device/hub binding-ledger semantics are the
+// single source of truth for what each field MEANS — see the annex.
+
+// Transport / device class the modem is attached over (binding-ledger:
+// `transport: usb|pcie-mhi|pcie-mtk|soc-qrtr|router-ethernet`). Read-only.
+export const modemDeviceClassSchema = z.enum([
+	'usb',
+	'pcie-mhi',
+	'pcie-mtk',
+	'soc-qrtr',
+	'router-ethernet',
+]);
+export type ModemDeviceClass = z.infer<typeof modemDeviceClassSchema>;
+
+// Per-modem recovery-ladder state (binding-ledger C3 state machine). Read-only.
+export const modemRecoveryStateSchema = z.enum([
+	'absent',
+	'detected',
+	'initializing',
+	'registered',
+	'connecting',
+	'online',
+	'degraded',
+	'recovering',
+]);
+export type ModemRecoveryState = z.infer<typeof modemRecoveryStateSchema>;
+
+// Active / recommended USB composition mode (binding-ledger W6.5b canonical enum).
+// `usb_mode` is a read-only observation from the W6.1 classifier;
+// `recommended_usb_mode` is a per-SKU most-stable advisory — informational, never
+// gating.
+export const usbCompositionModeSchema = z.enum([
+	'qmi',
+	'mbim',
+	'ecm-ncm',
+	'rndis',
+	'router-ethernet',
+]);
+export type UsbCompositionMode = z.infer<typeof usbCompositionModeSchema>;
+
+// Cellular data-usage totals (binding-ledger W6.7). `session_bytes` is the
+// current-boot total; `monthly_bytes` the UTC billing-cycle total. `cycle_day`
+// and `threshold_bytes` are the operator's optional configured meter bounds. All
+// counters are wire bytes (RX+TX), non-negative. Read-mostly (cycle_day/threshold
+// are operator-set via modems.configure in a later wave).
+export const modemDataUsageSchema = z.object({
+	session_bytes: z.number().nonnegative().optional(),
+	monthly_bytes: z.number().nonnegative().optional(),
+	cycle_day: z.number().int().min(1).max(31).optional(),
+	threshold_bytes: z.number().nonnegative().optional(),
+});
+export type ModemDataUsage = z.infer<typeof modemDataUsageSchema>;
+
+// Read-only eSIM facts (binding-ledger W6.8; MM 1.20 SimType/EsimStatus/EID).
+export const modemEsimSchema = z.object({
+	sim_type: z.enum(['physical', 'esim', 'unknown']).optional(),
+	esim_status: z.enum(['no-profiles', 'with-profiles', 'unknown']).optional(),
+	eid: z.string().optional(),
+});
+export type ModemEsim = z.infer<typeof modemEsimSchema>;
+
+// Read-only serving-cell telemetry (binding-ledger W6.8; MM 1.20 GetCellInfo).
+// NR uses `sinr` (NOT `snr` — round-10 ledger correction). `band` present only
+// when directly supplied by the modem. `provenance` records source + observed-at
+// per the W6.8 provenance model.
+export const modemCellInfoSchema = z.object({
+	tech: z.enum(['lte', 'nr', 'unknown']).optional(),
+	cell_id: z.string().optional(),
+	band: z.string().optional(),
+	rsrp: z.number().optional(),
+	rsrq: z.number().optional(),
+	// LTE signal-to-noise; NR signal-to-interference-plus-noise.
+	snr: z.number().optional(),
+	sinr: z.number().optional(),
+	provenance: z
+		.object({
+			source: z.string().optional(),
+			observed_at: z.number().int().optional(),
+		})
+		.optional(),
+});
+export type ModemCellInfo = z.infer<typeof modemCellInfoSchema>;
+
 // Modem schema
 export const modemSchema = z.object({
 	ifname: z.string(),
@@ -94,6 +180,23 @@ export const modemSchema = z.object({
 	status: modemStatusSchema.optional(),
 	no_sim: z.boolean().optional(),
 	sim_lock: simLockSchema.optional(),
+
+	// ── Phase-B additive-optional fields (T5.4) — ALL optional, additive-only.
+	// An old backend/frontend pair that omits every one of these still round-trips
+	// (contract-tested). Never promote any of these to required.
+	device_class: modemDeviceClassSchema.optional(),
+	// Human-readable reason a modem/slot is currently unavailable — drives the
+	// disabled-with-reason row on the Network destination.
+	availability_reason: z.string().optional(),
+	// Display label for the modem's active SIM slot (multi-slot boards).
+	slot_label: z.string().optional(),
+	recovery_state: modemRecoveryStateSchema.optional(),
+	usb_mode: usbCompositionModeSchema.optional(),
+	recommended_usb_mode: usbCompositionModeSchema.optional(),
+	data_usage: modemDataUsageSchema.optional(),
+	firmware_revision: z.string().optional(),
+	esim: modemEsimSchema.optional(),
+	cell_info: modemCellInfoSchema.optional(),
 });
 export type Modem = z.infer<typeof modemSchema>;
 
@@ -207,3 +310,34 @@ export const simPukUnlockOutputSchema = z.object({
 	error: simPukErrorSchema.optional(),
 });
 export type SimPukUnlockOutput = z.infer<typeof simPukUnlockOutputSchema>;
+
+// ── USB composition-mode switch (Phase B, T5.4) ──────────────────────────────
+// The guarded operator mutation gated by the `modem_provisioning` config key. The
+// full re-enumeration transaction is a later wave; THIS wave ships the schema plus
+// the default-absent refusal gate. `.strict()` + `confirm: z.literal(true)` are the
+// TOCTOU boundary hardening called out in the binding ledger (round-6 O5).
+export const setUsbModeInputSchema = z
+	.object({
+		device: z.string().min(1),
+		mode: usbCompositionModeSchema,
+		confirm: z.literal(true),
+	})
+	.strict();
+export type SetUsbModeInput = z.infer<typeof setUsbModeInputSchema>;
+
+// Typed refusal reasons for setUsbMode. `provisioning_disabled` is the
+// default-absent-`modem_provisioning` refusal (the T5.4 gate).
+export const setUsbModeRefusalSchema = z.enum([
+	'provisioning_disabled',
+	'unsupported_transition',
+	'streaming_active',
+	'unavailable_in_emulated_mode',
+	'error',
+]);
+export type SetUsbModeRefusal = z.infer<typeof setUsbModeRefusalSchema>;
+
+export const setUsbModeOutputSchema = z.object({
+	success: z.boolean(),
+	error: setUsbModeRefusalSchema.optional(),
+});
+export type SetUsbModeOutput = z.infer<typeof setUsbModeOutputSchema>;

--- a/packages/rpc/src/schemas/streaming.schema.ts
+++ b/packages/rpc/src/schemas/streaming.schema.ts
@@ -727,6 +727,10 @@ export const configMessageSchema = z.object({
 	// Sources dialog reflect the saved test-pattern visibility on reload. Written
 	// only by streaming.setSourceVisibility (never streaming.setConfig).
 	sources_visibility: sourcesVisibilitySchema.optional(),
+	// Opt-in `modem_provisioning` gate (Phase B, T5.4), echoed so the modem
+	// dialog can render USB-mode switching as enabled or disabled-with-reason.
+	// Default-absent: an absent key ⇒ switching stays gated/unreachable.
+	modem_provisioning: z.boolean().optional(),
 });
 export type ConfigMessage = z.infer<typeof configMessageSchema>;
 


### PR DESCRIPTION
## What

Phase-B cellular modem-stack integration for CeraUI, delivered as six wave-ordered
commits (one per rollout stage). This wires the `@ceralive/modem-control@0.2.0`
ModemManager backend into the device control plane behind an opt-in seam, keeping the
existing mmcli path byte-identical by default.

The six stages:

1. **`feat(modems): cellular stack composition root with mmcli|dbus backend seam`** —
   new `modules/cellular/` composition root (`getCellularStack()`, awaited init) with a
   `modem_backend: mmcli|dbus` config selector (default `mmcli`). The dbus backend is
   committed only after its first successful snapshot; init failure/hang falls back to
   mmcli with an observable degraded readiness. A typed `CELLULAR_STACK_INITIALIZING`
   error guards all modem procedures during the (dbus-only) init window.
2. **`feat(modems): modem_shadow observer with redacted divergence classifier`** — opt-in
   `modem_shadow` runs the dbus stack **read-only** beside live mmcli (zero `Signal.Setup`
   / zero non-read D-Bus calls, enforced by an auditing transport) and logs **redacted**
   divergences (no ICCID/PIN/secrets).
3. **`feat(modems): legacy numeric wire projection over modem-control`** — projects modem
   snapshots into the existing numeric-id wire shapes so frontend payloads are identical
   under mmcli vs dbus. `"auto"` is never echoed; router/unmanaged rows use a reserved
   ≥1000, collision-checked, replug-stable id namespace.
4. **`feat(modems): additive modem fields + bounded provisioning-gated UI`** — ten
   additive-**optional** schema fields (`device_class`, `availability_reason`, `slot_label`,
   `recovery_state`, `usb_mode`, `recommended_usb_mode`, `data_usage`, `firmware_revision`,
   `esim`, `cell_info`) plus a strictly-bounded frontend surface: disabled-with-reason rows,
   Auto-APN "Automatic (recommended)" default, usage controls, and a `modem_provisioning`
   default-absent gate on USB-mode switching (refused at the RPC boundary, not just hidden).
   i18n across all 10 locales.
5. **`feat(modems): streaming LifecycleInterlock for cellular recovery admission`** — a real
   `LifecycleInterlock` against streaming admission (both race orders, `finally`-release, no
   deadlock). A modem USB-composition switch cannot re-enumerate a modem while a stream is
   being admitted or is live; recovery stays default-disabled.
6. **`docs: modem Phase-B rollout notes + mmcli retirement criteria`** — the
   `TD-mmcli-retirement` technical-debt entry (verbatim exit criteria: ≥14 days shadow on
   ≥2 devices, zero unexplained divergences, HIL parity, rollback drill, one dbus-default
   release), CeraUI-local AGENTS docs, and the release-prep version bump to `2026.7.2`.

## Why

CeraLive devices need first-class cellular bonding links. Phase B introduces the modem
control stack **without** disturbing the shipping mmcli path: every new capability is
opt-in (`modem_backend`, `modem_shadow`, `modem_provisioning` are all additive-optional
config with no injected default, so an existing config echoes byte-identical). Shadow mode
lets us validate the dbus backend against live mmcli on real hardware before any cutover,
and the retirement TD entry encodes the exact evidence gate for retiring mmcli. The version
bump makes the PR merge release-ready for the Phase-B dispatch.

## How to verify

- Backend gate green: `bun run lint`, `bun run test` (backend suite includes the ~61 new
  Phase-B cellular/modem tests), `bun run check:tech-debt` (parses `TD-mmcli-retirement`),
  and production `bun run build`.
- **mmcli-default byte-identical**: with no `modem_backend`/`modem_shadow`/`modem_provisioning`
  keys, existing modem behaviour and wire payloads are unchanged (config echo is byte-for-byte).
- **Shadow safety**: the auditing-transport test asserts zero non-read D-Bus calls (including
  `Signal.Setup`) under shadow; the redaction test asserts no secrets reach the logs.
- **Wire parity**: the golden-fixture test asserts frontend payloads are identical under mmcli
  vs dbus; the ≥1000 collision/replug test covers synthetic-id stability.
- **Provisioning gate**: `setUsbMode` refuses with a typed error when `modem_provisioning` is
  absent (Tier-1 RPC test + e2e), proving the mutation is unreachable, not merely UI-hidden.
- **Interlock**: both race-order tests protect the stream; a throw after admission still
  releases the lease (no-deadlock test).

> Note: `test:e2e` requires the CI E2E lane's `srtla_send` binary (provisioned from the
> srtla-send-rs `.deb`) and the boot-shell login path; it cannot run to green on a bare local
> box. The load-bearing server-side refusals are proven by the Tier-1 RPC tests; the e2e is
> the through-UI proof that runs in CI.

## Risks

- **Blast radius is contained to the modem/cellular path.** The dbus backend only activates
  when `modem_backend: dbus` is set; shadow only when `modem_shadow: true`; USB-mode mutation
  only when `modem_provisioning: true`. Default devices exercise none of these.
- **Production dbus acceptance is deferred** (per the modem-control binding ledger): with no
  system bus (dev/CI/no-HW) the dbus factory rejects → mmcli fallback + degraded readiness,
  which is the designed acceptance path. Real-hardware dbus validation happens via shadow mode
  before any cutover, gated by the `TD-mmcli-retirement` criteria.
- **The `LifecycleInterlock` reserves a slot for a future, still-default-disabled recovery
  action** — no autonomous recovery loop is wired in this PR.
- Version bumped to `2026.7.2`; the actual release dispatch is a separate human checkpoint.
