### PR TITLE
fix(backend): keep update-check broadcasting when apt-get update warns

### DIFF
--- a/apps/backend/src/modules/system/software-updates.ts
+++ b/apps/backend/src/modules/system/software-updates.ts
@@ -437,6 +437,24 @@ export function resetSoftwareUpdateCheckRunner(): void {
 	softwareUpdateCheckRunner = checkForSoftwareUpdates;
 }
 
+// Discovery DI seam wrapping getSoftwareUpdateSize (the SOLE `available_updates`
+// broadcaster). Callers invoke it unconditionally: a noisy-but-nonfatal `apt-get update`
+// (benign apt warnings on stderr, or one repo down) must not suppress the broadcast, and
+// getSoftwareUpdateSize still surfaces a truly-broken apt via reportUpdateCheckFailure.
+type SoftwareUpdateSizeRunner = () => Promise<SoftwareUpdateError>;
+
+let softwareUpdateSizeRunner: SoftwareUpdateSizeRunner = getSoftwareUpdateSize;
+
+export function setSoftwareUpdateSizeRunner(
+	runner: SoftwareUpdateSizeRunner,
+): void {
+	softwareUpdateSizeRunner = runner;
+}
+
+export function resetSoftwareUpdateSizeRunner(): void {
+	softwareUpdateSizeRunner = getSoftwareUpdateSize;
+}
+
 let nextCheckForSoftwareUpdates = getms();
 let nextCheckForSoftwareUpdatesTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -464,7 +482,11 @@ export function periodicCheckForSoftwareUpdates() {
 	}
 
 	const started = softwareUpdateCheckRunner(async (err_, failures) => {
-		const err = err_ === null ? await getSoftwareUpdateSize() : err_;
+		// Discovery runs on every completed check; err_/failures drive ONLY the retry
+		// cadence, so a failed apt-get update refresh retries sooner without ever
+		// suppressing the available_updates broadcast.
+		const discovery = await softwareUpdateSizeRunner();
+		const err = err_ === null ? discovery : err_;
 		scheduleNextSoftwareUpdateCheck(computeNextCheckDelay(err, failures));
 	});
 
@@ -484,8 +506,8 @@ export function triggerManualUpdateCheck(): boolean {
 		broadcastMsg("status", { available_updates: availableUpdates });
 		return true;
 	}
-	return checkForSoftwareUpdates(async (err_) => {
-		if (err_ === null) await getSoftwareUpdateSize();
+	return softwareUpdateCheckRunner(async () => {
+		await softwareUpdateSizeRunner();
 	});
 }
 

--- a/apps/backend/src/tests/software-updates-schedule.test.ts
+++ b/apps/backend/src/tests/software-updates-schedule.test.ts
@@ -13,8 +13,11 @@ import {
 	periodicCheckForSoftwareUpdates,
 	RETRY_DELAY_SHORT_MS,
 	resetSoftwareUpdateCheckRunner,
+	resetSoftwareUpdateSizeRunner,
 	SKIP_RETRY_DELAY_MS,
 	setSoftwareUpdateCheckRunner,
+	setSoftwareUpdateSizeRunner,
+	triggerManualUpdateCheck,
 } from "../modules/system/software-updates.ts";
 
 describe("computeNextCheckDelay() — retry backoff", () => {
@@ -61,5 +64,58 @@ describe("periodicCheckForSoftwareUpdates() — reschedule after a skip", () => 
 		// Pre-fix the skip path scheduled nothing, so this array was empty and the
 		// loop was dead until the next backend restart.
 		expect(scheduledDelays).toContain(SKIP_RETRY_DELAY_MS);
+	});
+});
+
+/*
+ * Bug 3 — a nonfatal `apt-get update` (stderr present: benign duplicate-source
+ * warnings, or one repo down while others succeed) classified as an error (err_
+ * !== null) and the callback gated discovery on `err_ === null`, so
+ * getSoftwareUpdateSize never ran and `available_updates` was never broadcast.
+ * The manual "check for updates" then span its 30s FE fallback and showed nothing,
+ * even though `dist-upgrade --assume-no` would have reported the real state.
+ * apt-get update is a best-effort refresh: discovery must run regardless.
+ */
+describe("triggerManualUpdateCheck() — discovery survives an apt-get update failure", () => {
+	afterEach(() => {
+		resetSoftwareUpdateCheckRunner();
+		resetSoftwareUpdateSizeRunner();
+	});
+
+	function captureManualCheck() {
+		let discoveryRuns = 0;
+		setSoftwareUpdateSizeRunner(async () => {
+			discoveryRuns++;
+			return null;
+		});
+		let callback: ((err: unknown, failures: number) => unknown) | undefined;
+		setSoftwareUpdateCheckRunner((cb) => {
+			callback = cb;
+			return true;
+		});
+		const started = triggerManualUpdateCheck();
+		return {
+			started,
+			runDiscovery: () => discoveryRuns,
+			fireAptUpdateResult: (err: unknown, failures: number) =>
+				callback?.(err, failures),
+		};
+	}
+
+	it("still runs discovery when apt-get update reported a nonfatal failure (err_ !== null)", async () => {
+		const check = captureManualCheck();
+		expect(check.started).toBe(true);
+
+		// stderr present ⇒ classifyAptUpdateResult returned `true`. Pre-fix this branch
+		// skipped discovery entirely; the broadcast never fired.
+		await check.fireAptUpdateResult(true, 1);
+
+		expect(check.runDiscovery()).toBe(1);
+	});
+
+	it("runs discovery on the clean success path too (err_ === null)", async () => {
+		const check = captureManualCheck();
+		await check.fireAptUpdateResult(null, 0);
+		expect(check.runDiscovery()).toBe(1);
 	});
 });


### PR DESCRIPTION
## What
Run software-update discovery (`getSoftwareUpdateSize`) unconditionally on every completed check, instead of gating it on the exit status of `apt-get update`.

## Why
`apt-get update` emits stderr and a non-zero exit on perfectly healthy devices (benign duplicate-source warnings, or one repo down while others succeed). `classifyAptUpdateResult` flagged that as an error, so both the periodic and manual checks skipped the sole `available_updates` broadcaster. The manual "Check for updates" then ran out its 30s frontend fallback and showed nothing — even though `apt-get dist-upgrade --assume-no` reports the real state in ~1s.

## How
- Discovery now runs on every completed check; `apt-get update`'s stderr/exit only drives the retry cadence.
- `dist-upgrade`'s own `reportUpdateCheckFailure` still surfaces a genuinely-broken apt.

## How to verify
- `bun test apps/backend/src/tests/software-updates-schedule.test.ts`
- On a device with a benign apt warning, trigger a manual update check and confirm `available_updates` is broadcast promptly.

## Risks
Low. Additive to a single backend module plus its test; discovery was already implemented, only its gating changed.