### PR TITLE
feat(system): warn on setup.json hw drift from live board detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -407,6 +407,35 @@ Detection contract (fail-safe, defaults to `false`):
 5. Any probe throws (file absent/unreadable) → false for that probe (never propagates)
 6. Unrecognised or malformed identity → false. Jetson is deliberately unhandled/deferred.
 
+**Hardware-kind detection + `setup.json` drift guard (Todo 59 audit).**
+`device-detection.ts` also exports `detectHardwareKindFromDeviceTree()` —
+positively resolves the board family (`"rk3588" | "jetson" | "n100" | "unknown"`)
+from the SAME reliable probes `isRealDevice()` uses, checking
+`/proc/device-tree/compatible` FIRST (the marker that fixed the Todo 48 bug), then
+`model`, then the x86 DMI product name. Markers are matched conservatively (the
+specific SoC token, never a broad `"rockchip"`) so an unsupported RK3399/RK356x
+resolves `"unknown"` instead of being mis-stamped `rk3588`.
+
+`warnOnHardwareIdentityDrift()` is a boot-time, **warn-only** guard wired into
+`main.ts` (`guardNonCritical("hardware-identity-drift", …)`, fail-soft): on a real
+device it compares `setup.json` `hw` against the detected kind and logs a loud
+`logger.warn` on a POSITIVE mismatch (`"unknown"` defers to config; dev/emulated
+hosts are skipped). WHY: `setup.json` `hw` is a SINGLE hardcoded value packaged
+verbatim into the `ceralive-device` .deb for every board/arch — there is no
+per-board `setup.json`, and the image pipeline does NOT rewrite it (it leaves
+`/etc/ceralive/conf.d/hardware.conf` on `auto`). So an AMD64/N100 or Orange-Pi
+image still ships `hw:"rk3588"`, and `setup.hw` silently drives the wrong board
+profile in `sensors.ts` (sensor selection), `audio.ts` (device-label aliases),
+`pipelines.ts` (the `hardware` broadcast label), and `addons/reconciler.ts`
+(`{board}` artifact targeting). The guard turns that Todo-48-class silent drift
+into a visible boot signal WITHOUT changing any behaviour — every consumer still
+reads `setup.hw`. Converging those consumers onto auto-detection (making
+`setup.hw` a fallback/override) is a tracked follow-up, NOT done here (it touches
+module-load-time sync reads). cerastream's own `detect_hardware_kind` uses the
+same compatible→model→DMI precedence but does NOT echo the detected kind in
+`get-capabilities` (only derived caps), so CeraUI cannot consume it as a label
+today — a second follow-up.
+
 Real platform pairing parses `PLATFORM_URL` before any secret registration or
 claim request. HTTPS is required on production and real devices; plaintext HTTP
 is accepted only for `localhost`, `127.0.0.1`, or `[::1]` while the backend is in

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -99,6 +99,11 @@ import {
 	checkAutoStartStream,
 	srtlaSendExec,
 } from "./modules/streaming/streamloop.ts";
+import {
+	detectHardwareKindFromDeviceTree,
+	isRealDevice,
+	warnOnHardwareIdentityDrift,
+} from "./modules/system/device-detection.ts";
 import { initDeviceStats } from "./modules/system/device-stats.ts";
 import { initRevisions } from "./modules/system/revisions.ts";
 import {
@@ -275,6 +280,15 @@ await guardNonCritical("ssh-password-provision", ensureSshPasswordProvisioned);
 // host-key restore). Fail-soft: a sync failure must never brick boot.
 await guardNonCritical("ssh-password-sync", ensureSshPasswordSynced);
 void getSshStatus();
+
+await guardNonCritical("hardware-identity-drift", async () => {
+	await warnOnHardwareIdentityDrift({
+		detectKind: () => detectHardwareKindFromDeviceTree(),
+		configuredHw: () => setup.hw,
+		isRealDevice: () => isRealDevice(),
+		warn: (message) => logger.warn(message),
+	});
+});
 logger.info(bootTimer.phase("🖥️", "hardware"));
 
 void updateGwWrapper();

--- a/apps/backend/src/modules/system/device-detection.ts
+++ b/apps/backend/src/modules/system/device-detection.ts
@@ -193,3 +193,99 @@ export async function withDeviceType(
 		}
 	}
 }
