### PR TITLE
docs+feat(streaming): typed start-lifecycle contract (StartFailure, phases, suppression)

### DIFF
--- a/apps/backend/src/modules/streaming/start-failure-taxonomy.ts
+++ b/apps/backend/src/modules/streaming/start-failure-taxonomy.ts
@@ -1,0 +1,259 @@
+/**
+ * Start-failure taxonomy — the MAPPING layer for the start-lifecycle contract
+ * (device-quality-wave2 Todo 25, DESIGN + SCHEMA ONLY).
+ *
+ * The wire types live in `@ceraui/rpc/schemas` (`streaming-lifecycle.schema.ts`).
+ * This module is the backend-side mapping table + helpers that turn a concrete
+ * failure at a known start-path site into a typed `StartFailure`, plus the
+ * attempt-id generator (b), the retry policy (d), and the suppression-window
+ * predicate (c). It consumes the external `@ceralive/cerastream` error classes
+ * (which own the ENOENT/refused wrapping, hello/subscribe/request timeouts, and
+ * the JSON-RPC codes) — so those live behind the client, and CeraUI classifies
+ * their surfaced shapes here.
+ *
+ * NOTHING here is wired into a runtime path. `streaming.procedure.ts`,
+ * `session.ts`, and the engine backend are untouched — Todos 26-29 do the
+ * wiring. This module is pure + fully unit-tested against fabricated error
+ * shapes.
+ *
+ * ── Failure-site cross-check (every site found in the codebase, mapped) ──
+ *   params        zod (oRPC input / validateConfig safeParse / startParams.parse)
+ *                 + plain validation Errors            → start_invalid
+ *   connect       CerastreamConnectionError (ENOENT/ECONNREFUSED wrapped in the
+ *                 client)                              → engine_unavailable (retriable)
+ *   connect       CerastreamTimeoutError               → start_timeout (retriable)
+ *   hello         CerastreamRpcError -32000 / ZodError → protocol_incompatible
+ *   hello         CerastreamConnectionError (close)    → engine_unavailable
+ *   hello         CerastreamTimeoutError               → start_timeout (not retriable)
+ *   subscribe     CerastreamTimeoutError               → start_timeout (not retriable)
+ *   subscribe     CerastreamConnectionError            → engine_unavailable (not retriable)
+ *   start-rpc     -32602 params.invalid / -32003       → start_invalid
+ *   start-rpc     -32002 already / -32603 internal     → engine_internal
+ *   start-rpc     CerastreamTimeoutError (10s request) → start_timeout (not retriable)
+ *   playing-wait  CerastreamTimeoutError               → start_timeout (not retriable)
+ *   (unmapped)    any opaque shape                     → engine_internal + logged warn
+ */
+
+import {
+	CerastreamConnectionError,
+	CerastreamRpcError,
+	CerastreamTimeoutError,
+} from "@ceralive/cerastream";
+import {
+	isRetriableStartFailure,
+	type StartFailure,
+	type StartFailureClass,
+	type StartFailurePhase,
+} from "@ceraui/rpc/schemas";
+
+import { randomBase64 } from "../../helpers/crypto.ts";
+
+// ─── (b) Attempt-ID generation at the public start boundary ──────────────────
+
+// Monotonic-ish component so ids sort roughly by creation time in logs, plus a
+// random suffix for uniqueness within the same millisecond. Generated once per
+// public `start` entry and carried through queue/logs/notification (Todo 26).
+export function newAttemptId(): string {
+	const ts = Date.now().toString(36);
+	const rand = randomBase64(6)
+		.replace(/[^a-zA-Z0-9]/g, "")
+		.slice(0, 8);
+	return `att_${ts}_${rand}`;
+}
+
+// ─── (a) The mapping table ────────────────────────────────────────────────────
+
+// The known JSON-RPC numeric codes → taxonomy class. Anything not in this table
+// (including a novel engine code) falls through to `engine_internal`.
+const RPC_CODE_TO_CLASS: Record<number, StartFailureClass> = {
+	[-32000]: "protocol_incompatible", // cerastream.protocol.unsupported_version
+	[-32602]: "start_invalid", // cerastream.params.invalid
+	[-32003]: "start_invalid", // cerastream.device.not_found
+	[-32002]: "engine_internal", // cerastream.state.already_streaming (engine-side state conflict)
+	[-32603]: "engine_internal", // cerastream.internal
+};
+
+function isZodLikeError(err: unknown): boolean {
+	return (
+		typeof err === "object" &&
+		err !== null &&
+		(err as { name?: string }).name === "ZodError"
+	);
+}
+
+export interface ClassifyDeps {
+	warn: (message: string, meta?: Record<string, unknown>) => void;
+}
+
+const defaultClassifyDeps: ClassifyDeps = {
+	warn: () => {
+		/* default no-op; the real wiring (Todo 28) injects the logger */
+	},
+};
+
+/**
+ * Classify a concrete failure at a known start-path `phase` into a typed
+ * `StartFailure`. NEVER throws: an unmapped/opaque shape is bucketed as
+ * `engine_internal` and a warning is emitted so the drop-through is observable.
+ */
+export function classifyStartFailure(
+	phase: StartFailurePhase,
+	error: unknown,
+	attemptId: string,
+	deps: ClassifyDeps = defaultClassifyDeps,
+): StartFailure {
+	const { cls, code } = classifyClass(phase, error, deps);
+	return {
+		attemptId,
+		phase,
+		class: cls,
+		...(code !== undefined ? { code } : {}),
+		retriable: isRetriableStartFailure(cls, phase),
+	};
+}
+
+function classifyClass(
+	phase: StartFailurePhase,
+	error: unknown,
+	deps: ClassifyDeps,
+): { cls: StartFailureClass; code?: number | string } {
+	// A timeout is always a timeout, whatever the phase — retriability is derived
+	// per-phase downstream (connect-only) so we don't decide it here.
+	if (error instanceof CerastreamTimeoutError) {
+		return { cls: "start_timeout" };
+	}
+
+	// A lost/unreachable control connection means the engine isn't answering.
+	if (error instanceof CerastreamConnectionError) {
+		return { cls: "engine_unavailable" };
+	}
+
+	// A structured engine error response — map by its numeric JSON-RPC code. The
+	// carried `code` is the canonical NUMERIC JSON-RPC code (the stable machine
+	// identity the taxonomy enumerates: -32000/-32602/-32002/-32003/-32603); the
+	// human-readable string dataCode stays available on the raw error for logs.
+	if (error instanceof CerastreamRpcError) {
+		const mapped = RPC_CODE_TO_CLASS[error.code];
+		if (mapped !== undefined) {
+			return { cls: mapped, code: error.code };
+		}
+		// A real engine error with an unknown code is an engine-side fault.
+		return { cls: "engine_internal", code: error.code };
+	}
+
+	// A Zod validation failure: params-phase → invalid config; hello-phase →
+	// the engine spoke an incompatible hello shape.
+	if (isZodLikeError(error)) {
+		return {
+			cls: phase === "hello" ? "protocol_incompatible" : "start_invalid",
+		};
+	}
+
+	// Any other Error in the params/spawn phase is a local validation/setup fault.
+	if (
+		error instanceof Error &&
+		(phase === "params" || phase === "spawn-sender")
+	) {
+		return { cls: "start_invalid" };
+	}
+
+	// Unmapped/opaque — never throw. Bucket as engine_internal + a warning so the
+	// drop-through is visible (the Todo-25 failure QA scenario).
+	deps.warn("start-failure-taxonomy: unmapped error shape → engine_internal", {
+		phase,
+		errorName: error instanceof Error ? error.name : typeof error,
+	});
+	return { cls: "engine_internal" };
+}
+
+// ─── (d) Retry policy — bounded exponential backoff, retriable classes only ──
+
+export interface RetryPolicy {
+	/** Hard cap on the number of start attempts (including the first). */
+	maxAttempts: number;
+	/** Total wall-clock budget across all attempts, in ms. */
+	totalBudgetMs: number;
+	/** First backoff delay, in ms. */
+	baseDelayMs: number;
+	/** Backoff ceiling, in ms. */
+	maxDelayMs: number;
+}
+
+// Defaults chosen against the supervision windows (systemd RestartSec=5,
+// crash-loop 5/60s): a few short retries that comfortably span one restart
+// window, then escalate. Not yet consumed by any runtime loop (Todo 28 wires it).
+export const DEFAULT_START_RETRY_POLICY: RetryPolicy = {
+	maxAttempts: 5,
+	totalBudgetMs: 60_000,
+	baseDelayMs: 2_000,
+	maxDelayMs: 16_000,
+};
+
+/** Bounded exponential backoff for attempt `n` (0-based): base·2^n, capped. */
+export function nextBackoffDelayMs(
+	attempt: number,
+	policy: RetryPolicy = DEFAULT_START_RETRY_POLICY,
+): number {
+	const raw = policy.baseDelayMs * 2 ** Math.max(0, attempt);
+	return Math.min(raw, policy.maxDelayMs);
+}
+
+export interface RetryProgress {
+	/** Attempts made so far (>= 1 after the first attempt). */
+	attempts: number;
+	/** Wall-clock ms elapsed since the first attempt. */
+	elapsedMs: number;
+}
+
+/**
+ * Whether to schedule another start attempt after `failure`. Retries ONLY a
+ * retriable failure (the class/phase verdict on the failure itself), and only
+ * while both the attempt count and the total-time budget remain.
+ */
+export function shouldRetryStart(
+	failure: StartFailure,
+	progress: RetryProgress,
+	policy: RetryPolicy = DEFAULT_START_RETRY_POLICY,
+): boolean {
+	if (!failure.retriable) return false;
+	if (progress.attempts >= policy.maxAttempts) return false;
+	if (progress.elapsedMs >= policy.totalBudgetMs) return false;
+	return true;
+}
+
+// ─── (c) Suppression window — sourced from EXISTING signals ──────────────────
+
+/**
+ * The inputs to the suppression decision, each sourced from an EXISTING backend
+ * signal (Todo 28 binds them; this is the pure predicate + its shape):
+ *   - `softwareUpdateActive`   ← `isUpdating()` (software-updates module)
+ *   - `engineRestartWindow`    ← the engine-reconnect capability state
+ *                                (`engineUnavailable`/`engineStarting`) inside the
+ *                                systemd RestartSec=5 window
+ *   - `bootWindow`             ← the boot-readiness window (health/readiness module)
+ *   - `cancelledByStop`        ← the attempt was cancelled by a stop (first-class
+ *                                `cancelled` result — it notifies nothing)
+ */
+export interface SuppressionContext {
+	softwareUpdateActive: boolean;
+	engineRestartWindow: boolean;
+	bootWindow: boolean;
+	cancelledByStop: boolean;
+}
+
+/**
+ * True when a TRANSIENT (retriable) failure should show a calm "engine
+ * starting…" state instead of an error notification, because a known window
+ * explains it. A REAL terminal failure (budget exhausted, non-retriable class)
+ * is never suppressed — that gating lives in the retry loop (Todo 28), not here.
+ */
+export function shouldSuppressTransientFailure(
+	ctx: SuppressionContext,
+): boolean {
+	return (
+		ctx.softwareUpdateActive ||
+		ctx.engineRestartWindow ||
+		ctx.bootWindow ||
+		ctx.cancelledByStop
+	);
+}

