### PR TITLE
fix(backend): select global-scope interface IP over link-local for LAN ingest

### DIFF
--- a/apps/backend/src/modules/network/network-interfaces.ts
+++ b/apps/backend/src/modules/network/network-interfaces.ts
@@ -412,7 +412,9 @@ function selectPreferredAddress(
 	addrs: ScopedAddress[],
 ): ScopedAddress | undefined {
 	return (
-		addrs.find((a) => a.scope === "global" && !isLinkLocalIpv4(a.ip, a.scope)) ??
+		addrs.find(
+			(a) => a.scope === "global" && !isLinkLocalIpv4(a.ip, a.scope),
+		) ??
 		addrs.find((a) => !isLinkLocalIpv4(a.ip, a.scope)) ??
 		addrs[0]
 	);

--- a/apps/backend/src/modules/network/network-interfaces.ts
+++ b/apps/backend/src/modules/network/network-interfaces.ts
@@ -69,6 +69,11 @@ export type NetworkInterfaceMessage = {
 	};
 };
 
+/** A chosen interface IPv4; `netmask` is a dotted quad, not a prefix length. */
+export type IpAddrSelection = { ip: string; netmask: string };
+
+type ScopedAddress = { ip: string; prefix: number; scope: string };
+
 export const NETIF_ERR_DUPIPV4 = 0x01;
 export const NETIF_ERR_HOTSPOT = 0x02;
 
@@ -204,15 +209,44 @@ export function updateNetif() {
 		return;
 	}
 
-	run("ifconfig", [])
-		.then(processIfconfigOutput)
-		.catch((error: unknown) => {
-			const message = error instanceof Error ? error.message : String(error);
-			logger.error(`Error getting ifconfig: ${message}`);
-		});
+	void refreshNetifFromOs();
 }
 
