### PR TITLE
fix(preview): MSE live-edge policy + bounded drop-oldest proxy

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -44,7 +44,7 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 | **Wire-envelope Zod schema + contract tests** | `modules/remote-control/protocol.ts` — THIN re-export of `@ceralive/control-protocol` (device-tolerant `FrameSchema`/`CommandSchema`/`StatusSchema`/`IngestSlotsPayloadSchema` + `COMMAND_REGISTRY` incl. `INTERNAL_COMMANDS` + `NEVER_REMOTE` + `tolerantParse*`); `protocol.export-surface.test.ts` / `protocol.contract.test.ts` / `protocol.frame-exchange.test.ts` |
 | **RC-pin merge gate (rejects `-rc.` pins of `@ceralive/{control-protocol,cerastream}`)** | `scripts/check-rc-pins.sh` (root `check:rc-pins`, wired into `.github/workflows/build-check.yml` BE job) |
 | Kiosk loopback token (DC-3, single-use, tmpfs) | `modules/ui/kiosk-token.ts` + `rpc/server.ts` |
-| Preview WebSocket proxy (single-origin `/preview`; forks before oRPC upgrade; backpressure-aware) | `modules/ui/preview-proxy.ts` + `rpc/server.ts` + `rpc/adapter.ts` (`createServerWebSocketHandler`) |
+| Preview WebSocket proxy (single-origin `/preview`; forks before oRPC upgrade; backpressure-aware, bounded drop-oldest queue) | `modules/ui/preview-proxy.ts` + `modules/ui/preview-frame-queue.ts` (`BoundedDropOldestQueue`) + `rpc/server.ts` + `rpc/adapter.ts` (`createServerWebSocketHandler`) |
 | Preview single-use token store (in-memory, TTL 30s) + `system.mintPreviewToken` | `modules/ui/preview-token.ts` + `rpc/procedures/system.procedure.ts` |
 | SIM PIN secrets store (opt-in "remember PIN", chmod-600 tmpfs) | `modules/modems/sim-secrets.ts` |
 | Boot SIM PIN auto-unlock hook (bounded, single attempt) | `modules/modems/sim-autounlock.ts` |
@@ -140,14 +140,27 @@ divergence between dev and prod dial targets.
   identical URL/token flow. `PREVIEW_CLOSE_UPSTREAM_DOWN = 4502` (loopback
   unreachable), `PREVIEW_CLOSE_UPSTREAM_UNAVAILABLE = 4503` (preview
   unbound/disabled). Close-code constants live once in `@ceraui/rpc/schemas`.
-- **Backpressure:** frames are a transparent passthrough BOTH ways (text control
-  frames + binary access units). The downstream (browser) leg is
-  backpressure-aware — when the client's `getBufferedAmount()` exceeds
-  `PREVIEW_BACKPRESSURE_HWM_BYTES` (1 MiB) forwarding pauses and upstream frames
-  are held, resuming on `drain`. Pause/resume only — NEVER drop-oldest.
+- **Backpressure — bounded drop-oldest (Todo 14):** frames are a transparent
+  passthrough BOTH ways (text control frames + binary access units). The
+  downstream (browser) leg is backpressure-aware — when the client's
+  `getBufferedAmount()` exceeds `PREVIEW_BACKPRESSURE_HWM_BYTES` (1 MiB) forwarding
+  pauses and upstream frames are held in a BOUNDED DROP-OLDEST queue
+  (`modules/ui/preview-frame-queue.ts` `BoundedDropOldestQueue`), resuming on
+  `drain`. Above `PREVIEW_MAX_PENDING_FRAMES` (256) or `PREVIEW_MAX_PENDING_BYTES`
+  (1 MiB) the OLDEST media frame is evicted — the queue PLATEAUS, the socket stays
+  OPEN (a live-edge skip-on-lag), and the browser resumes at the freshest media,
+  paired with the frontend live-edge seek policy (`preview-live-edge.ts`). This
+  REPLACES the previous close-on-overflow ("NEVER drop-oldest") contract: a
+  permanently-slow consumer no longer tears the preview down. The newest MSE init
+  segment (codec-config text frame) is PINNED — never dropped, dequeued first — so
+  the latest fragments stay decodable. Socket close frees every buffered frame
+  (`freePreviewProxyState` clears the queue).
 
 Coverage: `tests/preview-token.test.ts` (mint/consume/expire/single-use) +
-`tests/preview-proxy.test.ts` (pipe, 4401/4502/4503, authed mint gate).
+`tests/preview-proxy.test.ts` (pipe, 4401/4502/4503, authed mint gate) +
+`tests/preview-frame-queue.test.ts` (drop-oldest by count/bytes, pinned init) +
+`tests/preview-proxy-bounded.test.ts` (slow-consumer plateau, socket stays open,
+teardown frees buffers).
 
 ## DEV MOCK SEAMS [EXISTS]
 

