### PR TITLE
test(audio): lock pseudo-source → audio.mode wire contract

### DIFF
--- a/apps/backend/src/modules/streaming/audio.ts
+++ b/apps/backend/src/modules/streaming/audio.ts
@@ -54,6 +54,28 @@ const PSEUDO_AUDIO_SOURCES: ReadonlySet<string> = new Set([
 export function isPseudoAudioSource(asrc: string): boolean {
 	return PSEUDO_AUDIO_SOURCES.has(asrc);
 }
+
+export type AudioMode = "none" | "default" | "device";
+
+export interface AudioModeSelection {
+	mode: AudioMode;
+	device?: string;
+}
+
+// Map an operator audio pick onto the engine's `audio.mode` discriminator so a
+// pseudo-source is never leaked into `audio.device` as a bogus ALSA id: "No
+// audio" is an explicit video-only stream, "Pipeline default" hands sourcing to
+// the engine, a network-embedded source rides the engine default, and any real
+// selection carries the resolved ALSA card id.
+export function resolveAudioMode(
+	asrc: string,
+	embeddedAudioActive: boolean,
+): AudioModeSelection {
+	if (asrc === NO_AUDIO_ID) return { mode: "none" };
+	if (asrc === DEFAULT_AUDIO_ID) return { mode: "default" };
+	if (embeddedAudioActive) return { mode: "default" };
+	return { mode: "device", device: getAudioSrcId(asrc) };
+}
 const BASE_AUDIO_SRC_ALIASES: Readonly<Record<string, string>> = {
 	C4K: "Cam Link 4K",
 	usbaudio: "USB audio",

--- a/apps/backend/src/modules/streaming/cerastream-backend.ts
+++ b/apps/backend/src/modules/streaming/cerastream-backend.ts
@@ -67,6 +67,7 @@ import {
 } from "@ceralive/cerastream";
 import type { ActiveEncode, BufferingStatus } from "@ceraui/rpc/schemas";
 import { toEngineResolution } from "@ceraui/rpc/schemas";
+import { z } from "zod";
 import type { RuntimeConfig } from "../../helpers/config-schemas.ts";
 import { logger as defaultLogger } from "../../helpers/logger.ts";
 import { getConfig, saveConfig } from "../config.ts";
@@ -75,7 +76,7 @@ import {
 	notificationBroadcast,
 	notificationExists,
 } from "../ui/notifications.ts";
-import { getAudioSrcId } from "./audio.ts";
+import { type AudioMode, resolveAudioMode } from "./audio.ts";
 import { resolveCerastreamError } from "./cerastream-error-mapping.ts";
 import { SRTLA_LISTEN_PORT } from "./constants.ts";
 import { deviceRegistry } from "./devices.ts";
@@ -254,6 +255,40 @@ export function supportsSignedReloadDelay(
 	return major > 0 || (major === 0 && (minor ?? 0) >= 4);
 }
 
+/**
+ * Whether the engine understands the additive `audio.mode` discriminator
+ * (schema ≥ 0.6.0). The published `@ceralive/cerastream` client Zod-STRIPS the
+ * unknown `mode` field, so a supporting engine must be driven through the raw
+ * `start` bridge below; an older engine is sent the typed (mode-less) params and
+ * falls back to its legacy device inference. Fail-safe `false` on an
+ * absent/unparseable version.
+ */
+export function supportsAudioMode(schemaVersion: string | undefined): boolean {
+	if (!schemaVersion) return false;
+	const [major, minor] = schemaVersion.split(".").map(Number);
+	if (major === undefined || Number.isNaN(major) || Number.isNaN(minor))
+		return false;
+	return major > 0 || (major === 0 && (minor ?? 0) >= 6);
+}
+
+// Local schema extension for the raw `start` bridge: the published client's
+// frozen `startParamsSchema` has no `audio.mode`, so a start carrying a mode is
+// validated here and dispatched over the raw JSON-RPC primitive (no npm publish).
+const audioModeSchema = z.enum(["none", "default", "device"]);
+export const startParamsWithAudioModeSchema = startParamsSchema.extend({
+	audio: z
+		.object({
+			mode: audioModeSchema.optional(),
+			device: z.string().optional(),
+			codec: z.string().optional(),
+			delay_ms: z.number().int().optional(),
+		})
+		.optional(),
+});
+export type StartParamsWithAudioMode = z.infer<
+	typeof startParamsWithAudioModeSchema
+>;
+
 function defaultCerastreamBackendDeps(): CerastreamBackendDeps {
 	return {
 		connect,
@@ -392,8 +427,25 @@ export class CerastreamBackend implements StreamingBackend {
 			this.subscription = await client.subscribeEvents({}, (event) =>
 				this.handleEvent(event),
 			);
-			await client.start(params);
+			await this.dispatchStart(client, params);
 		}, "start");
+	}
+
+	// Send `start` so `audio.mode` survives: a ≥0.6.0 engine is driven through the
+	// raw JSON-RPC primitive (the typed client Zod-strips `mode`); an older engine
+	// gets the typed call and its legacy device inference.
+	private async dispatchStart(
+		client: CerastreamClient,
+		params: StartParamsWithAudioMode,
+	): Promise<void> {
+		if (supportsAudioMode(client.hello.schema_version)) {
+			const raw = client as unknown as {
+				rawRequest(method: string, params?: unknown): Promise<unknown>;
+			};
+			await raw.rawRequest("start", params);
+			return;
+		}
+		await client.start(params as StartParams);
 	}
 
 	stop(onStopped: () => void): boolean {
@@ -682,18 +734,29 @@ export class CerastreamBackend implements StreamingBackend {
 		codec?: "h264" | "h265";
 		resolution?: string;
 		framerate?: number;
-		audio?: { device?: string; codec?: string; delay_ms?: number };
+		audio?: {
+			mode?: AudioMode;
+			device?: string;
+			codec?: string;
+			delay_ms?: number;
+		};
 	} {
 		const inputId = config.selected_video_input ?? this.deps.getActiveInput();
-		// Embedded network-ingest audio: when the engine routes the incoming
-		// stream's muxed audio, no ALSA device is used — omit `audio.device` so the
-		// engine takes the embedded path instead of the (unused) selectable one.
-		const audioDevice =
-			config.asrc !== undefined && !this.deps.isEmbeddedAudioActive(pipelineId)
-				? getAudioSrcId(config.asrc)
+		// The operator's audio pick maps onto the engine's `audio.mode`
+		// discriminator (never a pseudo-source string leaked into `audio.device`):
+		// "No audio" ⇒ none, "Pipeline default" / a network-embedded source ⇒
+		// default, a real device ⇒ device + its ALSA id. An absent `asrc` omits the
+		// section entirely (the engine's legacy inference, compat-preserved).
+		const selection =
+			config.asrc !== undefined
+				? resolveAudioMode(
+						config.asrc,
+						this.deps.isEmbeddedAudioActive(pipelineId),
+					)
 				: undefined;
 		const audio = {
-			...(audioDevice !== undefined ? { device: audioDevice } : {}),
+			...(selection !== undefined ? { mode: selection.mode } : {}),
+			...(selection?.device !== undefined ? { device: selection.device } : {}),
 			...(config.acodec !== undefined ? { codec: config.acodec } : {}),
 			...(config.delay !== undefined ? { delay_ms: config.delay } : {}),
 		};
@@ -715,7 +778,7 @@ export class CerastreamBackend implements StreamingBackend {
 	private buildStartParams(
 		config: RuntimeConfig,
 		opts: StreamRunOptions,
-	): StartParams {
+	): StartParamsWithAudioMode {
 		const srt: {
 			host: string;
 			port: number;
@@ -730,7 +793,7 @@ export class CerastreamBackend implements StreamingBackend {
 		};
 		if (opts.streamid) srt.streamid = opts.streamid;
 
-		return startParamsSchema.parse({
+		return startParamsWithAudioModeSchema.parse({
 			pipeline: config.pipeline ?? opts.pipeline,
 			srt,
 			bitrate: {

--- a/apps/backend/src/tests/cerastream-start-assembly.test.ts
+++ b/apps/backend/src/tests/cerastream-start-assembly.test.ts
@@ -295,9 +295,9 @@ describe("buildStartParams — pseudo-source → audio.mode wire contract (Todo 
 		await backend.settle();
 		const started = fake.calls.find((c) => c.op === "start");
 		expect(started).toBeDefined();
-		expect(
-			(started?.params as { audio?: { mode?: string } }).audio?.mode,
-		).toBe("device");
+		expect((started?.params as { audio?: { mode?: string } }).audio?.mode).toBe(
+			"device",
+		);
 	});
 });
 

--- a/apps/backend/src/tests/cerastream-start-assembly.test.ts
+++ b/apps/backend/src/tests/cerastream-start-assembly.test.ts
@@ -71,6 +71,12 @@ function makeFakeClient(schemaVersion: string): FakeHarness {
 			calls.push({ op: "start", params });
 			return { session_id: "s1", state: "streaming" as const };
 		},
+		rawRequest: async (method: string, params: unknown) => {
+			calls.push({ op: method, params });
+			if (method === "start")
+				return { session_id: "s1", state: "streaming" as const };
+			return {};
+		},
 		stop: async () => ({ state: "idle" as const }),
 		reloadConfig: async (params: unknown) => {
 			calls.push({ op: "reload-config", params });
@@ -166,8 +172,10 @@ describe("buildStartParams — full config forwards every field", () => {
 		expect(params.resolution).toBe("1920x1080");
 		expect(params.framerate).toBe(30);
 		expect(params.audio).toEqual({
+			// A real device selection resolves to mode:"device" + its ALSA id.
 			// getAudioSrcId("HDMI") → "rockchiphdmiin" only on rk3588; on a dev
 			// host the alias table has no HDMI entry, so it passes through as-is.
+			mode: "device",
 			device: (params.audio as { device: string }).device,
 			codec: "opus",
 			delay_ms: -2000,
@@ -215,19 +223,81 @@ describe("buildStartParams — absent fields are omitted (no undefined keys)", (
 });
 
 describe("buildStartParams — embedded network-ingest audio (Task 13)", () => {
-	test("OMITS audio.device when the embedded-audio gate is active", async () => {
+	test("mode:default + NO device when the embedded-audio gate is active", async () => {
 		const params = await startParamsFor(FULL_CONFIG, {
 			isEmbeddedAudioActive: () => true,
 		});
-		expect(params.audio).toEqual({ codec: "opus", delay_ms: -2000 });
+		expect(params.audio).toEqual({
+			mode: "default",
+			codec: "opus",
+			delay_ms: -2000,
+		});
 		expect(params.audio).not.toHaveProperty("device");
 	});
 
-	test("KEEPS audio.device when the gate is inactive (legacy ALSA path)", async () => {
+	test("mode:device + device id when the gate is inactive (ALSA path)", async () => {
 		const params = await startParamsFor(FULL_CONFIG, {
 			isEmbeddedAudioActive: () => false,
 		});
+		expect((params.audio as { mode: string }).mode).toBe("device");
 		expect((params.audio as { device: string }).device).toBeTruthy();
+	});
+});
+
+describe("buildStartParams — pseudo-source → audio.mode wire contract (Todo 17)", () => {
+	const BASE: RuntimeConfig = {
+		pipeline: "hdmi",
+		max_br: 8000,
+		srt_latency: 2000,
+		balancer: "adaptive",
+	};
+
+	test('"No audio" ⇒ mode:"none" with no device (a video-only stream)', async () => {
+		const params = await startParamsFor(
+			{ ...BASE, asrc: "No audio" },
+			{ schemaVersion: "0.6.0" },
+		);
+		expect(params.audio).toEqual({ mode: "none" });
+		expect(params.audio).not.toHaveProperty("device");
+	});
+
+	test('"Pipeline default" ⇒ mode:"default" with no device', async () => {
+		const params = await startParamsFor(
+			{ ...BASE, asrc: "Pipeline default" },
+			{ schemaVersion: "0.6.0" },
+		);
+		expect(params.audio).toEqual({ mode: "default" });
+		expect(params.audio).not.toHaveProperty("device");
+	});
+
+	test('a real device ⇒ mode:"device" + its ALSA id', async () => {
+		const params = await startParamsFor(
+			{ ...BASE, asrc: "usbaudio" },
+			{ schemaVersion: "0.6.0" },
+		);
+		expect(params.audio).toEqual({ mode: "device", device: "usbaudio" });
+	});
+
+	test("a legacy caller that omits asrc sends NO audio section (compat)", async () => {
+		const params = await startParamsFor(BASE, {
+			schemaVersion: "0.6.0",
+			activeInput: undefined,
+		});
+		expect(params).not.toHaveProperty("audio");
+	});
+
+	test("a ≥0.6.0 engine receives start over the RAW bridge (mode survives)", async () => {
+		const { backend, fake } = makeBackend(
+			{ ...BASE, asrc: "usbaudio" },
+			{ schemaVersion: "0.6.0" },
+		);
+		backend.start({ ...BASE, asrc: "usbaudio" }, RUN_OPTS);
+		await backend.settle();
+		const started = fake.calls.find((c) => c.op === "start");
+		expect(started).toBeDefined();
+		expect(
+			(started?.params as { audio?: { mode?: string } }).audio?.mode,
+		).toBe("device");
 	});
 });
 


### PR DESCRIPTION
What / Why / How to verify / Risks

## What
Map the operator audio pick onto the cerastream engine additive `audio.mode` discriminator, so a pseudo-source is never leaked into `audio.device` as a bogus ALSA id:

- `No audio` ⇒ `mode:"none"` (no device — a video-only stream)
- `Pipeline default` / a network-embedded source ⇒ `mode:"default"` (no device)
- a real device ⇒ `mode:"device"` + its ALSA id
- an absent `asrc` ⇒ NO `audio` section (the engine legacy inference, compat-preserved)

A `>=0.6.0` engine is driven through the raw `start` bridge (`rawRequest("start", ...)`), because the published `@ceralive/cerastream` client Zod-STRIPS the unknown `mode` field. An older engine gets the typed call and its legacy device inference. No npm publish.

## Why
CeraUI previously forwarded pseudo-source strings (`No audio`, `Pipeline default`) verbatim as `audio.device`, which the engine would treat as a bogus ALSA device id. Paired with cerastream PR #45 (program-owned audio mux + silence failover), this locks the UI→engine contract in both directions.

## How to verify
`bun run --filter backend check` + `biome check` clean; `bun test apps/backend/src/tests/cerastream-start-assembly.test.ts` — 19 pass, incl. the new pseudo-source wire-contract block (`"No audio" ⇒ mode:none`, `"Pipeline default" ⇒ mode:default`, real device ⇒ `mode:device`+id, legacy-omission compat, and the raw-bridge dispatch on a 0.6.0 engine).

## Risks
- Depends on cerastream `audio.mode` (schema 0.6.0) — gated on the engine `hello.schema_version`, so an older engine is unaffected. 3 pre-existing hardware-kind-cache tests fail identically on clean main on non-rk3588 hosts (host-dependent; CI authoritative). Reload-config carries no `mode` (audio mode is a start-time graph decision), so only the start path uses the raw bridge.