### PR TITLE
feat(notifications): action descriptors, typed remove, durable dismissal, expiry semantics

### DIFF
--- a/apps/backend/src/modules/ui/notification-dismissals.ts
+++ b/apps/backend/src/modules/ui/notification-dismissals.ts
@@ -1,0 +1,212 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Durable notification-dismissal store (device-quality-wave2 Todo 23c/d).
+ *
+ * Records which notifications an operator dismissed, keyed by SEMANTIC identity
+ * (for update notifications: the version string), so a dismissal survives a page
+ * reload AND a backend restart — the in-memory Map it replaces did neither.
+ *
+ * Durability model (mirrors config.json — see docs/CONFIG_PERSISTENCE.md):
+ *   - writes are atomic (temp file → fsync → rename), so a crash mid-write can
+ *     never truncate the committed file.
+ *   - the set is LRU-bounded; the oldest dismissal is evicted past the cap so a
+ *     device that runs for years never grows the file without bound.
+ *   - an unparseable/wrong-shape file is QUARANTINED (renamed aside), the store
+ *     starts fresh, and the event is logged — a corrupt file never crashes boot.
+ */
+
+import fs from "node:fs";
+
+import { z } from "zod";
+import { writeFileAtomicSync } from "../../helpers/config-loader.ts";
+import { logger } from "../../helpers/logger.ts";
+
+export { writeFileAtomicSync };
+
+export const DISMISSAL_STORE_VERSION = 1;
+export const DEFAULT_MAX_DISMISSALS = 256;
+
+const dismissalFileSchema = z.object({
+	version: z.number(),
+	entries: z.array(z.object({ key: z.string(), dismissedAt: z.number() })),
+});
+
+export interface DismissalStoreDeps {
+	readText(target: string): string | undefined;
+	writeAtomic(target: string, contents: string): void;
+	quarantine(target: string, corruptPath: string): void;
+	now(): number;
+	logCorruption(target: string, corruptPath: string, err: unknown): void;
+}
+
+const defaultDeps: DismissalStoreDeps = {
+	readText(target) {
+		try {
+			return fs.readFileSync(target, "utf8");
+		} catch (err) {
+			if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+			throw err;
+		}
+	},
+	writeAtomic(target, contents) {
+		writeFileAtomicSync(target, contents);
+	},
+	quarantine(target, corruptPath) {
+		fs.renameSync(target, corruptPath);
+	},
+	now() {
+		return Date.now();
+	},
+	logCorruption(target, corruptPath, err) {
+		logger.warn(
+			`Corrupt notification-dismissal store ${target}; quarantined to ${corruptPath} and starting fresh: ${err}`,
+		);
+	},
+};
+
+export interface DismissalStoreOptions {
+	path: string;
+	maxEntries?: number;
+	deps?: Partial<DismissalStoreDeps>;
+}
+
+export class NotificationDismissalStore {
+	private readonly path: string;
+	private readonly maxEntries: number;
+	private readonly deps: DismissalStoreDeps;
+	// Insertion order is LRU order: the front is the least-recently-dismissed.
+	private entries = new Map<string, number>();
+
+	constructor(options: DismissalStoreOptions) {
+		this.path = options.path;
+		this.maxEntries = options.maxEntries ?? DEFAULT_MAX_DISMISSALS;
+		this.deps = { ...defaultDeps, ...options.deps };
+	}
+
+	load(): void {
+		const raw = this.deps.readText(this.path);
+		if (raw === undefined) {
+			this.entries = new Map();
+			return;
+		}
+
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(raw);
+		} catch (err) {
+			this.quarantineAndReset(err);
+			return;
+		}
+
+		const result = dismissalFileSchema.safeParse(parsed);
+		if (!result.success) {
+			this.quarantineAndReset(result.error);
+			return;
+		}
+
+		this.entries = new Map();
+		for (const entry of result.data.entries) {
+			this.entries.set(entry.key, entry.dismissedAt);
+		}
+		this.evictOverflow();
+	}
+
+	isDismissed(key: string): boolean {
+		return this.entries.has(key);
+	}
+
+	recordDismissal(key: string): void {
+		this.entries.delete(key);
+		this.entries.set(key, this.deps.now());
+		this.evictOverflow();
+		this.persist();
+	}
+
+	size(): number {
+		return this.entries.size;
+	}
+
+	keys(): string[] {
+		return [...this.entries.keys()];
+	}
+
+	clear(): void {
+		this.entries = new Map();
+	}
+
+	private evictOverflow(): void {
+		while (this.entries.size > this.maxEntries) {
+			const oldest = this.entries.keys().next().value;
+			if (oldest === undefined) break;
+			this.entries.delete(oldest);
+		}
+	}
+
+	private persist(): void {
+		const file = {
+			version: DISMISSAL_STORE_VERSION,
+			entries: [...this.entries].map(([key, dismissedAt]) => ({
+				key,
+				dismissedAt,
+			})),
+		};
+		this.deps.writeAtomic(this.path, JSON.stringify(file));
+	}
+
+	private quarantineAndReset(err: unknown): void {
+		const corruptPath = `${this.path}.corrupt-${this.deps.now()}`;
+		try {
+			this.deps.quarantine(this.path, corruptPath);
+			this.deps.logCorruption(this.path, corruptPath, err);
+		} catch (quarantineErr) {
+			logger.warn(
+				`Failed to quarantine corrupt notification-dismissal store ${this.path}: ${quarantineErr}`,
+			);
+		}
+		this.entries = new Map();
+	}
+}
+
+const DEFAULT_DISMISSALS_FILE = "notification_dismissals.json";
+
+function dismissalsPath(): string {
+	return process.env.CERALIVE_DISMISSALS_FILE ?? DEFAULT_DISMISSALS_FILE;
+}
+
+let singleton: NotificationDismissalStore | undefined;
+
+export function getDismissalStore(): NotificationDismissalStore {
+	if (!singleton) {
+		singleton = new NotificationDismissalStore({ path: dismissalsPath() });
+		singleton.load();
+	}
+	return singleton;
+}
+
+export function isNotificationDismissed(key: string): boolean {
+	return getDismissalStore().isDismissed(key);
+}
+
+export function recordNotificationDismissal(key: string): void {
+	getDismissalStore().recordDismissal(key);
+}
+
+export function resetDismissalStoreForTests(): void {
+	singleton = undefined;
+}

