### PR TITLE
feat(updates): unified update state machine, keyed i18n, notification action + failed-update UX

### DIFF
--- a/apps/backend/src/modules/system/software-updates.ts
+++ b/apps/backend/src/modules/system/software-updates.ts
@@ -39,6 +39,14 @@ import {
 	parseFail,
 	parseOk,
 } from "./cli-parse.ts";
+import {
+	deriveUpdateIdentity,
+	deriveUpdateState,
+	type UpdateFailure,
+	type UpdateIdentity,
+	type UpdateState,
+	updateDismissalKey,
+} from "./update-state.ts";
 
 let availableUpdates:
 	| {
@@ -59,6 +67,15 @@ let aptGetUpdating = false;
 let aptGetUpdateFailures = 0;
 let aptHeldBackPackages: string | undefined;
 
+// Unified-update-state signals (Todo 24). The identity of the currently-available
+// update; the identity being installed; and the terminal outcome of the last run.
+// A terminal failure/success PERSISTS across background discovery re-runs — only a
+// new install (startSoftwareUpdate) or a manual re-check clears it.
+let availableIdentity: UpdateIdentity | null = null;
+let currentUpdateIdentity: UpdateIdentity | null = null;
+let lastUpdateFailure: UpdateFailure | null = null;
+let lastUpdateSucceeded = false;
+
 export function getAvailableUpdates() {
 	return availableUpdates;
 }
@@ -69,6 +86,35 @@ export function getSoftUpdateStatus() {
 
 export function isUpdating() {
 	return softUpdateStatus != null;
+}
+
+export function getUpdateState(): UpdateState {
+	const available =
+		availableUpdates === false
+			? false
+			: availableUpdates && availableIdentity
+				? {
+						identity: availableIdentity,
+						package_count: availableUpdates.package_count,
+						...(availableUpdates.download_size !== undefined
+							? { download_size: availableUpdates.download_size }
+							: {}),
+					}
+				: null;
+	return deriveUpdateState({
+		checking: aptGetUpdating,
+		available,
+		updating:
+			softUpdateStatus && softUpdateStatus.result === undefined
+				? softUpdateStatus
+				: null,
+		failure: lastUpdateFailure,
+		succeeded: lastUpdateSucceeded,
+	});
+}
+
+function broadcastUpdateState() {
+	broadcastMsg("status", { update_state: getUpdateState() });
 }
 
 // Auto-reboot runner DI seam: default runs the real argv-only run(); tests spy it.
@@ -99,6 +145,7 @@ export type AptUpgradeSummary = {
 	readonly upgradeCount: number;
 	readonly downloadSize?: string;
 	readonly ceralivePackages: boolean;
+	readonly packages: string[];
 };
 
 export function parseUpgradePackageCount(text: string): ParseResult<number> {
@@ -220,7 +267,7 @@ export function parseAptUpgradeSummary(
 	const upgradeCount = parseUpgradePackageCount(stdout);
 	if (!upgradeCount.ok) return upgradeCount;
 	if (upgradeCount.value === 0) {
-		return parseOk({ upgradeCount: 0, ceralivePackages: false });
+		return parseOk({ upgradeCount: 0, ceralivePackages: false, packages: [] });
 	}
 
 	const downloadSize = parseUpgradeDownloadSize(stdout);
@@ -243,6 +290,7 @@ export function parseAptUpgradeSummary(
 			packageList.value,
 			ceralivePackageList,
 		),
+		packages: packageList.value.split(/\s+/).filter((n) => n.length > 0),
 	});
 }
 
@@ -314,14 +362,31 @@ async function getSoftwareUpdateSize() {
 		aptHeldBackPackages = undefined;
 	}
 
-	if (res.ceralivePackages) {
+	availableIdentity =
+		res.upgradeCount > 0
+			? deriveUpdateIdentity(res.packages, res.upgradeCount, res.downloadSize)
+			: null;
+
+	if (res.ceralivePackages && availableIdentity) {
 		notificationBroadcast(
 			"ceralive_update",
 			"warning",
-			"A CERALIVE update is available. Scroll down to the System menu to install it.",
+			"A CERALIVE update is available. Open Settings → Software Updates to install it.",
 			0,
 			true,
-			false,
+			true,
+			true,
+			"notifications.ceraliveUpdateAvailable",
+			undefined,
+			{
+				action: {
+					schema: 1,
+					kind: "navigate",
+					target: "updates-dialog",
+					labelKey: "notifications.openUpdates",
+				},
+				dismissalKey: updateDismissalKey(availableIdentity),
+			},
 		);
 	}
 
@@ -331,7 +396,10 @@ async function getSoftwareUpdateSize() {
 			? { download_size: res.downloadSize }
 			: {}),
 	};
-	broadcastMsg("status", { available_updates: availableUpdates });
+	broadcastMsg("status", {
+		available_updates: availableUpdates,
+		update_state: getUpdateState(),
+	});
 
 	return null;
 }