+
+// =============================================================================
+// Hardware-kind detection + config-drift guard (Todo 59 audit)
+// =============================================================================
+
+/**
+ * The board family the device-tree / DMI can POSITIVELY identify. `unknown`
+ * means the probes did not name a supported board — the caller must defer to
+ * the configured value rather than assume a mismatch.
+ */
+export type DetectedHardwareKind = "rk3588" | "jetson" | "n100" | "unknown";
+
+/**
+ * Positively derive the board family from the device-tree `compatible` list
+ * (reliable, checked FIRST — always carries the SoC compatible string), then
+ * the device-tree `model`, then the x86 DMI product name. This mirrors
+ * cerastream's `detect_hardware_kind` precedence (compatible → model → DMI) and
+ * reuses the SAME reliable probe surface `isRealDevice()` already uses, so the
+ * two never diverge (the Todo 48 bug was one detector reading `model` only).
+ *
+ * Markers are matched conservatively — the specific SoC token, never a broad
+ * "rockchip" — so an unsupported Rockchip (RK3399 / RK356x) resolves `unknown`
+ * rather than being mis-stamped `rk3588`. Any probe failure is swallowed
+ * (`readOptional`); an unrecognised host resolves `unknown` and never throws.
+ */
+export async function detectHardwareKindFromDeviceTree(
+	deps: DeviceDetectionDeps = defaultDeviceDetectionDeps,
+): Promise<DetectedHardwareKind> {
+	for (const probe of [
+		deps.readDeviceTreeCompatible,
+		deps.readDeviceTreeModel,
+	]) {
+		const identity = (await readOptional(probe)).toLowerCase();
+		if (identity.includes("rk3588")) return "rk3588";
+		if (identity.includes("jetson") || identity.includes("tegra")) {
+			return "jetson";
+		}
+	}
+	const dmi = (await readOptional(deps.readDmiProductName)).toLowerCase();
+	if (dmi.includes("n100")) return "n100";
+	return "unknown";
+}
+
+/** Injected surface for {@link warnOnHardwareIdentityDrift}. */
+export type HardwareIdentityDriftDeps = {
+	/** Positively-detected board family (device-tree / DMI). */
+	detectKind: () => Promise<DetectedHardwareKind>;
+	/** The static `setup.json` `hw` value packaged in the .deb. */
+	configuredHw: () => string;
+	/** Only meaningful on a real device (dev hosts have no device-tree). */
+	isRealDevice: () => Promise<boolean>;
+	/** Loud, journal-visible warning sink. */
+	warn: (message: string) => void;
+};
+
+/**
+ * Boot-time guard that turns the Todo-48 class of bug — a static hardware
+ * identity silently disagreeing with the live board — from SILENT into LOUD.
+ *
+ * `setup.json` `hw` is a single hardcoded value packaged verbatim into the
+ * `ceralive-device` .deb for EVERY board/arch (there is no per-board
+ * `setup.json`), so an image built for a non-rk3588 board still ships
+ * `hw:"rk3588"`. That value drives sensor selection (`sensors.ts`), audio-device
+ * label aliases (`audio.ts`), the pipeline/sources `hardware` label
+ * (`pipelines.ts`), and add-on `{board}` artifact targeting (`reconciler.ts`) —
+ * all of which pick the wrong board profile on a mismatch.
+ *
+ * This guard is WARN-ONLY: it changes NO behaviour (every consumer still reads
+ * `setup.hw`), it just makes a mismatch visible in the journal at boot instead
+ * of failing silently for a whole session. It warns only on a POSITIVE
+ * mismatch — an `unknown` detection defers to the configured value (never cries
+ * wolf), and it is gated on `isRealDevice()` so a dev/emulated host (where
+ * `setup.hw` is only the checked-in default) stays quiet.
+ */
+export async function warnOnHardwareIdentityDrift(
+	deps: HardwareIdentityDriftDeps,
+): Promise<{ checked: boolean; drift: boolean }> {
+	if (!(await deps.isRealDevice())) return { checked: false, drift: false };
+
+	const detected = await deps.detectKind();
+	// `unknown` = probes could not name a supported board; defer to the
+	// configured value rather than assume a mismatch.
+	if (detected === "unknown") return { checked: true, drift: false };
+
+	const configured = deps.configuredHw();
+	if (detected === configured) return { checked: true, drift: false };
+
+	deps.warn(
+		`hardware identity drift: setup.json hw="${configured}" but the device-tree ` +
+			`identifies this board as "${detected}". setup.json.hw is a static, ` +
+			"image-baked value (one value for every board/arch), so a mismatch means " +
+			"sensors, audio-device labels, and add-on board targeting run the wrong " +
+			`board profile. Ship a "${detected}"-correct setup.json for this board.`,
+	);
+	return { checked: true, drift: true };
+}