--- a/apps/backend/src/tests/start-failure-taxonomy.test.ts
+++ b/apps/backend/src/tests/start-failure-taxonomy.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Start-failure taxonomy mapping tests (device-quality-wave2 Todo 25).
+ *
+ * Table-driven proof that EVERY known start-path failure site maps to exactly
+ * one taxonomy class + phase, that an unmapped/opaque error shape falls to
+ * `engine_internal` + a logged warning and NEVER throws, and that the
+ * attempt-id generator, retry policy, and suppression-window predicate behave
+ * as designed. Design-only: nothing here is imported by a runtime path yet
+ * (that is Todos 26-29).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+	CerastreamConnectionError,
+	CerastreamRpcError,
+	CerastreamTimeoutError,
+} from "@ceralive/cerastream";
+
+import {
+	classifyStartFailure,
+	newAttemptId,
+	nextBackoffDelayMs,
+	shouldRetryStart,
+	shouldSuppressTransientFailure,
+} from "../modules/streaming/start-failure-taxonomy.ts";
+
+// A ZodError-shaped object without importing zod's class directly — the
+// classifier recognizes it structurally (name === "ZodError"), mirroring the
+// existing `isZodLikeError` in cerastream-backend.ts.
+function zodLikeError(): Error {
+	const err = new Error("Invalid config: srt_latency - too small");
+	err.name = "ZodError";
+	return err;
+}
+
+describe("classifyStartFailure — table over every known failure site", () => {
+	const cases: Array<{
+		name: string;
+		phase: Parameters<typeof classifyStartFailure>[0];
+		error: unknown;
+		expectClass: string;
+		expectRetriable: boolean;
+		expectCode?: number | string;
+	}> = [
+		// ── params phase (zod / plain validation) ────────────────────────────
+		{
+			name: "oRPC/CeraUI zod parse failure → start_invalid",
+			phase: "params",
+			error: zodLikeError(),
+			expectClass: "start_invalid",
+			expectRetriable: false,
+		},
+		{
+			name: "plain Error from validateConfig → start_invalid",
+			phase: "params",
+			error: new Error("Invalid audio delay"),
+			expectClass: "start_invalid",
+			expectRetriable: false,
+		},
+		// ── connect phase (ENOENT / ECONNREFUSED wrapped) ────────────────────
+		{
+			name: "connect ENOENT (engine socket absent) → engine_unavailable, retriable",
+			phase: "connect",
+			error: new CerastreamConnectionError(
+				"failed to connect to cerastream control socket at /run/cerastream/control.sock",
+				Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+			),
+			expectClass: "engine_unavailable",
+			expectRetriable: true,
+		},
+		{
+			name: "connect ECONNREFUSED (engine down) → engine_unavailable, retriable",
+			phase: "connect",
+			error: new CerastreamConnectionError(
+				"failed to connect",
+				Object.assign(new Error("ECONNREFUSED"), { code: "ECONNREFUSED" }),
+			),
+			expectClass: "engine_unavailable",
+			expectRetriable: true,
+		},
+		{
+			name: "connect timeout → start_timeout, retriable (connect phase)",
+			phase: "connect",
+			error: new CerastreamTimeoutError("connect", 10_000),
+			expectClass: "start_timeout",
+			expectRetriable: true,
+		},
+		// ── hello phase ──────────────────────────────────────────────────────
+		{
+			name: "hello protocol-major mismatch (-32000) → protocol_incompatible",
+			phase: "hello",
+			error: new CerastreamRpcError(
+				-32000,
+				"unsupported protocol version",
+				"cerastream.protocol.unsupported_version",
+			),
+			expectClass: "protocol_incompatible",
+			expectRetriable: false,
+			expectCode: -32000,
+		},
+		{
+			name: "hello result-shape ZodError → protocol_incompatible",
+			phase: "hello",
+			error: zodLikeError(),
+			expectClass: "protocol_incompatible",
+			expectRetriable: false,
+		},
+		{
+			name: "hello connection lost → engine_unavailable, retriable",
+			phase: "hello",
+			error: new CerastreamConnectionError("control connection is not open"),
+			expectClass: "engine_unavailable",
+			expectRetriable: true,
+		},
+		{
+			name: "hello timeout → start_timeout, NOT retriable (post-connect)",
+			phase: "hello",
+			error: new CerastreamTimeoutError("hello", 10_000),
+			expectClass: "start_timeout",
+			expectRetriable: false,
+		},
+		// ── subscribe phase ──────────────────────────────────────────────────
+		{
+			name: "subscribe timeout → start_timeout, NOT retriable (post-connect)",
+			phase: "subscribe",
+			error: new CerastreamTimeoutError("subscribe-events", 10_000),
+			expectClass: "start_timeout",
+			expectRetriable: false,
+		},
+		{
+			name: "subscribe connection lost → engine_unavailable, NOT retriable (post-connect)",
+			phase: "subscribe",
+			error: new CerastreamConnectionError("control connection is not open"),
+			expectClass: "engine_unavailable",
+			expectRetriable: false,
+		},
+		// ── start-rpc phase (JSON-RPC codes) ─────────────────────────────────
+		{
+			name: "start-rpc -32602 params.invalid → start_invalid",
+			phase: "start-rpc",
+			error: new CerastreamRpcError(
+				-32602,
+				"invalid params",
+				"cerastream.params.invalid",
+			),
+			expectClass: "start_invalid",
+			expectRetriable: false,
+			expectCode: -32602,
+		},
+		{
+			name: "start-rpc -32002 already_streaming → engine_internal",
+			phase: "start-rpc",
+			error: new CerastreamRpcError(
+				-32002,
+				"already streaming",
+				"cerastream.state.already_streaming",
+			),
+			expectClass: "engine_internal",
+			expectRetriable: false,
+			expectCode: -32002,
+		},
+		{
+			name: "start-rpc -32003 device.not_found → start_invalid",
+			phase: "start-rpc",
+			error: new CerastreamRpcError(
+				-32003,
+				"device not found",
+				"cerastream.device.not_found",
+			),
+			expectClass: "start_invalid",
+			expectRetriable: false,
+			expectCode: -32003,
+		},
+		{
+			name: "start-rpc -32603 internal → engine_internal",
+			phase: "start-rpc",
+			error: new CerastreamRpcError(-32603, "internal", "cerastream.internal"),
+			expectClass: "engine_internal",
+			expectRetriable: false,
+			expectCode: -32603,
+		},
+		{
+			name: "start-rpc request timeout → start_timeout, NOT retriable (post-connect)",
+			phase: "start-rpc",
+			error: new CerastreamTimeoutError("start", 10_000),
+			expectClass: "start_timeout",
+			expectRetriable: false,
+		},
+		// ── playing-wait phase ───────────────────────────────────────────────
+		{
+			name: "playing-wait timeout → start_timeout, NOT retriable (post-connect)",
+			phase: "playing-wait",
+			error: new CerastreamTimeoutError("start", 10_000),
+			expectClass: "start_timeout",
+			expectRetriable: false,
+		},
+	];
+
+	for (const c of cases) {
+		test(c.name, () => {
+			const failure = classifyStartFailure(c.phase, c.error, "att_test");
+			expect(failure.phase).toBe(c.phase);
+			expect(failure.class).toBe(c.expectClass);
+			expect(failure.retriable).toBe(c.expectRetriable);
+			expect(failure.attemptId).toBe("att_test");
+			if (c.expectCode !== undefined) {
+				expect(failure.code).toBe(c.expectCode);
+			}
+		});
+	}
+
+	test("an unmapped/opaque error falls to engine_internal + a logged warning, never throws", () => {
+		const warnings: string[] = [];
+		const failure = classifyStartFailure(
+			"start-rpc",
+			{ weird: true },
+			"att_x",
+			{
+				warn: (m) => warnings.push(m),
+			},
+		);
+		expect(failure.class).toBe("engine_internal");
+		expect(failure.retriable).toBe(false);
+		expect(warnings.length).toBe(1);
+	});
+
+	test("an engine RPC code outside the known table falls to engine_internal", () => {
+		const failure = classifyStartFailure(
+			"start-rpc",
+			new CerastreamRpcError(-32099, "novel", "cerastream.future.code"),
+			"att_y",
+		);
+		expect(failure.class).toBe("engine_internal");
+	});
+});
+
+describe("newAttemptId — unique, prefixed, boundary-generated", () => {
+	test("is prefixed and unique across calls", () => {
+		const a = newAttemptId();
+		const b = newAttemptId();
+		expect(a.startsWith("att_")).toBe(true);
+		expect(a).not.toBe(b);
+	});
+});
+
+describe("retry policy — bounded exponential backoff, retriable classes only", () => {
+	test("backoff grows exponentially then caps", () => {
+		const d0 = nextBackoffDelayMs(0);
+		const d1 = nextBackoffDelayMs(1);
+		const d2 = nextBackoffDelayMs(2);
+		expect(d1).toBeGreaterThanOrEqual(d0);
+		expect(d2).toBeGreaterThanOrEqual(d1);
+		expect(nextBackoffDelayMs(50)).toBeLessThanOrEqual(
+			nextBackoffDelayMs(51) + 1,
+		);
+	});
+
+	test("a retriable connect failure retries within budget", () => {
+		const failure = classifyStartFailure(
+			"connect",
+			new CerastreamConnectionError("down"),
+			"att_r",
+		);
+		expect(shouldRetryStart(failure, { attempts: 1, elapsedMs: 1000 })).toBe(
+			true,
+		);
+	});
+
+	test("a non-retriable failure never retries", () => {
+		const failure = classifyStartFailure(
+			"start-rpc",
+			new CerastreamRpcError(-32602, "bad", "cerastream.params.invalid"),
+			"att_r",
+		);
+		expect(shouldRetryStart(failure, { attempts: 1, elapsedMs: 100 })).toBe(
+			false,
+		);
+	});
+
+	test("a retriable failure stops once max attempts is exhausted", () => {
+		const failure = classifyStartFailure(
+			"connect",
+			new CerastreamConnectionError("down"),
+			"att_r",
+		);
+		expect(shouldRetryStart(failure, { attempts: 99, elapsedMs: 100 })).toBe(
+			false,
+		);
+	});
+
+	test("a retriable failure stops once the total time budget is exhausted", () => {
+		const failure = classifyStartFailure(
+			"connect",
+			new CerastreamConnectionError("down"),
+			"att_r",
+		);
+		expect(
+			shouldRetryStart(failure, { attempts: 1, elapsedMs: 10_000_000 }),
+		).toBe(false);
+	});
+});
+
+describe("suppression window — sourced from existing signals", () => {
+	test("no active window → do not suppress (a real failure surfaces)", () => {
+		expect(
+			shouldSuppressTransientFailure({
+				softwareUpdateActive: false,
+				engineRestartWindow: false,
+				bootWindow: false,
+				cancelledByStop: false,
+			}),
+		).toBe(false);
+	});
+
+	test("software-update active suppresses a transient failure", () => {
+		expect(
+			shouldSuppressTransientFailure({
+				softwareUpdateActive: true,
+				engineRestartWindow: false,
+				bootWindow: false,
+				cancelledByStop: false,
+			}),
+		).toBe(true);
+	});
+
+	test("known engine-restart window suppresses", () => {
+		expect(
+			shouldSuppressTransientFailure({
+				softwareUpdateActive: false,
+				engineRestartWindow: true,
+				bootWindow: false,
+				cancelledByStop: false,
+			}),
+		).toBe(true);
+	});
+
+	test("boot window suppresses", () => {
+		expect(
+			shouldSuppressTransientFailure({
+				softwareUpdateActive: false,
+				engineRestartWindow: false,
+				bootWindow: true,
+				cancelledByStop: false,
+			}),
+		).toBe(true);
+	});
+
+	test("cancelled-by-stop suppresses (the attempt notifies nothing)", () => {
+		expect(
+			shouldSuppressTransientFailure({
+				softwareUpdateActive: false,
+				engineRestartWindow: false,
+				bootWindow: false,
+				cancelledByStop: true,
+			}),
+		).toBe(true);
+	});
+});