@@ -500,10 +568,18 @@ export function periodicCheckForSoftwareUpdates() {
 // Reuses the periodic discovery + skip guard but never touches its timer.
 // Returns false when skipped (streaming/updating/apt busy).
 export function triggerManualUpdateCheck(): boolean {
+	// A manual re-check supersedes a prior terminal outcome (Todo 24) — the
+	// dialog's retry affordance routes here to re-enter `checking`.
+	lastUpdateFailure = null;
+	lastUpdateSucceeded = false;
 	if (shouldUseMocks()) {
 		if (getIsStreaming() || isUpdating() || aptGetUpdating) return false;
 		availableUpdates = { package_count: 0 };
-		broadcastMsg("status", { available_updates: availableUpdates });
+		availableIdentity = null;
+		broadcastMsg("status", {
+			available_updates: availableUpdates,
+			update_state: getUpdateState(),
+		});
 		return true;
 	}
 	return softwareUpdateCheckRunner(async () => {
@@ -523,15 +599,52 @@ const defaultSoftwareUpdateRunner: SoftwareUpdateRunner = () => {
 		if (err === null) {
 			doSoftwareUpdate();
 		} else if (softUpdateStatus) {
-			softUpdateStatus.result =
+			const reason =
 				"Failed to fetch the updated package list; aborting the update.";
-			broadcastMsg("status", { updating: softUpdateStatus });
+			lastUpdateSucceeded = false;
+			lastUpdateFailure = {
+				reason,
+				...((currentUpdateIdentity ?? availableIdentity)
+					? {
+							identity: (currentUpdateIdentity ??
+								availableIdentity) as UpdateIdentity,
+						}
+					: {}),
+			};
+			notificationBroadcast(
+				"ceralive_update_failed",
+				"error",
+				"The software update failed. Open Settings → Software Updates to see the reason and retry.",
+				0,
+				true,
+				true,
+				true,
+				"notifications.ceraliveUpdateFailed",
+				undefined,
+				{
+					action: {
+						schema: 1,
+						kind: "navigate",
+						target: "updates-dialog",
+						labelKey: "notifications.openUpdates",
+					},
+				},
+			);
+			softUpdateStatus.result = reason;
+			broadcastMsg("status", {
+				updating: softUpdateStatus,
+				update_state: getUpdateState(),
+			});
 			softUpdateStatus = null;
+			broadcastUpdateState();
 		}
 	});
 
 	softUpdateStatus = { downloading: 0, unpacking: 0, setting_up: 0, total: 0 };
-	broadcastMsg("status", { updating: softUpdateStatus });
+	broadcastMsg("status", {
+		updating: softUpdateStatus,
+		update_state: getUpdateState(),
+	});
 };
 
 let softwareUpdateRunner: SoftwareUpdateRunner = defaultSoftwareUpdateRunner;
@@ -578,12 +691,23 @@ async function simulateMockSoftwareUpdate(): Promise<void> {
 	await Bun.sleep(MOCK_UPDATE_STEP_DELAY_MS);
 	if (!softUpdateStatus) return;
 	softUpdateStatus = { ...softUpdateStatus, result: 0 };
-	broadcastMsg("status", { updating: softUpdateStatus });
+	lastUpdateSucceeded = true;
+	lastUpdateFailure = null;
+	broadcastMsg("status", {
+		updating: softUpdateStatus,
+		update_state: getUpdateState(),
+	});
 	softUpdateStatus = null;
+	broadcastUpdateState();
 }
 
 export function startSoftwareUpdate() {
 	if (!setup.apt_update_enabled || getIsStreaming() || isUpdating()) return;
+
+	// A fresh install supersedes any prior terminal outcome (Todo 24).
+	currentUpdateIdentity = availableIdentity;
+	lastUpdateFailure = null;
+	lastUpdateSucceeded = false;
 
 	// if an apt-get update is already in progress, retry later
 	if (aptGetUpdating) {
@@ -702,9 +826,47 @@ function doSoftwareUpdate() {
 		]);
 
 		if (softUpdateStatus) {
+			if (code === 0) {
+				lastUpdateSucceeded = true;
+				lastUpdateFailure = null;
+			} else {
+				lastUpdateSucceeded = false;
+				lastUpdateFailure = {
+					reason: aptErr.trim() || `apt-get exited with code ${code}`,
+					...((currentUpdateIdentity ?? availableIdentity)
+						? {
+								identity: (currentUpdateIdentity ??
+									availableIdentity) as UpdateIdentity,
+							}
+						: {}),
+				};
+				notificationBroadcast(
+					"ceralive_update_failed",
+					"error",
+					"The software update failed. Open Settings → Software Updates to see the reason and retry.",
+					0,
+					true,
+					true,
+					true,
+					"notifications.ceraliveUpdateFailed",
+					undefined,
+					{
+						action: {
+							schema: 1,
+							kind: "navigate",
+							target: "updates-dialog",
+							labelKey: "notifications.openUpdates",
+						},
+					},
+				);
+			}
 			softUpdateStatus.result = code === 0 ? code : aptErr;
-			broadcastMsg("status", { updating: softUpdateStatus });
+			broadcastMsg("status", {
+				updating: softUpdateStatus,
+				update_state: getUpdateState(),
+			});
 			softUpdateStatus = null;
+			broadcastUpdateState();
 		}
 
 		if (aptLog) logger.info(aptLog);

--- a/apps/backend/src/modules/system/update-state.ts
+++ b/apps/backend/src/modules/system/update-state.ts
@@ -1,0 +1,83 @@
+import { createHash } from "node:crypto";
+
+import type {
+	UpdateIdentity,
+	UpdateProgress,
+	UpdateState,
+} from "@ceraui/rpc/schemas";
+
+export type { UpdateIdentity, UpdateState } from "@ceraui/rpc/schemas";
+
+export interface AvailableUpdate {
+	identity: UpdateIdentity;
+	package_count: number;
+	download_size?: string;
+}
+
+export interface UpdateFailure {
+	reason: string;
+	identity?: UpdateIdentity;
+}
+
+// The raw backend signals the reducer folds into ONE state. `available === false`
+// means apt-update is disabled; `null` means enabled-but-not-yet-discovered.
+export interface UpdateSnapshot {
+	checking: boolean;
+	available: AvailableUpdate | null | false;
+	updating: UpdateProgress | null;
+	failure: UpdateFailure | null;
+	succeeded: boolean;
+}
+
+// The version signature covers the sorted package set + count + download size, so
+// a same-name version bump (which changes the .deb size) still yields a new key —
+// the dismissal store then re-notifies for it (Todo-23 semantic-identity keying).
+export function deriveUpdateIdentity(
+	packages: string[],
+	packageCount: number,
+	downloadSize?: string,
+): UpdateIdentity {
+	const sorted = [...packages].sort();
+	const signature = createHash("sha256")
+		.update(`${sorted.join(" ")}|${packageCount}|${downloadSize ?? ""}`)
+		.digest("hex")
+		.slice(0, 12);
+	return { version: signature, packages: sorted };
+}
+
+export function updateDismissalKey(identity: UpdateIdentity): string {
+	return `update:${identity.version}`;
+}
+
+function deriveInstallState(progress: UpdateProgress): UpdateState {
+	const installing = progress.unpacking > 0 || progress.setting_up > 0;
+	return installing
+		? { kind: "installing", progress }
+		: { kind: "downloading", progress };
+}
+
+// Precedence: an in-flight install outranks everything, then a terminal
+// failure/success, then an available update, then a bare in-progress check.
+// Failure deliberately outranks `checking` so a background re-check never masks
+// a real failed-update state.
+export function deriveUpdateState(s: UpdateSnapshot): UpdateState {
+	if (s.updating) return deriveInstallState(s.updating);
+	if (s.failure) {
+		return s.failure.identity
+			? {
+					kind: "failed",
+					reason: s.failure.reason,
+					identity: s.failure.identity,
+				}
+			: { kind: "failed", reason: s.failure.reason };
+	}
+	if (s.succeeded) return { kind: "success" };
+	if (s.available && s.available.package_count > 0) {
+		const { identity, package_count, download_size } = s.available;
+		return download_size !== undefined
+			? { kind: "available", identity, package_count, download_size }
+			: { kind: "available", identity, package_count };
+	}
+	if (s.checking) return { kind: "checking" };
+	return { kind: "idle" };
+}

--- a/apps/backend/src/modules/ui/status.ts
+++ b/apps/backend/src/modules/ui/status.ts
@@ -48,6 +48,7 @@ import { getSensors } from "../system/sensors.ts";
 import {
 	getAvailableUpdates,
 	getSoftUpdateStatus,
+	getUpdateState,
 } from "../system/software-updates.ts";
 import { getCachedSshStatus, getSshStatus } from "../system/ssh.ts";
 import { wifiBuildMsg } from "../wifi/wifi.ts";
@@ -58,6 +59,7 @@ export type StatusResponseMessage = {
 	is_streaming?: ReturnType<typeof getIsStreaming>;
 	available_updates?: ReturnType<typeof getAvailableUpdates>;
 	updating?: ReturnType<typeof getSoftUpdateStatus>;
+	update_state?: ReturnType<typeof getUpdateState>;
 	ssh?: ReturnType<typeof getCachedSshStatus>;
 	wifi?: ReturnType<typeof wifiBuildMsg>;
 	modems?: ReturnType<typeof buildModemsMessage>;
@@ -82,6 +84,7 @@ export function sendStatus(conn: WebSocket) {
 			is_streaming: getIsStreaming(),
 			available_updates: getAvailableUpdates(),
 			updating: getSoftUpdateStatus(),
+			update_state: getUpdateState(),
 			ssh: getCachedSshStatus(),
 			wifi: wifiBuildMsg(),
 			modems: buildModemsMessage(),

--- a/apps/backend/src/rpc/procedures/status.procedure.ts
+++ b/apps/backend/src/rpc/procedures/status.procedure.ts
@@ -38,6 +38,7 @@ import { getSensors } from "../../modules/system/sensors.ts";
 import {
 	getAvailableUpdates,
 	getSoftUpdateStatus,
+	getUpdateState,
 } from "../../modules/system/software-updates.ts";
 import { getCachedSshStatus, getSshStatus } from "../../modules/system/ssh.ts";
 import { wifiBuildMsg } from "../../modules/wifi/wifi.ts";
@@ -68,6 +69,7 @@ export const getStatusProcedure = authedProcedure
 			is_streaming: getIsStreaming(),
 			available_updates: getAvailableUpdates(),
 			updating: getSoftUpdateStatus(),
+			update_state: getUpdateState(),
 			ssh: getCachedSshStatus(),
 			wifi: wifiBuildMsg(),
 			modems: modemListSchema.parse(buildModemsMessage()),
@@ -108,6 +110,7 @@ export function buildInitialStatus() {
 			is_streaming: getIsStreaming(),
 			available_updates: getAvailableUpdates(),
 			updating: getSoftUpdateStatus(),
+			update_state: getUpdateState(),
 			ssh: getCachedSshStatus(),
 			wifi: wifiBuildMsg(),
 			modems: modemListSchema.parse(buildModemsMessage()),

--- a/apps/backend/src/tests/software-updates-apt.test.ts
+++ b/apps/backend/src/tests/software-updates-apt.test.ts
@@ -120,6 +120,7 @@ Need to get 12.3 MB/44.0 MB of archives.
 				upgradeCount: 3,
 				downloadSize: "12.3 MB",
 				ceralivePackages: true,
+				packages: ["ceraui", "unrelated"],
 			});
 		}
 	});
@@ -133,6 +134,7 @@ Need to get 12.3 MB/44.0 MB of archives.
 			expect(result.value).toEqual({
 				upgradeCount: 0,
 				ceralivePackages: false,
+				packages: [],
 			});
 		}
 	});

