### PR TITLE
fix(backend): repair SSH first-boot password + clipboard-over-HTTP + branding + revision file

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -270,6 +270,34 @@ Effectful surface (`readShadow` / `applyPassword`) is injected via
 `SshPasswordSyncDeps` (mirrors `SshStatusDeps`) so `tests/ssh-password-sync.test.ts`
 drives it without a real `passwd`/`/etc/shadow`.
 
+### SSH password provisioning on first boot [EXISTS]
+
+`ensureSshPasswordProvisioned()` (`modules/system/ssh.ts`, wired into `main.ts` via
+`guardNonCritical("ssh-password-provision", …)` immediately BEFORE the
+`ssh-password-sync` step) mints an INITIAL `ssh_pass` on a device that has never
+had one. SSH is enabled-by-default at the OS/systemd level, but CeraUI only ever
+generated a password on an explicit operator "Start SSH" / "Reset" action — so a
+fresh device ran `sshd` with `ssh_pass` permanently `undefined` and the account
+effectively unreachable until a manual reset. Provisioning closes that gap: when NO
+`ssh_pass` is persisted it mints one through the SAME credential path the operator
+reset uses.
+
+The generation is shared between the operator reset and boot provisioning by the
+single private `mintAndApplySshPassword()` helper (random `ssh_pass` → stdin-only
+`passwd` apply → persist → re-probe hash → broadcast config + status), so both
+routes emit and persist the secret through EXACTLY the same code — never logged.
+`resetSshPassword()` wraps it with an operator notification on failure;
+`ensureSshPasswordProvisioned()` wraps it with a boot broadcast. It is called
+UNCONDITIONALLY at boot (independent of the `ssh.service` active/enabled state), so
+even a production device shipping with SSH disabled-by-default has a ready
+credential the instant SSH is enabled from the UI. Contract: never throws (BOOT
+FAIL-SOFT); a clean no-op under `shouldUseMocks()` or when a password is ALREADY
+persisted — it NEVER regenerates an existing credential (that stays
+`ensureSshPasswordSynced()`'s restore-only job). Effectful surface (`readShadow` /
+`applyPassword` / `persist` / `refreshStatus`) is injected via
+`SshPasswordProvisionDeps` so `tests/ssh-password-provision.test.ts` drives it
+without a real `passwd`/`/etc/shadow` (and without persisting to disk).
+
 ## CONVENTIONS
 
 - Runtime: Bun only. No Node-specific APIs (`fs/promises` ok; `node:cluster` not).

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -106,7 +106,11 @@ import {
 	stopDmesgWatchers,
 } from "./modules/system/sensors.ts";
 import { periodicCheckForSoftwareUpdates } from "./modules/system/software-updates.ts";
-import { ensureSshPasswordSynced, getSshStatus } from "./modules/system/ssh.ts";
+import {
+	ensureSshPasswordProvisioned,
+	ensureSshPasswordSynced,
+	getSshStatus,
+} from "./modules/system/ssh.ts";
 import { wifiStateInit } from "./modules/wifi/wifi-connections.ts";
 import { handleWifiMonitorEvent as handleHotspotMonitorEvent } from "./modules/wifi/wifi-hotspot-monitor.ts";
 import { onHeartbeatTick, startHeartbeat } from "./rpc/heartbeat.ts";
@@ -258,6 +262,12 @@ initHardwareMonitoring();
 initDeviceStats();
 await guardNonCritical("rtmp-ingest", initRTMPIngestStats);
 await guardNonCritical("srt-ingest", initSRTIngest);
+// Provision an initial SSH password on a device that has never had one BEFORE
+// the sync/probe below run — SSH is enabled-by-default at the OS level but a
+// password was only ever minted on an explicit operator action, leaving a fresh
+// device's account unreachable. Runs unconditionally so a password is ready the
+// instant SSH is enabled. Fail-soft; a clean no-op once one is persisted.
+await guardNonCritical("ssh-password-provision", ensureSshPasswordProvisioned);
 // Reconcile the OS-level SSH password against the /data-persisted one BEFORE the
 // status probe below reads /etc/shadow: /etc/shadow is rootfs-local and does NOT
 // survive an A/B OTA slot swap, so a fresh slot silently locks the operator out