--- a/docs/START-LIFECYCLE.md
+++ b/docs/START-LIFECYCLE.md
@@ -1,0 +1,267 @@
+# Start-Lifecycle Contract
+
+> **Status: DESIGN + SCHEMA ONLY** (device-quality-wave2 Todo 25).
+> This document and its two typed modules are the deliverable. Nothing here is
+> wired into a runtime path — the start/stop RPC handlers, the retry loop, the
+> suppression signals, and the frontend rendering are Todos 26-29. This contract
+> is the thing those todos build against.
+
+The streaming **start** is a multi-phase pipeline that can fail at any of several
+sites, in several ways, with very different correct responses (retry vs. surface
+vs. prompt-for-update vs. stay-calm). Today those failures are handled
+inconsistently: some become `void` notifications, some a bare `{success:false}`,
+some an untyped log line. This contract replaces that with ONE typed taxonomy so
+every later fix (unified lock, transactional launch, bounded retry, truthful
+copy, frontend watchdog) speaks the same language.
+
+Typed modules:
+
+| Concern | Module |
+|---------|--------|
+| Wire contract (`StartResult`, `StartFailure`, `StopResult`, state set, transitions, retriability) | `packages/rpc/src/schemas/streaming-lifecycle.schema.ts` |
+| Mapping table + attempt-id + retry policy + suppression predicate | `apps/backend/src/modules/streaming/start-failure-taxonomy.ts` |
+| Contract tests (schema) | `packages/rpc/src/schemas/streaming-lifecycle.schema.test.ts` |
+| Contract tests (table-driven mapping) | `apps/backend/src/tests/start-failure-taxonomy.test.ts` |
+
+The wire schema is browser-safe (pure Zod, no Node/Bun deps) so the backend
+producer (Todos 26-28) and the frontend renderer (Todo 29) consume the identical
+types. The mapping table is backend-only because it consumes the external
+`@ceralive/cerastream` error classes.
+
+---
+
+## (a) The wire RESULT UNION
+
+```
+StartResult = started | busy | cancelled | failed(StartFailure)
+```
+
+Every variant is a discriminated wire object on the `result` field, and **every
+variant echoes `attemptId`** — Todo 29 fences a stale response from an older
+attempt on it.
+
+| Variant | Shape | Meaning |
+|---------|-------|---------|
+| `started` | `{ result:'started', attemptId }` | The engine confirmed the stream reached PLAYING. |
+| `busy` | `{ result:'busy', attemptId }` | A concurrent start was already in flight (Todo 26 returns this for concurrent entry). |
+| `cancelled` | `{ result:'cancelled', attemptId }` | A stop arrived during start and cleanly cancelled this attempt (Todo 26). |
+| `failed` | `{ result:'failed', attemptId, failure: StartFailure }` | The attempt failed; `failure` carries the taxonomy. |
+
+**`busy` and `cancelled` are FIRST-CLASS results, not failure classes.** They are
+normal, expected outcomes of concurrency, not errors.
+
+**There is NO `superseded` failure class.** An attempt superseded/cancelled by a
+stop terminates as the first-class `cancelled` result — one concept, one
+representation. Introducing a `superseded` failure would be a second way to say
+the same thing.
+
+For the `failed` variant, the top-level `attemptId` **equals** `failure.attemptId`
+(a locked invariant — the schema test asserts it). Both are present because the
+plan requires every variant to echo `attemptId` at the variant level, and the
+`StartFailure` type independently carries it for standalone logging.
+
+### `StartFailure`
+
+```ts
+StartFailure = {
+  attemptId: string;                 // REQUIRED — Todo 29 fences on it
+  phase: 'params' | 'spawn-sender' | 'connect' | 'hello'
+       | 'subscribe' | 'start-rpc' | 'playing-wait';
+  class: 'engine_unavailable' | 'engine_restarting' | 'protocol_incompatible'
+       | 'start_invalid' | 'engine_internal' | 'start_timeout';
+  code?: number | string;            // engine JSON-RPC numeric code, or its string data-code
+  retriable: boolean;                // materialized verdict for THIS (class, phase)
+}
+```
+
+`phase` mirrors the real start pipeline; `class` is a small, behaviour-oriented
+bucket (retry vs. surface vs. update-prompt), NOT a 1:1 mirror of every engine
+code. `code`, when present, is the **canonical numeric JSON-RPC code** (the stable
+machine identity the taxonomy enumerates); the human-readable string data-code
+stays on the raw error for logs.
+
+### The stop-result union
+
+```
+StopResult = stopping | stopped | stop_failed(reason)
+```
+
+| Variant | Shape |
+|---------|-------|
+| `stopping` | `{ result:'stopping' }` |
+| `stopped` | `{ result:'stopped' }` |
+| `stop_failed` | `{ result:'stop_failed', reason }` |
+
+A stop that cancels an in-flight start produces a first-class **`cancelled`
+StartResult** for that attempt (above); the stop call itself returns a
+`StopResult`. Todo 27 makes stop return a bounded `stopping → stopped | stop_failed`.
+
+---
+
+## The failure-site mapping table (cross-check)
+
+Every failure site found by searching the codebase (and the pinned external
+`@ceralive/cerastream@2026.7.2` client, which owns the ENOENT/refused wrapping,
+the hello/subscribe/request timeouts, and the JSON-RPC codes) is mapped to
+exactly one taxonomy class. This is the checklist the acceptance criteria
+require — each row is a site that was found and mapped.
+
+| # | Failure site (searched for) | Location | Phase | Class | Retriable |
+|---|-----------------------------|----------|-------|-------|-----------|
+| 1 | oRPC input validation (Zod) | `packages/rpc/src/contracts/streaming.contract.ts:38` (input schema) | `params` | `start_invalid` | no |
+| 2 | `validateConfig` `safeParse` | `apps/backend/src/modules/streaming/streaming.ts:126-136` | `params` | `start_invalid` | no |
+| 3 | `startParamsWithAudioModeSchema.parse` | `cerastream-backend.ts:824-833` | `params` | `start_invalid` | no |
+| 4 | plain validation `Error`s (delay/pipeline/codec/bitrate/latency) | `streaming.ts:140-190` | `params` | `start_invalid` | no |
+| 5 | connect **ENOENT** (engine socket absent) → `CerastreamConnectionError` | client `client.js:52`; surfaced at `cerastream-backend.ts:447` | `connect` | `engine_unavailable` | **yes** |
+| 6 | connect **ECONNREFUSED** (engine down) → `CerastreamConnectionError` | client; surfaced at `cerastream-backend.ts:447` | `connect` | `engine_unavailable` | **yes** |
+| 7 | **transport-connect wrap** (generic `CerastreamConnectionError`) | `cerastream-backend.ts:384-387`, `729-744` | `connect` | `engine_unavailable` | **yes** |
+| 8 | connect **timeout** (`CerastreamTimeoutError`) | client `requestTimeoutMs: 10_000`, `client.js:9,133` | `connect` | `start_timeout` | **yes** |
+| 9 | **hello** protocol-major mismatch (`-32000` / `unsupported_version`) | `cerastream-backend.ts:366-375`; codes `errors.js:74` | `hello` | `protocol_incompatible` | no |
+| 10 | **hello** result-shape `ZodError` (`helloResultSchema.parse`) | client `client.js:61`; classified `cerastream-backend.ts:355-363` | `hello` | `protocol_incompatible` | no |
+| 11 | **hello** connection **close** (`CerastreamConnectionError`) | `cerastream-backend.ts:383-387` | `hello` | `engine_unavailable` | **yes** |
+| 12 | **hello** timeout (`CerastreamTimeoutError`) | client `client.js:131-134` | `hello` | `start_timeout` | no |
+| 13 | **subscribe** timeout (`CerastreamTimeoutError`) | `cerastream-backend.ts:449-451` (`subscribeEvents`) | `subscribe` | `start_timeout` | no |
+| 14 | **subscribe** connection lost (`CerastreamConnectionError`) | `cerastream-backend.ts:449-451` | `subscribe` | `engine_unavailable` | no |
+| 15 | start-RPC `-32000` unsupported_version | `errors.js:74` | `start-rpc` | `protocol_incompatible` | no |
+| 16 | start-RPC `-32602` params.invalid | `errors.js:75` | `start-rpc` | `start_invalid` | no |
+| 17 | start-RPC `-32002` already_streaming | `errors.js:77` | `start-rpc` | `engine_internal` | no |
+| 18 | start-RPC `-32003` device.not_found | `errors.js:78` | `start-rpc` | `start_invalid` | no |
+| 19 | start-RPC `-32603` internal | `errors.js:82` | `start-rpc` | `engine_internal` | no |
+| 20 | client **request timeout** (10s) on the `start` RPC | client `client.js:9` (`requestTimeoutMs: 10_000`) | `start-rpc` | `start_timeout` | no |
+| 21 | **PLAYING wait** timeout | (see note) | `playing-wait` | `start_timeout` | no |
+| 22 | any **unmapped/opaque** shape | fallback in `classifyStartFailure` | *(caller phase)* | `engine_internal` | no |
+
+**Notes on sites the plan assumed but the codebase does NOT currently have as
+literal code:**
+
+- **PLAYING wait timeout (row 21).** There is **no dedicated 5s PLAYING wait** in
+  CeraUI's start path today. The `@ceralive/cerastream` client's `start` call
+  resolves only when the engine confirms PLAYING, bounded by the SAME 10s
+  `requestTimeoutMs` — surfacing as a `CerastreamTimeoutError`. The `playing-wait`
+  phase and its `start_timeout → not-retriable` mapping are therefore reserved
+  for Todo 27, which introduces an explicit awaited PLAYING wait with a per-phase
+  deadline. (`health.ts:39` `FRAMES_FRESHNESS_MS = 5000` is a frame-freshness
+  value for the health rollup, NOT a start-time wait — do not conflate them.)
+- **`spawn-sender` phase.** The `srtla_send` spawn (`start-stream.ts`) has no
+  typed failure today (Todo 27 adds the transactional rollback). The phase is
+  reserved so a spawn failure has a home when that wiring lands. It maps to
+  `start_invalid`/`engine_internal` via the generic `Error` fallback in the
+  interim.
+- **`-32001` (not_streaming), `-32004` (bitrate), `-32005` (preview),
+  `-32006` (audio device)** exist in the client's `RPC_ERROR_NUMERIC`
+  (`errors.js:76-81`) but are not START-path outcomes (they belong to stop /
+  setBitrate / preview / audio-switch); an unexpected one at start falls through
+  to `engine_internal` (row 22) rather than being silently dropped.
+
+The mapping is realized by `classifyStartFailure(phase, error, attemptId)`, which
+**never throws**: an unmapped/opaque shape is bucketed as `engine_internal` and a
+warning is emitted so the drop-through is observable (asserted in the mapping
+tests).
+
+---
+
+## (b) Attempt-ID generation
+
+`newAttemptId()` (in `start-failure-taxonomy.ts`) mints one id at the **public
+`start` boundary** — a time-sortable prefix plus random entropy
+(`att_<base36 time>_<rand>`). It is carried through the queue, the logs, the
+notification detail, and every `StartResult` variant. Todo 26 generates it once
+per public start entry; Todo 29 uses it to fence stale responses.
+
+---
+
+## (c) Suppression window
+
+A transient (retriable) failure inside a KNOWN window should show a calm "engine
+starting…" state, not an error notification. `shouldSuppressTransientFailure(ctx)`
+is the pure predicate; each input is sourced from an **existing** backend signal
+(Todo 28 binds them — this contract defines the shape + the source map):
+
+| Window | `SuppressionContext` field | Existing signal source |
+|--------|----------------------------|------------------------|
+| Software update active | `softwareUpdateActive` | `isUpdating()` (software-updates module) |
+| Known engine restart (systemd `RestartSec=5`) | `engineRestartWindow` | engine-reconnect capability state (`engineUnavailable`/`engineStarting`) |
+| Boot window | `bootWindow` | boot-readiness/health module |
+| Cancelled by stop | `cancelledByStop` | the attempt ended as the first-class `cancelled` result — it notifies nothing |
+
+A **real terminal** failure (budget exhausted, or a non-retriable class) is NEVER
+suppressed — that gating lives in the retry loop (Todo 28), not in this predicate.
+
+---
+
+## (d) Retry policy
+
+Bounded exponential backoff, for **retriable classes only**, with a max-attempts
+AND a total-time budget (`DEFAULT_START_RETRY_POLICY`: 5 attempts / 60s budget /
+2s base / 16s ceiling — chosen against the supervision windows: systemd
+`RestartSec=5`, crash-loop 5/60s).
+
+- `nextBackoffDelayMs(attempt, policy)` — `base·2^attempt`, capped at `maxDelayMs`.
+- `shouldRetryStart(failure, {attempts, elapsedMs}, policy)` — retries iff the
+  failure is `retriable` AND both budgets remain.
+
+Retriability is **phase-scoped** (see the retriability table below): only failures
+in the connection-establishment phases (`connect`, and `hello` for the
+availability classes) are retriable, because a failure BEFORE the engine accepts
+the start is a boot/restart race a clean re-dial resolves, whereas a failure AFTER
+(`subscribe`/`start-rpc`/`playing-wait`) means the engine accepted us then
+faltered mid-start — a blind retry there would stack a duplicate/half-applied
+start, so Todo 27 rolls back and escalates instead.
+
+### Retriability table (every class marked, with a one-line WHY)
+
+| Class | Retriable phases | Why |
+|-------|------------------|-----|
+| `engine_unavailable` | `connect`, `hello` | The engine is not answering yet (ENOENT/refused/dropped while connecting); a bounded retry across the boot/restart window reconnects with no operator action — but only before the start is accepted. |
+| `engine_restarting` | `connect`, `hello` | A known systemd `RestartSec=5` restart is in flight; retrying across the restart window reaches the fresh engine — only while still establishing the connection. |
+| `start_timeout` | `connect` | A connect-phase timeout is a slow-boot race and retries cleanly; a timeout AFTER connect means a half-applied start on a wedged engine, so a retry would stack a duplicate start — escalate instead. |
+| `protocol_incompatible` | *(none)* | An engine/bindings protocol-major mismatch is deterministic — the same binaries never negotiate on retry, so surface an update prompt instead of looping. |
+| `start_invalid` | *(none)* | Invalid params/config are deterministic — an identical retry fails identically, so the operator (or cloud) must fix the input first. |
+| `engine_internal` | *(none)* | A deterministic engine-side fault or state conflict (e.g. already_streaming / -32603); retrying masks a real bug and can orphan resources — surface with a journal pointer. |
+
+---
+
+## (e) Lifecycle state set + legal transitions
+
+State set: `idle | starting | streaming | stopping | stop_failed | reconciling`.
+
+- `starting` is **distinct** from `streaming` (Todo 26: `is_streaming=true` only
+  after engine confirmation).
+- `reconciling` is the boot/reconnect state where the backend queries the
+  engine's actual runtime state and adopts it (the engine may be streaming while
+  CeraUI restarted).
+- `stop_failed` is a terminal-until-retried state a stop can land in.
+
+Legal transitions (anything else is an invariant violation → structured recovery,
+Todo 26 — never a silent state stomp; a self-loop is never a transition):
+
+```
+idle        → starting      (start requested)
+idle        → reconciling   (boot / reconnect entry)
+starting    → streaming     (engine confirmed PLAYING)
+starting    → idle          (terminal start failure, or cancelled-and-cleaned)
+starting    → stopping      (an explicit stop arrived mid-start)
+starting    → reconciling   (backend reconnect mid-start)
+streaming   → stopping      (stop requested)
+streaming   → reconciling   (backend reconnect while streaming)
+stopping    → idle          (stopped)
+stopping    → stop_failed   (stop did not settle within the bound)
+stop_failed → stopping      (retry the stop)
+stop_failed → idle          (reconciled / abandoned to idle)
+reconciling → streaming     (engine was streaming — adopt)
+reconciling → idle          (engine was idle — adopt)
+```
+
+`isLegalLifecycleTransition(from, to)` is the pure guard over
+`LEGAL_LIFECYCLE_TRANSITIONS`.
+
+---
+
+## What this unblocks
+
+| Todo | Uses from this contract |
+|------|-------------------------|
+| 26 (unified lock + boot reconciliation) | `busy`/`cancelled` results, `attemptId`, the state set + transitions, `reconciling` |
+| 27 (transactional launch + phase deadlines + honest stop) | per-phase `StartFailure`, `start_timeout`, `StopResult` |
+| 28 (bounded retry + suppression + truthful copy) | retry policy, retriability table, suppression predicate, `code`/`class` for copy |
+| 29 (frontend watchdog + generation identity + typed rendering) | `attemptId` fencing, `phase`+`class` → i18n rendering |