--- a/apps/backend/src/tests/update-state.test.ts
+++ b/apps/backend/src/tests/update-state.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+	deriveUpdateIdentity,
+	deriveUpdateState,
+	type UpdateSnapshot,
+	updateDismissalKey,
+} from "../modules/system/update-state.ts";
+
+const IDENTITY = deriveUpdateIdentity(["cerastream", "ceraui"], 2, "12.3 MB");
+
+function snapshot(overrides: Partial<UpdateSnapshot> = {}): UpdateSnapshot {
+	return {
+		checking: false,
+		available: false,
+		updating: null,
+		failure: null,
+		succeeded: false,
+		...overrides,
+	};
+}
+
+describe("deriveUpdateIdentity", () => {
+	it("sorts the package set so ordering never changes the identity", () => {
+		const a = deriveUpdateIdentity(["ceraui", "cerastream"], 2, "12.3 MB");
+		const b = deriveUpdateIdentity(["cerastream", "ceraui"], 2, "12.3 MB");
+		expect(a.packages).toEqual(["cerastream", "ceraui"]);
+		expect(a.version).toBe(b.version);
+	});
+
+	it("changes the version when the package set changes (new update re-notifies)", () => {
+		const a = deriveUpdateIdentity(["cerastream"], 1, "5 MB");
+		const b = deriveUpdateIdentity(["cerastream", "srtla"], 2, "9 MB");
+		expect(a.version).not.toBe(b.version);
+	});
+
+	it("changes the version when the download size changes (same-name version bump)", () => {
+		const a = deriveUpdateIdentity(["cerastream"], 1, "5 MB");
+		const b = deriveUpdateIdentity(["cerastream"], 1, "6 MB");
+		expect(a.version).not.toBe(b.version);
+	});
+});
+
+describe("updateDismissalKey", () => {
+	it("is namespaced by version so a new version key differs", () => {
+		expect(updateDismissalKey(IDENTITY)).toBe(`update:${IDENTITY.version}`);
+	});
+});
+
+describe("deriveUpdateState", () => {
+	it("is idle when nothing is happening", () => {
+		expect(deriveUpdateState(snapshot())).toEqual({ kind: "idle" });
+	});
+
+	it("is checking while apt discovery runs", () => {
+		expect(deriveUpdateState(snapshot({ checking: true }))).toEqual({
+			kind: "checking",
+		});
+	});
+
+	it("is available (with identity) when apt found packages — the dialog needs no re-check", () => {
+		const state = deriveUpdateState(
+			snapshot({
+				available: {
+					identity: IDENTITY,
+					package_count: 2,
+					download_size: "12.3 MB",
+				},
+			}),
+		);
+		expect(state).toEqual({
+			kind: "available",
+			identity: IDENTITY,
+			package_count: 2,
+			download_size: "12.3 MB",
+		});
+	});
+
+	it("is downloading while apt is fetching (no unpack/install yet)", () => {
+		const state = deriveUpdateState(
+			snapshot({
+				updating: { total: 2, downloading: 1, unpacking: 0, setting_up: 0 },
+				available: {
+					identity: IDENTITY,
+					package_count: 2,
+					download_size: "12.3 MB",
+				},
+			}),
+		);
+		expect(state.kind).toBe("downloading");
+	});
+
+	it("is installing once unpack/setup starts", () => {
+		const state = deriveUpdateState(
+			snapshot({
+				updating: { total: 2, downloading: 2, unpacking: 1, setting_up: 0 },
+			}),
+		);
+		expect(state.kind).toBe("installing");
+	});
+
+	it("is failed(reason) after a failed apt run, and failure outranks a still-available update", () => {
+		const state = deriveUpdateState(
+			snapshot({
+				failure: { reason: "dpkg was interrupted", identity: IDENTITY },
+				available: {
+					identity: IDENTITY,
+					package_count: 2,
+					download_size: "12.3 MB",
+				},
+			}),
+		);
+		expect(state).toEqual({
+			kind: "failed",
+			reason: "dpkg was interrupted",
+			identity: IDENTITY,
+		});
+	});
+
+	it("keeps failed visible while a background check runs (failure outranks checking)", () => {
+		const state = deriveUpdateState(
+			snapshot({
+				checking: true,
+				failure: { reason: "network down" },
+			}),
+		);
+		expect(state).toEqual({ kind: "failed", reason: "network down" });
+	});
+
+	it("is success after a clean install", () => {
+		expect(deriveUpdateState(snapshot({ succeeded: true }))).toEqual({
+			kind: "success",
+		});
+	});
+
+	it("prioritizes an in-flight install over a stale terminal flag", () => {
+		const state = deriveUpdateState(
+			snapshot({
+				succeeded: true,
+				updating: { total: 2, downloading: 2, unpacking: 1, setting_up: 0 },
+			}),
+		);
+		expect(state.kind).toBe("installing");
+	});
+
+	it("treats apt-disabled (available === false) as idle, not available", () => {
+		expect(deriveUpdateState(snapshot({ available: false }))).toEqual({
+			kind: "idle",
+		});
+	});
+});

--- a/apps/frontend/src/lib/rpc/subscriptions.svelte.ts
+++ b/apps/frontend/src/lib/rpc/subscriptions.svelte.ts
@@ -24,6 +24,7 @@ import type {
 	SensorsStatus,
 	SourcesMessage,
 	StatusResponse,
+	UpdateState,
 	WifiStatus,
 } from "@ceraui/rpc/schemas";
 import { notificationsMessageSchema } from "@ceraui/rpc/schemas";
@@ -93,6 +94,7 @@ let availableUpdatesState = $state<
 	StatusResponse["available_updates"] | undefined
 >(undefined);
 let updatingState = $state<StatusResponse["updating"]>(null);
+let updateStateState = $state<UpdateState | undefined>(undefined);
 
 // Network state
 let netifState = $state<NetifMessage | undefined>(undefined);
