### PR TITLE
fix(backend): discover audio cards from sysfs

### DIFF
--- a/apps/backend/setup.json
+++ b/apps/backend/setup.json
@@ -3,7 +3,7 @@
 	"engine": "cerastream",
 	"ssh_user": "ceralive",
 	"srtla_path": "/usr/bin",
-	"sound_device_dir": "/dev/snd",
+	"sound_device_dir": "/sys/class/sound",
 	"usb_device_dir": "/dev",
 	"ips_file": "/run/ceralive/srtla_ips"
 }

--- a/apps/backend/src/tests/audio-sources.test.ts
+++ b/apps/backend/src/tests/audio-sources.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import { audioSourceSchema } from "@ceraui/rpc/schemas";
 import { z } from "zod";
@@ -10,6 +13,7 @@ import {
 	deriveAudioSources,
 	getAudioDevices,
 	setMockAudioDevicesProvider,
+	updateAudioDevices,
 } from "../modules/streaming/audio.ts";
 
 const ENV_KEYS = ["MOCK_MODE", "MOCK_SCENARIO", "NODE_ENV"] as const;
@@ -91,5 +95,24 @@ describe("deriveAudioSources — typed audio-source model", () => {
 
 		const parsed = z.array(audioSourceSchema).parse(deriveAudioSources());
 		expect(parsed).toEqual(deriveAudioSources());
+	});
+});
+
+describe("updateAudioDevices — sysfs card discovery", () => {
+	test("finds card IDs from card*/id files in a sysfs-shaped directory", async () => {
+		const root = await mkdtemp(join(tmpdir(), "ceraui-audio-"));
+		try {
+			await mkdir(join(root, "card0"));
+			await mkdir(join(root, "card5"));
+			await Bun.write(join(root, "card0", "id"), "rockchiphdmi0\n");
+			await Bun.write(join(root, "card5", "id"), "usbaudio\n");
+
+			await updateAudioDevices(root);
+
+			expect(Object.keys(getAudioDevices())).toContain("USB audio");
+			expect(Object.keys(getAudioDevices())).not.toContain("rockchiphdmi0");
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
 	});
 });

--- a/scripts/ceralive-service.test.mjs
+++ b/scripts/ceralive-service.test.mjs
@@ -32,7 +32,7 @@ test('device backend compile command pins production mode', () => {
 test('device package uses the installed sender and does not require BCRPT at boot', () => {
 	expect(deviceSetup.ssh_user).toBe('ceralive');
 	expect(deviceSetup.srtla_path).toBe('/usr/bin');
-	expect(deviceSetup.sound_device_dir).toBe('/dev/snd');
+	expect(deviceSetup.sound_device_dir).toBe('/sys/class/sound');
 	expect(deviceSetup.usb_device_dir).toBe('/dev');
 	expect(deviceSetup.bcrpt_path).toBeUndefined();
 	expect(backendMain).toContain('if (setup.bcrpt_path) {');


### PR DESCRIPTION
## What
- Set the backend setup template's `sound_device_dir` to `/sys/class/sound`.
- Add a regression test with a realistic `card*/id` sysfs tree.
- Update the service-contract assertion for the shipped default.

## Why
`/dev/snd` contains flat device nodes, not `card*/id` directories, so the scanner returned only pseudo-sources on real devices.

## Verification
- `cd apps/backend && bun run lint && bun tsc --noEmit && bun test` — passed (1950 tests).
- Targeted audio/service tests and Biome checks passed.
- Live board `192.168.78.131`: both `/opt/ceralive/setup.json` and `/data/ceralive/setup.json` were patched to `/sys/class/sound`; `ceralive.service` restarted and is active. Authenticated status broadcast changed from `asrcs: ["No audio", "Pipeline default"]` to `asrcs: ["HDMI", "USB audio", "No audio", "Pipeline default"]`; typed `audio_sources` includes `{id:"USB audio",kind:"device"}`. `/sys/class/sound/card5/id` is `usbaudio`.

## Risk
Config-only runtime path correction; scanner logic is unchanged.