--- a/apps/backend/src/modules/system/revisions.ts
+++ b/apps/backend/src/modules/system/revisions.ts
@@ -41,7 +41,7 @@ function readRevision(cmd: string) {
 
 export async function initRevisions() {
 	try {
-		revisions.ceralive = await Bun.file("revision").text();
+		revisions.ceralive = (await Bun.file("revision").text()).trim();
 	} catch (_err) {
 		revisions.ceralive = readRevision("git rev-parse --short HEAD");
 	}

--- a/apps/backend/src/modules/system/ssh.ts
+++ b/apps/backend/src/modules/system/ssh.ts
@@ -267,17 +267,68 @@ export async function startStopSsh(
 		: status?.active === false;
 }
 
+/**
+ * Injectable surface for {@link mintAndApplySshPassword}. Defaults talk to the
+ * real OS (stdin-only `passwd`, JS `/etc/shadow` read) and drive a real status
+ * refresh; tests inject deterministic stand-ins so the credential-minting path
+ * can be exercised without a real `passwd` spawn.
+ */
+export type SshPasswordProvisionDeps = {
+	/** Read the raw /etc/shadow document (JS, no `grep` subprocess). */
+	readShadow: () => string | Promise<string>;
+	/** Apply `password` to `user`'s OS account via `passwd` (stdin only). */
+	applyPassword: (user: string, password: string) => Promise<void>;
+	/** Persist the mutated config (defaults to the real `saveConfig`). */
+	persist: () => void;
+	/** Re-probe + broadcast the SSH status after the credential changed. */
+	refreshStatus: () => Promise<void>;
+};
+
+const defaultSshPasswordProvisionDeps: SshPasswordProvisionDeps = {
+	readShadow: () => Bun.file("/etc/shadow").text(),
+	applyPassword: async (user, password) => {
+		// `passwd` reads the new password twice from stdin. The secret is fed via
+		// stdin ONLY — never on argv, never through a shell string.
+		await runWithStdin("passwd", [user], `${password}\n${password}\n`);
+	},
+	persist: saveConfig,
+	refreshStatus: async () => {
+		await getSshStatus();
+	},
+};
+
+/**
+ * The single SSH-credential-minting path, shared verbatim by the operator
+ * "Reset" RPC ({@link resetSshPassword}) and boot-time provisioning
+ * ({@link ensureSshPasswordProvisioned}): generate a random password, apply it
+ * stdin-only, persist it, re-probe the hash, broadcast config + status. Throws
+ * only on {@link SshPasswordProvisionDeps.applyPassword} failure so callers pick
+ * how to surface it (operator notification vs boot broadcast).
+ */
+async function mintAndApplySshPassword(
+	ssh_user: string,
+	deps: SshPasswordProvisionDeps = defaultSshPasswordProvisionDeps,
+): Promise<string> {
+	const password = randomBase64(24).replace(/[+/=]/g, "").substring(0, 20);
+
+	await deps.applyPassword(ssh_user, password);
+
+	const config = getConfig();
+	config.ssh_pass = password;
+	sshPasswordHash = await probeSshUserHash(deps.readShadow, ssh_user);
+	deps.persist();
+	broadcastMsg("config", config);
+	await deps.refreshStatus();
+	return password;
+}
+
 export async function resetSshPassword(
 	conn: MessageSocket,
 ): Promise<string | undefined> {
 	const ssh_user = resolveSshUser();
 
-	const password = randomBase64(24).replace(/[+/=]/g, "").substring(0, 20);
-
 	try {
-		// `passwd` reads the new password twice from stdin. The secret is fed via
-		// stdin ONLY — never on argv, never through a shell string.
-		await runWithStdin("passwd", [ssh_user], `${password}\n${password}\n`);
+		return await mintAndApplySshPassword(ssh_user);
 	} catch (err) {
 		logger.error(`Failed to reset the SSH password for ${ssh_user}: ${err}`);
 		notificationSend(
@@ -289,17 +340,57 @@ export async function resetSshPassword(
 		);
 		return undefined;
 	}
+}
 
-	const config = getConfig();
-	config.ssh_pass = password;
-	sshPasswordHash = await probeSshUserHash(
-		() => Bun.file("/etc/shadow").text(),
-		ssh_user,
-	);
-	saveConfig();
-	broadcastMsg("config", config);
-	await getSshStatus();
-	return password;
+/**
+ * Boot-time provisioning of an initial SSH password when the device has never
+ * had one. SSH is enabled-by-default at the OS/systemd level (image-baked), but
+ * CeraUI only ever minted a password on an explicit operator "Start SSH" /
+ * "Reset" click — so a fresh device ran `sshd` with `ssh_pass` permanently
+ * `undefined` until a manual reset. When NO `ssh_pass` is persisted this mints
+ * one through the SAME {@link mintAndApplySshPassword} path the reset uses.
+ *
+ * Called UNCONDITIONALLY at boot (independent of the `ssh.service` active/enabled
+ * state) so even a production device shipping with SSH disabled-by-default has a
+ * ready credential the instant SSH is enabled from the UI. Contract: never throws
+ * (BOOT FAIL-SOFT); a clean no-op under `shouldUseMocks()` or when a password is
+ * ALREADY persisted — it NEVER regenerates an existing credential (that is
+ * {@link ensureSshPasswordSynced}'s restore-only job). The secret is minted,
+ * persisted, and broadcast through the existing RPC/config path only, never logged.
+ */
+export async function ensureSshPasswordProvisioned(
+	deps: Partial<SshPasswordProvisionDeps> = {},
+): Promise<void> {
+	if (shouldUseMocks()) return;
+
+	let ssh_user: string;
+	try {
+		ssh_user = resolveSshUser();
+	} catch (err) {
+		logger.error(`Skipping SSH password provisioning: ${err}`);
+		return;
+	}
+
+	if (getConfig().ssh_pass !== undefined) return;
+
+	try {
+		await mintAndApplySshPassword(ssh_user, {
+			...defaultSshPasswordProvisionDeps,
+			...deps,
+		});
+		logger.info(`Generated an initial SSH password for ${ssh_user}`);
+	} catch (err) {
+		logger.error(
+			`Failed to provision an initial SSH password for ${ssh_user}: ${err}`,
+		);
+		notificationBroadcast(
+			"ssh_pass_provision",
+			"error",
+			`Failed to generate the initial SSH password for ${ssh_user}`,
+			0,
+			true,
+		);
+	}
 }
 
 /**

--- a/apps/backend/src/tests/ssh-password-provision.test.ts
+++ b/apps/backend/src/tests/ssh-password-provision.test.ts
@@ -1,0 +1,185 @@
+/*
+ * ssh-password-provision.test.ts — boot-time initial SSH password generation.
+ *
+ * `ensureSshPasswordProvisioned()` mints an initial `ssh_pass` on a device that
+ * has never had one (SSH is enabled-by-default at the OS level, but CeraUI only
+ * ever generated a password on an explicit operator action, so a fresh device's
+ * account was unreachable). It mints through the SAME credential path as the
+ * operator "Reset" RPC, and is a strict no-op when a password is ALREADY
+ * persisted — that stays ensureSshPasswordSynced's restore-only job.
+ *
+ * Like ssh-password-sync.test.ts, every OS effect (the /etc/shadow read, the
+ * `passwd` spawn, the status refresh) is injected through the
+ * SshPasswordProvisionDeps seam, so the suite asserts WHETHER a password
+ * materialized and that it was applied stdin-only — never spawning passwd or
+ * reading the real shadow file.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { initMockService, shouldUseMocks } from "../mocks/mock-service.ts";
+import { getConfig } from "../modules/config.ts";
+import { setup } from "../modules/setup.ts";
+import {
+	ensureSshPasswordProvisioned,
+	getSshPasswordHash,
+	type SshPasswordProvisionDeps,
+	setSshPasswordHash,
+} from "../modules/system/ssh.ts";
+
+function shadowLine(user: string, hash: string): string {
+	return `root:!:19000:0:99999:7:::\n${user}:${hash}:19000:0:99999:7:::\n`;
+}
+
+function captureApply(
+	calls: Array<{ user: string; password: string }>,
+): SshPasswordProvisionDeps["applyPassword"] {
+	return async (user, password) => {
+		calls.push({ user, password });
+	};
+}
+
+let savedNodeEnv: string | undefined;
+let savedMockMode: string | undefined;
+let savedDeviceType: string | undefined;
+let savedSshUser: string | undefined;
+let savedSshPass: string | undefined;
+let savedSshPasswordHash: string | undefined;
+
+beforeEach(() => {
+	savedNodeEnv = process.env.NODE_ENV;
+	savedMockMode = process.env.MOCK_MODE;
+	savedDeviceType = process.env.CERALIVE_DEVICE_TYPE;
+	savedSshUser = setup.ssh_user;
+	savedSshPass = getConfig().ssh_pass;
+	savedSshPasswordHash = getSshPasswordHash();
+});
+
+afterEach(() => {
+	const restore = (key: string, value: string | undefined) => {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	};
+	restore("NODE_ENV", savedNodeEnv);
+	restore("MOCK_MODE", savedMockMode);
+	restore("CERALIVE_DEVICE_TYPE", savedDeviceType);
+	setup.ssh_user = savedSshUser;
+	getConfig().ssh_pass = savedSshPass;
+	setSshPasswordHash(savedSshPasswordHash);
+});
+
+function enterProd(): void {
+	process.env.NODE_ENV = "production";
+	delete process.env.MOCK_MODE;
+	delete process.env.CERALIVE_DEVICE_TYPE;
+}
+
+describe("ensureSshPasswordProvisioned — no password persisted yet", () => {
+	test("(prod) mints, applies stdin-only, and persists a fresh password", async () => {
+		enterProd();
+		setup.ssh_user = "produser";
+		getConfig().ssh_pass = undefined;
+		setSshPasswordHash(undefined);
+		expect(shouldUseMocks()).toBe(false);
+
+		const calls: Array<{ user: string; password: string }> = [];
+		let persisted = 0;
+		let statusRefreshed = 0;
+		await ensureSshPasswordProvisioned({
+			readShadow: () => shadowLine("produser", "$6$new$freshhash"),
+			applyPassword: captureApply(calls),
+			persist: () => {
+				persisted++;
+			},
+			refreshStatus: async () => {
+				statusRefreshed++;
+			},
+		});
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.user).toBe("produser");
+		const applied = calls[0]?.password ?? "";
+		expect(applied).toMatch(/^[A-Za-z0-9]{20}$/);
+		expect(getConfig().ssh_pass).toBe(applied);
+		expect(getSshPasswordHash()).toBe("$6$new$freshhash");
+		expect(persisted).toBe(1);
+		expect(statusRefreshed).toBe(1);
+	});
+});
+
+describe("ensureSshPasswordProvisioned — password already persisted", () => {
+	test("(prod) never regenerates an existing credential", async () => {
+		enterProd();
+		setup.ssh_user = "produser";
+		getConfig().ssh_pass = "already-there";
+		setSshPasswordHash("$6$old$existinghash");
+		expect(shouldUseMocks()).toBe(false);
+
+		const calls: Array<{ user: string; password: string }> = [];
+		let shadowReads = 0;
+		await ensureSshPasswordProvisioned({
+			readShadow: () => {
+				shadowReads++;
+				return shadowLine("produser", "$6$old$existinghash");
+			},
+			applyPassword: captureApply(calls),
+			persist: () => {},
+			refreshStatus: async () => {},
+		});
+
+		expect(calls).toHaveLength(0);
+		expect(shadowReads).toBe(0);
+		expect(getConfig().ssh_pass).toBe("already-there");
+		expect(getSshPasswordHash()).toBe("$6$old$existinghash");
+	});
+});
+
+describe("ensureSshPasswordProvisioned — boot-safety (never propagates)", () => {
+	test("(prod) a passwd failure is swallowed, config left unset", async () => {
+		enterProd();
+		setup.ssh_user = "produser";
+		getConfig().ssh_pass = undefined;
+		setSshPasswordHash(undefined);
+
+		await expect(
+			ensureSshPasswordProvisioned({
+				readShadow: () => shadowLine("produser", "$6$x$y"),
+				applyPassword: async () => {
+					throw new Error("passwd exited with code 1");
+				},
+				persist: () => {},
+				refreshStatus: async () => {},
+			}),
+		).resolves.toBeUndefined();
+
+		expect(getConfig().ssh_pass).toBeUndefined();
+	});
+});
+
+describe("ensureSshPasswordProvisioned — dev mock seam", () => {
+	test("(dev) no shadow read and no passwd apply under mocks", async () => {
+		process.env.NODE_ENV = "development";
+		delete process.env.MOCK_MODE;
+		delete process.env.CERALIVE_DEVICE_TYPE;
+		initMockService("multi-modem-wifi");
+		setup.ssh_user = "devuser";
+		getConfig().ssh_pass = undefined;
+		setSshPasswordHash(undefined);
+		expect(shouldUseMocks()).toBe(true);
+
+		const calls: Array<{ user: string; password: string }> = [];
+		let shadowReads = 0;
+		await ensureSshPasswordProvisioned({
+			readShadow: () => {
+				shadowReads++;
+				return shadowLine("devuser", "$6$x$y");
+			},
+			applyPassword: captureApply(calls),
+			persist: () => {},
+			refreshStatus: async () => {},
+		});
+
+		expect(shadowReads).toBe(0);
+		expect(calls).toHaveLength(0);
+		expect(getConfig().ssh_pass).toBeUndefined();
+	});
+});

--- a/apps/frontend/src/lib/components/custom/NetworkIngestSection.svelte
+++ b/apps/frontend/src/lib/components/custom/NetworkIngestSection.svelte
@@ -43,6 +43,7 @@ import { toast } from 'svelte-sonner';
 import InfoPopover from '$lib/components/custom/InfoPopover.svelte';
 import { Button } from '$lib/components/ui/button';
 import * as Card from '$lib/components/ui/card';
+import { copyToClipboard } from '$lib/helpers/clipboard';
 import { generateDeviceAccessQr } from '$lib/helpers/NetworkHelper';
 import { rpc } from '$lib/rpc/client';
 import {
@@ -182,10 +183,9 @@ $effect(() => {
 
 async function copyUrl(url: string | null): Promise<void> {
 	if (!url) return;
-	try {
-		await navigator.clipboard.writeText(url);
+	if (await copyToClipboard(url)) {
 		toast.success($LL.live.networkIngest.copied());
-	} catch {
+	} else {
 		toast.error($LL.live.networkIngest.copyFailed());
 	}
 }

--- a/apps/frontend/src/lib/components/custom/SourceSection.svelte
+++ b/apps/frontend/src/lib/components/custom/SourceSection.svelte
@@ -56,6 +56,7 @@ import InfoPopover from '$lib/components/custom/InfoPopover.svelte';
 import { Button } from '$lib/components/ui/button';
 import * as Card from '$lib/components/ui/card';
 import * as Select from '$lib/components/ui/select';
+import { copyToClipboard } from '$lib/helpers/clipboard';
 import { generateDeviceAccessQr } from '$lib/helpers/NetworkHelper';
 import { rpc } from '$lib/rpc';
 import {
@@ -340,10 +341,9 @@ $effect(() => {
 
 async function copyNetworkIngestUrl(url: string | null): Promise<void> {
 	if (!url) return;
-	try {
-		await navigator.clipboard.writeText(url);
+	if (await copyToClipboard(url)) {
 		toast.success($LL.live.networkIngest.copied());
-	} catch {
+	} else {
 		toast.error($LL.live.networkIngest.copyFailed());
 	}
 }

--- a/apps/frontend/src/lib/helpers/clipboard.test.ts
+++ b/apps/frontend/src/lib/helpers/clipboard.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { copyToClipboard } from "./clipboard";
+
+const originalNavigator = Object.getOwnPropertyDescriptor(
+	globalThis,
+	"navigator",
+);
+
+function setClipboard(clipboard: unknown): void {
+	Object.defineProperty(globalThis.navigator, "clipboard", {
+		configurable: true,
+		value: clipboard,
+	});
+}
+
+afterEach(() => {
+	if (originalNavigator) {
+		Object.defineProperty(globalThis, "navigator", originalNavigator);
+	}
+	vi.restoreAllMocks();
+});
+
+describe("copyToClipboard — secure-context Clipboard API", () => {
+	it("uses navigator.clipboard.writeText when available", async () => {
+		const writeText = vi.fn(async () => {});
+		setClipboard({ writeText });
+
+		const ok = await copyToClipboard("hello");
+
+		expect(ok).toBe(true);
+		expect(writeText).toHaveBeenCalledWith("hello");
+	});
+});
+
+describe("copyToClipboard — plain-HTTP fallback (no Clipboard API)", () => {
+	it("falls back to execCommand('copy') when navigator.clipboard is absent", async () => {
+		setClipboard(undefined);
+		const execCommand = vi.fn(() => true);
+		Object.defineProperty(document, "execCommand", {
+			configurable: true,
+			value: execCommand,
+		});
+
+		const ok = await copyToClipboard("over-http");
+
+		expect(ok).toBe(true);
+		expect(execCommand).toHaveBeenCalledWith("copy");
+		// The transient textarea is always removed after the copy attempt.
+		expect(document.querySelector("textarea")).toBeNull();
+	});
+
+	it("falls back to execCommand when writeText rejects (permission denied)", async () => {
+		const writeText = vi.fn(async () => {
+			throw new Error("NotAllowedError");
+		});
+		setClipboard({ writeText });
+		const execCommand = vi.fn(() => true);
+		Object.defineProperty(document, "execCommand", {
+			configurable: true,
+			value: execCommand,
+		});
+
+		const ok = await copyToClipboard("retry-me");
+
+		expect(ok).toBe(true);
+		expect(writeText).toHaveBeenCalledWith("retry-me");
+		expect(execCommand).toHaveBeenCalledWith("copy");
+	});
+
+	it("returns false when both the API and execCommand fail", async () => {
+		setClipboard(undefined);
+		const execCommand = vi.fn(() => false);
+		Object.defineProperty(document, "execCommand", {
+			configurable: true,
+			value: execCommand,
+		});
+
+		const ok = await copyToClipboard("nope");
+
+		expect(ok).toBe(false);
+		expect(document.querySelector("textarea")).toBeNull();
+	});
+});

--- a/apps/frontend/src/lib/helpers/clipboard.ts
+++ b/apps/frontend/src/lib/helpers/clipboard.ts
@@ -1,0 +1,45 @@
+/**
+ * Copy `text` to the clipboard, working over plain HTTP as well as HTTPS.
+ *
+ * `navigator.clipboard` only exists in a secure context (HTTPS or localhost), so
+ * a device reached over plain HTTP by LAN IP has no Clipboard API and copy
+ * buttons silently fail. Fall back to a hidden `<textarea>` +
+ * `document.execCommand('copy')` when the async API is absent or throws, so
+ * copying works without a real TLS certificate.
+ *
+ * @returns `true` when the text was copied, `false` when every path failed.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+	if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+		try {
+			await navigator.clipboard.writeText(text);
+			return true;
+		} catch {
+			// Secure-context API present but refused (permissions/focus) — fall
+			// through to the execCommand path rather than reporting a failure.
+		}
+	}
+	return legacyCopy(text);
+}
+
+function legacyCopy(text: string): boolean {
+	if (typeof document === "undefined") return false;
+
+	const textarea = document.createElement("textarea");
+	textarea.value = text;
+	textarea.setAttribute("readonly", "");
+	textarea.style.position = "fixed";
+	textarea.style.top = "-9999px";
+	textarea.style.opacity = "0";
+	document.body.appendChild(textarea);
+
+	try {
+		textarea.focus();
+		textarea.select();
+		return document.execCommand("copy");
+	} catch {
+		return false;
+	} finally {
+		document.body.removeChild(textarea);
+	}
+}

--- a/apps/frontend/src/main/dialogs/HotspotDialog.svelte
+++ b/apps/frontend/src/main/dialogs/HotspotDialog.svelte
@@ -25,6 +25,7 @@ import { Button } from '$lib/components/ui/button';
 import { Input } from '$lib/components/ui/input';
 import { Label } from '$lib/components/ui/label';
 import * as Select from '$lib/components/ui/select';
+import { copyToClipboard } from '$lib/helpers/clipboard';
 import { generateWifiQr } from '$lib/helpers/NetworkHelper';
 import {
 	confirmOperation,
@@ -201,10 +202,9 @@ $effect(() => {
 // ── Copy SSID / password to clipboard (never logs the secret) ──
 async function copyName() {
 	if (!name) return;
-	try {
-		await navigator.clipboard.writeText(name);
+	if (await copyToClipboard(name)) {
 		toast.success($LL.network.clipboard.nameCopied());
-	} catch {
+	} else {
 		toast.error($LL.network.clipboard.copyFailed(), {
 			description: $LL.network.clipboard.copyFailedDescription(),
 		});
@@ -213,10 +213,9 @@ async function copyName() {
 
 async function copyPassword() {
 	if (!password) return;
-	try {
-		await navigator.clipboard.writeText(password);
+	if (await copyToClipboard(password)) {
 		toast.success($LL.network.clipboard.passwordCopied());
-	} catch {
+	} else {
 		toast.error($LL.network.clipboard.copyFailed(), {
 			description: $LL.network.clipboard.copyFailedDescription(),
 		});

--- a/apps/frontend/src/main/dialogs/SshDialog.svelte
+++ b/apps/frontend/src/main/dialogs/SshDialog.svelte
@@ -16,6 +16,7 @@ import { AppDialog } from '$lib/components/dialogs';
 import { Button } from '$lib/components/ui/button';
 import { Input } from '$lib/components/ui/input';
 import { Label } from '$lib/components/ui/label';
+import { copyToClipboard } from '$lib/helpers/clipboard';
 import { resetSSHPasword } from '$lib/helpers/SystemHelper';
 import {
 	confirmOperation,
@@ -49,11 +50,9 @@ let toggleTarget = $state<boolean | null>(null);
 
 async function copyPassword() {
 	if (!sshPass) return;
-	try {
-		await navigator.clipboard.writeText(sshPass);
+	if (await copyToClipboard(sshPass)) {
 		toast.success($LL.advanced.passwordCopied(), { description: $LL.advanced.passwordCopiedDesc() });
-	} catch (error) {
-		console.error('Failed to copy SSH password:', error);
+	} else {
 		toast.error($LL.advanced.copyFailed());
 	}
 }

--- a/apps/frontend/src/main/dialogs/VersionsDialog.svelte
+++ b/apps/frontend/src/main/dialogs/VersionsDialog.svelte
@@ -26,7 +26,7 @@ const revisions = $derived(getRevisions());
 const rows = $derived(
 	revisions
 		? [
-				{ label: 'CeraLive', value: revisions.ceralive },
+				{ label: 'CeraUI', value: revisions.ceralive },
 				{ label: 'SRTLA', value: revisions.srtla },
 				{ label: 'Bun Runtime', value: revisions.bun },
 				...(revisions['CERALIVE image']

--- a/scripts/build/build-debian-package.sh
+++ b/scripts/build/build-debian-package.sh
@@ -89,6 +89,12 @@ cp dist/99-ceralive-check-usb-devices.rules "$TEMP_DIR/etc/udev/rules.d/"
 cp -r dist/public/* "$TEMP_DIR/var/www/ceralive/"
 cp dist/config.json "$TEMP_DIR/etc/ceralive/"
 cp apps/backend/setup.json "$TEMP_DIR/opt/ceralive/"
+# Stamp the build commit into the packaged tree so the backend's initRevisions()
+# reads it at runtime (WorkingDirectory=/opt/ceralive). A deployed /opt/ceralive is
+# not a git checkout, so without this file both the primary read AND its
+# `git rev-parse` fallback fail — "unknown revision" would be the always-taken path
+# on every real device.
+printf '%s\n' "$COMMIT" > "$TEMP_DIR/opt/ceralive/revision"
 ln -s /var/www/ceralive "$TEMP_DIR/opt/ceralive/public"
 cp dist/override-belaui.sh "$TEMP_DIR/usr/local/bin/"
 cp dist/reset-to-default.sh "$TEMP_DIR/usr/local/bin/"


### PR DESCRIPTION
**Affected repo & language:** CeraUI — TypeScript (Bun backend + Svelte 5 frontend), Bash (build script)

## What

Four small, independently-verifiable device-readiness fixes, bundled as one pre-release PR:

1. **SSH first-boot password generation.** A fresh device now generates and persists an initial SSH password at boot when none exists, so the account is reachable the instant SSH is enabled — instead of the operator having to click "Reset SSH Password" first.
2. **Clipboard copy over plain HTTP.** The four "copy" buttons (SSH password, hotspot SSID/password, RTMP/SRT publish URLs) now work when the device is reached over plain HTTP by LAN IP, not only over HTTPS/localhost.
3. **Device Versions dialog branding.** The software-revision row is relabeled `CeraLive` → `CeraUI` (it shows CeraUI's own build revision, a software-identity label per `docs/BRANDING.md`).
4. **"unknown revision" fix.** The `.deb` build now writes the build commit into `/opt/ceralive/revision`, so the Versions dialog shows the real commit instead of always falling back to `unknown revision`.

## Why

- **SSH (fix 1):** `ensureSshPasswordSynced()` is restore-only (no-ops when `ssh_pass` is unset) and `resetSshPassword()` only fires from an explicit operator action. SSH is enabled-by-default at the OS/systemd level (image-baked), so a fresh device ran `sshd` with `ssh_pass` permanently `undefined` and the account effectively unreachable until a manual reset.
- **Clipboard (fix 2):** `navigator.clipboard` only exists in a secure context (HTTPS or localhost). On a plain-HTTP LAN-IP device it is `undefined`, so every copy button silently failed.
- **Branding (fix 3):** the row is parallel to the `SRTLA` / `Bun Runtime` rows — it is CeraUI's own software revision, not the CeraLive platform brand.
- **Revision (fix 4):** the build never wrote a `revision` file into the packaged tree, so the backend's `Bun.file("revision")` read always threw ENOENT and its `git rev-parse` fallback also failed (a deployed `/opt/ceralive` is not a git checkout) — `unknown revision` was the *always-taken* path on every real device.

Implementation notes:

- Fix 1 extracts a single private `mintAndApplySshPassword()` helper shared verbatim by both the operator "Reset" RPC and the new boot-time `ensureSshPasswordProvisioned()`, so the secret is minted, applied (stdin-only `passwd`), persisted, and broadcast through **exactly one** code path — never logged. Boot provisioning runs unconditionally (independent of the `ssh.service` state), is a strict no-op when a password already exists (never regenerates), and is boot fail-soft (never throws). The restore-only OTA-slot-swap sync is untouched.
- Fix 2 extracts one shared `copyToClipboard(text)` helper (async Clipboard API first, hidden-`<textarea>` + `execCommand('copy')` fallback) used at all four call sites, replacing the duplicated try/catch.

## How to verify

- **Backend gate:** `bun run --filter backend test` → 1949 pass / 0 fail; `bun run --filter backend check` → exit 0; `bun run check:tech-debt` → OK; `bunx biome check .` → exit 0 (warnings are pre-existing).
- **Fix 1:** `bun test apps/backend/src/tests/ssh-password-provision.test.ts` — asserts a 20-char password is minted stdin-only + persisted when unset, is never regenerated when already present, is boot-safe on `passwd` failure, and no-ops under mocks.
- **Fix 2:** `bunx vitest run src/lib/helpers/clipboard.test.ts` (from `apps/frontend`) — asserts the API path, the no-API fallback, the writeText-rejects fallback, and the both-fail→`false` path.
- **Fix 3:** open Settings → Versions; the first row reads **CeraUI**.
- **Fix 4:** build a `.deb` (`BUILD_ARCH=amd64 ./scripts/build/build-debian-package.sh`) and inspect the packaged tree — `/opt/ceralive/revision` contains the real short commit (verified this build: `dac75058`), not `unknown revision`.

## Risks

- **Low.** Fix 1 reuses the existing, security-reviewed credential path (no new secret handling, nothing logged) and only adds behaviour on the "no password yet" branch. Fix 2 is a superset of the old behaviour (still tries the Clipboard API first). Fixes 3 and 4 are a one-line label change and a build-time file write.
- **Deployment (out of scope for this PR):** taking these fixes to a currently-flashed board requires a subsequent CeraUI release + image rebuild + reflash. That reflash is **deferred and separately authorized** — not part of this PR.
- Rollback: revert the commit; no migrations, no persisted-schema changes.

---

**Checklist**

- [x] Docs updated if behavior or structure changed (Rule A: `apps/backend/AGENTS.md` gains a "SSH password provisioning on first boot" subsection)
- [x] Started from updated main; branch off latest canonical `main` (Rule B)
- [x] Rule D local-scratch reference check passes for tracked files
- [x] Tests pass; QA evidence in "How to verify"