@@ -185,6 +187,10 @@ export function getAvailableUpdates() {
 
 export function getUpdating() {
 	return updatingState;
+}
+
+export function getUpdateState() {
+	return updateStateState;
 }
 
 export function getNetif() {
@@ -372,6 +378,9 @@ function handleMessage(type: string, data: unknown, seq?: number): void {
 			}
 			if (statusData.updating !== undefined) {
 				updatingState = statusData.updating;
+			}
+			if (statusData.update_state !== undefined) {
+				updateStateState = statusData.update_state;
 			}
 			if (statusData.wifi !== undefined) {
 				wifiState = statusData.wifi;

--- a/apps/frontend/src/lib/stores/dialog-request.svelte.ts
+++ b/apps/frontend/src/lib/stores/dialog-request.svelte.ts
@@ -1,0 +1,59 @@
+import type { NotificationActionTarget } from "@ceraui/rpc/schemas";
+
+// A single-slot request bus so an allowlisted notification action can deep-link
+// into a config dialog. The producer (a notification tap) calls requestDialog();
+// the owning view (SettingsView for `updates-dialog`) consumes it via an effect
+// and clears it. Held on globalThis for the same dev dual-URL reason as the
+// notification store — the toast host and SettingsView must share ONE slot.
+interface DialogRequestStore {
+	get requested(): NotificationActionTarget | undefined;
+	set(target: NotificationActionTarget | undefined): void;
+}
+
+function createStore(): DialogRequestStore {
+	let requested = $state<NotificationActionTarget | undefined>(undefined);
+	return {
+		get requested() {
+			return requested;
+		},
+		set(target) {
+			requested = target;
+		},
+	};
+}
+
+const STORE_KEY = Symbol.for("ceraui.dialogRequest");
+type GlobalWithStore = typeof globalThis & {
+	[STORE_KEY]?: DialogRequestStore;
+};
+
+const singleton: DialogRequestStore = ((): DialogRequestStore => {
+	const g = globalThis as GlobalWithStore;
+	const existing = g[STORE_KEY] ?? createStore();
+	g[STORE_KEY] = existing;
+	return existing;
+})();
+
+export function requestDialog(target: NotificationActionTarget): void {
+	singleton.set(target);
+	if (target === "updates-dialog") {
+		// Lazy import so `$lib/config` (which statically pulls the dev-only DevTools
+		// → pwa → window.matchMedia chain) stays OUT of this module's static graph.
+		// It only resolves when a notification is actually tapped at runtime, where
+		// the browser has matchMedia — so importers like SettingsView never drag it
+		// into a jsdom test that doesn't stub matchMedia.
+		void (async () => {
+			const { navElements } = await import("$lib/config");
+			const { navigateTo } = await import("$lib/stores/navigation.svelte");
+			if (navElements.settings) navigateTo({ settings: navElements.settings });
+		})();
+	}
+}
+
+export function getRequestedDialog(): NotificationActionTarget | undefined {
+	return singleton.requested;
+}
+
+export function clearRequestedDialog(): void {
+	singleton.set(undefined);
+}

--- a/apps/frontend/src/lib/stores/notifications.svelte.ts
+++ b/apps/frontend/src/lib/stores/notifications.svelte.ts
@@ -33,7 +33,11 @@
  * `* 1000` — never `* 2500`.
  */
 import { getLL } from "@ceraui/i18n/svelte";
-import type { Notification, NotificationType } from "@ceraui/rpc/schemas";
+import type {
+	Notification,
+	NotificationAction,
+	NotificationType,
+} from "@ceraui/rpc/schemas";
 
 // ============================================
 // Types
@@ -55,6 +59,8 @@ export interface ActiveNotification {
 	durationMs: number;
 	/** When this entry was pushed (ms epoch). */
 	receivedAt: number;
+	/** Optional versioned deep-link affordance (Todo 24) — undefined for legacy notifications. */
+	action?: NotificationAction;
 }
 
 /** A callable translation leaf as exposed by the `$LL` proxy. */
@@ -150,6 +156,9 @@ export function toActiveNotification(
 		isPersistent: notification.is_persistent,
 		durationMs: notification.duration * 1000,
 		receivedAt: now,
+		...(notification.action !== undefined
+			? { action: notification.action }
+			: {}),
 	};
 }
 

--- a/apps/frontend/src/main.ts
+++ b/apps/frontend/src/main.ts
@@ -9,7 +9,6 @@ import App from "./App.svelte";
 import { initSubscriptions } from "./lib/rpc";
 import { initAsyncOperations } from "./lib/rpc/async-operation.svelte";
 import { initFieldSyncState } from "./lib/rpc/field-sync-state.svelte";
-import { push } from "./lib/stores/notifications.svelte";
 import { setStoredVersion } from "./lib/stores/version.svelte";
 
 // Feeds the HUD's `subscriptions.svelte` getters from the same shared socket the
@@ -25,27 +24,20 @@ initFieldSyncState();
 // later external transitions (begin/confirm/reconcile) never reach the surface.
 initAsyncOperations();
 
-// Register Service Worker for PWA updates
+// Register the Service Worker for PWA auto-update. There is deliberately NO
+// onNeedRefresh notification (Todo 24): the SW is registerType:"autoUpdate" with
+// skipWaiting+clientsClaim (pwa.config.ts), so a new bundle is applied
+// automatically — a manual "Update Available" toast never actually fired under
+// autoUpdate and was a SECOND, frontend-only "update available" source of truth
+// that bypassed the durable dismissal/action system. Device (apt) updates are the
+// ONE unified update state machine now; the browser-bundle refresh is silent.
 registerSW({
 	immediate: true,
-	onNeedRefresh() {
-		// Show update notification when new version is available
-		push({
-			name: "pwa-update-available",
-			type: "info",
-			msg: "Update Available",
-			key: "notifications.updateAvailable",
-			is_dismissable: true,
-			is_persistent: true,
-			duration: 0,
-		});
-	},
 	onOfflineReady() {
 		/* no-op: offline readiness is surfaced via the PWA UI, not logged */
 	},
 	onRegistered(registration) {
 		if (registration) {
-			// Update stored version when PWA registers successfully
 			setStoredVersion(__APP_VERSION__);
 		}
 	},

--- a/apps/frontend/src/main/SettingsView.svelte
+++ b/apps/frontend/src/main/SettingsView.svelte
@@ -37,6 +37,7 @@ import { AppDialog } from '$lib/components/dialogs';
 import { osCommand } from '$lib/rpc/async-operation.svelte';
 import { rpc } from '$lib/rpc/client';
 import { getConfig, getKiosk } from '$lib/rpc/subscriptions.svelte';
+import { clearRequestedDialog, getRequestedDialog } from '$lib/stores/dialog-request.svelte';
 import { cn } from '$lib/utils';
 
 import CloudRemoteDialog from './dialogs/CloudRemoteDialog.svelte';
@@ -238,6 +239,15 @@ function openEntry(entry: Entry) {
 }
 
 const ActiveIcon = $derived(active?.icon);
+
+// A notification tap (Todo 24) requests the Updates dialog via the dialog-request
+// bus, which has already switched the destination to Settings; open it here.
+$effect(() => {
+	if (getRequestedDialog() === 'updates-dialog') {
+		updatesOpen = true;
+		clearRequestedDialog();
+	}
+});
 </script>
 
 <div class="flex-col md:flex">

--- a/apps/frontend/src/main/dialogs/UpdatesDialog.svelte
+++ b/apps/frontend/src/main/dialogs/UpdatesDialog.svelte
@@ -8,8 +8,7 @@
 -->
 <script lang="ts">
 import { LL } from '@ceraui/i18n/svelte';
-import type { UpdateProgress } from '@ceraui/rpc/schemas';
-import { Download, RefreshCw } from '@lucide/svelte';
+import { AlertTriangle, Download, RefreshCw } from '@lucide/svelte';
 
 import { AppDialog } from '$lib/components/dialogs';
 import { Button } from '$lib/components/ui/button';
@@ -20,7 +19,7 @@ import {
 	osCommand,
 } from '$lib/rpc/async-operation.svelte';
 import { rpc } from '$lib/rpc/client';
-import { getAvailableUpdates, getUpdating } from '$lib/rpc/subscriptions.svelte';
+import { getUpdateState } from '$lib/rpc/subscriptions.svelte';
 
 interface Props {
 	open?: boolean;
@@ -28,27 +27,32 @@ interface Props {
 
 let { open = $bindable(false) }: Props = $props();
 
-// `available_updates` is `false`/`null` (no updates / not yet checked) or the
-// package summary object; narrow to the object so falsy sentinels read as zero.
-const updates = $derived(getAvailableUpdates());
-const updateInfo = $derived(
-	updates && typeof updates === 'object' ? updates : undefined,
-);
-const count = $derived(updateInfo?.package_count ?? 0);
-const size = $derived(updateInfo?.download_size ?? '');
+// The ONE update state machine (Todo 24). The dialog and the notification both
+// derive from this, so an `available` state already carries the version + summary
+// — no manual re-check is needed to render it.
+const updateState = $derived(getUpdateState());
 
-const updating = $derived(getUpdating());
-// In progress = literal true OR a progress object that hasn't resolved (result !== 0).
-const isUpdating = $derived(
-	updating === true ||
-		(typeof updating === 'object' && updating !== null && updating.result !== 0),
+const available = $derived(
+	updateState?.kind === 'available' ? updateState : undefined,
+);
+const count = $derived(available?.package_count ?? 0);
+const size = $derived(available?.download_size ?? '');
+const version = $derived(available?.identity.version ?? '');
+const packages = $derived(available?.identity.packages ?? []);
+
+const failed = $derived(updateState?.kind === 'failed' ? updateState : undefined);
+const inProgress = $derived(
+	updateState?.kind === 'downloading' || updateState?.kind === 'installing',
+);
+const progress = $derived(
+	updateState?.kind === 'downloading' || updateState?.kind === 'installing'
+		? updateState.progress
+		: undefined,
 );
 
-// Best-effort percentage when a structured progress object is present.
 const progressValue = $derived.by(() => {
-	if (typeof updating !== 'object' || updating === null) return undefined;
-	const p = updating as UpdateProgress;
-	if (!p.total || p.total <= 0) return undefined;
+	const p = progress;
+	if (!p?.total || p.total <= 0) return undefined;
 	const done = (p.downloading ?? 0) + (p.unpacking ?? 0) + (p.setting_up ?? 0);
 	return Math.min(100, Math.max(0, Math.round((100 * done) / (3 * p.total))));
 });
@@ -56,9 +60,7 @@ const progressValue = $derived.by(() => {
 let confirmOpen = $state(false);
 
 // `update` op covers ONLY the brief start-dispatch window: it stays `pending`
-// from the startUpdate dispatch until the first `updating` broadcast confirms it
-// (or a `{ success: false }`/reject fails it with a calm toast). The progress UI
-// below keeps reading the broadcast directly — it is NOT under this op's TTL.
+// from the startUpdate dispatch until the first in-progress state confirms it.
 const starting = $derived(getOperationPhase('update') === 'pending');
 
 async function doInstall() {
@@ -67,18 +69,15 @@ async function doInstall() {
 		rpc: () => rpc.system.startUpdate(),
 		failMessage: () => $LL.network.os.operationFailed(),
 		busyMessage: () => $LL.network.os.deviceBusy(),
-		// NO confirmOnResolve — the first `updating` broadcast confirms the start.
 	});
 }
 
 let checking = $state(false);
 let checkTimeout: ReturnType<typeof setTimeout> | undefined;
-let checkBaseline: typeof updates = undefined;
 
 async function doCheck() {
-	if (checking || isUpdating) return;
+	if (checking || inProgress) return;
 	checking = true;
-	checkBaseline = updates;
 	clearTimeout(checkTimeout);
 	checkTimeout = setTimeout(() => {
 		checking = false;
@@ -90,9 +89,9 @@ async function doCheck() {
 	}
 }
 
-// A fresh available_updates broadcast (new object ref) confirms the check ran.
+// A transition OUT of `checking`/`failed` confirms the re-check ran.
 $effect(() => {
-	if (checking && updates !== checkBaseline) {
+	if (checking && updateState?.kind !== 'checking' && updateState?.kind !== 'failed') {
 		checking = false;
 		clearTimeout(checkTimeout);
 	}
@@ -100,10 +99,10 @@ $effect(() => {
 
 $effect(() => () => clearTimeout(checkTimeout));
 
-// Confirm the start-dispatch op once the first `updating` broadcast lands.
+// Confirm the start-dispatch op once the first in-progress state lands.
 $effect(() => {
 	if (getOperationPhase('update') !== 'pending') return;
-	if (isUpdating) confirmOperation('update');
+	if (inProgress) confirmOperation('update');
 });
 </script>
 
@@ -115,9 +114,22 @@ $effect(() => {
 	title={$LL.settings.index.updates()}
 >
 	<div class="space-y-5">
-		<!-- Availability summary -->
-		<div class="bg-muted/40 rounded-lg border p-4">
-			{#if count > 0}
+		<!-- Availability summary — the version is already present in the `available`
+		     state, so it renders without any manual re-check. -->
+		<div class="bg-muted/40 rounded-lg border p-4" data-testid="update-summary">
+			{#if failed}
+				<div class="flex items-start gap-2" data-testid="update-failed">
+					<AlertTriangle class="text-destructive mt-0.5 size-5 shrink-0" />
+					<div class="min-w-0">
+						<p class="text-destructive text-lg font-semibold">
+							{$LL.general.updateFailed()}
+						</p>
+						<p class="text-muted-foreground mt-1 text-sm break-words" data-testid="update-failed-reason">
+							{failed.reason}
+						</p>
+					</div>
+				</div>
+			{:else if count > 0}
 				<p class="text-2xl font-bold">
 					{count}
 					{count === 1 ? $LL.general.package() : $LL.general.packages()}
@@ -125,13 +137,22 @@ $effect(() => {
 				{#if size}
 					<p class="text-muted-foreground mt-0.5 text-sm">{size}</p>
 				{/if}
+				{#if version}
+					<p class="text-muted-foreground mt-1 font-mono text-xs" data-testid="update-version">
+						{version}
+					</p>
+				{/if}
+				{#if packages.length > 0}
+					<p class="text-muted-foreground mt-1 text-xs break-words" data-testid="update-packages">
+						{packages.join(', ')}
+					</p>
+				{/if}
 			{:else}
 				<p class="text-lg font-semibold">{$LL.general.noUpdatesAvailable()}</p>
 			{/if}
 		</div>
 
-		{#if isUpdating}
-			<!-- In-progress (reads the live broadcast, not the start-dispatch op) -->
+		{#if inProgress}
 			<div class="space-y-2" aria-live="polite">
 				<div class="flex items-center gap-2 text-sm font-medium">
 					<RefreshCw class="text-primary size-4 motion-safe:animate-spin" />
@@ -140,21 +161,30 @@ $effect(() => {
 				<Progress value={progressValue ?? 100} />
 			</div>
 		{:else if starting}
-			<!-- Brief start-dispatch window before the first `updating` broadcast -->
 			<div class="flex items-center gap-2 text-sm font-medium" aria-live="polite">
 				<RefreshCw class="text-primary size-4 motion-safe:animate-spin" />
 				{$LL.network.os.applying()}
 			</div>
+		{:else if failed}
+			<Button
+				aria-busy={checking}
+				class="w-full gap-2"
+				disabled={checking}
+				onclick={doCheck}
+				variant="outline"
+				data-testid="update-retry"
+			>
+				<RefreshCw class="size-4 {checking ? 'motion-safe:animate-spin' : ''}" />
+				{$LL.general.retryUpdateCheck()}
+			</Button>
 		{:else if count > 0}
-			<!-- Install action (opens destructive confirmation) -->
 			<Button class="w-full gap-2" onclick={() => (confirmOpen = true)}>
 				<Download class="size-4" />
 				{$LL.general.updateButton()}
 			</Button>
 		{/if}
 
-		{#if !isUpdating && !starting}
-			<!-- Manual re-check: re-runs the discovery pipeline on the device -->
+		{#if !inProgress && !starting && !failed}
 			<Button
 				aria-busy={checking}
 				class="w-full gap-2"

--- a/apps/frontend/src/main/dialogs/UpdatesDialog.test.ts
+++ b/apps/frontend/src/main/dialogs/UpdatesDialog.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+/**
+ * UpdatesDialog — derives from the ONE unified update state machine (Todo 24).
+ *
+ * The load-bearing guarantee: when the backend reports `state=available`, the
+ * dialog renders the update (version + packages) WITHOUT any manual re-check —
+ * `checkForUpdates` is never dispatched on open. The `failed(reason)` state
+ * surfaces the truthful reason and a retry affordance that re-enters checking.
+ */
+
+import type { UpdateState } from "@ceraui/rpc/schemas";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { rpc } from "$lib/rpc/client";
+
+import UpdatesDialog from "./UpdatesDialog.svelte";
+
+// AppDialog's responsive chrome reads `window.matchMedia` — absent in jsdom.
+// Stub it to the desktop branch (mirrors LogsDialog/NetifDialog tests).
+beforeAll(() => {
+	if (!window.matchMedia) {
+		window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+			matches: true,
+			media: query,
+			onchange: null,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		}));
+	}
+});
+
+vi.mock("$lib/rpc/client", () => ({
+	rpc: {
+		system: {
+			startUpdate: vi.fn(async () => ({ success: true })),
+			checkForUpdates: vi.fn(async () => ({ success: true })),
+		},
+	},
+}));
+
+vi.mock("svelte-sonner", () => ({
+	toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+let mockState: UpdateState | undefined;
+vi.mock("$lib/rpc/subscriptions.svelte", () => ({
+	getUpdateState: () => mockState,
+}));
+
+vi.mock("$lib/rpc/async-operation.svelte", () => ({
+	osCommand: vi.fn(),
+	getOperationPhase: () => "idle",
+	confirmOperation: vi.fn(),
+}));
+
+const checkForUpdates = vi.mocked(rpc.system.checkForUpdates);
+
+afterEach(() => {
+	mockState = undefined;
+	vi.clearAllMocks();
+});
+
+const AVAILABLE: UpdateState = {
+	kind: "available",
+	identity: { version: "abc123def456", packages: ["cerastream", "ceraui"] },
+	package_count: 2,
+	download_size: "12.3 MB",
+};
+
+describe("UpdatesDialog — unified state machine", () => {
+	it("renders the available version WITHOUT a manual re-check (state=available)", async () => {
+		mockState = AVAILABLE;
+		const { getByTestId } = render(UpdatesDialog, { open: true });
+
+		await waitFor(() => {
+			expect(getByTestId("update-version").textContent).toContain(
+				"abc123def456",
+			);
+		});
+		expect(getByTestId("update-packages").textContent).toContain("cerastream");
+		// The dialog already knew — it never asked the device to re-check.
+		expect(checkForUpdates).not.toHaveBeenCalled();
+	});
+
+	it("surfaces the failure reason and a retry affordance (state=failed)", async () => {
+		mockState = { kind: "failed", reason: "dpkg was interrupted" };
+		const { getByTestId } = render(UpdatesDialog, { open: true });
+
+		await waitFor(() => {
+			expect(getByTestId("update-failed-reason").textContent).toContain(
+				"dpkg was interrupted",
+			);
+		});
+
+		const retry = getByTestId("update-retry");
+		await fireEvent.click(retry);
+		expect(checkForUpdates).toHaveBeenCalledTimes(1);
+	});
+
+	it("shows the up-to-date state when idle", async () => {
+		mockState = { kind: "idle" };
+		const { queryByTestId } = render(UpdatesDialog, { open: true });
+		await waitFor(() => {
+			expect(queryByTestId("update-version")).toBeNull();
+			expect(queryByTestId("update-failed")).toBeNull();
+		});
+	});
+});

--- a/apps/frontend/src/main/layout/LayoutToastHost.svelte
+++ b/apps/frontend/src/main/layout/LayoutToastHost.svelte
@@ -1,12 +1,29 @@
 <script lang="ts">
+import { getLL } from '@ceraui/i18n/svelte';
 import { toast } from 'svelte-sonner';
 
 import { Toaster } from '$lib/components/ui/sonner';
+import { requestDialog } from '$lib/stores/dialog-request.svelte';
 import {
 	startStreaming as startStreamingFn,
 	stopStreaming as stopStreamingFn,
 } from '$lib/helpers/SystemHelper';
 import { clearNotifications, dismiss, getActive } from '$lib/stores/notifications.svelte';
+
+// Resolve the action label i18n key against the live translation tree, falling
+// back to the raw key so an unknown label never blocks the deep-link affordance.
+function resolveActionLabel(key: string): string {
+	const ll = getLL() as Record<string, unknown>;
+	let node: unknown = ll;
+	for (const seg of key.split('.')) {
+		if (node && typeof node === 'object' && seg in (node as object)) {
+			node = (node as Record<string, unknown>)[seg];
+		} else {
+			return key;
+		}
+	}
+	return typeof node === 'function' ? (node as () => string)() : key;
+}
 
 // Bookkeeping for which active notifications have already been surfaced as a
 // toast. Keyed by the store's dedup key (`name`) → the `receivedAt` stamp of
@@ -26,6 +43,7 @@ $effect(() => {
 		if (renderedAt.get(notification.name) === notification.receivedAt) continue;
 		renderedAt.set(notification.name, notification.receivedAt);
 
+		const action = notification.action;
 		toast[notification.type](notification.text, {
 			id: notification.name,
 			duration: notification.isPersistent
@@ -34,6 +52,17 @@ $effect(() => {
 			dismissable: notification.isDismissable,
 			onDismiss: () => dismiss(notification.name),
 			onAutoClose: () => dismiss(notification.name),
+			...(action?.kind === 'navigate'
+				? {
+						action: {
+							label: resolveActionLabel(action.labelKey),
+							onClick: () => {
+								requestDialog(action.target);
+								toast.dismiss(notification.name);
+							},
+						},
+					}
+				: {}),
 		});
 	}
 

--- a/apps/frontend/src/main/notifications/NotificationsPanel.svelte
+++ b/apps/frontend/src/main/notifications/NotificationsPanel.svelte
@@ -28,9 +28,22 @@ import AppDialog from '$lib/components/dialogs/AppDialog.svelte';
 import { Badge } from '$lib/components/ui/badge';
 import { Button } from '$lib/components/ui/button';
 import { rpc } from '$lib/rpc';
+import { requestDialog } from '$lib/stores/dialog-request.svelte';
 import { getDisplayProfile, prefersEinkTheme } from '$lib/stores/display-profile.svelte';
 import { dismiss, getPersistent } from '$lib/stores/notifications.svelte';
 import { cn } from '$lib/utils';
+
+function lookupLabel(key: string): string {
+	let node: unknown = $LL;
+	for (const seg of key.split('.')) {
+		if (node && typeof node === 'object' && seg in (node as object)) {
+			node = (node as Record<string, unknown>)[seg];
+		} else {
+			return key;
+		}
+	}
+	return typeof node === 'function' ? (node as () => string)() : key;
+}
 
 let open = $state(false);
 
@@ -110,9 +123,26 @@ async function handleDismiss(name: string) {
 					data-notification={item.name}
 				>
 					<Icon class={cn('mt-0.5 size-4 shrink-0', TONES[item.type])} aria-hidden="true" />
-					<p class="text-foreground min-w-0 flex-1 text-sm leading-relaxed break-words">
-						{item.text}
-					</p>
+					<div class="min-w-0 flex-1">
+						<p class="text-foreground text-sm leading-relaxed break-words">
+							{item.text}
+						</p>
+						{#if item.action?.kind === 'navigate'}
+							<Button
+								class="mt-2 h-7 px-2 text-xs"
+								size="sm"
+								variant="outline"
+								data-testid="notification-action"
+								onclick={() => {
+									const target = item.action?.target;
+									if (target) requestDialog(target);
+									open = false;
+								}}
+							>
+								{lookupLabel(item.action.labelKey)}
+							</Button>
+						{/if}
+					</div>
 					{#if item.isDismissable}
 						<Button
 							class="size-7 shrink-0"

--- a/apps/frontend/tests/e2e/audit-settings.spec.ts
+++ b/apps/frontend/tests/e2e/audit-settings.spec.ts
@@ -205,11 +205,22 @@ test.describe("Audit A3 — Settings destination + dialogs", { tag: "@audit" }, 
 	test("software-update start walk shows the mock progress frames (seam asserted)", async ({
 		page,
 	}) => {
-		// Reveal the install action: additive available_updates over the socket
-		// (the default scenario reports no pending updates).
+		// Reveal the install action: the dialog derives from the ONE unified update
+		// state machine (Todo 24), so drive `update_state` (the authoritative wire
+		// field) — `available_updates` stays alongside it exactly as the backend
+		// broadcasts both together (the default scenario reports no pending updates).
 		send({
 			status: {
 				available_updates: { package_count: 2, download_size: "24.5 MB" },
+				update_state: {
+					kind: "available",
+					identity: {
+						version: "e2e-audit-01",
+						packages: ["cerastream", "ceraui"],
+					},
+					package_count: 2,
+					download_size: "24.5 MB",
+				},
 			},
 		});
 
@@ -227,11 +238,18 @@ test.describe("Audit A3 — Settings destination + dialogs", { tag: "@audit" }, 
 		await confirm.getByRole("button", { name: "Update", exact: true }).click();
 
 		// The seeded e2e backend has no apt_update_enabled, so the real apt seam
-		// (simulateMockSoftwareUpdate) early-returns; the mock seam's OUTPUT — the
-		// {updating:…} status frame — is modeled over the socket, and the dialog
-		// renders the in-progress state from it exactly as it would on a device.
+		// (simulateMockSoftwareUpdate) early-returns; the mock seam's OUTPUT is
+		// modeled over the socket. The dialog derives its in-progress state from
+		// `update_state` (the unified machine, Todo 24) — driven here as the backend
+		// broadcasts it alongside the legacy `updating` frame during a download.
 		send({
-			status: { updating: { total: 100, downloading: 40, unpacking: 0, setting_up: 0 } },
+			status: {
+				updating: { total: 100, downloading: 40, unpacking: 0, setting_up: 0 },
+				update_state: {
+					kind: "downloading",
+					progress: { total: 100, downloading: 40, unpacking: 0, setting_up: 0 },
+				},
+			},
 		});
 		await expect(updates.getByText(/Updating/i)).toBeVisible({ timeout: 5000 });
 		expect(pageErrors).toEqual([]);

--- a/apps/frontend/tests/e2e/ssh-power-update.spec.ts
+++ b/apps/frontend/tests/e2e/ssh-power-update.spec.ts
@@ -284,9 +284,21 @@ test.describe(
 			const updates = page.getByRole("dialog", { name: UPDATES_DIALOG });
 			await expect(updates).toBeVisible();
 
-			// Advertise an available update so the install action renders.
+			// Advertise an available update so the install action renders. The dialog
+			// derives from the ONE unified update state machine (Todo 24), so drive
+			// `update_state` (the authoritative wire field) alongside the legacy
+			// `available_updates` — exactly as the backend broadcasts both together.
 			await emit(page, "status", {
 				available_updates: { package_count: 3, download_size: "12 MB" },
+				update_state: {
+					kind: "available",
+					identity: {
+						version: "e2e-power-01",
+						packages: ["cerastream", "ceraui", "srtla-send-rs"],
+					},
+					package_count: 3,
+					download_size: "12 MB",
+				},
 			});
 			const install = updates.getByRole("button", { name: "Update", exact: true });
 			await expect(install).toBeVisible();

--- a/packages/i18n/src/ar/index.ts
+++ b/packages/i18n/src/ar/index.ts
@@ -153,6 +153,9 @@ const ar = {
 			"سطح المكتب + الهاتف (5 علامات تبويب، موضوعان لكل منها) + غير متصل (موضوعان) = 22 إجمالي",
 	},
 	general: {
+		updateFailed: "فشل التحديث",
+		retryUpdateCheck: "أعد المحاولة",
+		updateComplete: "اكتمل التحديث",
 		status: "الحالة",
 		streaming: "البث",
 		offline: "غير متصل",
@@ -1454,6 +1457,11 @@ const ar = {
 		bitrateRange: "يجب أن يكون معدل البت بين 2000 و12000 كيلوبت/ثانية",
 	},
 	notifications: {
+		ceraliveUpdateAvailable:
+			"يتوفر تحديث CERALIVE. افتح الإعدادات ← تحديثات البرامج لتثبيته.",
+		ceraliveUpdateFailed:
+			"فشل تحديث البرنامج. افتح الإعدادات ← تحديثات البرامج لمعرفة السبب وإعادة المحاولة.",
+		openUpdates: "فتح التحديثات",
 		error: "خطأ",
 		saved: "تم الحفظ",
 		saveFailed: "فشل الحفظ",

--- a/packages/i18n/src/de/index.ts
+++ b/packages/i18n/src/de/index.ts
@@ -169,6 +169,9 @@ const de = {
 		loadingCompleteDesc: "Der Ladevorgang wurde erfolgreich abgeschlossen.",
 	},
 	general: {
+		updateFailed: "Update fehlgeschlagen",
+		retryUpdateCheck: "Erneut versuchen",
+		updateComplete: "Update abgeschlossen",
 		status: "Status",
 		streaming: "Streaming",
 		offline: "Offline",
@@ -749,6 +752,11 @@ const de = {
 		bitrateRange: "Die Bitrate muss zwischen 2000 und 12000 Kbps liegen",
 	},
 	notifications: {
+		ceraliveUpdateAvailable:
+			"Ein CERALIVE-Update ist verfügbar. Öffnen Sie Einstellungen → Softwareupdates, um es zu installieren.",
+		ceraliveUpdateFailed:
+			"Das Softwareupdate ist fehlgeschlagen. Öffnen Sie Einstellungen → Softwareupdates, um den Grund zu sehen und es erneut zu versuchen.",
+		openUpdates: "Updates öffnen",
 		error: "Fehler",
 		saved: "Gespeichert",
 		saveFailed: "Speichern fehlgeschlagen",

--- a/packages/i18n/src/en/index.ts
+++ b/packages/i18n/src/en/index.ts
@@ -161,6 +161,9 @@ const en = {
 			"Desktop + Mobile (5 tabs, 2 themes each) + Offline (2 themes) = 22 total",
 	},
 	general: {
+		updateFailed: "Update failed",
+		retryUpdateCheck: "Try again",
+		updateComplete: "Update complete",
 		status: "Status",
 		streaming: "Streaming",
 		offline: "Offline",
@@ -731,6 +734,11 @@ const en = {
 		bitrateRange: "Bitrate must be between 2000 and 12000 Kbps",
 	},
 	notifications: {
+		ceraliveUpdateAvailable:
+			"A CERALIVE update is available. Open Settings → Software Updates to install it.",
+		ceraliveUpdateFailed:
+			"The software update failed. Open Settings → Software Updates to see the reason and retry.",
+		openUpdates: "Open updates",
 		error: "Error",
 		saved: "Saved",
 		saveFailed: "Failed to save",

--- a/packages/i18n/src/es/index.ts
+++ b/packages/i18n/src/es/index.ts
@@ -169,6 +169,9 @@ const es = {
 			"Escritorio + Móvil (5 pestañas, 2 temas cada una) + Offline (2 temas) = 22 total",
 	},
 	general: {
+		updateFailed: "Error en la actualización",
+		retryUpdateCheck: "Reintentar",
+		updateComplete: "Actualización completada",
 		status: "Estado",
 		streaming: "Transmitiendo",
 		offline: "Desconectado",
@@ -752,6 +755,11 @@ const es = {
 		bitrateRange: "El bitrate debe estar entre 2000 y 12000 Kbps",
 	},
 	notifications: {
+		ceraliveUpdateAvailable:
+			"Hay una actualización de CERALIVE disponible. Abre Ajustes → Actualizaciones de software para instalarla.",
+		ceraliveUpdateFailed:
+			"La actualización de software falló. Abre Ajustes → Actualizaciones de software para ver el motivo y reintentar.",
+		openUpdates: "Abrir actualizaciones",
 		error: "Error",
 		saved: "Guardado",
 		saveFailed: "Error al guardar",

--- a/packages/i18n/src/fr/index.ts
+++ b/packages/i18n/src/fr/index.ts
@@ -167,6 +167,9 @@ const fr = {
 			"Bureau + Mobile (5 onglets, 2 thèmes chacun) + Hors ligne (2 thèmes) = 22 total",
 	},
 	general: {
+		updateFailed: "Échec de la mise à jour",
+		retryUpdateCheck: "Réessayer",
+		updateComplete: "Mise à jour terminée",
 		status: "Statut",
 		streaming: "En streaming",
 		offline: "Hors ligne",
@@ -1515,6 +1518,11 @@ const fr = {
 		bitrateRange: "Le débit doit être compris entre 2000 et 12000 Kbps",
 	},
 	notifications: {
+		ceraliveUpdateAvailable:
+			"Une mise à jour CERALIVE est disponible. Ouvrez Paramètres → Mises à jour logicielles pour l'installer.",
+		ceraliveUpdateFailed:
+			"La mise à jour logicielle a échoué. Ouvrez Paramètres → Mises à jour logicielles pour voir la raison et réessayer.",
+		openUpdates: "Ouvrir les mises à jour",
 		error: "Erreur",
 		saved: "Enregistré",
 		saveFailed: "Échec de l'enregistrement",

--- a/packages/i18n/src/hi/index.ts
+++ b/packages/i18n/src/hi/index.ts
@@ -15,6 +15,9 @@ const hi = {
 		steps: "चरण",
 	},
 	general: {
+		updateFailed: "अपडेट विफल",
+		retryUpdateCheck: "पुनः प्रयास करें",
+		updateComplete: "अपडेट पूर्ण",
 		status: "स्थिति",
 		streaming: "स्ट्रीमिंग",
 		offline: "ऑफलाइन",
@@ -1315,6 +1318,11 @@ const hi = {
 		bitrateRange: "बिटरेट 2000 और 12000 Kbps के बीच होना चाहिए",
 	},
 	notifications: {
+		ceraliveUpdateAvailable:
+			"एक CERALIVE अपडेट उपलब्ध है। इसे इंस्टॉल करने के लिए सेटिंग्स → सॉफ़्टवेयर अपडेट खोलें।",
+		ceraliveUpdateFailed:
+			"सॉफ़्टवेयर अपडेट विफल रहा। कारण देखने और पुनः प्रयास करने के लिए सेटिंग्स → सॉफ़्टवेयर अपडेट खोलें।",
+		openUpdates: "अपडेट खोलें",
 		error: "त्रुटि",
 		saved: "सहेजा गया",
 		saveFailed: "सहेजने में विफल",

--- a/packages/i18n/src/ja/index.ts
+++ b/packages/i18n/src/ja/index.ts
@@ -15,6 +15,9 @@ const ja = {
 		steps: "ステップ",
 	},
 	general: {
+		updateFailed: "更新に失敗しました",
+		retryUpdateCheck: "再試行",
+		updateComplete: "更新が完了しました",
 		status: "ステータス",
 		streaming: "ストリーミング",
 		offline: "オフライン",
@@ -1357,6 +1360,11 @@ const ja = {
 		bitrateRange: "ビットレートは2000から12000 Kbpsの間でなければなりません",
 	},
 	notifications: {
+		ceraliveUpdateAvailable:
+			"CERALIVE のアップデートがあります。設定 → ソフトウェア更新 を開いてインストールしてください。",
+		ceraliveUpdateFailed:
+			"ソフトウェア更新に失敗しました。設定 → ソフトウェア更新 を開いて理由を確認し、再試行してください。",
+		openUpdates: "更新を開く",
 		error: "エラー",
 		saved: "保存しました",
 		saveFailed: "保存に失敗しました",

--- a/packages/i18n/src/ko/index.ts
+++ b/packages/i18n/src/ko/index.ts
@@ -15,6 +15,9 @@ const ko = {
 		steps: "단계",
 	},
 	general: {
+		updateFailed: "업데이트 실패",
+		retryUpdateCheck: "다시 시도",
+		updateComplete: "업데이트 완료",
 		status: "상태",
 		streaming: "스트리밍",
 		offline: "오프라인",
@@ -1331,6 +1334,11 @@ const ko = {
 		bitrateRange: "비트레이트는 2000에서 12000 Kbps 사이여야 합니다",
 	},
 	notifications: {
+		ceraliveUpdateAvailable:
+			"CERALIVE 업데이트가 있습니다. 설정 → 소프트웨어 업데이트를 열어 설치하세요.",
+		ceraliveUpdateFailed:
+			"소프트웨어 업데이트에 실패했습니다. 설정 → 소프트웨어 업데이트를 열어 이유를 확인하고 다시 시도하세요.",
+		openUpdates: "업데이트 열기",
 		error: "오류",
 		saved: "저장됨",
 		saveFailed: "저장하지 못했습니다",

--- a/packages/i18n/src/pt-BR/index.ts
+++ b/packages/i18n/src/pt-BR/index.ts
@@ -167,6 +167,9 @@ const ptBR = {
 			"Desktop + Móvel (5 abas, 2 temas cada) + Offline (2 temas) = 22 total",
 	},
 	general: {
+		updateFailed: "Falha na atualização",
+		retryUpdateCheck: "Tentar novamente",
+		updateComplete: "Atualização concluída",
 		status: "Status",
 		streaming: "Transmitindo",
 		offline: "Offline",
@@ -1490,6 +1493,11 @@ const ptBR = {
 		bitrateRange: "A taxa de bits deve estar entre 2000 e 12000 Kbps",
 	},
 	notifications: {
+		ceraliveUpdateAvailable:
+			"Há uma atualização do CERALIVE disponível. Abra Configurações → Atualizações de software para instalá-la.",
+		ceraliveUpdateFailed:
+			"A atualização de software falhou. Abra Configurações → Atualizações de software para ver o motivo e tentar novamente.",
+		openUpdates: "Abrir atualizações",
 		error: "Erro",
 		saved: "Salvo",
 		saveFailed: "Falha ao salvar",

--- a/packages/i18n/src/zh/index.ts
+++ b/packages/i18n/src/zh/index.ts
@@ -14,6 +14,9 @@ const zh = {
 		steps: "步骤",
 	},
 	general: {
+		updateFailed: "更新失败",
+		retryUpdateCheck: "重试",
+		updateComplete: "更新完成",
 		status: "状态",
 		streaming: "直播中",
 		offline: "离线",
@@ -1267,6 +1270,10 @@ const zh = {
 		bitrateRange: "比特率必须在 2000 到 12000 Kbps 之间",
 	},
 	notifications: {
+		ceraliveUpdateAvailable:
+			"有可用的 CERALIVE 更新。打开 设置 → 软件更新 进行安装。",
+		ceraliveUpdateFailed: "软件更新失败。打开 设置 → 软件更新 查看原因并重试。",
+		openUpdates: "打开更新",
 		error: "错误",
 		saved: "已保存",
 		saveFailed: "保存失败",

--- a/packages/rpc/src/schemas/status.schema.ts
+++ b/packages/rpc/src/schemas/status.schema.ts
@@ -5,7 +5,12 @@ import { z } from 'zod';
 
 import { modemListSchema } from './modems.schema';
 import { audioSourceSchema } from './streaming.schema';
-import { availableUpdatesSchema, sshStatusSchema, updatingStatusSchema } from './system.schema';
+import {
+	availableUpdatesSchema,
+	sshStatusSchema,
+	updateStateSchema,
+	updatingStatusSchema,
+} from './system.schema';
 import { wifiStatusSchema } from './wifi.schema';
 
 // Audio sources enum
@@ -47,6 +52,7 @@ export const statusMessageSchema = z.object({
 	is_streaming: z.boolean(),
 	available_updates: availableUpdatesFieldSchema,
 	updating: updatingStatusSchema,
+	update_state: updateStateSchema.optional(),
 	ssh: sshStatusSchema,
 	wifi: wifiStatusSchema,
 	asrcs: z.array(z.string()),
@@ -172,6 +178,7 @@ export const statusResponseSchema = z.object({
 	is_streaming: z.boolean().optional(),
 	available_updates: availableUpdatesFieldSchema.optional(),
 	updating: updatingStatusSchema.optional(),
+	update_state: updateStateSchema.optional(),
 	ssh: sshStatusSchema.optional(),
 	wifi: wifiStatusSchema.optional(),
 	modems: modemListSchema.optional(),

--- a/packages/rpc/src/schemas/system.schema.ts
+++ b/packages/rpc/src/schemas/system.schema.ts
@@ -56,6 +56,51 @@ export type UpdateProgress = z.infer<typeof updateProgressSchema>;
 export const updatingStatusSchema = z.union([z.boolean(), z.null(), updateProgressSchema]);
 export type UpdatingStatus = z.infer<typeof updatingStatusSchema>;
 
+// =============================================================================
+// Unified update state machine (Todo 24)
+// =============================================================================
+// Single source of truth for update availability + lifecycle. Both the backend
+// notification producer AND the frontend UpdatesDialog derive from this one wire
+// value, so the dialog already shows an available update with no manual re-check.
+// `available_updates`/`updating` stay on the wire (back-compat) but are computed
+// from the SAME backend signals this state derives from.
+
+// Semantic identity (Todo-23 dismissal key source): a NEW `version` re-notifies
+// even if the previous update was dismissed.
+export const updateIdentitySchema = z.object({
+	version: z.string(),
+	packages: z.array(z.string()),
+});
+export type UpdateIdentity = z.infer<typeof updateIdentitySchema>;
+
+export const updateStateSchema = z.discriminatedUnion('kind', [
+	z.object({ kind: z.literal('idle') }),
+	z.object({ kind: z.literal('checking') }),
+	z.object({
+		kind: z.literal('available'),
+		identity: updateIdentitySchema,
+		package_count: z.number(),
+		download_size: z.string().optional(),
+	}),
+	z.object({
+		kind: z.literal('downloading'),
+		progress: updateProgressSchema,
+		identity: updateIdentitySchema.optional(),
+	}),
+	z.object({
+		kind: z.literal('installing'),
+		progress: updateProgressSchema,
+		identity: updateIdentitySchema.optional(),
+	}),
+	z.object({ kind: z.literal('success') }),
+	z.object({
+		kind: z.literal('failed'),
+		reason: z.string(),
+		identity: updateIdentitySchema.optional(),
+	}),
+]);
+export type UpdateState = z.infer<typeof updateStateSchema>;
+
 // System command input schema
 export const systemCommandInputSchema = z.object({
 	command: z.enum([


### PR DESCRIPTION
## What

Introduces ONE typed update state machine
(`idle → checking → available(version) → downloading → installing → success | failed(reason)`)
as the single source of truth for software-update availability + lifecycle. The
backend notification producer AND the frontend `UpdatesDialog` both derive from it,
so when the notification says an update exists, the dialog already shows it — no
manual re-check.

- **Keyed i18n + correct nav.** The raw English `"Scroll down to the System menu"`
  string is replaced by keyed i18n (`notifications.ceraliveUpdateAvailable`) across
  all 10 locales, pointing at the REAL path **Settings → Software Updates** (there is
  no "System" menu).
- **Notification action.** The update notification now carries the versioned
  `target: 'updates-dialog'` action descriptor; tapping "Open updates" navigates to
  Settings and opens the Updates dialog (navigate-only — install stays behind the
  dialog's own explicit button).
- **Semantic identity.** `available` carries a version signature derived from the real
  apt package set + count + download size — this is the version-keyed dismissal key, so
  a new update re-notifies even if the old one was dismissed.
- **Truthful failed-update UX.** `failed(reason)` surfaces a persistent notification +
  a dialog failure band with a retry affordance that re-enters checking. No invented
  rollback mechanics (narrowed scope).
- **PWA producer removed.** The frontend-only PWA "Update Available" push
  (`main.ts`) is removed — it was a second, dismissal-bypassing source of truth for a
  different domain (web-bundle refresh, which `registerType:"autoUpdate"` already applies
  silently). Rationale recorded inline so it can't be silently re-added.

## Why

The old update notification pointed operators at a non-existent "System" menu, was an
unkeyed English string, and could not open the Updates dialog. The dialog and the
notification derived update availability from separate signals, so the dialog could
disagree with the notification and require a manual re-check. A failed update was also
rendered as success. This unifies all of it behind one machine.

## How to verify

- `bun test apps/backend/src/tests/update-state.test.ts` — reducer (14 tests, red→green:
  module-absent → green).
- `apps/frontend/src/main/dialogs/UpdatesDialog.test.ts` — `state=available` renders the
  version with NO `checkForUpdates` call; `state=failed` renders the reason + retry
  (red→green proven by stashing the dialog).
- `bun test packages/i18n/tests/locale-parity-gate.test.ts` — all 10 locales have the
  new keys (identical keysets).
- Board (rk3588): the `available` state was exercised through the REAL apt discovery
  path (genuinely pending `libnss3` + `srtla-send-rs`, NOT a stub) — the dialog showed the
  version with no re-check, the notification appeared, and tapping "Open updates" from the
  Live destination opened the dialog on the same version. Screenshots + apt snapshot/restore
  receipt in the effort evidence.

## Risks

- Additive wire field (`update_state` on the `status` message) — legacy consumers ignore
  it; `available_updates`/`updating` are unchanged and still broadcast.
- The i18n non-EN strings are machine-translated (marked for review); the KEY exists in
  all 10 locales (parity gate enforced).
- Notification-before-connect: a persistent update notification created before a browser
  connects is not re-surfaced on that session's initial snapshot (pre-existing behavior,
  not introduced here) — a fresh discovery/check pushes it live.