--- a/apps/backend/src/tests/hardware-identity-drift.test.ts
+++ b/apps/backend/src/tests/hardware-identity-drift.test.ts
@@ -1,0 +1,144 @@
+/*
+ * Todo 59 audit — hardware-kind detection + config-drift guard.
+ *
+ * Covers `detectHardwareKindFromDeviceTree` (compatible-first, conservative
+ * marker matching) and `warnOnHardwareIdentityDrift` (warn-only, isRealDevice
+ * gated, unknown-defers). Every probe is injected so no test reads a host file.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+	type DeviceDetectionDeps,
+	detectHardwareKindFromDeviceTree,
+	warnOnHardwareIdentityDrift,
+} from "../modules/system/device-detection.ts";
+
+function makeDeps(
+	overrides: Partial<DeviceDetectionDeps> = {},
+): DeviceDetectionDeps {
+	return {
+		getDeviceTypeOverride: () => undefined,
+		isDevelopment: () => false,
+		readDeviceTreeModel: async () => {
+			throw new Error("ENOENT: /proc/device-tree/model");
+		},
+		readDeviceTreeCompatible: async () => {
+			throw new Error("ENOENT: /proc/device-tree/compatible");
+		},
+		readCeraliveRelease: async () => {
+			throw new Error("ENOENT: /etc/ceralive/release");
+		},
+		readDmiProductName: async () => {
+			throw new Error("ENOENT: /sys/class/dmi/id/product_name");
+		},
+		readDmiBoardName: async () => {
+			throw new Error("ENOENT: /sys/class/dmi/id/board_name");
+		},
+		...overrides,
+	};
+}
+
+describe("detectHardwareKindFromDeviceTree", () => {
+	test("Radxa ROCK 5B+ compatible marker → rk3588 (model omits the SoC)", async () => {
+		const deps = makeDeps({
+			readDeviceTreeModel: async () => "Radxa ROCK 5B+ \n",
+			readDeviceTreeCompatible: async () =>
+				"radxa,rock-5b-plus\u0000rockchip,rk3588\u0000",
+		});
+		expect(await detectHardwareKindFromDeviceTree(deps)).toBe("rk3588");
+	});
+
+	test("model naming the SoC → rk3588 when compatible is absent", async () => {
+		const deps = makeDeps({
+			readDeviceTreeModel: async () => "Orange Pi 5 Plus RK3588",
+		});
+		expect(await detectHardwareKindFromDeviceTree(deps)).toBe("rk3588");
+	});
+
+	test("Jetson/Tegra marker → jetson", async () => {
+		const deps = makeDeps({
+			readDeviceTreeCompatible: async () =>
+				"nvidia,p3737-0000\u0000nvidia,tegra234\u0000",
+		});
+		expect(await detectHardwareKindFromDeviceTree(deps)).toBe("jetson");
+	});
+
+	test("x86 DMI N100 marker → n100", async () => {
+		const deps = makeDeps({
+			readDmiProductName: async () => "Intel N100 Mini PC",
+		});
+		expect(await detectHardwareKindFromDeviceTree(deps)).toBe("n100");
+	});
+
+	test("unsupported Rockchip (RK3399) is NOT mis-stamped rk3588 → unknown", async () => {
+		const deps = makeDeps({
+			readDeviceTreeModel: async () => "Rockchip RK3399 reference board",
+			readDeviceTreeCompatible: async () =>
+				"vendor,board\u0000rockchip,rk3399\u0000",
+		});
+		expect(await detectHardwareKindFromDeviceTree(deps)).toBe("unknown");
+	});
+
+	test("all probes absent/unreadable → unknown (never throws)", async () => {
+		expect(await detectHardwareKindFromDeviceTree(makeDeps())).toBe("unknown");
+	});
+});
+
+describe("warnOnHardwareIdentityDrift", () => {
+	function makeDriftDeps(overrides: {
+		detected: "rk3588" | "jetson" | "n100" | "unknown";
+		configuredHw: string;
+		isRealDevice?: boolean;
+	}) {
+		const warnings: string[] = [];
+		const deps = {
+			detectKind: async () => overrides.detected,
+			configuredHw: () => overrides.configuredHw,
+			isRealDevice: async () => overrides.isRealDevice ?? true,
+			warn: (m: string) => warnings.push(m),
+		};
+		return { deps, warnings };
+	}
+
+	test("matching kind → no warning", async () => {
+		const { deps, warnings } = makeDriftDeps({
+			detected: "rk3588",
+			configuredHw: "rk3588",
+		});
+		const result = await warnOnHardwareIdentityDrift(deps);
+		expect(result).toEqual({ checked: true, drift: false });
+		expect(warnings).toHaveLength(0);
+	});
+
+	test("positive mismatch (n100 board, rk3588 setup.json) → loud warning", async () => {
+		const { deps, warnings } = makeDriftDeps({
+			detected: "n100",
+			configuredHw: "rk3588",
+		});
+		const result = await warnOnHardwareIdentityDrift(deps);
+		expect(result).toEqual({ checked: true, drift: true });
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain('hw="rk3588"');
+		expect(warnings[0]).toContain('"n100"');
+	});
+
+	test("unknown detection defers to config → no warning", async () => {
+		const { deps, warnings } = makeDriftDeps({
+			detected: "unknown",
+			configuredHw: "rk3588",
+		});
+		const result = await warnOnHardwareIdentityDrift(deps);
+		expect(result).toEqual({ checked: true, drift: false });
+		expect(warnings).toHaveLength(0);
+	});
+
+	test("emulated/dev host is not checked → no warning", async () => {
+		const { deps, warnings } = makeDriftDeps({
+			detected: "n100",
+			configuredHw: "rk3588",
+			isRealDevice: false,
+		});
+		const result = await warnOnHardwareIdentityDrift(deps);
+		expect(result).toEqual({ checked: false, drift: false });
+		expect(warnings).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## What

Merge the additive hardware-identity drift warning. On a real device, if
`setup.json.hw` disagrees with what live board detection reports, the backend logs
a loud `warn` at boot — making the previously-silent multi-board drift visible.

- `device-detection.ts`: `detectHardwareKindFromDeviceTree()` (positive kind:
  `rk3588 | jetson | n100 | unknown`, compatible-first, reusing `isRealDevice`'s
  reliable probes; conservative marker match — a bare `rockchip` token → `unknown`,
  never mis-stamped `rk3588`) + `warnOnHardwareIdentityDrift()`.
- `main.ts`: `guardNonCritical("hardware-identity-drift", …)` fail-soft boot guard.
- `tests/hardware-identity-drift.test.ts`: 10 tests.

## Why

Zero behavior change — every consumer still reads `setup.hw`; this only surfaces
drift. It is the low-risk half of the hardware-identity unification: the loud
warning lands now; the consumer migration onto the live detected kind is a
separate follow-up. `unknown` defers to config (never cries wolf); dev/emulated
hosts are skipped.

## How to verify

- `bun run --filter backend check` (typecheck) — green.
- `bun run --filter backend lint` + `biome check` on the changed files — green.
- `bun test src/tests/hardware-identity-drift.test.ts` — 10 pass; full backend
  suite 1970 pass / 0 fail.

## Risks

Additive only; no consumer reads the new detection helper yet, so no runtime
behavior changes on any board. Rebased onto current `main` (#173).