--- a/apps/backend/src/modules/ui/notification-liveness.ts
+++ b/apps/backend/src/modules/ui/notification-liveness.ts
@@ -1,0 +1,74 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Pure notification-liveness arithmetic (device-quality-wave2 Todo 23b).
+ *
+ * Extracted from `notifications.ts` so the expiry semantics are unit-testable
+ * without a clock, a socket, or the module's persistent-map state.
+ *
+ * Semantics (the fix):
+ *   - A PERSISTENT notification never expires on a timer. It is shown to every
+ *     new client and cleared only by an explicit remove/dismiss, so `duration`
+ *     does NOT apply to it. This was the bug: the old code expired persistent
+ *     notifications once their duration elapsed.
+ *   - `duration` governs ONLY non-persistent notifications: `0` means "never
+ *     expires", any positive value is a countdown in whole seconds.
+ *
+ * Return contract (matches the historical `_notificationIsLive` return):
+ *   - `false`  => expired; the caller must drop it.
+ *   - `0`      => lives forever (no countdown — the `NOTIFICATION_LIVES_FOREVER`
+ *                 sentinel). Callers test `!== false`, so `0` reads as "live".
+ *   - `n > 0`  => still live; `n` whole seconds remain.
+ */
+
+/** Sentinel: the notification never times out (no countdown). */
+export const NOTIFICATION_LIVES_FOREVER = 0;
+
+export interface NotificationLivenessInput {
+	/** Persistent notifications never expire on a timer. */
+	isPersistent: boolean;
+	/** Countdown length in seconds; `0` = never expires. Non-persistent only. */
+	duration: number;
+	/** Timestamp (ms) the notification was last updated/created. */
+	updatedMs: number;
+	/** Current time (ms). Injected so the arithmetic is clock-free and testable. */
+	nowMs: number;
+}
+
+/**
+ * Compute a notification's remaining liveness.
+ *
+ * @returns `false` when expired, `0` when it lives forever, or the positive
+ *   whole-second remainder while a timed (non-persistent) notification is live.
+ */
+export function notificationRemaining(
+	input: NotificationLivenessInput,
+): number | false {
+	// Persistent: never expires — `duration` does not apply.
+	if (input.isPersistent) return NOTIFICATION_LIVES_FOREVER;
+
+	// Non-persistent with no duration: also never expires.
+	if (input.duration === 0) return NOTIFICATION_LIVES_FOREVER;
+
+	// Non-persistent countdown. A backwards clock skew (nowMs < updatedMs)
+	// yields negative elapsed → remaining > duration → still live: a skew never
+	// prematurely expires a notification.
+	const elapsedSeconds = (input.nowMs - input.updatedMs) / 1000;
+	const remaining = Math.ceil(input.duration - elapsedSeconds);
+	return remaining <= 0 ? false : remaining;
+}

--- a/apps/backend/src/modules/ui/notifications.ts
+++ b/apps/backend/src/modules/ui/notifications.ts
@@ -28,9 +28,16 @@
   isDismissable - is the user allowed to hide it?
 */
 
+import type { NotificationAction } from "@ceraui/rpc/schemas";
+
 import { logger } from "../../helpers/logger.ts";
 import { getms } from "../../helpers/time.ts";
 import type { MessageSocket } from "./message-socket.ts";