-export function processIfconfigOutput(stdout: string) {
+// ifconfig (net-tools) reports only ONE IPv4 per interface, so on a link that
+// carries both an RFC-3927 link-local (169.254/16) and a real DHCP lease it can
+// surface the link-local as THE address. `ip -4 addr show` lists every address
+// with a `scope`, letting us prefer the routable global-scope lease. ifconfig
+// still drives throughput, RUNNING flags, and the WiFi device list; a missing or
+// failing `ip` degrades to ifconfig-only (the prior single-address behavior).
+async function resolveIpAddrOverrides(): Promise<
+	Map<string, IpAddrSelection> | undefined
+> {
+	try {
+		return parseIpAddrShow(await run("ip", ["-4", "addr", "show"]));
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		logger.debug(`ip -4 addr show unavailable, using ifconfig IPs: ${message}`);
+		return undefined;
+	}
+}
+
+async function refreshNetifFromOs(): Promise<void> {
+	try {
+		const [ifconfigOut, ipOverrides] = await Promise.all([
+			run("ifconfig", []),
+			resolveIpAddrOverrides(),
+		]);
+		processIfconfigOutput(ifconfigOut, ipOverrides);
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		logger.error(`Error getting ifconfig: ${message}`);
+	}
+}
+
+export function processIfconfigOutput(
+	stdout: string,
+	ipOverrides?: Map<string, IpAddrSelection>,
+) {
 	let intsChanged = false;
 	const newInterfaces: Record<string, NetworkInterface> = {};
 
@@ -227,11 +261,16 @@ export function processIfconfigOutput(stdout: string) {
 			if (name === "lo" || name.match("^docker") || name.match("^l4tbr"))
 				continue;
 
+			// Prefer the scope-annotated `ip -4 addr` address (a routable global
+			// lease over a link-local) when present; fall back to ifconfig's single
+			// inet line otherwise.
+			const ipOverride = ipOverrides?.get(name);
+
 			const inetAddrMatch = int.match(/inet (\d+\.\d+\.\d+\.\d+)/);
-			const inetAddr = inetAddrMatch?.[1];
+			const inetAddr = ipOverride?.ip ?? inetAddrMatch?.[1];
 
 			const netmaskMatch = int.match(/netmask (\d+\.\d+\.\d+\.\d+)/);
-			const netmask = netmaskMatch?.[1];
+			const netmask = ipOverride?.netmask ?? netmaskMatch?.[1];
 
 			const flags = (int.match(/flags=\d+<([A-Z,]+)>/)?.[1] ?? "").split(",");
 			const isRunning = flags.includes("RUNNING");
@@ -357,6 +396,72 @@ function intToIp(int: number): string {
 		(int >>> 8) & 0xff,
 		int & 0xff,
 	].join(".");
+}
+
+// An RFC-3927 link-local (169.254/16, iproute2 `scope link`) is a kernel/NM
+// auto-assigned fallback; it must never outrank a real routable lease on a link
+// that has both.
+function isLinkLocalIpv4(ip: string, scope: string): boolean {
+	return scope === "link" || ip.startsWith("169.254.");
+}
+
+// A global-scope routable lease wins; then any other non-link-local address;
+// only as a last resort the link-local (parity with the old single-address read
+// for a link that carries nothing else).
+function selectPreferredAddress(
+	addrs: ScopedAddress[],
+): ScopedAddress | undefined {
+	return (
+		addrs.find((a) => a.scope === "global" && !isLinkLocalIpv4(a.ip, a.scope)) ??
+		addrs.find((a) => !isLinkLocalIpv4(a.ip, a.scope)) ??
+		addrs[0]
+	);
+}
+
+function prefixToNetmask(prefix: number): string {
+	if (prefix <= 0) return "0.0.0.0";
+	if (prefix >= 32) return "255.255.255.255";
+	return intToIp((0xffffffff << (32 - prefix)) >>> 0);
+}
+
+/**
+ * Parse `ip -4 addr show` into iface → chosen {ip, netmask}. `ip` lists EVERY
+ * IPv4 per interface with its `scope`, so unlike single-address ifconfig we can
+ * prefer the routable global lease over an RFC-3927 link-local when a link has
+ * both — the fix for a board that would otherwise advertise its link-local.
+ */
+export function parseIpAddrShow(stdout: string): Map<string, IpAddrSelection> {
+	const byIface = new Map<string, ScopedAddress[]>();
+	let current: string | undefined;
+
+	for (const line of stdout.split("\n")) {
+		const header = line.match(/^\d+:\s+([^:@\s]+)/);
+		if (header?.[1]) {
+			current = header[1];
+			continue;
+		}
+		if (current === undefined) continue;
+
+		const addr = line.match(/^\s*inet\s+(\d+\.\d+\.\d+\.\d+)\/(\d+)\b/);
+		if (!addr?.[1] || !addr[2]) continue;
+		const scope = line.match(/\bscope\s+(\S+)/)?.[1] ?? "global";
+
+		const list = byIface.get(current) ?? [];
+		list.push({ ip: addr[1], prefix: Number.parseInt(addr[2], 10), scope });
+		byIface.set(current, list);
+	}
+
+	const selected = new Map<string, IpAddrSelection>();
+	for (const [name, addrs] of byIface) {
+		const chosen = selectPreferredAddress(addrs);
+		if (chosen) {
+			selected.set(name, {
+				ip: chosen.ip,
+				netmask: prefixToNetmask(chosen.prefix),
+			});
+		}
+	}
+	return selected;
 }
 
 function netmaskToPrefix(netmask: string): number {

--- a/apps/backend/src/tests/netif-ip-selection.test.ts
+++ b/apps/backend/src/tests/netif-ip-selection.test.ts
@@ -1,17 +1,17 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import {
+	buildRtmpUrl,
+	buildSrtUrl,
+	resolvePrimaryLanIp,
+} from "../modules/network/network-ingest.ts";
+import {
 	getNetworkInterfaces,
 	netIfBuildMsg,
 	parseIpAddrShow,
 	processIfconfigOutput,
 	setNetifDupIpSuppression,
 } from "../modules/network/network-interfaces.ts";
-import {
-	buildRtmpUrl,
-	buildSrtUrl,
-	resolvePrimaryLanIp,
-} from "../modules/network/network-ingest.ts";
 import { setNetifState } from "../modules/network/state/netif-state.ts";
 
 // Verbatim from the live board (192.168.78.131): eth0 carries BOTH an RFC-3927

--- a/apps/backend/src/tests/netif-ip-selection.test.ts
+++ b/apps/backend/src/tests/netif-ip-selection.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+	getNetworkInterfaces,
+	netIfBuildMsg,
+	parseIpAddrShow,
+	processIfconfigOutput,
+	setNetifDupIpSuppression,
+} from "../modules/network/network-interfaces.ts";
+import {
+	buildRtmpUrl,
+	buildSrtUrl,
+	resolvePrimaryLanIp,
+} from "../modules/network/network-ingest.ts";
+import { setNetifState } from "../modules/network/state/netif-state.ts";
+
+// Verbatim from the live board (192.168.78.131): eth0 carries BOTH an RFC-3927
+// link-local (`scope link`) AND the real DHCP lease (`scope global dynamic`).
+// This is the exact multi-address shape `ip -4 addr show` reports and that
+// single-address ifconfig cannot express.
+const IP_ADDR_SHOW_REAL_BOARD = [
+	"1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000",
+	"    inet 127.0.0.1/8 scope host lo",
+	"       valid_lft forever preferred_lft forever",
+	"2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000",
+	"    inet 169.254.149.160/16 brd 169.254.255.255 scope link noprefixroute eth0",
+	"    inet 192.168.78.131/24 brd 192.168.78.255 scope global dynamic noprefixroute eth0",
+	"       valid_lft 84567sec preferred_lft 84567sec",
+].join("\n");
+
+// What `/sbin/ifconfig eth0` reports on that SAME board: ONLY the link-local.
+// The DHCP address is absent from ifconfig's output entirely.
+const IFCONFIG_ETH0_LINK_LOCAL_ONLY = [
+	"eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500",
+	"        inet 169.254.149.160  netmask 255.255.0.0  broadcast 169.254.255.255",
+	"        ether 00:48:54:20:42:e3  txqueuelen 1000  (Ethernet)",
+	"        RX packets 200  bytes 20000 (20.0 KB)",
+	"        TX packets 100  bytes 1000 (1.0 KB)",
+].join("\n");
+
+function resetState(): void {
+	const netif = getNetworkInterfaces();
+	for (const name of Object.keys(netif)) delete netif[name];
+	setNetifState({});
+	for (const name of ["eth0", "lo"]) setNetifDupIpSuppression(name, false);
+}
+
+beforeEach(() => {
+	resetState();
+});
+
+describe("parseIpAddrShow scope preference", () => {
+	test("prefers the global-scope DHCP lease over the link-local on the real board", () => {
+		const selected = parseIpAddrShow(IP_ADDR_SHOW_REAL_BOARD);
+
+		expect(selected.get("eth0")).toEqual({
+			ip: "192.168.78.131",
+			netmask: "255.255.255.0",
+		});
+		expect(selected.get("lo")).toEqual({
+			ip: "127.0.0.1",
+			netmask: "255.0.0.0",
+		});
+	});
+
+	test("falls back to the link-local when it is the only address", () => {
+		const linkLocalOnly = [
+			"2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500",
+			"    inet 169.254.149.160/16 brd 169.254.255.255 scope link noprefixroute eth0",
+		].join("\n");
+
+		expect(parseIpAddrShow(linkLocalOnly).get("eth0")).toEqual({
+			ip: "169.254.149.160",
+			netmask: "255.255.0.0",
+		});
+	});
+
+	test("takes the first global address when several are present", () => {
+		const multiGlobal = [
+			"2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500",
+			"    inet 10.0.0.5/24 brd 10.0.0.255 scope global eth0",
+			"    inet 192.168.1.9/24 brd 192.168.1.255 scope global secondary eth0",
+		].join("\n");
+
+		expect(parseIpAddrShow(multiGlobal).get("eth0")?.ip).toBe("10.0.0.5");
+	});
+
+	test("keys a VLAN sub-interface by its base name", () => {
+		const vlan = [
+			"7: eth0.10@eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500",
+			"    inet 192.168.20.4/24 brd 192.168.20.255 scope global eth0.10",
+		].join("\n");
+
+		const selected = parseIpAddrShow(vlan);
+		expect(selected.get("eth0.10")).toEqual({
+			ip: "192.168.20.4",
+			netmask: "255.255.255.0",
+		});
+	});
+
+	test("returns an empty map for empty or address-less output", () => {
+		expect(parseIpAddrShow("").size).toBe(0);
+		expect(parseIpAddrShow("garbage\nno interfaces here").size).toBe(0);
+	});
+});
+
+describe("netif IP selection end-to-end (the LAN-ingest bug)", () => {
+	test("the ip override corrects eth0 to the DHCP lease and drives the LAN-ingest URLs", () => {
+		const overrides = parseIpAddrShow(IP_ADDR_SHOW_REAL_BOARD);
+		processIfconfigOutput(IFCONFIG_ETH0_LINK_LOCAL_ONLY, overrides);
+
+		const eth0 = getNetworkInterfaces().eth0;
+		expect(eth0?.ip).toBe("192.168.78.131");
+		expect(eth0?.netmask).toBe("255.255.255.0");
+		expect(netIfBuildMsg().eth0?.ip).toBe("192.168.78.131");
+
+		const lanIp = resolvePrimaryLanIp(getNetworkInterfaces());
+		expect(lanIp).toBe("192.168.78.131");
+		expect(buildRtmpUrl(lanIp ?? "")).toBe(
+			"rtmp://192.168.78.131:1935/publish/live",
+		);
+		expect(buildSrtUrl(lanIp ?? "")).toBe("srt://192.168.78.131:4001");
+	});
+
+	test("without an override it degrades to ifconfig's single (link-local) address", () => {
+		processIfconfigOutput(IFCONFIG_ETH0_LINK_LOCAL_ONLY);
+
+		expect(getNetworkInterfaces().eth0?.ip).toBe("169.254.149.160");
+		expect(resolvePrimaryLanIp(getNetworkInterfaces())).toBe("169.254.149.160");
+	});
+});


### PR DESCRIPTION
## What
When an interface carries both an RFC-3927 link-local address (169.254/16) and a real DHCP lease, prefer the routable global-scope address for `NetIf.ip` by querying `ip -4 addr show` alongside `ifconfig`.

## Why
`ifconfig` (net-tools) reports only one IPv4 per interface and can surface the link-local as the interface address. That wrong `NetIf.ip` flowed into `resolvePrimaryLanIp()`, which builds the RTMP/SRT LAN-ingest publish URLs and the QR code shown to operators — advertising a link-local address that may not work for LAN publishing.

## How
- Query `ip -4 addr show` and prefer the routable global-scope address per interface; `ifconfig` still drives throughput, flags, and the WiFi device list.
- A missing or failing `ip` degrades gracefully to prior `ifconfig`-only behavior.
- Corrected IP+netmask flows uniformly to every `NetIf.ip` consumer (`resolvePrimaryLanIp`, gateway connectivity probe, bcrpt bonding source IPs, dup-IP/same-subnet detection).

## How to verify
- `bun test apps/backend/src/tests/netif-ip-selection.test.ts`
- On a device whose link has both a link-local and a DHCP lease, confirm the LAN-ingest URL/QR uses the routable address.

## Risks
Low. Additive to a single backend module plus its test; falls back to existing behavior when `ip` is unavailable.