--- a/packages/rpc/src/schemas/index.ts
+++ b/packages/rpc/src/schemas/index.ts
@@ -19,5 +19,6 @@ export * from './sources-visibility.schema';
 export * from './status.schema';
 export * from './stream-profile.schema';
 export * from './streaming.schema';
+export * from './streaming-lifecycle.schema';
 export * from './system.schema';
 export * from './wifi.schema';

--- a/packages/rpc/src/schemas/streaming-lifecycle.schema.test.ts
+++ b/packages/rpc/src/schemas/streaming-lifecycle.schema.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Start-lifecycle contract schema tests (device-quality-wave2 Todo 25).
+ *
+ * Locks the WIRE RESULT UNION (`StartResult = started | busy | cancelled |
+ * failed`), the `StartFailure` shape, the stop-result union
+ * (`stopping → stopped | stop_failed`), the lifecycle state set, and the
+ * legal-transition table. Design-only: these types are consumed by Todos 26-29;
+ * nothing is wired into a runtime path yet.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import {
+	isLegalLifecycleTransition,
+	isRetriableStartFailure,
+	LEGAL_LIFECYCLE_TRANSITIONS,
+	LIFECYCLE_STATES,
+	lifecycleStateSchema,
+	START_FAILURE_CLASSES,
+	START_FAILURE_PHASES,
+	START_FAILURE_RETRIABILITY,
+	startFailureClassSchema,
+	startFailurePhaseSchema,
+	startFailureSchema,
+	startResultSchema,
+	stopResultSchema,
+} from './streaming-lifecycle.schema';
+
+describe('StartFailure shape', () => {
+	const base = {
+		attemptId: 'att_abc123',
+		phase: 'connect' as const,
+		class: 'engine_unavailable' as const,
+		retriable: true,
+	};
+
+	test('accepts a well-formed failure (no code)', () => {
+		const parsed = startFailureSchema.parse(base);
+		expect(parsed.attemptId).toBe('att_abc123');
+		expect(parsed.phase).toBe('connect');
+		expect(parsed.class).toBe('engine_unavailable');
+		expect(parsed.retriable).toBe(true);
+		expect(parsed.code).toBeUndefined();
+	});
+
+	test('accepts an optional numeric engine code', () => {
+		const parsed = startFailureSchema.parse({
+			...base,
+			phase: 'start-rpc',
+			class: 'engine_internal',
+			retriable: false,
+			code: -32603,
+		});
+		expect(parsed.code).toBe(-32603);
+	});
+
+	test('accepts an optional string engine data-code', () => {
+		const parsed = startFailureSchema.parse({
+			...base,
+			phase: 'hello',
+			class: 'protocol_incompatible',
+			retriable: false,
+			code: 'cerastream.protocol.unsupported_version',
+		});
+		expect(parsed.code).toBe('cerastream.protocol.unsupported_version');
+	});
+
+	test('REJECTS an unknown phase', () => {
+		expect(startFailurePhaseSchema.safeParse('warmup').success).toBe(false);
+	});
+
+	test('REJECTS an unknown class', () => {
+		expect(startFailureClassSchema.safeParse('superseded').success).toBe(false);
+	});
+
+	test('REJECTS a failure missing attemptId (Todo 29 fencing needs it)', () => {
+		const { attemptId: _drop, ...noId } = base;
+		expect(startFailureSchema.safeParse(noId).success).toBe(false);
+	});
+});
+
+describe('StartResult wire union — every variant echoes attemptId', () => {
+	test('started', () => {
+		const parsed = startResultSchema.parse({ result: 'started', attemptId: 'att_1' });
+		expect(parsed.result).toBe('started');
+		expect(parsed.attemptId).toBe('att_1');
+	});
+
+	test('busy is a FIRST-CLASS result, not a failure class', () => {
+		const parsed = startResultSchema.parse({ result: 'busy', attemptId: 'att_2' });
+		expect(parsed.result).toBe('busy');
+		expect(parsed.attemptId).toBe('att_2');
+		expect(START_FAILURE_CLASSES).not.toContain('busy');
+	});
+
+	test('cancelled is a FIRST-CLASS result (no superseded failure class)', () => {
+		const parsed = startResultSchema.parse({ result: 'cancelled', attemptId: 'att_3' });
+		expect(parsed.result).toBe('cancelled');
+		expect(START_FAILURE_CLASSES).not.toContain('cancelled');
+		expect(START_FAILURE_CLASSES).not.toContain('superseded');
+	});
+
+	test('failed carries a StartFailure whose attemptId matches the variant (fencing invariant)', () => {
+		const parsed = startResultSchema.parse({
+			result: 'failed',
+			attemptId: 'att_4',
+			failure: {
+				attemptId: 'att_4',
+				phase: 'start-rpc',
+				class: 'start_invalid',
+				retriable: false,
+				code: -32602,
+			},
+		});
+		if (parsed.result !== 'failed') throw new Error('discriminant lost');
+		expect(parsed.attemptId).toBe(parsed.failure.attemptId);
+	});
+
+	test('REJECTS every variant missing attemptId', () => {
+		expect(startResultSchema.safeParse({ result: 'started' }).success).toBe(false);
+		expect(startResultSchema.safeParse({ result: 'busy' }).success).toBe(false);
+		expect(startResultSchema.safeParse({ result: 'cancelled' }).success).toBe(false);
+	});
+
+	test('REJECTS an unknown result discriminant', () => {
+		expect(startResultSchema.safeParse({ result: 'superseded', attemptId: 'att_x' }).success).toBe(
+			false,
+		);
+	});
+});
+
+describe('StopResult wire union — stopping → stopped | stop_failed', () => {
+	test('stopping', () => {
+		expect(stopResultSchema.parse({ result: 'stopping' }).result).toBe('stopping');
+	});
+
+	test('stopped', () => {
+		expect(stopResultSchema.parse({ result: 'stopped' }).result).toBe('stopped');
+	});
+
+	test('stop_failed carries a reason', () => {
+		const parsed = stopResultSchema.parse({ result: 'stop_failed', reason: 'engine wedged' });
+		if (parsed.result !== 'stop_failed') throw new Error('discriminant lost');
+		expect(parsed.reason).toBe('engine wedged');
+	});
+
+	test('REJECTS an unknown stop discriminant', () => {
+		expect(stopResultSchema.safeParse({ result: 'aborted' }).success).toBe(false);
+	});
+});
+
+describe('lifecycle state set + legal transitions', () => {
+	test('the state set is exactly the six documented states', () => {
+		expect([...LIFECYCLE_STATES].sort()).toEqual(
+			['idle', 'reconciling', 'starting', 'stop_failed', 'stopping', 'streaming'].sort(),
+		);
+	});
+
+	test('every state parses', () => {
+		for (const s of LIFECYCLE_STATES) {
+			expect(lifecycleStateSchema.parse(s)).toBe(s);
+		}
+	});
+
+	test('the happy path is legal (idle→starting→streaming→stopping→idle)', () => {
+		expect(isLegalLifecycleTransition('idle', 'starting')).toBe(true);
+		expect(isLegalLifecycleTransition('starting', 'streaming')).toBe(true);
+		expect(isLegalLifecycleTransition('streaming', 'stopping')).toBe(true);
+		expect(isLegalLifecycleTransition('stopping', 'idle')).toBe(true);
+	});
+
+	test('start failure/cancel returns to idle (starting→idle is legal)', () => {
+		expect(isLegalLifecycleTransition('starting', 'idle')).toBe(true);
+	});
+
+	test('boot reconciliation adopts the engine truth (reconciling→streaming|idle)', () => {
+		expect(isLegalLifecycleTransition('idle', 'reconciling')).toBe(true);
+		expect(isLegalLifecycleTransition('reconciling', 'streaming')).toBe(true);
+		expect(isLegalLifecycleTransition('reconciling', 'idle')).toBe(true);
+	});
+
+	test('stop_failed can retry the stop or reconcile to idle', () => {
+		expect(isLegalLifecycleTransition('stopping', 'stop_failed')).toBe(true);
+		expect(isLegalLifecycleTransition('stop_failed', 'stopping')).toBe(true);
+		expect(isLegalLifecycleTransition('stop_failed', 'idle')).toBe(true);
+	});
+
+	test('an illegal jump is rejected (idle→streaming skips starting)', () => {
+		expect(isLegalLifecycleTransition('idle', 'streaming')).toBe(false);
+	});
+
+	test('a self-loop is not a transition', () => {
+		expect(isLegalLifecycleTransition('idle', 'idle')).toBe(false);
+	});
+
+	test('every declared transition uses only real states', () => {
+		for (const [from, to] of LEGAL_LIFECYCLE_TRANSITIONS) {
+			expect(LIFECYCLE_STATES).toContain(from);
+			expect(LIFECYCLE_STATES).toContain(to);
+		}
+	});
+});
+
+describe('retriability — every class has an explicit WHY', () => {
+	test('every taxonomy class has a retriability entry with a rationale', () => {
+		for (const cls of START_FAILURE_CLASSES) {
+			const entry = START_FAILURE_RETRIABILITY[cls];
+			expect(entry).toBeDefined();
+			expect(typeof entry.why).toBe('string');
+			expect(entry.why.length).toBeGreaterThan(10);
+		}
+	});
+
+	test('engine_unavailable + engine_restarting are always retriable', () => {
+		expect(isRetriableStartFailure('engine_unavailable', 'connect')).toBe(true);
+		expect(isRetriableStartFailure('engine_restarting', 'connect')).toBe(true);
+	});
+
+	test('start_timeout is retriable ONLY on the connect phase', () => {
+		expect(isRetriableStartFailure('start_timeout', 'connect')).toBe(true);
+		expect(isRetriableStartFailure('start_timeout', 'hello')).toBe(false);
+		expect(isRetriableStartFailure('start_timeout', 'subscribe')).toBe(false);
+		expect(isRetriableStartFailure('start_timeout', 'start-rpc')).toBe(false);
+		expect(isRetriableStartFailure('start_timeout', 'playing-wait')).toBe(false);
+	});
+
+	test('protocol_incompatible / start_invalid / engine_internal are never retriable', () => {
+		for (const phase of START_FAILURE_PHASES) {
+			expect(isRetriableStartFailure('protocol_incompatible', phase)).toBe(false);
+			expect(isRetriableStartFailure('start_invalid', phase)).toBe(false);
+			expect(isRetriableStartFailure('engine_internal', phase)).toBe(false);
+		}
+	});
+});