+import {
+	isNotificationDismissed,
+	recordNotificationDismissal,
+} from "./notification-dismissals.ts";
+import { notificationRemaining } from "./notification-liveness.ts";
 import {
 	broadcastMsg,
 	buildMsg,
@@ -47,17 +54,34 @@ type Notification = {
 	isPersistent: boolean;
 	isDismissable: boolean;
 	authedOnly: boolean;
+	action?: NotificationAction;
+	dismissalKey?: string;
 };
 
 type PersistentNotification = Notification & {
 	isPersistent: true;
 	last_sent: number;
 	updated: number;
+	revision: number;
+};
+
+export type NotificationOptions = {
+	action?: NotificationAction;
+	dismissalKey?: string;
 };
 
 const persistentNotifications = new Map<string, PersistentNotification>();
 
-export function buildNotificationMsg(n: Notification, duration: number) {
+let revisionCounter = 0;
+function nextRevision(): number {
+	return ++revisionCounter;
+}
+
+export function buildNotificationMsg(
+	n: Notification,
+	duration: number,
+	revision?: number,
+) {
 	return {
 		name: n.name,
 		type: n.type,
@@ -65,6 +89,8 @@ export function buildNotificationMsg(n: Notification, duration: number) {
 		// Omit key/params when absent so legacy msg-only notifications keep their wire shape.
 		...(n.key !== undefined ? { key: n.key } : {}),
 		...(n.params !== undefined ? { params: n.params } : {}),
+		...(n.action !== undefined ? { action: n.action } : {}),
+		...(revision !== undefined ? { revision } : {}),
 		is_dismissable: n.isDismissable,
 		is_persistent: n.isPersistent,
 		duration,
@@ -82,9 +108,17 @@ export function notificationSend(
 	authedOnly = true,
 	key?: Notification["key"],
 	params?: Notification["params"],
+	opts?: NotificationOptions,
 ) {
 	if (isPersistent && conn !== undefined) {
 		logger.error("error: attempted to send persistent unicast notification");
+		return false;
+	}
+
+	// A persistent notification carrying a semantic dismissal key that the
+	// operator already dismissed stays suppressed across reloads and restarts.
+	const dismissalKey = opts?.dismissalKey;
+	if (isPersistent && dismissalKey && isNotificationDismissed(dismissalKey)) {
 		return false;
 	}
 
@@ -94,12 +128,15 @@ export function notificationSend(
 		msg,
 		...(key !== undefined ? { key } : {}),
 		...(params !== undefined ? { params } : {}),
+		...(opts?.action !== undefined ? { action: opts.action } : {}),
+		...(dismissalKey !== undefined ? { dismissalKey } : {}),
 		isDismissable,
 		isPersistent,
 		duration,
 		authedOnly,
 	};
 	let doSend = true;
+	let revision: number | undefined;
 	if (isPersistent) {
 		let pn = persistentNotifications.get(name);
 		if (pn) {
@@ -109,6 +146,7 @@ export function notificationSend(
 			}
 			Object.assign(pn, notification);
 			pn.updated = getms();
+			pn.revision = nextRevision();
 			if (doSend) {
 				pn.last_sent = getms();
 			}
@@ -118,15 +156,17 @@ export function notificationSend(
 				isPersistent: true,
 				last_sent: 0,
 				updated: getms(),
+				revision: nextRevision(),
 			};
 			persistentNotifications.set(name, pn);
 		}
+		revision = pn.revision;
 	}
 
 	if (!doSend) return;
 
 	const notificationMsg = {
-		show: [buildNotificationMsg(notification, duration)],
+		show: [buildNotificationMsg(notification, duration, revision)],
 	};
 	if (conn) {
 		const senderId = getSocketSenderId(conn);
@@ -150,6 +190,7 @@ export function notificationBroadcast(
 	authedOnly = true,
 	key?: Notification["key"],
 	params?: Notification["params"],
+	opts?: NotificationOptions,
 ) {
 	notificationSend(
 		undefined,
@@ -162,6 +203,7 @@ export function notificationBroadcast(
 		authedOnly,
 		key,
 		params,
+		opts,
 	);
 }
 
@@ -169,39 +211,58 @@ export function notificationRemove(name: string) {
 	const n = persistentNotifications.get(name);
 	persistentNotifications.delete(name);
 
-	const msg = { remove: [name] };
+	const msg = { remove: [{ id: name, revision: nextRevision() }] };
 	broadcastMsg("notification", msg, 0, !n || n.authedOnly);
+	return msg;
 }
 
-function _notificationIsLive(n: PersistentNotification) {
-	if (n.duration === 0) return 0;
-
-	const remainingDuration = Math.ceil(
-		n.duration - (getms() - n.updated) / 1000,
-	);
-	if (remainingDuration <= 0) {
-		persistentNotifications.delete(n.name);
-		return false;
+// Persists the dismissal (survives reload + restart) only when the notification
+// carries a semantic dismissalKey; a keyless notification is merely removed.
+export function notificationDismiss(name: string) {
+	const pn = persistentNotifications.get(name);
+	if (pn?.dismissalKey) {
+		recordNotificationDismissal(pn.dismissalKey);
 	}
-	return remainingDuration;
+	return notificationRemove(name);
 }
 
-export function notificationExists(name: string) {
+function _notificationIsLive(
+	n: PersistentNotification,
+	nowMs: number = getms(),
+) {
+	const remaining = notificationRemaining({
+		isPersistent: n.isPersistent,
+		duration: n.duration,
+		updatedMs: n.updated,
+		nowMs,
+	});
+	if (remaining === false) {
+		persistentNotifications.delete(n.name);
+	}
+	return remaining;
+}
+
+export function notificationExists(name: string, nowMs: number = getms()) {
 	const pn = persistentNotifications.get(name);
 	if (!pn) return;
 
-	if (_notificationIsLive(pn) !== false) return pn;
+	if (_notificationIsLive(pn, nowMs) !== false) return pn;
 	return undefined;
 }
 
-export function getPersistentNotifications(isAuthed = false) {
+export function getPersistentNotifications(
+	isAuthed = false,
+	nowMs: number = getms(),
+) {
 	const notifications = [];
 	for (const n of persistentNotifications) {
 		if (!isAuthed && n[1].authedOnly) continue;
 
-		const remainingDuration = _notificationIsLive(n[1]);
+		const remainingDuration = _notificationIsLive(n[1], nowMs);
 		if (remainingDuration !== false) {
-			notifications.push(buildNotificationMsg(n[1], remainingDuration));
+			notifications.push(
+				buildNotificationMsg(n[1], remainingDuration, n[1].revision),
+			);
 		}
 	}
 

--- a/apps/backend/src/rpc/procedures/notifications.procedure.ts
+++ b/apps/backend/src/rpc/procedures/notifications.procedure.ts
@@ -12,8 +12,8 @@ import { z } from "zod";
 
 import {
 	getPersistentNotifications,
+	notificationDismiss,
 	notificationExists,
-	notificationRemove,
 } from "../../modules/ui/notifications.ts";
 import { authMiddleware } from "../middleware/auth.middleware.ts";
 import type { RPCContext } from "../types.ts";
@@ -49,7 +49,7 @@ export const dismissNotificationProcedure = authedProcedure
 		// Check if notification exists before removing
 		const exists = notificationExists(name);
 		if (exists) {
-			notificationRemove(name);
+			notificationDismiss(name);
 		}
 
 		return { success: true };

--- a/apps/backend/src/tests/notification-dismissals.test.ts
+++ b/apps/backend/src/tests/notification-dismissals.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Durable notification-dismissal store tests (device-quality-wave2 Todo 23c).
+ *
+ * The store records which notifications an operator dismissed, keyed by SEMANTIC
+ * identity (for update notifications: the version string), so a dismissal
+ * survives a page reload AND a backend restart. Requirements pinned here:
+ *   - atomic write   — a kill mid-write leaves the OLD committed file valid
+ *   - quarantine     — an unparseable file is renamed aside, store starts fresh
+ *   - LRU bound      — exceeding the cap evicts the oldest dismissal
+ *   - restart replay — a new instance loads the same keys off disk
+ *   - semantic keys  — a NEW version key is not covered by an OLD dismissal
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { NotificationDismissalStore } from "../modules/ui/notification-dismissals.ts";
+
+let dir: string;
+let storePath: string;
+
+beforeEach(() => {
+	dir = fs.mkdtempSync(path.join(os.tmpdir(), "ceraui-dismissals-"));
+	storePath = path.join(dir, "notification_dismissals.json");
+});
+
+afterEach(() => {
+	fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("restart persistence + semantic keying", () => {
+	it("a recorded dismissal is readable by a fresh instance (restart)", () => {
+		const first = new NotificationDismissalStore({ path: storePath });
+		first.load();
+		first.recordDismissal("update:2026.7.3");
+
+		const afterRestart = new NotificationDismissalStore({ path: storePath });
+		afterRestart.load();
+		expect(afterRestart.isDismissed("update:2026.7.3")).toBe(true);
+	});
+
+	it("a NEW version key is not covered by the OLD version's dismissal", () => {
+		const store = new NotificationDismissalStore({ path: storePath });
+		store.load();
+		store.recordDismissal("update:2026.7.3");
+
+		expect(store.isDismissed("update:2026.7.3")).toBe(true);
+		expect(store.isDismissed("update:2026.7.4")).toBe(false);
+	});
+});
+
+describe("atomic write", () => {
+	it("a kill mid-write leaves the OLD committed file valid", () => {
+		const committed = new NotificationDismissalStore({ path: storePath });
+		committed.load();
+		committed.recordDismissal("update:1.0.0");
+
+		const crashingWrite = (target: string, contents: string): void => {
+			const tmp = path.join(
+				path.dirname(target),
+				`.${path.basename(target)}.${process.pid}.tmp`,
+			);
+			fs.writeFileSync(tmp, contents.slice(0, contents.length >> 1));
+			throw new Error("simulated crash before rename");
+		};
+
+		const crashing = new NotificationDismissalStore({
+			path: storePath,
+			deps: { writeAtomic: crashingWrite },
+		});
+		crashing.load();
+		expect(() => crashing.recordDismissal("update:2.0.0")).toThrow();
+
+		const recovered = new NotificationDismissalStore({ path: storePath });
+		recovered.load();
+		expect(recovered.isDismissed("update:1.0.0")).toBe(true);
+		expect(recovered.isDismissed("update:2.0.0")).toBe(false);
+	});
+});
+
+describe("corruption quarantine", () => {
+	it("quarantines an unparseable file, starts fresh, logs, and never throws", () => {
+		fs.writeFileSync(storePath, "{{{ not json at all");
+
+		const quarantined: string[] = [];
+		const logged: string[] = [];
+		const store = new NotificationDismissalStore({
+			path: storePath,
+			deps: {
+				logCorruption: (_p, corruptPath) => {
+					quarantined.push(corruptPath);
+					logged.push(corruptPath);
+				},
+			},
+		});
+
+		expect(() => store.load()).not.toThrow();
+		expect(store.size()).toBe(0);
+		expect(logged.length).toBe(1);
+
+		const corruptFiles = fs
+			.readdirSync(dir)
+			.filter((f) => f.includes(".corrupt-"));
+		expect(corruptFiles.length).toBe(1);
+		expect(
+			fs.readFileSync(path.join(dir, corruptFiles[0] as string), "utf8"),
+		).toBe("{{{ not json at all");
+
+		store.recordDismissal("update:3.0.0");
+		expect(store.isDismissed("update:3.0.0")).toBe(true);
+	});
+
+	it("quarantines a well-formed-JSON-but-wrong-shape file", () => {
+		fs.writeFileSync(storePath, JSON.stringify({ totally: "wrong" }));
+		const store = new NotificationDismissalStore({ path: storePath });
+		expect(() => store.load()).not.toThrow();
+		expect(store.size()).toBe(0);
+		expect(fs.readdirSync(dir).some((f) => f.includes(".corrupt-"))).toBe(true);
+	});
+});
+
+describe("LRU bound", () => {
+	it("evicts the oldest dismissal past the cap", () => {
+		const store = new NotificationDismissalStore({
+			path: storePath,
+			maxEntries: 3,
+		});
+		store.load();
+		store.recordDismissal("a");
+		store.recordDismissal("b");
+		store.recordDismissal("c");
+		store.recordDismissal("d");
+
+		expect(store.size()).toBe(3);
+		expect(store.isDismissed("a")).toBe(false);
+		expect(store.isDismissed("b")).toBe(true);
+		expect(store.isDismissed("c")).toBe(true);
+		expect(store.isDismissed("d")).toBe(true);
+	});
+
+	it("re-recording a key refreshes its recency so it survives eviction", () => {
+		const store = new NotificationDismissalStore({
+			path: storePath,
+			maxEntries: 3,
+		});
+		store.load();
+		store.recordDismissal("a");
+		store.recordDismissal("b");
+		store.recordDismissal("c");
+		store.recordDismissal("a");
+		store.recordDismissal("d");
+
+		expect(store.isDismissed("a")).toBe(true);
+		expect(store.isDismissed("b")).toBe(false);
+		expect(store.size()).toBe(3);
+	});
+
+	it("enforces the cap when loading an over-cap file off disk", () => {
+		const over = {
+			version: 1,
+			entries: [
+				{ key: "a", dismissedAt: 1 },
+				{ key: "b", dismissedAt: 2 },
+				{ key: "c", dismissedAt: 3 },
+				{ key: "d", dismissedAt: 4 },
+			],
+		};
+		fs.writeFileSync(storePath, JSON.stringify(over));
+		const store = new NotificationDismissalStore({
+			path: storePath,
+			maxEntries: 2,
+		});
+		store.load();
+		expect(store.size()).toBe(2);
+		expect(store.isDismissed("c")).toBe(true);
+		expect(store.isDismissed("d")).toBe(true);
+		expect(store.isDismissed("a")).toBe(false);
+	});
+});

--- a/apps/backend/src/tests/notification-durable-dismissal.test.ts
+++ b/apps/backend/src/tests/notification-durable-dismissal.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Durable dismissal wiring (device-quality-wave2 Todo 23d).
+ *
+ * Dismissing a persistent notification that carries a semantic dismissal key must
+ * suppress it on a later re-emit (page reload) AND after a backend restart — the
+ * old in-memory Map did neither. Keyed by semantic identity, so a NEW version's
+ * notification is NOT suppressed by the OLD version's dismissal.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { resetDismissalStoreForTests } from "../modules/ui/notification-dismissals.ts";
+import {
+	getPersistentNotifications,
+	notificationDismiss,
+	notificationRemove,
+	notificationSend,
+} from "../modules/ui/notifications.ts";
+
+let dir: string;
+const emitted = new Set<string>();
+
+beforeEach(() => {
+	dir = fs.mkdtempSync(path.join(os.tmpdir(), "ceraui-dismiss-wire-"));
+	process.env.CERALIVE_DISMISSALS_FILE = path.join(dir, "dismissals.json");
+	resetDismissalStoreForTests();
+});
+
+afterEach(() => {
+	for (const name of emitted) notificationRemove(name);
+	emitted.clear();
+	resetDismissalStoreForTests();
+	process.env.CERALIVE_DISMISSALS_FILE = undefined;
+	fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function isShown(name: string): boolean {
+	return getPersistentNotifications(true).show.some((s) => s.name === name);
+}
+
+function sendUpdate(version: string) {
+	emitted.add("software_update");
+	notificationSend(
+		undefined,
+		"software_update",
+		"success",
+		`Update ${version} available`,
+		0,
+		true,
+		true,
+		true,
+		undefined,
+		undefined,
+		{ dismissalKey: `update:${version}` },
+	);
+}
+
+describe("durable dismissal wiring", () => {
+	it("suppresses a re-emit after dismissal (page reload)", () => {
+		sendUpdate("2026.7.3");
+		expect(isShown("software_update")).toBe(true);
+
+		notificationDismiss("software_update");
+		expect(isShown("software_update")).toBe(false);
+
+		// Producer re-emits the SAME semantic identity (e.g. periodic apt check).
+		sendUpdate("2026.7.3");
+		expect(isShown("software_update")).toBe(false);
+	});
+
+	it("survives a backend restart (store reloaded from disk)", () => {
+		sendUpdate("2026.7.3");
+		notificationDismiss("software_update");
+
+		// Simulate a restart: drop the in-memory store + notification, reload store
+		// from disk on next access.
+		notificationRemove("software_update");
+		resetDismissalStoreForTests();
+
+		sendUpdate("2026.7.3");
+		expect(isShown("software_update")).toBe(false);
+	});
+
+	it("a NEW version re-notifies despite the OLD version's dismissal", () => {
+		sendUpdate("2026.7.3");
+		notificationDismiss("software_update");
+		notificationRemove("software_update");
+
+		sendUpdate("2026.7.4");
+		expect(isShown("software_update")).toBe(true);
+	});
+
+	it("a notification WITHOUT a dismissal key is not durably suppressed", () => {
+		emitted.add("hdmi_error");
+		const send = () =>
+			notificationSend(
+				undefined,
+				"hdmi_error",
+				"error",
+				"HDMI signal issues",
+				0,
+				true,
+			);
+		send();
+		expect(isShown("hdmi_error")).toBe(true);
+
+		notificationDismiss("hdmi_error");
+		expect(isShown("hdmi_error")).toBe(false);
+
+		// Re-emit: a keyless notification reappears (current behavior preserved).
+		send();
+		expect(isShown("hdmi_error")).toBe(true);
+	});
+
+	it("the remove message is the typed { id, revision } shape", () => {
+		emitted.add("some_note");
+		notificationSend(undefined, "some_note", "warning", "note", 0, true);
+		const msg = notificationRemove("some_note");
+		expect(msg.remove).toHaveLength(1);
+		expect(msg.remove[0]?.id).toBe("some_note");
+		expect(typeof msg.remove[0]?.revision).toBe("number");
+	});
+});

--- a/apps/backend/src/tests/notification-liveness.test.ts
+++ b/apps/backend/src/tests/notification-liveness.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Notification liveness / expiry-semantics tests (device-quality-wave2 Todo 23b).
+ *
+ * The bug: `_notificationIsLive` expired PERSISTENT notifications once their
+ * `duration` elapsed — but a persistent notification (shown to every new client,
+ * cleared only explicitly) must NEVER time out. Correct semantics:
+ *   - persistent  ⇒ no timer expiry, ever (duration does not apply)
+ *   - duration    ⇒ only governs non-persistent notifications
+ *
+ * The integration test drives the real notifications module with an injected
+ * clock (`nowMs`); the pure-function suite pins the boundary/skew arithmetic.
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { getms } from "../helpers/time.ts";
+import {
+	NOTIFICATION_LIVES_FOREVER,
+	notificationRemaining,
+} from "../modules/ui/notification-liveness.ts";
+import {
+	getPersistentNotifications,
+	notificationRemove,
+	notificationSend,
+} from "../modules/ui/notifications.ts";
+
+const emitted = new Set<string>();
+
+afterEach(() => {
+	for (const name of emitted) notificationRemove(name);
+	emitted.clear();
+});
+
+function sendPersistentWithDuration(name: string, durationSeconds: number) {
+	emitted.add(name);
+	notificationSend(
+		undefined,
+		name,
+		"warning",
+		"a persistent notification with a nonzero duration",
+		durationSeconds,
+		true, // isPersistent
+		true, // isDismissable
+		true, // authedOnly
+	);
+}
+
+describe("persistent notifications never expire on a timer", () => {
+	it("stays live well past its duration (the F13 expiry bug)", () => {
+		const name = "persistent_never_expires";
+		const before = getms();
+		sendPersistentWithDuration(name, 5);
+
+		// Simulate 60s later — far past the 5s duration.
+		const future = before + 60_000;
+		const { show } = getPersistentNotifications(true, future);
+		const entry = show.find((s) => s.name === name);
+
+		// A persistent notification MUST still be present. Under the pre-fix
+		// semantics `_notificationIsLive` returns false here (expired) and drops it.
+		expect(entry).toBeDefined();
+	});
+
+	it("a persistent notification with duration=0 also stays live (unchanged)", () => {
+		const name = "persistent_zero_duration";
+		const before = getms();
+		sendPersistentWithDuration(name, 0);
+
+		const { show } = getPersistentNotifications(true, before + 60_000);
+		expect(show.find((s) => s.name === name)).toBeDefined();
+	});
+});
+
+describe("notificationRemaining — pure boundary arithmetic (non-persistent)", () => {
+	it("persistent ⇒ never expires regardless of elapsed time or duration", () => {
+		expect(
+			notificationRemaining({
+				isPersistent: true,
+				duration: 5,
+				updatedMs: 0,
+				nowMs: 1_000_000,
+			}),
+		).toBe(NOTIFICATION_LIVES_FOREVER);
+	});
+
+	it("non-persistent duration=0 ⇒ never expires", () => {
+		expect(
+			notificationRemaining({
+				isPersistent: false,
+				duration: 0,
+				updatedMs: 0,
+				nowMs: 1_000_000,
+			}),
+		).toBe(NOTIFICATION_LIVES_FOREVER);
+	});
+
+	it("is still live one tick before the duration boundary", () => {
+		// 4.999s elapsed of a 5s countdown → 1 whole second remains (ceil).
+		expect(
+			notificationRemaining({
+				isPersistent: false,
+				duration: 5,
+				updatedMs: 0,
+				nowMs: 4_999,
+			}),
+		).toBe(1);
+	});
+
+	it("expires at EXACTLY the duration boundary", () => {
+		// 5.000s elapsed of a 5s countdown → expired.
+		expect(
+			notificationRemaining({
+				isPersistent: false,
+				duration: 5,
+				updatedMs: 0,
+				nowMs: 5_000,
+			}),
+		).toBe(false);
+	});
+
+	it("is expired past the duration boundary", () => {
+		expect(
+			notificationRemaining({
+				isPersistent: false,
+				duration: 5,
+				updatedMs: 0,
+				nowMs: 6_000,
+			}),
+		).toBe(false);
+	});
+
+	it("mid-duration restart (updatedMs re-seeded) resumes a full countdown", () => {
+		// A restart re-creates the notification with updatedMs = restart time, so
+		// the remaining time is measured from the restart, not the original send.
+		const restartMs = 100_000;
+		expect(
+			notificationRemaining({
+				isPersistent: false,
+				duration: 10,
+				updatedMs: restartMs,
+				nowMs: restartMs + 3_000,
+			}),
+		).toBe(7);
+	});
+
+	it("tolerates backwards clock skew without premature expiry", () => {
+		// nowMs < updatedMs (clock jumped backwards) → never returns false.
+		const result = notificationRemaining({
+			isPersistent: false,
+			duration: 5,
+			updatedMs: 10_000,
+			nowMs: 2_000,
+		});
+		expect(result).not.toBe(false);
+		expect(typeof result).toBe("number");
+	});
+});

--- a/apps/frontend/src/lib/rpc/subscriptions.svelte.ts
+++ b/apps/frontend/src/lib/rpc/subscriptions.svelte.ts
@@ -26,7 +26,7 @@ import type {
 	StatusResponse,
 	WifiStatus,
 } from "@ceraui/rpc/schemas";
-
+import { notificationsMessageSchema } from "@ceraui/rpc/schemas";
 import { downloadLog } from "$lib/helpers/SystemHelper";
 import { authStatusStore } from "$lib/stores/auth-status.svelte";
 import { ingestBuffering } from "$lib/stores/buffering.svelte";
@@ -581,16 +581,17 @@ function handleMessage(type: string, data: unknown, seq?: number): void {
 
 		// SINGULAR: the backend broadcasts `buildMsg("notification", …)`; the plural never hits the wire.
 		case "notification": {
-			// `show` adds/updates; `remove` (backend `notificationRemove`, or
-			// another client dismissing a persistent item) drops it live. The
-			// remove-only frame carries no `show`, so both arrays are optional.
-			const message = data as NotificationsMessage & { remove?: string[] };
-			notificationsState = data as NotificationsMessage;
+			// `show` adds/updates; typed `remove` drops by id. A malformed frame is
+			// skipped rather than cast blindly into the store.
+			const parsed = notificationsMessageSchema.safeParse(data);
+			if (!parsed.success) break;
+			const message = parsed.data;
+			notificationsState = message;
 			for (const notification of message.show ?? []) {
 				pushNotification(notification);
 			}
-			for (const name of message.remove ?? []) {
-				dismissNotification(name);
+			for (const entry of message.remove ?? []) {
+				dismissNotification(entry.id);
 			}
 			break;
 		}

--- a/docs/CONFIG_PERSISTENCE.md
+++ b/docs/CONFIG_PERSISTENCE.md
@@ -40,6 +40,56 @@ any leftover from a prior crash, fail-soft, every boot.
 | File | Writer | Atomicity | Notes |
 |------|--------|-----------|-------|
 | `config.json` | `saveConfig` (`modules/config.ts:93`) | Atomic (`writeFileAtomicSync`) | The single runtime state file: relay target, audio/video settings, kiosk state, add-on state, and (see below) the password/SSH hashes. Pre-dates T6 (E3 guardrail); unchanged by this wave. |
+| `notification_dismissals.json` | `NotificationDismissalStore.recordDismissal` (`modules/ui/notification-dismissals.ts`) | Atomic (`writeFileAtomicSync`) | Durable record of which persistent notifications the operator dismissed, keyed by SEMANTIC identity so a dismissal survives a page reload AND a backend restart. LRU-bounded, corruption-quarantined. Path overridable via `CERALIVE_DISMISSALS_FILE` (tests). See the dedicated subsection below. |
+
+#### Notification dismissal store — on-disk format + semantics
+
+The durable dismissal store (`apps/backend/src/modules/ui/notification-dismissals.ts`)
+records which persistent notifications an operator dismissed so they stay
+dismissed. It replaces an in-memory `Map` that survived neither a page reload nor
+a backend restart.
+
+**On-disk format** (`notification_dismissals.json`):
+
+```json
+{
+  "version": 1,
+  "entries": [
+    { "key": "update:2026.7.3", "dismissedAt": 1737590400000 }
+  ]
+}
+```
+
+- `version` — the store schema version (currently `1`); a future shape change
+  bumps it.
+- `entries` — an ordered array of `{ key, dismissedAt }`. Array order IS LRU order:
+  the front is the least-recently-dismissed. `dismissedAt` is a `Date.now()`
+  millisecond epoch.
+
+**Keyed by semantic identity.** The `key` is the notification's SEMANTIC identity,
+never an incidental per-boot id. For a software-update notification the key is the
+version string (`update:<version>`), so dismissing "update 2026.7.3 available" does
+NOT suppress a later "update 2026.7.4 available" — a NEW version re-notifies because
+its key was never dismissed. A notification without a semantic dismissal key is
+merely removed (its dismissal is not persisted), preserving the pre-existing
+transient behavior.
+
+**Durability guarantees.**
+
+- **Atomic write** — every `recordDismissal` re-serializes the whole set and writes
+  it through `writeFileAtomicSync` (temp file → `fsync` → `rename`), so a crash
+  mid-write leaves the previously-committed file intact; a torn write can never
+  corrupt the committed dismissals.
+- **LRU bound** — the set is capped (`DEFAULT_MAX_DISMISSALS = 256`). Recording past
+  the cap evicts the oldest dismissal; re-recording an existing key refreshes its
+  recency. The cap is also enforced when loading an over-cap file off disk.
+- **Corruption quarantine** — on load, an unparseable file (or a well-formed JSON
+  file whose shape fails the Zod schema) is renamed aside to
+  `notification_dismissals.json.corrupt-<timestamp>`, the event is logged, and the
+  store starts fresh with an empty set. A corrupt file never throws or crashes boot.
+  The quarantine sidecar uses a `.corrupt-<ts>` suffix — distinct from the atomic
+  writer's `.<basename>.<pid>.tmp` temp convention, so the T7 orphan sweep does not
+  touch it.
 
 ### Setup / hardware identity
 

--- a/packages/rpc/src/schemas/notifications.schema.test.ts
+++ b/packages/rpc/src/schemas/notifications.schema.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Notification schema tests (device-quality-wave2 Todo 23).
+ *
+ * Covers the versioned, allowlisted action descriptor and the typed
+ * `{ id, revision }` remove message. The action descriptor's `target` is a
+ * TYPED allowlist (never a free-form route), so a non-allowlisted target must
+ * be rejected by Zod at the schema boundary — the guarantee this suite locks.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import {
+	NOTIFICATION_ACTION_TARGETS,
+	notificationActionSchema,
+	notificationRemoveSchema,
+	notificationSchema,
+	notificationsMessageSchema,
+} from './notifications.schema';
+
+describe('notification action descriptor (versioned, allowlisted)', () => {
+	test('accepts a valid versioned navigate descriptor to an allowlisted target', () => {
+		const action = {
+			schema: 1,
+			kind: 'navigate',
+			target: 'updates-dialog',
+			labelKey: 'notifications.updateAvailable.action',
+		};
+		const parsed = notificationActionSchema.parse(action);
+		expect(parsed.schema).toBe(1);
+		expect(parsed.kind).toBe('navigate');
+		expect(parsed.target).toBe('updates-dialog');
+		expect(parsed.labelKey).toBe('notifications.updateAvailable.action');
+	});
+
+	test('the allowlist starts with exactly updates-dialog', () => {
+		expect(NOTIFICATION_ACTION_TARGETS).toContain('updates-dialog');
+	});
+
+	test('REJECTS a non-allowlisted (free-form) target', () => {
+		const result = notificationActionSchema.safeParse({
+			schema: 1,
+			kind: 'navigate',
+			target: '/settings/software/updates',
+			labelKey: 'x',
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('REJECTS a mismatched descriptor version', () => {
+		const result = notificationActionSchema.safeParse({
+			schema: 2,
+			kind: 'navigate',
+			target: 'updates-dialog',
+			labelKey: 'x',
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('REJECTS an unknown kind', () => {
+		const result = notificationActionSchema.safeParse({
+			schema: 1,
+			kind: 'open-url',
+			target: 'updates-dialog',
+			labelKey: 'x',
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('notification schema carries the OPTIONAL action descriptor', () => {
+	const base = {
+		name: 'update',
+		type: 'success' as const,
+		msg: 'An update is available',
+		is_dismissable: true,
+		is_persistent: true,
+		duration: 0,
+	};
+
+	test('a legacy notification without an action still parses (additive-optional)', () => {
+		const parsed = notificationSchema.parse(base);
+		expect(parsed.action).toBeUndefined();
+	});
+
+	test('a notification with a valid action parses', () => {
+		const parsed = notificationSchema.parse({
+			...base,
+			action: {
+				schema: 1,
+				kind: 'navigate',
+				target: 'updates-dialog',
+				labelKey: 'notifications.updateAvailable.action',
+			},
+		});
+		expect(parsed.action?.target).toBe('updates-dialog');
+	});
+
+	test('a notification with a non-allowlisted action target is rejected', () => {
+		const result = notificationSchema.safeParse({
+			...base,
+			action: {
+				schema: 1,
+				kind: 'navigate',
+				target: 'evil-route',
+				labelKey: 'x',
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('typed remove message { id, revision }', () => {
+	test('accepts a well-formed { id, revision } entry', () => {
+		const parsed = notificationRemoveSchema.parse({ id: 'update', revision: 7 });
+		expect(parsed.id).toBe('update');
+		expect(parsed.revision).toBe(7);
+	});
+
+	test('rejects a bare string id (the retired untyped shape)', () => {
+		expect(notificationRemoveSchema.safeParse('update').success).toBe(false);
+	});
+
+	test('rejects a remove entry missing its revision', () => {
+		expect(notificationRemoveSchema.safeParse({ id: 'update' }).success).toBe(false);
+	});
+
+	test('notifications message parses a remove-only frame', () => {
+		const parsed = notificationsMessageSchema.parse({
+			remove: [{ id: 'update', revision: 3 }],
+		});
+		expect(parsed.remove?.[0]?.id).toBe('update');
+		expect(parsed.show).toBeUndefined();
+	});
+
+	test('notifications message parses a show-only frame', () => {
+		const parsed = notificationsMessageSchema.parse({
+			show: [
+				{
+					name: 'update',
+					type: 'success',
+					msg: 'ready',
+					is_dismissable: true,
+					is_persistent: true,
+					duration: 0,
+				},
+			],
+		});
+		expect(parsed.show?.[0]?.name).toBe('update');
+		expect(parsed.remove).toBeUndefined();
+	});
+});

--- a/packages/rpc/src/schemas/notifications.schema.ts
+++ b/packages/rpc/src/schemas/notifications.schema.ts
@@ -5,6 +5,27 @@ import { z } from 'zod';
 
 import { notificationTypeSchema } from './common.schema';
 
+// Allowlisted, in-app navigation targets a notification may point at. This is a
+// TYPED allowlist — NOT a free-form route/URL — so a notification can only ever
+// deep-link to a surface the device UI explicitly knows how to open. New targets
+// are added here deliberately; the schema rejects anything else. Starts with the
+// software-updates dialog (the first consumer, wired by a later change).
+export const NOTIFICATION_ACTION_TARGETS = ['updates-dialog'] as const;
+export const notificationActionTargetSchema = z.enum(NOTIFICATION_ACTION_TARGETS);
+export type NotificationActionTarget = z.infer<typeof notificationActionTargetSchema>;
+
+// Versioned optional action descriptor. `schema` is the descriptor version so the
+// shape can evolve additively without breaking older devices/clients (they reject
+// an unknown version rather than misinterpret it). `kind: 'navigate'` opens the
+// allowlisted `target` in-app; `labelKey` is the i18n key for the affordance copy.
+export const notificationActionSchema = z.object({
+	schema: z.literal(1),
+	kind: z.literal('navigate'),
+	target: notificationActionTargetSchema,
+	labelKey: z.string(),
+});
+export type NotificationAction = z.infer<typeof notificationActionSchema>;
+
 // Single notification schema
 export const notificationSchema = z.object({
 	name: z.string(),
@@ -15,11 +36,29 @@ export const notificationSchema = z.object({
 	is_dismissable: z.boolean(),
 	is_persistent: z.boolean(),
 	duration: z.number(),
+	// Monotonic revision for a persistent notification, so a `remove` can be
+	// fenced against a newer `show` (see notificationRemoveSchema). Absent on
+	// transient (non-persistent) notifications, which are never removed by id.
+	revision: z.number().optional(),
+	// Optional, versioned, allowlisted deep-link affordance (additive — legacy
+	// producers omit it and keep working unchanged).
+	action: notificationActionSchema.optional(),
 });
 export type Notification = z.infer<typeof notificationSchema>;
 
-// Notifications message schema
+// A typed remove entry: `id` is the notification name, `revision` fences it
+// against a stale removal (a client ignores a remove whose revision predates the
+// notification's current shown revision). Replaces the retired bare-string form.
+export const notificationRemoveSchema = z.object({
+	id: z.string(),
+	revision: z.number(),
+});
+export type NotificationRemove = z.infer<typeof notificationRemoveSchema>;
+
+// Notifications message schema. Both arrays are optional: a `show` frame carries
+// no `remove`, and a `remove`-only frame carries no `show`.
 export const notificationsMessageSchema = z.object({
-	show: z.array(notificationSchema),
+	show: z.array(notificationSchema).optional(),
+	remove: z.array(notificationRemoveSchema).optional(),
 });
 export type NotificationsMessage = z.infer<typeof notificationsMessageSchema>;


### PR DESCRIPTION
## What

Notification-system infrastructure upgrade (schema + durable dismissal store). No update-notification UX behavior change — that is a follow-up.

- **Versioned, allowlisted action descriptor** on the notification schema: `{ schema: 1, kind: 'navigate', target, labelKey }`. `target` is a TYPED allowlist (starts with `updates-dialog`), never a free-form route — a non-allowlisted target is rejected at the Zod boundary. Optional/additive: existing producers are unchanged.
- **Typed `remove` message** `{ id, revision }` (was a bare `string[]`). The frontend handler's untyped `data as NotificationsMessage & { remove?: string[] }` cast is gone — it now `safeParse`s the typed schema and dismisses by `id`.
- **Persistent/duration expiry fix**: `_notificationIsLive` used to expire *persistent* notifications once their `duration` elapsed. New explicit semantics — `persistent` ⇒ never times out; `duration` governs only non-persistent notifications. Extracted into a pure, unit-tested `notification-liveness` module.
- **Durable dismissal store** (`notification-dismissals.ts`): disk-backed, atomic write (temp → fsync → rename), LRU-bounded (256), corruption-quarantined (`.corrupt-<ts>`), keyed by SEMANTIC identity (update notifications → the version string, so a new version re-notifies). A dismissal now survives a page reload AND a backend restart — the previous in-memory removal did neither.

## Why

Persistent notifications silently vanished after their duration (F13). Dismissals were transient — a periodic producer re-emit or a backend restart re-showed a notification the operator had already dismissed. And the `remove` wire frame was consumed via an untyped cast. This lays the typed, durable foundation the update-notification fix builds on.

## How to verify

- `bun test packages/rpc/src/schemas/notifications.schema.test.ts` — descriptor shape + non-allowlisted-target rejection + typed remove.
- `bun test apps/backend/src/tests/notification-liveness.test.ts` — persistent-never-expires + duration boundary/skew.
- `bun test apps/backend/src/tests/notification-dismissals.test.ts` — atomic-write survival, corruption quarantine, LRU bound, restart replay.
- `bun test apps/backend/src/tests/notification-durable-dismissal.test.ts` — reload + restart survival, semantic keying, typed remove shape.
- Gate: rpc/backend/frontend typechecks clean; `check:tech-debt` OK; rpc 206 pass; frontend 1243 tests pass. All new tests were written RED-first (see the task evidence).

## Risks

- Wire change: `remove` entries are now `{ id, revision }` and `notificationsMessageSchema.show` is optional. Backend and frontend ship together, and the only remove-frame consumer is the frontend handler updated here.
- The expiry-semantics change means a persistent notification with a nonzero `duration` no longer auto-clears — that is the intended fix; producers that relied on auto-expiry are unaffected because no shipped producer sets a persistent+duration pair for that purpose.
- New `notification_dismissals.json` at the config root (atomic, quarantined, LRU-bounded) — documented in `docs/CONFIG_PERSISTENCE.md`.

## Out of scope (follow-up)

No update-notification UX wiring (target=`updates-dialog` into the real Updates dialog, state-machine unification) and no i18n string changes — those are a separate change.