--- a/apps/backend/src/modules/ui/preview-frame-queue.ts
+++ b/apps/backend/src/modules/ui/preview-frame-queue.ts
@@ -1,0 +1,153 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Bounded drop-oldest queue for the `/preview` proxy's slow-consumer buffering.
+ *
+ * When the downstream (browser) socket can't drain fast enough, held frames are
+ * queued here. Rather than close the socket on overflow (the old behaviour), the
+ * queue drops the OLDEST media frames once it exceeds either the frame-count or
+ * the byte cap — so it plateaus under a permanently-slow consumer instead of
+ * tearing the preview down, and the browser resumes at the freshest media (a
+ * live-edge skip-on-lag, paired with the frontend's live-edge seek policy).
+ *
+ * A single PINNED frame (the newest MSE codec-config / init segment) is retained
+ * separately: it is never dropped and is dequeued FIRST, so the latest fragments
+ * stay decodable after any eviction. Pure and side-effect-free so the policy is
+ * unit-testable in isolation (`preview-frame-queue.test.ts`).
+ */
+
+export interface BoundedDropOldestQueueOptions<T> {
+	/** Hard cap on queued MEDIA frames (the pinned init frame does not count). */
+	maxItems: number;
+	/** Hard cap on queued MEDIA bytes (the pinned init frame does not count). */
+	maxBytes: number;
+	/** Byte size of one frame — used for the byte budget. */
+	sizeOf: (item: T) => number;
+	/**
+	 * Classify a frame as the pinned init frame (kept, never dropped, sent first).
+	 * When omitted, no frame is pinned and every frame is droppable media.
+	 */
+	isPinned?: (item: T) => boolean;
+}
+
+/** How many oldest media frames/bytes an `enqueue` evicted (0 when under cap). */
+export interface EnqueueResult {
+	droppedItems: number;
+	droppedBytes: number;
+}
+
+export class BoundedDropOldestQueue<T> {
+	private readonly maxItems: number;
+	private readonly maxBytes: number;
+	private readonly sizeOf: (item: T) => number;
+	private readonly isPinned: (item: T) => boolean;
+
+	private media: T[] = [];
+	private mediaBytes = 0;
+	private pinned: T | null = null;
+	private pinnedPending = false;
+
+	constructor(options: BoundedDropOldestQueueOptions<T>) {
+		this.maxItems = options.maxItems;
+		this.maxBytes = options.maxBytes;
+		this.sizeOf = options.sizeOf;
+		this.isPinned = options.isPinned ?? (() => false);
+	}
+
+	/**
+	 * Enqueue a frame. A pinned (init) frame replaces any older pinned frame and
+	 * is never dropped. A media frame is appended, then the oldest media frames are
+	 * evicted while the queue exceeds the frame-count OR byte cap — always keeping
+	 * at least the just-enqueued newest frame.
+	 */
+	enqueue(item: T): EnqueueResult {
+		if (this.isPinned(item)) {
+			this.pinned = item;
+			this.pinnedPending = true;
+			return { droppedItems: 0, droppedBytes: 0 };
+		}
+
+		this.media.push(item);
+		this.mediaBytes += this.sizeOf(item);
+
+		let droppedItems = 0;
+		let droppedBytes = 0;
+		while (
+			(this.media.length > this.maxItems || this.mediaBytes > this.maxBytes) &&
+			this.media.length > 1
+		) {
+			const evicted = this.media.shift();
+			if (evicted === undefined) {
+				break;
+			}
+			this.mediaBytes -= this.sizeOf(evicted);
+			droppedItems += 1;
+			droppedBytes += this.sizeOf(evicted);
+		}
+		return { droppedItems, droppedBytes };
+	}
+
+	/**
+	 * Dequeue the next frame to forward: the pending pinned init frame first (once),
+	 * then the oldest media frame. Returns `undefined` when empty.
+	 */
+	dequeue(): T | undefined {
+		if (this.pinnedPending && this.pinned !== null) {
+			this.pinnedPending = false;
+			return this.pinned;
+		}
+		const next = this.media.shift();
+		if (next !== undefined) {
+			this.mediaBytes -= this.sizeOf(next);
+		}
+		return next;
+	}
+
+	/** Total queued frames, including a pending pinned init frame. */
+	get length(): number {
+		return this.media.length + (this.pinnedPending ? 1 : 0);
+	}
+
+	/** Total queued bytes, including a pending pinned init frame. */
+	get byteLength(): number {
+		return (
+			this.mediaBytes +
+			(this.pinnedPending && this.pinned !== null
+				? this.sizeOf(this.pinned)
+				: 0)
+		);
+	}
+
+	/** Test/introspection: the queued frames in dequeue order (pinned first). */
+	peekAll(): T[] {
+		const out: T[] = [];
+		if (this.pinnedPending && this.pinned !== null) {
+			out.push(this.pinned);
+		}
+		out.push(...this.media);
+		return out;
+	}
+
+	/** Free every buffered frame and byte (teardown). */
+	clear(): void {
+		this.media = [];
+		this.mediaBytes = 0;
+		this.pinned = null;
+		this.pinnedPending = false;
+	}
+}

--- a/apps/backend/src/modules/ui/preview-proxy.ts
+++ b/apps/backend/src/modules/ui/preview-proxy.ts
@@ -30,8 +30,13 @@
  *
  * Frames are a transparent passthrough (text control frames + binary access units)
  * in BOTH directions. The downstream (browser) leg is backpressure-aware: when the
- * client's buffered amount exceeds a bounded high-water mark, upstream frames are
- * held and forwarding pauses, resuming on `drain` — never drop-oldest.
+ * client's buffered amount exceeds a bounded high-water mark forwarding pauses and
+ * upstream frames are held in a BOUNDED drop-oldest queue (`preview-frame-queue.ts`)
+ * — the newest MSE init segment is pinned and the latest fragments are kept, the
+ * oldest media is evicted once the queue exceeds its frame/byte cap. A permanently
+ * slow consumer therefore plateaus the proxy's memory instead of tearing the
+ * preview down, and the browser resumes at the freshest media (a live-edge
+ * skip-on-lag, paired with the frontend's live-edge seek policy).
  */
 
 import {
@@ -46,10 +51,22 @@ import { shouldUseMocks } from "../../mocks/mock-service.ts";
 import { getMockPreviewPort } from "../../mocks/providers/preview.ts";
 import type { PreviewSocketData, ServerSocketData } from "../../rpc/types.ts";
 import { getLastCapabilities } from "../streaming/capabilities.ts";
+import { BoundedDropOldestQueue } from "./preview-frame-queue.ts";
 import { consumePreviewToken } from "./preview-token.ts";
 
 type PreviewSocket = ServerWebSocket<PreviewSocketData>;
 type Frame = string | ArrayBuffer;
+
+/**
+ * The minimal downstream-socket surface the pause/resume pipe needs. Bun's
+ * `ServerWebSocket` satisfies it structurally; a fake satisfies it in tests so the
+ * drop-oldest + teardown behaviour is drivable without a live socket.
+ */
+export interface PreviewDownSocket {
+	send(data: Frame): number | void;
+	getBufferedAmount(): number;
+	close(code?: number, reason?: string): void;
+}
 
 /** Copy a Bun `message` Buffer into a standalone ArrayBuffer for passthrough. */
 function toFrame(data: string | Buffer): Frame {
@@ -71,22 +88,54 @@ function toFrame(data: string | Buffer): Frame {
 export const PREVIEW_BACKPRESSURE_HWM_BYTES = 1_048_576;
 
 /**
- * Hard cap on frames held while forwarding is paused. Exceeding it means the
- * downstream is not draining at all; the socket is torn down (a controlled close,
- * NOT drop-oldest) so the proxy never buffers without bound.
+ * Frame-count cap on the held (paused) queue. Above it the OLDEST media frame is
+ * evicted (drop-oldest) — the queue plateaus, the socket stays open. 256 slots
+ * absorb a burst of preview access units on a briefly-slow link.
  */
-export const PREVIEW_MAX_PENDING_FRAMES = 512;
+export const PREVIEW_MAX_PENDING_FRAMES = 256;
+
+/** Byte cap on the held (paused) queue — the oldest media is evicted above it. */
+export const PREVIEW_MAX_PENDING_BYTES = 1_048_576;
 
 interface PreviewProxyState {
 	upstream: WebSocket;
 	upstreamOpen: boolean;
 	paused: boolean;
 	downClosed: boolean;
-	pending: Frame[];
+	queue: BoundedDropOldestQueue<Frame>;
 	outbox: Frame[];
 }
 
 const states = new Map<PreviewSocket, PreviewProxyState>();
+
+function frameByteLength(frame: Frame): number {
+	return typeof frame === "string"
+		? Buffer.byteLength(frame)
+		: frame.byteLength;
+}
+
+// The MSE init segment the fragments depend on rides a text codec-config frame;
+// pin it so an eviction never drops it (the latest fragments stay decodable).
+function isInitFrame(frame: Frame): boolean {
+	if (typeof frame !== "string") {
+		return false;
+	}
+	try {
+		const msg = JSON.parse(frame) as { type?: unknown };
+		return msg?.type === "codec-config" || msg?.type === "config";
+	} catch {
+		return false;
+	}
+}
+
+export function createPreviewQueue(): BoundedDropOldestQueue<Frame> {
+	return new BoundedDropOldestQueue<Frame>({
+		maxItems: PREVIEW_MAX_PENDING_FRAMES,
+		maxBytes: PREVIEW_MAX_PENDING_BYTES,
+		sizeOf: frameByteLength,
+		isPinned: isInitFrame,
+	});
+}
 
 /** Injected collaborators so tests drive the pipe against a fake upstream. */
 export interface PreviewProxyDeps {
@@ -131,8 +180,8 @@ export function isPreviewSocket(
 	return (ws.data as Partial<PreviewSocketData>).kind === "preview";
 }
 
-function closeDown(
-	ws: PreviewSocket,
+export function closeDown(
+	ws: PreviewDownSocket,
 	state: PreviewProxyState,
 	code: number,
 	reason: string,
@@ -141,6 +190,7 @@ function closeDown(
 		return;
 	}
 	state.downClosed = true;
+	state.queue.clear();
 	try {
 		state.upstream.close();
 	} catch {
@@ -153,8 +203,8 @@ function closeDown(
 	}
 }
 
-function forward(
-	ws: PreviewSocket,
+export function forward(
+	ws: PreviewDownSocket,
 	state: PreviewProxyState,
 	data: Frame,
 ): void {
@@ -162,15 +212,9 @@ function forward(
 		return;
 	}
 	if (state.paused) {
-		state.pending.push(data);
-		if (state.pending.length > PREVIEW_MAX_PENDING_FRAMES) {
-			closeDown(
-				ws,
-				state,
-				PREVIEW_CLOSE_UPSTREAM_DOWN,
-				"backpressure_overflow",
-			);
-		}
+		// Held while the browser drains: bounded drop-oldest — never close on
+		// overflow. The queue plateaus; the socket stays open.
+		state.queue.enqueue(data);
 		return;
 	}
 	ws.send(data);
@@ -179,18 +223,18 @@ function forward(
 	}
 }
 
-function resume(ws: PreviewSocket, state: PreviewProxyState): void {
+export function resume(ws: PreviewDownSocket, state: PreviewProxyState): void {
 	while (
-		state.pending.length > 0 &&
+		state.queue.length > 0 &&
 		ws.getBufferedAmount() <= PREVIEW_BACKPRESSURE_HWM_BYTES
 	) {
-		const next = state.pending.shift();
+		const next = state.queue.dequeue();
 		if (next !== undefined) {
 			ws.send(next);
 		}
 	}
 	if (
-		state.pending.length === 0 &&
+		state.queue.length === 0 &&
 		ws.getBufferedAmount() <= PREVIEW_BACKPRESSURE_HWM_BYTES
 	) {
 		state.paused = false;
@@ -278,7 +322,7 @@ export function createPreviewWebSocketHandler(
 				upstreamOpen: false,
 				paused: false,
 				downClosed: false,
-				pending: [],
+				queue: createPreviewQueue(),
 				outbox: [],
 			};
 			states.set(ws, state);
@@ -315,13 +359,41 @@ export function createPreviewWebSocketHandler(
 				return;
 			}
 			states.delete(ws);
-			state.downClosed = true;
-			try {
-				state.upstream.close();
-			} catch {
-				// upstream already closing
-			}
+			freePreviewProxyState(state);
 		},
+	};
+}
+
+/**
+ * Release a torn-down pair: mark it closed, free every buffered frame/byte, and
+ * close the upstream. The socket-close handler and every `closeDown` path route
+ * through here so no buffer survives teardown.
+ */
+export function freePreviewProxyState(state: PreviewProxyState): void {
+	state.downClosed = true;
+	state.queue.clear();
+	try {
+		state.upstream.close();
+	} catch {
+		// upstream already closing
+	}
+}
+
+/**
+ * Build a proxy state around a downstream queue + `upstream`. The socket-open
+ * path and tests both use it, so the pause/resume/drop-oldest/teardown behaviour
+ * is drivable without a live upstream socket.
+ */
+export function createPreviewProxyState(
+	upstream: WebSocket,
+): PreviewProxyState {
+	return {
+		upstream,
+		upstreamOpen: false,
+		paused: false,
+		downClosed: false,
+		queue: createPreviewQueue(),
+		outbox: [],
 	};
 }
 
@@ -329,3 +401,5 @@ export function createPreviewWebSocketHandler(
 export function getActivePreviewProxyCount(): number {
 	return states.size;
 }
+
+export type { PreviewProxyState };

--- a/apps/backend/src/tests/preview-frame-queue.test.ts
+++ b/apps/backend/src/tests/preview-frame-queue.test.ts
@@ -1,0 +1,131 @@
+/*
+ * Todo 14 (CeraUI half) — bounded drop-oldest preview-frame queue.
+ *
+ * The pure queue behind the `/preview` proxy's slow-consumer buffering. It keeps
+ * a PINNED init frame (the newest MSE codec-config) plus the LATEST media
+ * fragments, dropping the oldest media when it exceeds either the frame-count or
+ * the byte cap — never growing without bound, and never dropping the init frame
+ * that keeps the fragments decodable.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { BoundedDropOldestQueue } from "../modules/ui/preview-frame-queue.ts";
+
+const sizeOf = (): number => 1;
+
+function newQueue(overrides?: {
+	maxItems?: number;
+	maxBytes?: number;
+	isPinned?: (n: number) => boolean;
+}) {
+	return new BoundedDropOldestQueue<number>({
+		maxItems: overrides?.maxItems ?? 3,
+		maxBytes: overrides?.maxBytes ?? Number.POSITIVE_INFINITY,
+		sizeOf,
+		isPinned: overrides?.isPinned,
+	});
+}
+
+describe("BoundedDropOldestQueue — drop-oldest by frame count", () => {
+	it("keeps the newest N media frames, evicting the oldest", () => {
+		const q = newQueue({ maxItems: 3 });
+		expect(q.enqueue(1)).toEqual({ droppedItems: 0, droppedBytes: 0 });
+		q.enqueue(2);
+		q.enqueue(3);
+		expect(q.length).toBe(3);
+		// The 4th push evicts the oldest (1).
+		expect(q.enqueue(4)).toEqual({ droppedItems: 1, droppedBytes: 1 });
+		expect(q.peekAll()).toEqual([2, 3, 4]);
+	});
+
+	it("plateaus — 1000 enqueues never exceed the cap (bounded memory)", () => {
+		const q = newQueue({ maxItems: 4 });
+		for (let i = 0; i < 1000; i++) q.enqueue(i);
+		expect(q.length).toBe(4);
+		expect(q.byteLength).toBe(4);
+		expect(q.peekAll()).toEqual([996, 997, 998, 999]);
+	});
+});
+
+describe("BoundedDropOldestQueue — drop-oldest by byte budget", () => {
+	it("evicts oldest until under the byte cap, keeping at least the newest frame", () => {
+		const q = new BoundedDropOldestQueue<number>({
+			maxItems: Number.POSITIVE_INFINITY,
+			maxBytes: 10,
+			sizeOf: (n) => n, // frame's byte size == its value
+		});
+		q.enqueue(4);
+		q.enqueue(4);
+		expect(q.byteLength).toBe(8);
+		// +5 → 13 bytes > 10: evict oldest 4 → 9 bytes.
+		expect(q.enqueue(5)).toEqual({ droppedItems: 1, droppedBytes: 4 });
+		expect(q.byteLength).toBe(9);
+		expect(q.peekAll()).toEqual([4, 5]);
+	});
+
+	it("keeps a single oversized frame rather than dropping to empty", () => {
+		const q = new BoundedDropOldestQueue<number>({
+			maxItems: Number.POSITIVE_INFINITY,
+			maxBytes: 10,
+			sizeOf: (n) => n,
+		});
+		expect(q.enqueue(50)).toEqual({ droppedItems: 0, droppedBytes: 0 });
+		expect(q.length).toBe(1);
+		expect(q.peekAll()).toEqual([50]);
+	});
+});
+
+describe("BoundedDropOldestQueue — pinned init frame", () => {
+	// Values >= 100 are "init" frames in this fixture.
+	const isPinned = (n: number) => n >= 100;
+
+	it("never drops the pinned init frame and dequeues it FIRST", () => {
+		const q = newQueue({ maxItems: 2, isPinned });
+		q.enqueue(100); // init
+		q.enqueue(1);
+		q.enqueue(2);
+		q.enqueue(3); // evicts media 1, init untouched
+		// init pending + 2 media = length 3 (init is pinned, not a media slot).
+		expect(q.length).toBe(3);
+		expect(q.dequeue()).toBe(100); // init first
+		expect(q.dequeue()).toBe(2);
+		expect(q.dequeue()).toBe(3);
+		expect(q.dequeue()).toBeUndefined();
+	});
+
+	it("replaces an older pinned init with the newest one", () => {
+		const q = newQueue({ maxItems: 3, isPinned });
+		q.enqueue(100);
+		q.enqueue(101); // newer init replaces 100
+		q.enqueue(1);
+		expect(q.dequeue()).toBe(101);
+		expect(q.dequeue()).toBe(1);
+	});
+
+	it("re-arms the init send after a new init arrives post-dequeue", () => {
+		const q = newQueue({ maxItems: 3, isPinned });
+		q.enqueue(100);
+		expect(q.dequeue()).toBe(100);
+		q.enqueue(1);
+		expect(q.dequeue()).toBe(1);
+		// A fresh init (e.g. a source-change codec-config) must be sent again.
+		q.enqueue(200);
+		expect(q.dequeue()).toBe(200);
+	});
+});
+
+describe("BoundedDropOldestQueue — teardown", () => {
+	it("clear() frees all buffered bytes and frames", () => {
+		const q = newQueue({ maxItems: 5, isPinned: (n) => n >= 100 });
+		q.enqueue(100);
+		q.enqueue(1);
+		q.enqueue(2);
+		expect(q.length).toBeGreaterThan(0);
+		expect(q.byteLength).toBeGreaterThan(0);
+		q.clear();
+		expect(q.length).toBe(0);
+		expect(q.byteLength).toBe(0);
+		expect(q.peekAll()).toEqual([]);
+		expect(q.dequeue()).toBeUndefined();
+	});
+});

--- a/apps/backend/src/tests/preview-proxy-bounded.test.ts
+++ b/apps/backend/src/tests/preview-proxy-bounded.test.ts
@@ -1,0 +1,201 @@
+/*
+ * Todo 14 (CeraUI half), part (e) — proxy bounded-memory + teardown.
+ *
+ * A slow-consumer fake (downstream `getBufferedAmount()` stays permanently above
+ * the high-water mark) proves the paused proxy queue PLATEAUS instead of growing
+ * without bound, keeps the newest init segment, and NEVER closes the socket on
+ * overflow. `legacyForward` below reproduces the pre-fix close-on-overflow
+ * semantics to lock the bound the old code provably violated ("stays open under a
+ * slow consumer"). A teardown check proves closing the pair frees every buffer.
+ */
+import { describe, expect, it } from "bun:test";
+
+import {
+	closeDown,
+	createPreviewProxyState,
+	forward,
+	freePreviewProxyState,
+	PREVIEW_BACKPRESSURE_HWM_BYTES,
+	PREVIEW_MAX_PENDING_BYTES,
+	PREVIEW_MAX_PENDING_FRAMES,
+	type PreviewDownSocket,
+	resume,
+} from "../modules/ui/preview-proxy.ts";
+
+type Frame = string | ArrayBuffer;
+
+/** Downstream whose buffer never drains — models a permanently-slow browser. */
+class SlowConsumerSocket implements PreviewDownSocket {
+	sent: Frame[] = [];
+	closed: { code?: number; reason?: string } | null = null;
+	buffered = PREVIEW_BACKPRESSURE_HWM_BYTES + 1;
+
+	send(data: Frame): number {
+		this.sent.push(data);
+		return this.buffered;
+	}
+	getBufferedAmount(): number {
+		return this.buffered;
+	}
+	close(code?: number, reason?: string): void {
+		this.closed = { code, reason };
+	}
+}
+
+function fakeUpstream(): { close: () => void; closedCount: number } {
+	const up = { closedCount: 0, close: () => {} };
+	up.close = () => {
+		up.closedCount += 1;
+	};
+	return up;
+}
+
+function mediaFrame(bytes: number): ArrayBuffer {
+	return new Uint8Array(bytes).buffer;
+}
+
+const INIT_FRAME = JSON.stringify({
+	type: "codec-config",
+	codec: "avc1.42001f",
+});
+
+describe("preview proxy — bounded memory under a slow consumer", () => {
+	it("plateaus the paused queue and never closes on overflow", () => {
+		const up = fakeUpstream();
+		const state = createPreviewProxyState(up as unknown as WebSocket);
+		const ws = new SlowConsumerSocket();
+
+		forward(ws, state, INIT_FRAME);
+		for (let i = 0; i < 5000; i++) {
+			forward(ws, state, mediaFrame(1024));
+		}
+
+		// Bounded — the queue never grew past the caps (+1 for the pinned init).
+		expect(state.queue.length).toBeLessThanOrEqual(
+			PREVIEW_MAX_PENDING_FRAMES + 1,
+		);
+		expect(state.queue.byteLength).toBeLessThanOrEqual(
+			PREVIEW_MAX_PENDING_BYTES + Buffer.byteLength(INIT_FRAME),
+		);
+		// The socket stayed OPEN — the bound the old close-on-overflow violated.
+		expect(ws.closed).toBeNull();
+		expect(state.downClosed).toBe(false);
+		expect(up.closedCount).toBe(0);
+	});
+
+	it("keeps the newest init segment through thousands of media evictions", () => {
+		const up = fakeUpstream();
+		const state = createPreviewProxyState(up as unknown as WebSocket);
+		const ws = new SlowConsumerSocket();
+
+		// First media frame is sent directly and trips the pause; the init frame
+		// then arrives while paused (as a source-change codec-config would) so it is
+		// queued and pinned.
+		forward(ws, state, mediaFrame(1024));
+		forward(ws, state, INIT_FRAME);
+		for (let i = 0; i < 5000; i++) {
+			forward(ws, state, mediaFrame(1024));
+		}
+
+		// The pinned init frame survived and is queued to be sent FIRST on drain.
+		expect(state.queue.peekAll()[0]).toBe(INIT_FRAME);
+	});
+
+	it("drains the plateaued queue once the consumer catches up", () => {
+		const up = fakeUpstream();
+		const state = createPreviewProxyState(up as unknown as WebSocket);
+		const ws = new SlowConsumerSocket();
+
+		forward(ws, state, mediaFrame(1024)); // sent directly, trips pause
+		forward(ws, state, INIT_FRAME); // queued + pinned while paused
+		for (let i = 0; i < 1000; i++) {
+			forward(ws, state, mediaFrame(1024));
+		}
+		expect(state.paused).toBe(true);
+		const queuedBefore = state.queue.length;
+		expect(queuedBefore).toBeGreaterThan(0);
+
+		// The browser catches up (buffer empties): resume flushes the queue and
+		// forwards the pinned init frame first.
+		ws.buffered = 0;
+		const sentBefore = ws.sent.length;
+		resume(ws, state);
+
+		expect(state.queue.length).toBe(0);
+		expect(state.paused).toBe(false);
+		expect(ws.sent.length).toBe(sentBefore + queuedBefore);
+		expect(ws.sent[sentBefore]).toBe(INIT_FRAME);
+	});
+});
+
+describe("preview proxy — legacy close-on-overflow (bound the old code violated)", () => {
+	// Faithful reproduction of the PRE-fix forward: unbounded push while paused,
+	// then a hard close once the pending array exceeds the 512-frame cap.
+	function legacyForward(
+		ws: SlowConsumerSocket,
+		pending: Frame[],
+		state: { paused: boolean; closed: boolean },
+		data: Frame,
+	): void {
+		if (state.closed) return;
+		if (state.paused) {
+			pending.push(data);
+			if (pending.length > 512) {
+				state.closed = true;
+				ws.close(4502, "backpressure_overflow");
+			}
+			return;
+		}
+		ws.send(data);
+		if (ws.getBufferedAmount() > PREVIEW_BACKPRESSURE_HWM_BYTES) {
+			state.paused = true;
+		}
+	}
+
+	it("the old behavior CLOSES the socket under the same slow consumer", () => {
+		const ws = new SlowConsumerSocket();
+		const pending: Frame[] = [];
+		const state = { paused: false, closed: false };
+		for (let i = 0; i < 5000; i++)
+			legacyForward(ws, pending, state, mediaFrame(1024));
+
+		// The old code tore the socket down (backpressure_overflow) — exactly the
+		// "stays open" bound the new bounded drop-oldest queue satisfies above.
+		expect(state.closed).toBe(true);
+		expect(ws.closed?.reason).toBe("backpressure_overflow");
+	});
+});
+
+describe("preview proxy — teardown frees all buffers", () => {
+	it("freePreviewProxyState clears the queue and closes upstream", () => {
+		const up = fakeUpstream();
+		const state = createPreviewProxyState(up as unknown as WebSocket);
+		const ws = new SlowConsumerSocket();
+
+		forward(ws, state, INIT_FRAME);
+		for (let i = 0; i < 1000; i++) forward(ws, state, mediaFrame(1024));
+		expect(state.queue.byteLength).toBeGreaterThan(0);
+
+		freePreviewProxyState(state);
+
+		expect(state.queue.length).toBe(0);
+		expect(state.queue.byteLength).toBe(0);
+		expect(state.downClosed).toBe(true);
+		expect(up.closedCount).toBe(1);
+	});
+
+	it("closeDown also frees the queue (controlled-close path)", () => {
+		const up = fakeUpstream();
+		const state = createPreviewProxyState(up as unknown as WebSocket);
+		const ws = new SlowConsumerSocket();
+
+		forward(ws, state, INIT_FRAME);
+		for (let i = 0; i < 1000; i++) forward(ws, state, mediaFrame(1024));
+
+		closeDown(ws, state, 1000, "upstream_closed");
+
+		expect(state.queue.byteLength).toBe(0);
+		expect(state.downClosed).toBe(true);
+		expect(ws.closed?.code).toBe(1000);
+	});
+});

--- a/apps/frontend/src/lib/components/preview/PreviewCanvas.svelte
+++ b/apps/frontend/src/lib/components/preview/PreviewCanvas.svelte
@@ -33,6 +33,12 @@ import {
 	PREVIEW_CLOSE_REASON_BACKPRESSURE,
 	type PreviewAvailability,
 } from '$lib/components/preview/preview-availability';
+import {
+	DEFAULT_LIVE_EDGE_POLICY,
+	deriveLiveEdgeAction,
+	type PlaybackSample,
+	pushBoundedSegment,
+} from '$lib/components/preview/preview-live-edge';
 import { Button } from '$lib/components/ui/button';
 import { getPreviewSocketUrl } from '$lib/env';
 import { rpc } from '$lib/rpc';
@@ -265,9 +271,60 @@ function decodeAccessUnit(buffer: ArrayBuffer): void {
 	decoder.decode(new EncodedVideoChunk({ type: isKey ? 'key' : 'delta', timestamp, data }));
 }
 
+// Read the current playhead vs. buffered live edge, or `null` when the
+// `<video>` has no buffered range yet.
+function readBufferedSample(): PlaybackSample | null {
+	const v = videoEl;
+	if (!v || v.buffered.length === 0) return null;
+	return {
+		bufferedStart: v.buffered.start(0),
+		bufferedEnd: v.buffered.end(v.buffered.length - 1),
+		currentTime: v.currentTime,
+	};
+}
+
+// Live-edge policy: pin the MSE playhead to live so preview never drifts behind
+// the encoder. A large drift hard-seeks to the edge; a moderate drift applies a
+// modest catch-up playbackRate inside the soft window; the back-buffer is trimmed
+// once it grows past the window. Pure decision in `preview-live-edge.ts`.
+function applyLiveEdge(): void {
+	const v = videoEl;
+	if (!v) return;
+	const sample = readBufferedSample();
+	if (!sample) return;
+	const decision = deriveLiveEdgeAction(sample);
+	if (decision.seekTo !== null) {
+		try {
+			v.currentTime = decision.seekTo;
+		} catch {
+			/* seek rejected mid-load */
+		}
+	}
+	if (v.playbackRate !== decision.playbackRate) v.playbackRate = decision.playbackRate;
+	const sb = sourceBuffer;
+	// Trim only when nothing is queued to append (append keeps priority) and the
+	// SourceBuffer is idle — `remove` would otherwise race a pending `appendBuffer`.
+	if (
+		decision.trimBackBufferTo !== null &&
+		sb &&
+		!sb.updating &&
+		pendingSegments.length === 0 &&
+		decision.trimBackBufferTo > sample.bufferedStart
+	) {
+		try {
+			sb.remove(0, decision.trimBackBufferTo);
+		} catch {
+			/* remove rejected mid-update */
+		}
+	}
+}
+
 function appendMseSegment(buffer: ArrayBuffer): void {
-	pendingSegments.push(buffer);
+	// Drop-oldest bound so a stalled SourceBuffer can never grow the queue without
+	// bound; `applyLiveEdge` seeks over any gap the eviction opens.
+	pushBoundedSegment(pendingSegments, buffer, DEFAULT_LIVE_EDGE_POLICY.maxPendingSegments);
 	flushSegments();
+	applyLiveEdge();
 	if (videoEl && videoEl.readyState >= 2) status = 'live';
 }
 

--- a/apps/frontend/src/lib/components/preview/preview-live-edge.test.ts
+++ b/apps/frontend/src/lib/components/preview/preview-live-edge.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import {
+	DEFAULT_LIVE_EDGE_POLICY,
+	deriveLiveEdgeAction,
+	type LiveEdgePolicy,
+	pushBoundedSegment,
+} from "./preview-live-edge";
+
+// A tight policy for deterministic assertions independent of the shipped defaults.
+const POLICY: LiveEdgePolicy = {
+	maxPendingSegments: 3,
+	catchupThresholdSec: 0.5,
+	seekThresholdSec: 1,
+	catchupPlaybackRate: 1.05,
+	backBufferSec: 8,
+	seekMarginSec: 0.1,
+};
+
+describe("pushBoundedSegment — drop-oldest bound", () => {
+	it("keeps the queue at or below the cap, dropping the OLDEST first", () => {
+		const q: number[] = [];
+		expect(pushBoundedSegment(q, 1, 3)).toBe(0);
+		expect(pushBoundedSegment(q, 2, 3)).toBe(0);
+		expect(pushBoundedSegment(q, 3, 3)).toBe(0);
+		expect(q).toEqual([1, 2, 3]);
+		// The 4th push evicts the oldest (1), keeping the newest 3.
+		expect(pushBoundedSegment(q, 4, 3)).toBe(1);
+		expect(q).toEqual([2, 3, 4]);
+	});
+
+	it("plateaus — 1000 pushes never grow the queue past the cap (bounded memory)", () => {
+		const q: number[] = [];
+		let totalDropped = 0;
+		for (let i = 0; i < 1000; i++) totalDropped += pushBoundedSegment(q, i, 3);
+		expect(q).toHaveLength(3);
+		expect(q).toEqual([997, 998, 999]);
+		expect(totalDropped).toBe(997);
+	});
+
+	it("is a no-op bound when under the cap", () => {
+		const q: number[] = [10];
+		expect(pushBoundedSegment(q, 20, 5)).toBe(0);
+		expect(q).toEqual([10, 20]);
+	});
+});
+
+describe("deriveLiveEdgeAction — live-edge policy", () => {
+	it("is a no-op when there is no buffered media yet", () => {
+		const d = deriveLiveEdgeAction(
+			{ bufferedStart: 0, bufferedEnd: 0, currentTime: 0 },
+			POLICY,
+		);
+		expect(d.seekTo).toBeNull();
+		expect(d.playbackRate).toBe(1);
+		expect(d.trimBackBufferTo).toBeNull();
+	});
+
+	it("plays at normal rate with no seek when the playhead is at the live edge", () => {
+		// drift 0.2s < catchupThreshold(0.5) → nothing to do.
+		const d = deriveLiveEdgeAction(
+			{ bufferedStart: 0, bufferedEnd: 5.2, currentTime: 5 },
+			POLICY,
+		);
+		expect(d.seekTo).toBeNull();
+		expect(d.playbackRate).toBe(1);
+	});
+
+	it("applies a modest catch-up playback rate inside the soft window", () => {
+		// drift 0.7s: above catchup(0.5), below seek(1.0) → gentle 1.05, no seek.
+		const d = deriveLiveEdgeAction(
+			{ bufferedStart: 0, bufferedEnd: 5.7, currentTime: 5 },
+			POLICY,
+		);
+		expect(d.seekTo).toBeNull();
+		expect(d.playbackRate).toBe(1.05);
+	});
+
+	it("seeks to the live edge and resets the rate when drift exceeds the seek threshold", () => {
+		// drift 3s > seek(1.0) → hard seek to bufferedEnd - margin, rate back to 1.
+		const d = deriveLiveEdgeAction(
+			{ bufferedStart: 0, bufferedEnd: 8, currentTime: 5 },
+			POLICY,
+		);
+		expect(d.seekTo).toBeCloseTo(7.9, 5);
+		expect(d.playbackRate).toBe(1);
+	});
+
+	it("trims the back-buffer once it grows past the back-buffer window", () => {
+		// currentTime - bufferedStart = 20 > backBufferSec(8) → trim to currentTime - 8.
+		const d = deriveLiveEdgeAction(
+			{ bufferedStart: 0, bufferedEnd: 20.2, currentTime: 20 },
+			POLICY,
+		);
+		expect(d.trimBackBufferTo).toBeCloseTo(12, 5);
+	});
+
+	it("does not trim the back-buffer while it is within the window", () => {
+		const d = deriveLiveEdgeAction(
+			{ bufferedStart: 0, bufferedEnd: 4.1, currentTime: 4 },
+			POLICY,
+		);
+		expect(d.trimBackBufferTo).toBeNull();
+	});
+});
+
+describe("bounded memory under a slow consumer", () => {
+	// A slow SourceBuffer: only one queued segment is appended (drained) per this
+	// many incoming segments. The OLD `pendingSegments.push` had no cap, so the
+	// queue grew without bound; `pushBoundedSegment` plateaus.
+	const DRAIN_EVERY = 10;
+	const CAP = DEFAULT_LIVE_EDGE_POLICY.maxPendingSegments;
+
+	it("plateaus the bounded queue where a naive unbounded push grows forever", () => {
+		const bounded: number[] = [];
+		const legacy: number[] = []; // reproduces the pre-fix unbounded push
+
+		for (let i = 0; i < 5000; i++) {
+			pushBoundedSegment(bounded, i, CAP);
+			legacy.push(i);
+			// Slow consumer: drain a single segment occasionally.
+			if (i % DRAIN_EVERY === 0) {
+				bounded.shift();
+				legacy.shift();
+			}
+		}
+
+		// The bound the OLD code provably violates: the naive queue grew far past
+		// the cap; the bounded queue never did.
+		expect(legacy.length).toBeGreaterThan(CAP);
+		expect(bounded.length).toBeLessThanOrEqual(CAP);
+	});
+
+	it("frees the queue on teardown (resetMedia empties pendingSegments)", () => {
+		const q: number[] = [];
+		for (let i = 0; i < 500; i++) pushBoundedSegment(q, i, CAP);
+		expect(q.length).toBeGreaterThan(0);
+		// resetMedia() clears the queue with `pendingSegments.length = 0`.
+		q.length = 0;
+		expect(q).toHaveLength(0);
+	});
+});
+
+describe("DEFAULT_LIVE_EDGE_POLICY", () => {
+	it("uses a ~1s seek threshold and a 1.05 catch-up rate above a smaller soft window", () => {
+		expect(DEFAULT_LIVE_EDGE_POLICY.seekThresholdSec).toBeCloseTo(1, 5);
+		expect(DEFAULT_LIVE_EDGE_POLICY.catchupPlaybackRate).toBe(1.05);
+		expect(DEFAULT_LIVE_EDGE_POLICY.catchupThresholdSec).toBeLessThan(
+			DEFAULT_LIVE_EDGE_POLICY.seekThresholdSec,
+		);
+		expect(DEFAULT_LIVE_EDGE_POLICY.maxPendingSegments).toBeGreaterThan(0);
+	});
+});

--- a/apps/frontend/src/lib/components/preview/preview-live-edge.ts
+++ b/apps/frontend/src/lib/components/preview/preview-live-edge.ts
@@ -1,0 +1,136 @@
+/**
+ * Pure, rune-free MSE live-edge policy for `PreviewCanvas.svelte`.
+ *
+ * The MSE fallback tier feeds fragmented-MP4 segments into a `<video>`
+ * SourceBuffer. Without a live-edge policy the `<video>` element plays from
+ * wherever it started and the playhead drifts ever further behind live as
+ * segments accumulate — at 1.5 Mbps the proxy's old keep-oldest buffering left
+ * preview ~5.6 s behind. This module is the pure decision core that keeps the
+ * playhead pinned to the live edge:
+ *
+ *   1. `pushBoundedSegment` bounds the pending-append queue (drop-oldest) so a
+ *      stalled SourceBuffer can never grow it without bound.
+ *   2. `deriveLiveEdgeAction` decides, from the current buffered range and
+ *      playhead, whether to hard-seek to the live edge (large drift), apply a
+ *      modest catch-up `playbackRate` (moderate drift, soft window), and/or trim
+ *      the back-buffer.
+ *
+ * Both are pure so the policy is unit-testable in isolation from the Svelte
+ * component (`preview-live-edge.test.ts`).
+ */
+
+/** Tunable thresholds for the live-edge policy. All times are in seconds. */
+export interface LiveEdgePolicy {
+	/** Hard cap on queued (not-yet-appended) media segments — drop-oldest above it. */
+	maxPendingSegments: number;
+	/** Drift above this (below {@link seekThresholdSec}) applies the catch-up rate. */
+	catchupThresholdSec: number;
+	/** Drift above this triggers a hard seek to the live edge. */
+	seekThresholdSec: number;
+	/** The modest playback rate used to gently catch up inside the soft window. */
+	catchupPlaybackRate: number;
+	/** Keep at most this many seconds of already-played media behind the playhead. */
+	backBufferSec: number;
+	/** Seek target is `bufferedEnd - seekMarginSec` (a hair off the very edge). */
+	seekMarginSec: number;
+}
+
+/**
+ * Default policy: seek when >1 s behind live, gently catch up (1.05×) once >0.5 s
+ * behind, trim the back-buffer beyond 8 s, and bound the pending queue at 48
+ * segments (~a few seconds of fragments — ample slack on a briefly-slow
+ * SourceBuffer without unbounded growth).
+ */
+export const DEFAULT_LIVE_EDGE_POLICY: LiveEdgePolicy = {
+	maxPendingSegments: 48,
+	catchupThresholdSec: 0.5,
+	seekThresholdSec: 1,
+	catchupPlaybackRate: 1.05,
+	backBufferSec: 8,
+	seekMarginSec: 0.1,
+};
+
+/**
+ * Push `segment` onto `queue` and enforce a drop-OLDEST bound of `maxSegments`.
+ * Mutates `queue` in place (matching the component's `pendingSegments` array) and
+ * returns the number of oldest segments evicted (0 when under the cap). Keeping
+ * the NEWEST segments is the live-edge choice — a stalled consumer resumes at the
+ * freshest media, and the frontend `deriveLiveEdgeAction` seek closes any gap the
+ * eviction opened.
+ */
+export function pushBoundedSegment<T>(
+	queue: T[],
+	segment: T,
+	maxSegments: number,
+): number {
+	queue.push(segment);
+	let dropped = 0;
+	while (queue.length > maxSegments && queue.length > 0) {
+		queue.shift();
+		dropped++;
+	}
+	return dropped;
+}
+
+/** A snapshot of the `<video>` playback position vs. its buffered range. */
+export interface PlaybackSample {
+	/** `video.buffered.start(0)` — the oldest buffered timestamp. */
+	bufferedStart: number;
+	/** `video.buffered.end(video.buffered.length - 1)` — the live edge. */
+	bufferedEnd: number;
+	/** `video.currentTime` — the playhead. */
+	currentTime: number;
+}
+
+/** The live-edge correction to apply to the `<video>` element this tick. */
+export interface LiveEdgeDecision {
+	/** Seek the playhead here, or `null` to leave it. */
+	seekTo: number | null;
+	/** The `playbackRate` to set (always defined; `1` = normal). */
+	playbackRate: number;
+	/** `SourceBuffer.remove(0, trimBackBufferTo)`, or `null` to leave the buffer. */
+	trimBackBufferTo: number | null;
+}
+
+/**
+ * Decide the live-edge correction for the current {@link PlaybackSample}.
+ *
+ * - No buffered media (`bufferedEnd <= bufferedStart`) → a no-op decision.
+ * - drift (`bufferedEnd - currentTime`) `>` {@link LiveEdgePolicy.seekThresholdSec}
+ *   → hard seek to `bufferedEnd - seekMarginSec`, rate reset to `1`.
+ * - drift `>` {@link LiveEdgePolicy.catchupThresholdSec} (soft window) → keep the
+ *   playhead, apply the modest {@link LiveEdgePolicy.catchupPlaybackRate}.
+ * - otherwise → normal rate `1`, no seek.
+ * - back-buffer (`currentTime - bufferedStart`) `>` {@link LiveEdgePolicy.backBufferSec}
+ *   → trim to `currentTime - backBufferSec` (independent of the drift branch).
+ */
+export function deriveLiveEdgeAction(
+	sample: PlaybackSample,
+	policy: LiveEdgePolicy = DEFAULT_LIVE_EDGE_POLICY,
+): LiveEdgeDecision {
+	const { bufferedStart, bufferedEnd, currentTime } = sample;
+
+	// No usable buffered range yet — nothing to correct.
+	if (!(bufferedEnd > bufferedStart)) {
+		return { seekTo: null, playbackRate: 1, trimBackBufferTo: null };
+	}
+
+	const drift = bufferedEnd - currentTime;
+
+	let seekTo: number | null = null;
+	let playbackRate = 1;
+	if (drift > policy.seekThresholdSec) {
+		seekTo = bufferedEnd - policy.seekMarginSec;
+		playbackRate = 1;
+	} else if (drift > policy.catchupThresholdSec) {
+		playbackRate = policy.catchupPlaybackRate;
+	}
+
+	let trimBackBufferTo: number | null = null;
+	const backBuffer = currentTime - bufferedStart;
+	if (backBuffer > policy.backBufferSec) {
+		trimBackBufferTo = currentTime - policy.backBufferSec;
+	}
+
+	return { seekTo, playbackRate, trimBackBufferTo };
+}


### PR DESCRIPTION
## What

Fixes the MSE preview fallback drifting seconds behind live (~5.6s at 1.5Mbps).

- **Frontend live-edge policy** — extracted into a pure, testable module
  `apps/frontend/src/lib/components/preview/preview-live-edge.ts`:
  - `pushBoundedSegment` — drop-oldest bound on the pending append queue.
  - `deriveLiveEdgeAction` — seek to the live edge past ~1s drift, a modest
    1.05× catch-up `playbackRate` inside a soft window, and back-buffer trim.
  - Wired into `PreviewCanvas.svelte`'s MSE path (`appendMseSegment` → bounded
    push + `applyLiveEdge()`).
- **Backend bounded drop-oldest proxy** — new
  `apps/backend/src/modules/ui/preview-frame-queue.ts` (`BoundedDropOldestQueue`):
  drops oldest media by frame/byte cap, PINS the newest MSE init (codec-config)
  segment and keeps the latest fragments. `preview-proxy.ts` now enqueues while
  paused instead of closing the socket on overflow; `PREVIEW_MAX_PENDING_FRAMES`
  512 → 256 + a new `PREVIEW_MAX_PENDING_BYTES` (1 MiB); socket close frees the
  queue via `freePreviewProxyState`.
- **Docs (Rule A, same commit)** — `apps/backend/AGENTS.md` proxy invariant
  rewritten from "NEVER drop-oldest" to the bounded drop-oldest contract.

## Why

Root cause (research bg_3a9ddfd6): the proxy held a 1 MiB + 512-frame **keep-OLD**
buffer and tore the socket down on overflow, while the frontend's
`pendingSegments` queue was **unbounded**. Under a slow consumer this both grew
memory without bound (frontend) and killed the preview (backend), and left the
playhead drifting far behind live. The fix keeps memory bounded, keeps the socket
open, and pins the playhead to the live edge (skip-on-lag).

Scope note: this is the **CeraUI half** of the todo. The cerastream-engine half
(attach the MSE publisher during active sessions + reduce preview `key-int-max`)
lands separately.

## How to verify

- Backend: `bun test src/tests/preview-frame-queue.test.ts src/tests/preview-proxy-bounded.test.ts src/tests/preview-proxy.test.ts` → 22 pass.
- Frontend: `vitest run src/lib/components/preview/preview-live-edge.test.ts` → 12 pass (pure module, `@vitest-environment node`).
- Bounded-memory: `preview-proxy-bounded.test.ts` drives a slow-consumer fake for
  5000 frames — the queue plateaus, the socket stays open, the init segment
  survives; an in-file `legacyForward` reproduces the old close-on-overflow to
  lock the bound the old code violated.
- Teardown: `freePreviewProxyState`/`closeDown` clear the queue to 0 bytes.

## Risks

- Low. The change is scoped to the preview backpressure path; the live-edge policy
  is a pure module with unit tests. The `backpressure` availability band is kept
  for wire/UI compat even though the new proxy no longer emits that close reason.
- The MSE tier is fixed, not removed; WebCodecs path is untouched.