--- a/packages/rpc/src/schemas/streaming-lifecycle.schema.ts
+++ b/packages/rpc/src/schemas/streaming-lifecycle.schema.ts
@@ -1,0 +1,212 @@
+/**
+ * Start-lifecycle contract — the typed WIRE CONTRACT for the streaming
+ * start/stop lifecycle (device-quality-wave2 Todo 25, DESIGN + SCHEMA ONLY).
+ *
+ * This module is the single source of truth for:
+ *   (a) the wire RESULT UNION `StartResult = started | busy | cancelled | failed`
+ *       and the `StartFailure` taxonomy it carries;
+ *   (b) the stop-result union `stopping → stopped | stop_failed`;
+ *   (e) the lifecycle state set + its legal transitions.
+ *
+ * `busy` and `cancelled` are FIRST-CLASS results, NOT failure classes: a later
+ * change (Todo 26) returns them for concurrent-entry and stop-during-start. There
+ * is deliberately NO `superseded` failure class — an attempt superseded/cancelled
+ * by a stop terminates as the first-class `cancelled` result (one concept, one
+ * representation).
+ *
+ * EVERY union variant is a discriminated wire object carrying `attemptId` so a
+ * later change (Todo 29) can fence a stale response from an older attempt.
+ *
+ * Nothing here is wired into a runtime path — the start/stop RPC handlers,
+ * retry loop, and suppression signals are Todos 26-29. This is browser-safe
+ * (pure Zod + pure predicates, no Node/Bun deps) so both the backend producer
+ * and the frontend renderer consume the identical types.
+ */
+
+import { z } from 'zod';
+
+// ─── (a) StartFailure taxonomy ───────────────────────────────────────────────
+
+/**
+ * The phase of the start pipeline a failure surfaced in. Mirrors the real start
+ * flow: input validation → sender spawn → engine connect → hello handshake →
+ * event subscription → the `start` RPC → the wait for the engine to reach
+ * PLAYING.
+ */
+export const START_FAILURE_PHASES = [
+	'params',
+	'spawn-sender',
+	'connect',
+	'hello',
+	'subscribe',
+	'start-rpc',
+	'playing-wait',
+] as const;
+export const startFailurePhaseSchema = z.enum(START_FAILURE_PHASES);
+export type StartFailurePhase = z.infer<typeof startFailurePhaseSchema>;
+
+/**
+ * The taxonomy class a failure is bucketed into. Deliberately small and
+ * behaviour-oriented (retry vs surface vs update-prompt), NOT a 1:1 mirror of
+ * every engine code — many codes collapse onto one class.
+ *
+ * There is NO `superseded` class: a stop-cancelled attempt is the first-class
+ * `cancelled` StartResult, never a failure.
+ */
+export const START_FAILURE_CLASSES = [
+	'engine_unavailable',
+	'engine_restarting',
+	'protocol_incompatible',
+	'start_invalid',
+	'engine_internal',
+	'start_timeout',
+] as const;
+export const startFailureClassSchema = z.enum(START_FAILURE_CLASSES);
+export type StartFailureClass = z.infer<typeof startFailureClassSchema>;
+
+/**
+ * A structured start failure. `attemptId` is REQUIRED on every failure (Todo 29
+ * fences stale responses on it). `code` is the engine's numeric JSON-RPC code
+ * (e.g. -32603) or its stable string data-code (e.g.
+ * `cerastream.protocol.unsupported_version`) when the failure came from an
+ * engine error response; absent for local/transport failures. `retriable` is
+ * the MATERIALIZED verdict for THIS (class, phase) — see `isRetriableStartFailure`.
+ */
+export const startFailureSchema = z.object({
+	attemptId: z.string(),
+	phase: startFailurePhaseSchema,
+	class: startFailureClassSchema,
+	code: z.union([z.number(), z.string()]).optional(),
+	retriable: z.boolean(),
+});
+export type StartFailure = z.infer<typeof startFailureSchema>;
+
+// ─── (a) StartResult wire union — every variant echoes attemptId ─────────────
+
+export const startResultSchema = z.discriminatedUnion('result', [
+	z.object({ result: z.literal('started'), attemptId: z.string() }),
+	z.object({ result: z.literal('busy'), attemptId: z.string() }),
+	z.object({ result: z.literal('cancelled'), attemptId: z.string() }),
+	z.object({
+		result: z.literal('failed'),
+		attemptId: z.string(),
+		failure: startFailureSchema,
+	}),
+]);
+export type StartResult = z.infer<typeof startResultSchema>;
+
+// ─── (a) Stop-result wire union — stopping → stopped | stop_failed ───────────
+
+export const stopResultSchema = z.discriminatedUnion('result', [
+	z.object({ result: z.literal('stopping') }),
+	z.object({ result: z.literal('stopped') }),
+	z.object({ result: z.literal('stop_failed'), reason: z.string() }),
+]);
+export type StopResult = z.infer<typeof stopResultSchema>;
+
+// ─── (e) Lifecycle state set + legal transitions ─────────────────────────────
+
+/**
+ * The backend lifecycle state set. `starting` is DISTINCT from `streaming`
+ * (Todo 26: `is_streaming=true` only after engine confirmation); `reconciling`
+ * is the boot/reconnect state where the backend queries the engine's actual
+ * runtime state and adopts it; `stop_failed` is a terminal-until-retried state
+ * a stop can land in.
+ */
+export const LIFECYCLE_STATES = [
+	'idle',
+	'starting',
+	'streaming',
+	'stopping',
+	'stop_failed',
+	'reconciling',
+] as const;
+export const lifecycleStateSchema = z.enum(LIFECYCLE_STATES);
+export type LifecycleState = z.infer<typeof lifecycleStateSchema>;
+
+/**
+ * The complete set of LEGAL `[from, to]` transitions. Anything not listed is
+ * illegal (an invariant violation Todo 26 turns into structured recovery, not a
+ * silent state stomp). A self-loop is never a transition.
+ */
+export const LEGAL_LIFECYCLE_TRANSITIONS: ReadonlyArray<readonly [LifecycleState, LifecycleState]> =
+	[
+		// start requested / boot reconcile entry
+		['idle', 'starting'],
+		['idle', 'reconciling'],
+		// launch outcomes
+		['starting', 'streaming'], // engine confirmed PLAYING
+		['starting', 'idle'], // terminal start failure OR cancelled-and-cleaned
+		['starting', 'stopping'], // an explicit stop arrived mid-start
+		['starting', 'reconciling'], // backend reconnect mid-start
+		// running
+		['streaming', 'stopping'],
+		['streaming', 'reconciling'], // backend reconnect while streaming
+		// stopping outcomes
+		['stopping', 'idle'], // stopped
+		['stopping', 'stop_failed'], // stop did not settle within the bound
+		// stop recovery
+		['stop_failed', 'stopping'], // retry the stop
+		['stop_failed', 'idle'], // reconciled/abandoned to idle
+		// reconcile outcomes — adopt the engine truth
+		['reconciling', 'streaming'],
+		['reconciling', 'idle'],
+	] as const;
+
+const LEGAL_TRANSITION_KEYS = new Set(
+	LEGAL_LIFECYCLE_TRANSITIONS.map(([from, to]) => `${from}>${to}`),
+);
+
+/** True iff `from → to` is a declared legal lifecycle transition. */
+export function isLegalLifecycleTransition(from: LifecycleState, to: LifecycleState): boolean {
+	return LEGAL_TRANSITION_KEYS.has(`${from}>${to}`);
+}
+
+// ─── (d) Retriability — every class carries an explicit WHY ───────────────────
+
+/**
+ * Per-class retriability metadata. `retriablePhases` is the exact set of phases
+ * on which the class is retriable (empty = never); `why` is the required one-line
+ * rationale — a bare boolean is not a decision.
+ *
+ * Retriability is phase-scoped to the connection-establishment phases because a
+ * failure BEFORE the engine has accepted the start (connect/hello) is a
+ * boot/restart race a clean re-dial resolves, whereas a failure AFTER
+ * (subscribe/start-rpc/playing-wait) means the engine accepted us then faltered
+ * mid-start — a blind retry there would stack a duplicate/half-applied start, so
+ * Todo 27 rolls back and escalates instead.
+ */
+export const START_FAILURE_RETRIABILITY: Record<
+	StartFailureClass,
+	{ retriablePhases: readonly StartFailurePhase[]; why: string }
+> = {
+	engine_unavailable: {
+		retriablePhases: ['connect', 'hello'],
+		why: 'The engine is not answering yet (ENOENT/refused/dropped while connecting); a bounded retry across the boot/restart window reconnects with no operator action — but only before the start is accepted.',
+	},
+	engine_restarting: {
+		retriablePhases: ['connect', 'hello'],
+		why: 'A known systemd RestartSec=5 restart is in flight; retrying across the restart window reaches the fresh engine — only while still establishing the connection.',
+	},
+	start_timeout: {
+		retriablePhases: ['connect'],
+		why: 'A connect-phase timeout is a slow-boot race and retries cleanly; a timeout AFTER connect means a half-applied start on a wedged engine, so a retry would stack a duplicate start — escalate instead.',
+	},
+	protocol_incompatible: {
+		retriablePhases: [],
+		why: 'An engine/bindings protocol-major mismatch is deterministic — the same binaries never negotiate on retry, so surface an update prompt instead of looping.',
+	},
+	start_invalid: {
+		retriablePhases: [],
+		why: 'Invalid params/config are deterministic — an identical retry fails identically, so the operator (or cloud) must fix the input first.',
+	},
+	engine_internal: {
+		retriablePhases: [],
+		why: 'A deterministic engine-side fault or state conflict (e.g. already_streaming / -32603); retrying masks a real bug and can orphan resources — surface with a journal pointer.',
+	},
+};
+
+/** The materialized retriability verdict for a concrete (class, phase). */
+export function isRetriableStartFailure(cls: StartFailureClass, phase: StartFailurePhase): boolean {
+	return START_FAILURE_RETRIABILITY[cls].retriablePhases.includes(phase);
+}


