### PR TITLE
fix(frontend): show specific capture pipeline on source rows, not a coarse USB badge

### DIFF
--- a/apps/frontend/src/lib/components/custom/SourceSection.svelte
+++ b/apps/frontend/src/lib/components/custom/SourceSection.svelte
@@ -250,8 +250,11 @@ function rowLabel(source: StreamSource): string {
 	return source.origin === 'capture' ? source.displayName : t(source.labelKey);
 }
 
-// Capture kind → coarse device family (drives the icon + the kind badge). A UVC
-// dongle (`uvc_h264`) is USB family, so its badge reads "USB" — never "HDMI".
+// Capture kind → coarse device FAMILY. Drives the ICON only: a UVC dongle
+// (`uvc_h264`) is USB family, so it gets the USB glyph — the grouping is right for
+// iconography. It is NO LONGER the source of the visible label: that collapsed
+// every USB-family kind (`uvc_h264`/`uvc_h265`/`mjpeg`/`camlink`) into one
+// indistinguishable "USB" pill, hiding which capture pipeline the device runs.
 type KindFamily = 'hdmi' | 'usb' | 'network' | 'other';
 function kindFamily(kind: DeviceKind): KindFamily {
 	if (kind === 'hdmi') return 'hdmi';
@@ -268,8 +271,22 @@ function kindFamily(kind: DeviceKind): KindFamily {
 	return 'other';
 }
 const KIND_ICON = { hdmi: Cable, usb: Usb, network: Radio, other: Video } as const;
+// The SPECIFIC pipeline/profile label — resolved straight off the raw `kind`, so
+// `uvc_h264` reads "UVC H.264", `mjpeg` reads "MJPEG", `camlink` reads "Cam Link"
+// (the `live.inputPicker.groups.*` family already carries a key per DeviceKind).
+// This is what lets the operator tell hardware H.264/H.265 UVC from raw MJPEG from
+// HDMI from CamLink at a glance, instead of one coarse "USB" badge.
 function kindLabel(kind: DeviceKind): string {
-	return t(`live.inputPicker.groups.${kindFamily(kind)}`);
+	return t(`live.inputPicker.groups.${kind}`);
+}
+// Hardware-encoding UVC kinds run onboard H.264/H.265 — surface that with the
+// phosphor-lime "live" accent so the hardware-encode path reads distinctly from
+// raw/other capture (which stay neutral). The text differs per kind regardless,
+// so colour is reinforcement, never the sole signal.
+function kindBadgeClass(kind: DeviceKind): string {
+	return kind === 'uvc_h264' || kind === 'uvc_h265'
+		? 'bg-primary/10 text-primary'
+		: 'bg-muted text-muted-foreground';
 }
 function rowIcon(source: StreamSource) {
 	if (source.origin === 'capture') return KIND_ICON[kindFamily(source.kind)];
@@ -533,7 +550,7 @@ const showEmbedded = $derived(audioEmbeddedActive || resolvedAudio.embedded);
 									<span class="flex shrink-0 items-center gap-1.5">
 										{#if source.origin === 'capture'}
 											<span
-												class="bg-muted text-muted-foreground rounded px-1.5 py-0.5 text-xs font-medium"
+												class="{kindBadgeClass(source.kind)} rounded px-1.5 py-0.5 text-xs font-medium"
 												data-source-kind={source.kind}
 												data-testid={`source-kind-${source.id}`}
 											>

--- a/apps/frontend/src/lib/components/custom/SourceSection.test.ts
+++ b/apps/frontend/src/lib/components/custom/SourceSection.test.ts
@@ -207,18 +207,21 @@ describe("SourceSection — unified device-first source list (Task 13)", () => {
 		).not.toBeNull();
 	});
 
-	it("renders a capture row with the REAL device name + a USB kind badge, never 'HDMI Capture'", () => {
+	it("renders a capture row with the REAL device name + the SPECIFIC 'UVC H.264' pipeline badge, never 'HDMI Capture' or the coarse 'USB'", () => {
 		const { container } = mount({ sources: sourcesMsg([RODE]) });
 		const row = container.querySelector<HTMLElement>(
 			'[data-testid="source-row-usb"]',
 		);
 		expect(row).not.toBeNull();
 		expect(row?.textContent).toContain("RØDE HDMI to USB-C: RØDE HDMI");
-		// The uvc_h264 dongle reads as a USB device (kind glyph + badge)…
-		expect(row?.textContent).toContain("USB");
-		expect(
-			container.querySelector('[data-source-kind="uvc_h264"]'),
-		).not.toBeNull();
+		// The uvc_h264 dongle's badge names its SPECIFIC capture pipeline
+		// ("UVC H.264"), not the coarse "USB" family collapse — asserted on the
+		// badge element itself so the displayName's own "USB-C" can't mask it.
+		const kindBadge = container.querySelector<HTMLElement>(
+			'[data-source-kind="uvc_h264"]',
+		);
+		expect(kindBadge).not.toBeNull();
+		expect(kindBadge?.textContent?.trim()).toBe("UVC H.264");
 		// …never the coarse "HDMI Capture" mislabel.
 		expect(row?.textContent).not.toContain("HDMI Capture");
 	});

--- a/apps/frontend/src/main/dialogs/EncoderDialog.svelte
+++ b/apps/frontend/src/main/dialogs/EncoderDialog.svelte
@@ -254,9 +254,10 @@ const activeSource = $derived(
 	getSources()?.sources.find((source) => source.id === savedConfig?.source),
 );
 
-// Capture kind → coarse device family (drives the context-line icon + kind label).
-// A UVC dongle (`uvc_h264`) is USB family, so its label reads "USB", never "HDMI" —
-// the same rule SourceSection applies to its rows.
+// Capture kind → coarse device family. Drives the context-line ICON only: a UVC
+// dongle (`uvc_h264`) is USB family, so it gets the USB glyph. The visible kind
+// label below is the SPECIFIC pipeline/profile ("UVC H.264", "MJPEG", "Cam Link"),
+// mirroring SourceSection — never the coarse "USB" collapse.
 type SourceKindFamily = 'hdmi' | 'usb' | 'network' | 'other';
 function kindFamily(kind: DeviceKind): SourceKindFamily {
 	if (kind === 'hdmi') return 'hdmi';
@@ -274,7 +275,7 @@ function kindFamily(kind: DeviceKind): SourceKindFamily {
 }
 const SOURCE_KIND_ICON = { hdmi: Cable, usb: Usb, network: Radio, other: Video } as const;
 function sourceKindLabel(source: StreamSource): string {
-	if (source.origin === 'capture') return t(`live.inputPicker.groups.${kindFamily(source.kind)}`);
+	if (source.origin === 'capture') return t(`live.inputPicker.groups.${source.kind}`);
 	if (source.origin === 'network') return t('live.inputPicker.groups.network');
 	if (source.origin === 'virtual') return t('live.inputPicker.groups.test');
 	return t('live.inputPicker.groups.other');

--- a/apps/frontend/src/main/live/LiveSourceSwitch.svelte
+++ b/apps/frontend/src/main/live/LiveSourceSwitch.svelte
@@ -105,8 +105,17 @@ const t = (key: string): string => {
 	}
 	return typeof result === 'function' ? (result as () => string)() : key;
 };
+// The SPECIFIC pipeline/profile label — mirrors SourceSection so the same device
+// reads identically ("UVC H.264", "MJPEG", "Cam Link") whether idle or streaming,
+// never the coarse "USB" collapse. `kindFamily` above still drives only the icon.
 function kindLabel(kind: DeviceKind): string {
-	return t(`live.inputPicker.groups.${kindFamily(kind)}`);
+	return t(`live.inputPicker.groups.${kind}`);
+}
+// Hardware-encode UVC accent, mirroring SourceSection's kind badge.
+function kindBadgeClass(kind: DeviceKind): string {
+	return kind === 'uvc_h264' || kind === 'uvc_h265'
+		? 'bg-primary/10 text-primary'
+		: 'bg-muted text-muted-foreground';
 }
 </script>
 
@@ -136,7 +145,7 @@ function kindLabel(kind: DeviceKind): string {
 							/>
 							<span class="truncate text-sm font-medium">{source.displayName}</span>
 							<span
-								class="bg-muted text-muted-foreground shrink-0 rounded px-1.5 py-0.5 text-xs font-medium"
+								class="{kindBadgeClass(source.kind)} shrink-0 rounded px-1.5 py-0.5 text-xs font-medium"
 								data-source-kind={source.kind}
 							>
 								{kindLabel(source.kind)}

--- a/apps/frontend/tests/e2e/truthfulness.spec.ts
+++ b/apps/frontend/tests/e2e/truthfulness.spec.ts
@@ -559,10 +559,12 @@ test.describe("Capability truthfulness (functional)", () => {
 		await expect(page.getByTestId("source-row-name-video-usb")).toHaveText(
 			RODE_DISPLAY_NAME,
 		);
-		// …classified by its engine kind (uvc_h264 → USB family), NOT hdmi…
+		// …classified by its SPECIFIC engine kind (uvc_h264 → hardware "UVC H.264"
+		// pipeline badge), NOT the coarse "USB" collapse and NOT hdmi. The raw kind
+		// stays on the data attribute as the stable test/telemetry hook.
 		const kindBadge = page.getByTestId("source-kind-video-usb");
 		await expect(kindBadge).toHaveAttribute("data-source-kind", "uvc_h264");
-		await expect(kindBadge).toHaveText("USB");
+		await expect(kindBadge).toHaveText("UVC H.264");
 		// …and the coarse "HDMI Capture" pipeline label never appears on the row.
 		await expect(row).not.toContainText("HDMI Capture");
 	});


### PR DESCRIPTION
## What

The Live **Source** picker showed a single coarse `USB` badge for every USB-family
capture device, collapsing four distinct capture pipelines into one indistinguishable
label:

- `uvc_h264` — hardware H.264 UVC
- `uvc_h265` — hardware H.265 UVC
- `mjpeg` — raw MJPEG / USB capture
- `camlink` — legacy CamLink

Each source row now names its **specific** pipeline (`UVC H.264`, `UVC H.265`, `MJPEG`,
`Cam Link`, `HDMI`) beside the device's display name, with a phosphor-lime accent on the
hardware-encoding UVC kinds so the onboard-encode path reads at a glance. Applied
consistently to the three surfaces that showed the badge/label: `SourceSection` (idle
Source list), `LiveSourceSwitch` (streaming-mode switch), and the `EncoderDialog`
active-source context line.

Before → after (two USB-family devices, mocked `uvc_h264` + `mjpeg`):

| kind | before | after |
|------|--------|-------|
| `uvc_h264` | `USB` | `UVC H.264` (lime accent) |
| `mjpeg` | `USB` | `MJPEG` (neutral) |

## Why

The engine already classifies each device from real advertised caps
(`cerastream engine.rs`), and the specific `kind`/`pipelineId` was already present in
frontend state (`StreamSource`) — it was simply never rendered. `SourceSection`'s
`kindFamily()` mapped all USB-family kinds to `'usb'` and then labelled off the *family*,
so the operator could not tell a hardware-H.264 UVC dongle from a raw MJPEG webcam or a
CamLink. This is a pure display gap; no classification, routing, or grouping logic changed.

## How

- `kindFamily()` now drives **only the row icon** (a UVC device is still a USB glyph — the
  grouping is correct for iconography).
- The visible label resolves straight off the raw `kind` via the existing
  `live.inputPicker.groups.*` i18n family, which **already** carried a key per `DeviceKind`
  in all 10 locales — so **no i18n change was required**.
- New `kindBadgeClass()` gives hardware-encode UVC kinds a `bg-primary/10 text-primary`
  accent; every other kind stays neutral. The badge **text** differs per kind regardless,
  so colour is reinforcement, never the sole signal (a11y-safe).
- `data-source-kind` (raw kind value) is preserved as the stable test/telemetry hook — no
  test id removed.
- Scope is label/badge only: no pipeline-override control, no backend/routing change.

## How to verify

- `bun run --filter frontend check` → 0 errors.
- Unit: `SourceSection.test.ts`, `LiveSourceSwitch.test.ts`, `EncoderDialog.axes.test.ts`
  (updated `SourceSection.test.ts` to assert the badge element text is exactly
  `UVC H.264`, since the old `toContain("USB")` was masked by the display name `USB-C`).
- E2E: `truthfulness.spec.ts` capability-truthfulness gate — the capture-source label
  assertion was extended from `USB` → `UVC H.264` and passes.
- Visual: a `uvc_h264` RØDE dongle renders a lime `UVC H.264` badge and an `mjpeg` webcam a
  neutral `MJPEG` badge side by side.

## Risks

Low — display-only. The coarse `kindFamily()` grouping is retained for icons, so no
grouping/filtering/routing behaviour changes. Only the rendered badge/label text (and a
purely cosmetic accent) differ.