### PR TITLE
fix(backend): use cerastream 2026.7.2 client

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ setup.json are coerced to `"cerastream"` at parse time with a warning).
 The backend resolves both streaming deps as public-npm registry packages — no sibling checkout, no vendored tarball:
 
 ```
-"@ceralive/cerastream":  "2026.7.1"   (public npm, @ceralive scope)
+"@ceralive/cerastream":  "2026.7.2"   (public npm, @ceralive scope)
 "@ceralive/srtla-send":  "2026.6.2"   (public npm, @ceralive scope)
 ```
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -9,7 +9,7 @@
 		"bun": ">=1.3.0"
 	},
 	"dependencies": {
-		"@ceralive/cerastream": "2026.7.1",
+		"@ceralive/cerastream": "2026.7.2",
 		"@ceralive/control-protocol": "2026.7.0",
 		"@ceralive/srtla-send": "2026.6.2",
 		"@ceraui/rpc": "workspace:*",

--- a/apps/backend/src/modules/streaming/capabilities.ts
+++ b/apps/backend/src/modules/streaming/capabilities.ts
@@ -29,12 +29,10 @@
 //   3. minimal — a TestPattern-only safe set, flagged `engineUnavailable` +
 //                `engineStarting` (the engine has never been reachable this run)
 //
-// `get-capabilities` is the additive method #9 (post-V1, not on the frozen
-// `CerastreamClient` surface yet), so the default fetch probes for it on the
-// connected client and degrades down the ladder when a stub binding has not
-// implemented it. A `schema_version` skew is informational only (additive within
-// `cerastream-ipc/1`, mirroring `probeEngine`): it warns and flags the response,
-// never throws.
+// `get-capabilities` is the additive method #9 on the published
+// `CerastreamClient` surface. A `schema_version` skew is informational only
+// (additive within `cerastream-ipc/1`, mirroring `probeEngine`): it warns and
+// flags the response, never throws.
 
 import {
 	type CaptureCap,
@@ -177,16 +175,6 @@ export const MINIMAL_SAFE_CAPABILITIES: GetCapabilitiesResult = {
 };
 
 /**
- * Client surface for the additive `get-capabilities` method (#9). The published
- * {@link CerastreamClient} interface does not expose it yet (it is post-V1 and
- * additive), so the default fetch probes for it and falls down the ladder when a
- * stub binding has not implemented it — the typed contract still ships ahead.
- */
-interface CapabilitiesCapableClient extends CerastreamClient {
-	getCapabilities?: () => Promise<unknown>;
-}
-
-/**
  * Default engine fetch: connect, read the negotiated `schema_version`, call
  * `get-capabilities`, and validate the result against the frozen Zod contract.
  * The connection is a short-lived probe — `close()` only drops our socket; it
@@ -204,13 +192,7 @@ async function defaultFetchEngineCapabilities(): Promise<EngineCapabilitiesSnaps
 	try {
 		client = await connect(connectOptions);
 		const schemaVersion = client.hello.schema_version;
-		const capable = client as CapabilitiesCapableClient;
-		if (typeof capable.getCapabilities !== "function") {
-			throw new Error(
-				"cerastream client does not expose get-capabilities (additive method #9)",
-			);
-		}
-		const raw = await capable.getCapabilities();
+		const raw = await client.getCapabilities();
 		const caps = getCapabilitiesResultSchema.parse(raw);
 		// `transports` is additive and not on the frozen result schema (which
 		// strips unknowns), so read it from the raw response before the parse drop.

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -19,7 +19,7 @@ Svelte 5 PWA for CeraUI — the on-device control plane for CeraLive streaming h
 The `backend` app consumes both streaming bindings as pinned public npm packages:
 
 ```
-"@ceralive/cerastream": "2026.7.1"   (public npm, @ceralive scope)
+"@ceralive/cerastream": "2026.7.2"   (public npm, @ceralive scope)
 "@ceralive/srtla-send": "2026.6.2"   (public npm, @ceralive scope)
 ```
 

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
       "name": "backend",
       "version": "2026.6.2",
       "dependencies": {
-        "@ceralive/cerastream": "2026.7.1",
+        "@ceralive/cerastream": "2026.7.2",
         "@ceralive/control-protocol": "2026.7.0",
         "@ceralive/srtla-send": "2026.6.2",
         "@ceraui/rpc": "workspace:*",
@@ -342,7 +342,7 @@
 
     "@ceralive/biome-config": ["@ceralive/biome-config@2026.6.2", "", {}, "sha512-LqDaJufxLOC3Rm38u/ocpUro/ub8llv1q9pcS3W/Ys7gBy+wLjS2TmcyhMjNMRg9c7pCQlPMI6eS8JkhpN+ecw=="],
 
-    "@ceralive/cerastream": ["@ceralive/cerastream@2026.7.1", "", { "dependencies": { "zod": "^4.3.5" } }, "sha512-YxgIgAxbHVHgyswu06Uvj9bhnfBd42nTLOrxl8YbU/aVxvlSDig65ilkpG0Ml+7yMmWE079uNjXAlKTNe42+8g=="],
+    "@ceralive/cerastream": ["@ceralive/cerastream@2026.7.2", "", { "dependencies": { "zod": "^4.3.5" } }, "sha512-5Zw7XJ7qhtAHSd1kZRUnBD8ZHQGjhhLwgZj2ZluXRqNBMoEieEp+9p4WrPDwJZluBc6pMbj6T+5zDSqdFxrLTw=="],
 
     "@ceralive/control-protocol": ["@ceralive/control-protocol@2026.7.0", "", { "dependencies": { "zod": "^4.3.5" } }, "sha512-/pLQpo3bTUzzxaQJK0zta4XKS6EJWr26p5jj2YST69ejxafQiCCjXKgdOkMWU9VjKm0XeMNQehxXOb6ylMGGHg=="],
 


### PR DESCRIPTION
## What
- Pin `@ceralive/cerastream` to exact version `2026.7.2` and refresh `bun.lock`.
- Use the published client's typed `getCapabilities()` method in the capability probe.

## Why
The bundled `2026.7.1` client could not speak the `get-capabilities` protocol expected by the running `2026.7.2` cerastream daemon. This caused repeated capability-fetch failures and the backend's permanent `engineUnavailable` state, producing the observed “streaming engine offline”, “Test Pattern” stuck, and false RTMP+SRT-down UI symptoms on the physically flashed Rock 5B+ board.

## How to verify
- `npm view @ceralive/cerastream@2026.7.2`
- `bun install`
- Targeted capability/reconnect/binding tests: 27 pass
- `bun run --filter backend check`
- `bun run check:tech-debt`
- `bun run lint && bun run test && bun run check:tech-debt` reaches the known local Vitest `localStorage.getItem` collection failure in 59 pre-existing suites; 1,198 frontend tests pass.

## Risks
The fix requires a CeraUI release, image rebuild, and reflash before it takes effect on real hardware; that deployment is deferred and separately authorized. The capability fallback ladder is unchanged. GitHub CI remains the authoritative full gate.