### PR DESCRIPTION
## What

Adds the **typed start-lifecycle contract** for the streaming engine — a design +
schema deliverable, **no behavior wiring**. Two typed modules plus a doc:

- `packages/rpc/src/schemas/streaming-lifecycle.schema.ts` — the wire contract:
  the `StartResult = started | busy | cancelled | failed(StartFailure)` union
  (every variant echoes `attemptId`), the `StartFailure` taxonomy
  (`phase` × `class` × `code?` × `retriable`), the stop union
  `stopping → stopped | stop_failed`, the lifecycle state set
  (`idle | starting | streaming | stopping | stop_failed | reconciling`) with its
  legal-transition table, and the per-class retriability table (each class marked
  retriable/not with a one-line rationale).
- `apps/backend/src/modules/streaming/start-failure-taxonomy.ts` — the mapping
  layer: `classifyStartFailure(phase, error, attemptId)` maps every known
  start-path failure site to a taxonomy class (never throws — an unmapped shape
  falls to `engine_internal` + a logged warning), plus `newAttemptId()`, the
  bounded-backoff retry policy, and the suppression-window predicate.
- `docs/START-LIFECYCLE.md` — the contract doc (sub-parts a–e) with the full
  failure-site cross-check table.

`busy` and `cancelled` are **first-class results**, not failure classes. There is
deliberately **no `superseded` class** — a stop-cancelled attempt is the
first-class `cancelled` result.

## Why

The streaming start is a multi-phase pipeline that fails at several sites in
several ways with very different correct responses (retry vs. surface vs.
update-prompt vs. stay-calm). Today those failures are handled inconsistently —
some become `void` notifications, some a bare `{success:false}`, some an untyped
log line. This contract is the single typed vocabulary the four follow-up
lifecycle fixes (unified lock + boot reconciliation, transactional launch +
phase deadlines, bounded retry + suppression, frontend watchdog + typed
rendering) all build against. Nailing it down first prevents each of those from
inventing its own ad-hoc shapes.

## How to verify

```bash
bun test packages/rpc/src/schemas/streaming-lifecycle.schema.test.ts   # 29 pass
bun test apps/backend/src/tests/start-failure-taxonomy.test.ts         # 30 pass
bun run check:tech-debt                                                # OK
bun run --filter @ceraui/rpc check                                     # tsc exit 0
```

The mapping test is table-driven over every failure source found in the codebase
AND in the pinned external `@ceralive/cerastream@2026.7.2` client (zod parse,
connect ENOENT/ECONNREFUSED, hello timeout/close/protocol-major, subscribe
timeout, start-RPC codes -32000/-32002/-32003/-32602/-32603, transport-connect
wrap, the client's 10s request timeout, the reserved PLAYING wait) — each mapped
to one taxonomy class, cross-checked in the doc. The tests were written RED-first
(module-not-found), then made GREEN.

## Risks

Low — **purely additive**. The two modules are imported by nothing on any runtime
path (verified by grep: only the module itself + the inert `@ceraui/rpc/schemas`
barrel re-export). No change to `streaming.procedure.ts`, `session.ts`, or
`cerastream-backend.ts`; no engine-side change. The `playing-wait` and
`spawn-sender` phases are reserved for the follow-up that introduces those awaited
sites — documented in the doc as sites the codebase does not literally have yet.
