### PR TITLE
feat(audio): always-visible level meter + engine bridge + real device naming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ setup.json are coerced to `"cerastream"` at parse time with a warning).
 The backend resolves both streaming deps as public-npm registry packages — no sibling checkout, no vendored tarball:
 
 ```
-"@ceralive/cerastream":  "2026.7.2"   (public npm, @ceralive scope)
+"@ceralive/cerastream":  "2026.7.3"   (public npm, @ceralive scope)
 "@ceralive/srtla-send":  "2026.6.2"   (public npm, @ceralive scope)
 ```
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -9,7 +9,7 @@
 		"bun": ">=1.3.0"
 	},
 	"dependencies": {
-		"@ceralive/cerastream": "2026.7.2",
+		"@ceralive/cerastream": "2026.7.3",
 		"@ceralive/control-protocol": "2026.7.0",
 		"@ceralive/srtla-send": "2026.6.2",
 		"@ceraui/rpc": "workspace:*",

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -77,6 +77,7 @@ import {
 	startAudioDeviceWatcher,
 	updateAudioDevices,
 } from "./modules/streaming/audio.ts";
+import { initAudioMeterBridge } from "./modules/streaming/audio-meter-bridge.ts";
 import { startBcrpt } from "./modules/streaming/bcrpt.ts";
 import { checkCamlinkUsb2 } from "./modules/streaming/camlink.ts";
 import { checkEngineCompatibilityOnStartup } from "./modules/streaming/cerastream-backend.ts";
@@ -264,6 +265,15 @@ await guardNonCritical("sources", () =>
 			: undefined,
 	),
 );
+// Always-on audio-level bridge: one long-lived subscription to the engine's
+// `audio-level` topic, re-broadcast over the main authed WS so the LiveView meter
+// moves while idle with no preview open (device-quality-wave2 Todo 22). Skipped
+// under mocks (no real engine socket); fire-and-forget, never blocks boot.
+if (!shouldUseMocks()) {
+	await guardNonCritical("audio-meter", async () => {
+		initAudioMeterBridge();
+	});
+}
 logger.info(bootTimer.phase("🔌", "pipelines"));
 
 // DEV-ONLY preview WebSocket server: `startMockPreviewServer` gates on

--- a/apps/backend/src/modules/streaming/audio-meter-bridge.ts
+++ b/apps/backend/src/modules/streaming/audio-meter-bridge.ts
@@ -1,0 +1,256 @@
+/*
+    CeraUI - web UI for the CERALIVE project
+    Copyright (C) 2024-2025 CeraLive project
+
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+// Always-on audio-level bridge (device-quality-wave2 Todo 22).
+//
+// The cerastream engine runs an ALWAYS-ON level-meter sidecar (ADR-0007): a real
+// per-channel audio level flows on the `audio-level` event topic whether the
+// device is IDLE or STREAMING (the Todo-18 lease FSM hands the device between the
+// idle sidecar and the streaming leg without a gap). This bridge holds ONE
+// long-lived subscription to that topic — independent of the streaming session's
+// own connection in `cerastream-backend.ts` — and re-broadcasts every event over
+// the MAIN authenticated backend WS as an `audio-level` message. That is what
+// drives the LiveView meter OUTSIDE a preview (an always-visible slot), so the
+// bars move on a clap while idle with no preview open.
+//
+// The engine emits an `unavailable` variant (no fabricated silence) for a lease
+// handoff gap, a missing device, or `audio.mode=none` — forwarded verbatim so the
+// meter can render its `unavailable` state per the ADR contract.
+//
+// Resilience: the `@ceralive/cerastream` client's `autoReconnect` re-subscribes on
+// a dropped socket, so once connected the bridge self-heals. The only gap it must
+// cover itself is the INITIAL connect when the engine is not up yet (a systemd
+// ordering race) — a bounded backoff retry, mirroring `engine-reconnect.ts`. It
+// NEVER throws and NEVER blocks boot; every collaborator is injected for tests.
+
+import type {
+	CerastreamClient,
+	ConnectOptions,
+	EventParams,
+	Subscription,
+} from "@ceralive/cerastream";
+import { connect as defaultConnect } from "@ceralive/cerastream";
+import type { AudioLevelMessage } from "@ceraui/rpc/schemas";
+import { logger as defaultLogger } from "../../helpers/logger.ts";
+import { setup } from "../setup.ts";
+import { broadcastMsg } from "../ui/websocket-server.ts";
+
+/** Backoff bounds for the initial-connect retry. Mirrors `engine-reconnect.ts`. */
+export const AUDIO_METER_CONNECT_BASE_MS = 2_000;
+export const AUDIO_METER_CONNECT_MAX_MS = 30_000;
+
+type TimerHandle = ReturnType<typeof setTimeout>;
+
+export interface AudioMeterBridgeLogger {
+	info(message: string): void;
+	warn(message: string): void;
+	debug(message: string): void;
+}
+
+export interface AudioMeterBridgeDeps {
+	connect: (options?: ConnectOptions) => Promise<CerastreamClient>;
+	connectOptions: ConnectOptions;
+	/** Re-broadcast one audio-level payload over the main authenticated WS. */
+	broadcast: (payload: AudioLevelMessage) => void;
+	logger: AudioMeterBridgeLogger;
+	random: () => number;
+	setTimer: (fn: () => void, ms: number) => TimerHandle;
+	clearTimer: (timer: TimerHandle) => void;
+	baseDelayMs: number;
+	maxDelayMs: number;
+}
+
+/**
+ * Project a cerastream `audio-level` event onto the wire message: drop the
+ * envelope `type`/`seq` (the broadcast layer stamps its own `seq`) and keep every
+ * level/unavailable field. Exported for the bridge test.
+ */
+export function toAudioLevelMessage(
+	event: Extract<EventParams, { type: "audio-level" }>,
+): AudioLevelMessage {
+	return {
+		...(event.source !== undefined ? { source: event.source } : {}),
+		...(event.channels !== undefined ? { channels: event.channels } : {}),
+		...(event.rms_db !== undefined ? { rms_db: event.rms_db } : {}),
+		...(event.peak_db !== undefined ? { peak_db: event.peak_db } : {}),
+		...(event.floor_db !== undefined ? { floor_db: event.floor_db } : {}),
+		...(event.unavailable !== undefined
+			? { unavailable: event.unavailable }
+			: {}),
+		...(event.reason !== undefined ? { reason: event.reason } : {}),
+	};
+}
+
+function defaultDeps(): AudioMeterBridgeDeps {
+	return {
+		connect: defaultConnect,
+		connectOptions: {
+			...(setup.cerastream_socket
+				? { socketPath: setup.cerastream_socket }
+				: {}),
+			// The binding re-subscribes on a dropped socket, so post-connect
+			// resilience is free; the outer loop only covers the first connect.
+			autoReconnect: true,
+			client: "ceraui-audio-meter",
+		},
+		broadcast: (payload) => broadcastMsg("audio-level", payload),
+		logger: defaultLogger,
+		random: Math.random,
+		setTimer: (fn, ms) => setTimeout(fn, ms),
+		clearTimer: (timer) => clearTimeout(timer),
+		baseDelayMs: AUDIO_METER_CONNECT_BASE_MS,
+		maxDelayMs: AUDIO_METER_CONNECT_MAX_MS,
+	};
+}
+
+interface BridgeState {
+	deps: AudioMeterBridgeDeps;
+	attempt: number;
+	timer: TimerHandle | undefined;
+	stopped: boolean;
+	client: CerastreamClient | undefined;
+	subscription: Subscription | undefined;
+	/** Tail of the in-flight connect attempt (test seam via settleAudioMeterBridge). */
+	inflight: Promise<void>;
+}
+
+let state: BridgeState | undefined;
+
+/** Equal-jitter exponential backoff; mirrors `engine-reconnect.ts backoffDelay`. */
+function backoffDelay(
+	attempt: number,
+	baseMs: number,
+	maxMs: number,
+	random: () => number,
+): number {
+	const capped = Math.min(baseMs * 2 ** attempt, maxMs);
+	return capped / 2 + random() * (capped / 2);
+}
+
+function errMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
+function handleEvent(event: EventParams): void {
+	if (!state || state.stopped) return;
+	if (event.type !== "audio-level") return;
+	try {
+		state.deps.broadcast(toAudioLevelMessage(event));
+	} catch (err) {
+		state.deps.logger.debug(
+			`audio-meter bridge: broadcast threw: ${errMessage(err)}`,
+		);
+	}
+}
+
+/**
+ * One connect + subscribe attempt. Resolves `true` when the subscription is live
+ * (the binding's autoReconnect then owns resilience), `false` to reschedule.
+ */
+async function runAttempt(): Promise<boolean> {
+	if (!state || state.stopped) return false;
+	const { deps } = state;
+	try {
+		const client = await deps.connect(deps.connectOptions);
+		if (!state || state.stopped) {
+			await client.close().catch(() => undefined);
+			return false;
+		}
+		const subscription = await client.subscribeEvents(
+			{ topics: ["audio-level"] },
+			handleEvent,
+		);
+		if (!state || state.stopped) {
+			subscription.close();
+			await client.close().catch(() => undefined);
+			return false;
+		}
+		state.client = client;
+		state.subscription = subscription;
+		deps.logger.info(
+			"audio-meter bridge: subscribed to the engine audio-level topic",
+		);
+		return true;
+	} catch (err) {
+		deps.logger.debug(
+			`audio-meter bridge: connect/subscribe failed, will retry: ${errMessage(err)}`,
+		);
+		return false;
+	}
+}
+
+function scheduleRetry(): void {
+	if (!state || state.stopped || state.timer !== undefined) return;
+	const { deps } = state;
+	const delay = backoffDelay(
+		state.attempt,
+		deps.baseDelayMs,
+		deps.maxDelayMs,
+		deps.random,
+	);
+	state.attempt += 1;
+	state.timer = deps.setTimer(() => {
+		if (!state) return;
+		state.timer = undefined;
+		state.inflight = tick();
+	}, delay);
+}
+
+async function tick(): Promise<void> {
+	if (!state || state.stopped) return;
+	const connected = await runAttempt();
+	if (!state || state.stopped) return;
+	if (!connected) scheduleRetry();
+}
+
+/**
+ * Boot entry point. Runs the first connect attempt (fire-and-forget — the meter
+ * is never on the boot critical path) and, if the engine is not up yet, arms a
+ * bounded backoff retry. Idempotent — a prior bridge is torn down first.
+ */
+export function initAudioMeterBridge(
+	overrides: Partial<AudioMeterBridgeDeps> = {},
+): void {
+	stopAudioMeterBridge();
+	state = {
+		deps: { ...defaultDeps(), ...overrides },
+		attempt: 0,
+		timer: undefined,
+		stopped: false,
+		client: undefined,
+		subscription: undefined,
+		inflight: Promise.resolve(),
+	};
+	state.inflight = tick();
+}
+
+/** Test seam: resolve once the in-flight connect attempt has settled. */
+export function settleAudioMeterBridge(): Promise<void> {
+	return state?.inflight ?? Promise.resolve();
+}
+
+/** Tear down the bridge (close the subscription + connection, clear the timer). */
+export function stopAudioMeterBridge(): void {
+	if (!state) return;
+	const s = state;
+	s.stopped = true;
+	if (s.timer !== undefined) s.deps.clearTimer(s.timer);
+	s.subscription?.close();
+	void s.client?.close().catch(() => undefined);
+	state = undefined;
+}

--- a/apps/backend/src/modules/streaming/audio-naming.ts
+++ b/apps/backend/src/modules/streaming/audio-naming.ts
@@ -54,6 +54,17 @@ export interface EngineAudioDevice {
 	input_id: string;
 	display_name: string;
 	alsa_card_id?: string;
+	product_name?: string;
+	transport?: AudioDeviceTransport;
+	stable_id?: string;
+}
+
+export type AudioDeviceTransport = "usb" | "hdmi" | "bluetooth" | "onboard";
+
+export interface AudioDeviceIdentity {
+	product_name?: string;
+	transport?: AudioDeviceTransport;
+	stable_id?: string;
 }
 
 /**
@@ -180,16 +191,25 @@ function resolveOneLabel(
 	engineAudio: readonly EngineAudioDevice[],
 	longnames: Map<string, string>,
 ): string {
-	// (1) engine-join: an audio entry whose join key matches this card AND whose
-	//     display_name is a real human name (the heuristic rejects junk so the
-	//     longname path below wins over a generic GStreamer label).
+	// (1) engine-join: an audio entry whose join key matches this card. The real
+	//     `product_name` (cerastream Todo 20) wins outright; else the generic
+	//     `display_name` only if it passes the human-name heuristic (rejects junk
+	//     so the longname path below wins over a generic GStreamer label).
 	const engineMatch = engineAudio.find(
-		(d) =>
-			d.alsa_card_id !== undefined &&
-			d.alsa_card_id === cardId &&
-			isHumanAudioName(d.display_name, cardId),
+		(d) => d.alsa_card_id !== undefined && d.alsa_card_id === cardId,
 	);
-	if (engineMatch !== undefined) return engineMatch.display_name;
+	if (
+		engineMatch?.product_name !== undefined &&
+		engineMatch.product_name.length > 0
+	) {
+		return engineMatch.product_name;
+	}
+	if (
+		engineMatch !== undefined &&
+		isHumanAudioName(engineMatch.display_name, cardId)
+	) {
+		return engineMatch.display_name;
+	}
 
 	// (2) the `/proc/asound/cards` longname for that card.
 	const longname = longnames.get(cardId);
@@ -232,4 +252,35 @@ export function resolveAudioLabels(
 		labels.set(asrcKey, nextCount === 1 ? raw : `${raw} (${nextCount})`);
 	}
 	return labels;
+}
+
+/**
+ * Resolve the stable-identity metadata (`product_name` / `transport` /
+ * `stable_id`, cerastream Todo 20) for every DEVICE card, joining the engine
+ * `list-devices` audio entries on `alsa_card_id`. A card with no matching engine
+ * entry — or an engine on the pre-2026.7.3 pin that strips the fields — yields no
+ * entry, so the frontend falls back to the plain label. Pseudo-sources are
+ * skipped. The `cards` argument is never mutated.
+ */
+export function resolveAudioIdentities(
+	cards: Record<string, string>,
+	engineAudio: readonly EngineAudioDevice[],
+): Map<string, AudioDeviceIdentity> {
+	const identities = new Map<string, AudioDeviceIdentity>();
+	for (const [asrcKey, cardId] of Object.entries(cards)) {
+		if (PSEUDO_SOURCE_IDS.has(cardId)) continue;
+		const match = engineAudio.find(
+			(d) => d.alsa_card_id !== undefined && d.alsa_card_id === cardId,
+		);
+		if (match === undefined) continue;
+		const identity: AudioDeviceIdentity = {
+			...(match.product_name !== undefined
+				? { product_name: match.product_name }
+				: {}),
+			...(match.transport !== undefined ? { transport: match.transport } : {}),
+			...(match.stable_id !== undefined ? { stable_id: match.stable_id } : {}),
+		};
+		if (Object.keys(identity).length > 0) identities.set(asrcKey, identity);
+	}
+	return identities;
 }

--- a/apps/backend/src/modules/streaming/audio-naming.ts
+++ b/apps/backend/src/modules/streaming/audio-naming.ts
@@ -191,18 +191,26 @@ function resolveOneLabel(
 	engineAudio: readonly EngineAudioDevice[],
 	longnames: Map<string, string>,
 ): string {
-	// (1) engine-join: an audio entry whose join key matches this card. The real
-	//     `product_name` (cerastream Todo 20) wins outright; else the generic
-	//     `display_name` only if it passes the human-name heuristic (rejects junk
-	//     so the longname path below wins over a generic GStreamer label).
+	// (1) engine-join: an audio entry whose join key matches this card. Prefer the
+	//     real `product_name` (cerastream Todo 20), then the generic `display_name`
+	//     — but each ONLY if it passes the human-name heuristic. The heuristic
+	//     rejects a value equal to the card id ("usbaudio"), so a generic engine
+	//     product_name never beats the longname path below (which carries the real
+	//     "RØDE …" name for a device the engine mislabels generically).
 	const engineMatch = engineAudio.find(
 		(d) => d.alsa_card_id !== undefined && d.alsa_card_id === cardId,
 	);
 	if (
 		engineMatch?.product_name !== undefined &&
-		engineMatch.product_name.length > 0
+		isHumanAudioName(engineMatch.product_name, cardId)
 	) {
 		return engineMatch.product_name;
+	}
+	if (
+		engineMatch !== undefined &&
+		isHumanAudioName(engineMatch.display_name, cardId)
+	) {
+		return engineMatch.display_name;
 	}
 	if (
 		engineMatch !== undefined &&
@@ -273,10 +281,15 @@ export function resolveAudioIdentities(
 			(d) => d.alsa_card_id !== undefined && d.alsa_card_id === cardId,
 		);
 		if (match === undefined) continue;
+		// Only surface a product_name that passes the human-name heuristic, so a
+		// generic engine value (e.g. "usbaudio", equal to the card id) is never
+		// composed as `<Product Name> · <Transport>` — the transport tag still
+		// rides on its own, and the picker falls back to the longname-derived label.
+		const hasRealProduct =
+			match.product_name !== undefined &&
+			isHumanAudioName(match.product_name, cardId);
 		const identity: AudioDeviceIdentity = {
-			...(match.product_name !== undefined
-				? { product_name: match.product_name }
-				: {}),
+			...(hasRealProduct ? { product_name: match.product_name } : {}),
 			...(match.transport !== undefined ? { transport: match.transport } : {}),
 			...(match.stable_id !== undefined ? { stable_id: match.stable_id } : {}),
 		};

--- a/apps/backend/src/modules/streaming/audio.ts
+++ b/apps/backend/src/modules/streaming/audio.ts
@@ -29,7 +29,12 @@ import { isRealDevice } from "../system/device-detection.ts";
 import { getHardwareKindCached } from "../system/hardware-kind.ts";
 import { notificationBroadcast } from "../ui/notifications.ts";
 import { broadcastMsg } from "../ui/websocket-server.ts";
-import { parseAsoundCards, resolveAudioLabels } from "./audio-naming.ts";
+import type { AudioDeviceIdentity } from "./audio-naming.ts";
+import {
+	parseAsoundCards,
+	resolveAudioIdentities,
+	resolveAudioLabels,
+} from "./audio-naming.ts";
 import {
 	type AudioDeviceWatcher,
 	createAudioDeviceWatcher,
@@ -161,6 +166,7 @@ export function warnIfConfiguredAudioSourceUnavailable(
 export function deriveAudioSources(
 	devices: Record<string, string> = getAudioDevices(),
 	labels?: Map<string, string>,
+	identities?: Map<string, AudioDeviceIdentity>,
 ): AudioSource[] {
 	return Object.keys(devices).map((name): AudioSource => {
 		if (name === NO_AUDIO_ID) {
@@ -174,10 +180,20 @@ export function deriveAudioSources(
 			};
 		}
 		const label = labels?.get(name);
+		const identity = identities?.get(name);
 		return {
 			id: name,
 			kind: "device",
 			...(label !== undefined ? { label } : {}),
+			...(identity?.product_name !== undefined
+				? { product_name: identity.product_name }
+				: {}),
+			...(identity?.transport !== undefined
+				? { transport: identity.transport }
+				: {}),
+			...(identity?.stable_id !== undefined
+				? { stable_id: identity.stable_id }
+				: {}),
 		};
 	});
 }
@@ -285,9 +301,13 @@ export async function updateAudioDevices(dir: string = deviceDir) {
 	});
 
 	const labels = await resolveAudioLabelsForTick(audioDevices);
+	const identities = resolveAudioIdentities(
+		audioDevices,
+		getEngineAudioDevices(),
+	);
 	broadcastMsg("status", {
 		asrcs: Object.keys(audioDevices),
-		audio_sources: deriveAudioSources(audioDevices, labels),
+		audio_sources: deriveAudioSources(audioDevices, labels, identities),
 	});
 
 	// A re-enumeration may change what "Auto" resolves to; refresh the idle

--- a/apps/backend/src/modules/streaming/sources.ts
+++ b/apps/backend/src/modules/streaming/sources.ts
@@ -661,11 +661,27 @@ export async function refreshEngineDeviceCache(
 		engineAudioDeviceCache = result.devices
 			.filter((d) => d.media_class === "audio")
 			.map((d) => {
-				const alsaCardId = (d as { alsa_card_id?: string }).alsa_card_id;
+				const extra = d as {
+					alsa_card_id?: string;
+					product_name?: string;
+					transport?: EngineAudioDevice["transport"];
+					stable_id?: string;
+				};
 				return {
 					input_id: d.input_id,
 					display_name: d.display_name,
-					...(alsaCardId !== undefined ? { alsa_card_id: alsaCardId } : {}),
+					...(extra.alsa_card_id !== undefined
+						? { alsa_card_id: extra.alsa_card_id }
+						: {}),
+					...(extra.product_name !== undefined
+						? { product_name: extra.product_name }
+						: {}),
+					...(extra.transport !== undefined
+						? { transport: extra.transport }
+						: {}),
+					...(extra.stable_id !== undefined
+						? { stable_id: extra.stable_id }
+						: {}),
 				};
 			});
 		recordObservedDevices(engineDeviceCache);

--- a/apps/backend/src/tests/audio-meter-bridge.test.ts
+++ b/apps/backend/src/tests/audio-meter-bridge.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type {
+	CerastreamClient,
+	EventHandler,
+	EventParams,
+	Subscription,
+} from "@ceralive/cerastream";
+import type { AudioLevelMessage } from "@ceraui/rpc/schemas";
+import {
+	type AudioMeterBridgeDeps,
+	type AudioMeterBridgeLogger,
+	initAudioMeterBridge,
+	settleAudioMeterBridge,
+	stopAudioMeterBridge,
+	toAudioLevelMessage,
+} from "../modules/streaming/audio-meter-bridge.ts";
+
+const silent: AudioMeterBridgeLogger = {
+	info: () => {},
+	warn: () => {},
+	debug: () => {},
+};
+
+type TimerHandle = ReturnType<typeof setTimeout>;
+
+// A fake engine: `connect` either throws (engine down) or resolves a client whose
+// `subscribeEvents` captures the handler so the test can push events by hand. The
+// manual timer queue drives the boot-retry loop with no real time.
+function harness(connectOutcomes: boolean[]) {
+	const timers: Array<{ fn: () => void }> = [];
+	let idx = 0;
+	let handler: EventHandler | undefined;
+	let subscriptionClosed = false;
+	let clientClosed = false;
+	let subscribedTopics: readonly string[] | undefined;
+	const broadcasts: AudioLevelMessage[] = [];
+
+	const subscription: Subscription = {
+		result: { topics: ["audio-level"] },
+		close: () => {
+			subscriptionClosed = true;
+		},
+	};
+	const client: CerastreamClient = {
+		subscribeEvents: async (params, h) => {
+			subscribedTopics = params.topics;
+			handler = h;
+			return subscription;
+		},
+		close: async () => {
+			clientClosed = true;
+		},
+		// biome-ignore lint/suspicious/noExplicitAny: the bridge only uses connect/subscribeEvents/close.
+	} as any;
+
+	const deps: AudioMeterBridgeDeps = {
+		connect: async () => {
+			const ok =
+				connectOutcomes[Math.min(idx, connectOutcomes.length - 1)] ?? false;
+			idx += 1;
+			if (!ok) throw new Error("engine down (test)");
+			return client;
+		},
+		connectOptions: {},
+		broadcast: (payload) => broadcasts.push(payload),
+		logger: silent,
+		random: () => 0.5,
+		setTimer: (fn: () => void, _ms: number): TimerHandle => {
+			timers.push({ fn });
+			return timers.length as unknown as TimerHandle;
+		},
+		clearTimer: () => {},
+		baseDelayMs: 1,
+		maxDelayMs: 4,
+	};
+
+	return {
+		deps,
+		broadcasts,
+		emit: (event: EventParams) => handler?.(event),
+		fireNextTimer: async () => {
+			const next = timers.shift();
+			next?.fn();
+			await settleAudioMeterBridge();
+		},
+		pendingTimers: () => timers.length,
+		state: () => ({ subscriptionClosed, clientClosed, subscribedTopics }),
+	};
+}
+
+const levelEvent: Extract<EventParams, { type: "audio-level" }> = {
+	type: "audio-level",
+	seq: 3,
+	source: { identity: "card:usbaudio", owner: "sidecar" },
+	channels: 2,
+	rms_db: [-18, -19],
+	peak_db: [-6, -7],
+	floor_db: -1e6,
+};
+
+const unavailableEvent: Extract<EventParams, { type: "audio-level" }> = {
+	type: "audio-level",
+	seq: 4,
+	unavailable: true,
+	reason: "mode_none",
+};
+
+afterEach(() => stopAudioMeterBridge());
+
+describe("audio-meter bridge — forwards engine audio-level over the main WS", () => {
+	test("subscribes to ONLY the audio-level topic and forwards a level event", async () => {
+		const h = harness([true]);
+		initAudioMeterBridge(h.deps);
+		await settleAudioMeterBridge();
+
+		expect(h.state().subscribedTopics).toEqual(["audio-level"]);
+
+		h.emit(levelEvent);
+		expect(h.broadcasts).toHaveLength(1);
+		expect(h.broadcasts[0]).toEqual({
+			source: { identity: "card:usbaudio", owner: "sidecar" },
+			channels: 2,
+			rms_db: [-18, -19],
+			peak_db: [-6, -7],
+			floor_db: -1e6,
+		});
+		// The envelope `type`/`seq` are dropped — the broadcast layer stamps seq.
+		expect("type" in (h.broadcasts[0] as object)).toBe(false);
+		expect("seq" in (h.broadcasts[0] as object)).toBe(false);
+	});
+
+	test("forwards the `unavailable` marker verbatim (never a fabricated level)", async () => {
+		const h = harness([true]);
+		initAudioMeterBridge(h.deps);
+		await settleAudioMeterBridge();
+
+		h.emit(unavailableEvent);
+		expect(h.broadcasts).toEqual([{ unavailable: true, reason: "mode_none" }]);
+	});
+
+	test("ignores non-audio-level events on the shared subscription", async () => {
+		const h = harness([true]);
+		initAudioMeterBridge(h.deps);
+		await settleAudioMeterBridge();
+
+		h.emit({
+			type: "bitrate",
+			seq: 1,
+			current_bitrate: 4000,
+			max_bitrate: 6000,
+		});
+		expect(h.broadcasts).toHaveLength(0);
+	});
+
+	test("retries the initial connect with backoff when the engine is down at boot", async () => {
+		const h = harness([false, false, true]);
+		initAudioMeterBridge(h.deps);
+		await settleAudioMeterBridge();
+
+		// First attempt failed → a retry is armed, nothing subscribed yet.
+		expect(h.state().subscribedTopics).toBeUndefined();
+		expect(h.pendingTimers()).toBe(1);
+
+		await h.fireNextTimer(); // 2nd attempt fails → re-arm
+		expect(h.state().subscribedTopics).toBeUndefined();
+		expect(h.pendingTimers()).toBe(1);
+
+		await h.fireNextTimer(); // 3rd attempt succeeds → subscribed, no more timers
+		expect(h.state().subscribedTopics).toEqual(["audio-level"]);
+		expect(h.pendingTimers()).toBe(0);
+
+		h.emit(levelEvent);
+		expect(h.broadcasts).toHaveLength(1);
+	});
+
+	test("stop() closes the subscription and connection and halts forwarding", async () => {
+		const h = harness([true]);
+		initAudioMeterBridge(h.deps);
+		await settleAudioMeterBridge();
+
+		stopAudioMeterBridge();
+		expect(h.state().subscriptionClosed).toBe(true);
+		expect(h.state().clientClosed).toBe(true);
+
+		h.emit(levelEvent);
+		expect(h.broadcasts).toHaveLength(0);
+	});
+});
+
+describe("toAudioLevelMessage — envelope projection", () => {
+	test("keeps every level field and drops type/seq", () => {
+		expect(toAudioLevelMessage(levelEvent)).toEqual({
+			source: { identity: "card:usbaudio", owner: "sidecar" },
+			channels: 2,
+			rms_db: [-18, -19],
+			peak_db: [-6, -7],
+			floor_db: -1e6,
+		});
+	});
+});

--- a/apps/backend/src/tests/audio-naming.test.ts
+++ b/apps/backend/src/tests/audio-naming.test.ts
@@ -394,6 +394,36 @@ describe("device naming/identity (device-quality-wave2 Todo 22)", () => {
 		).toBe(0);
 	});
 
+	test("a GENERIC engine product_name (equal to the card id) is dropped — transport still rides", () => {
+		// The board RØDE audio node: cerastream emits product_name "usbaudio"
+		// (generic, == the card id). It must not compose "usbaudio · USB"; the
+		// transport tag survives and the label falls back to the longname.
+		const generic: EngineAudioDevice[] = [
+			{
+				input_id: "audio:usbaudio",
+				display_name:
+					"RØDE RØDE HDMI to USB-C at usb-xhci-hcd.17.auto-1, super speed",
+				alsa_card_id: "usbaudio",
+				product_name: "usbaudio",
+				transport: "usb",
+				stable_id: "card:usbaudio",
+			},
+		];
+		const identity = resolveAudioIdentities(
+			{ "USB audio": "usbaudio" },
+			generic,
+		).get("USB audio");
+		expect(identity?.product_name).toBeUndefined();
+		expect(identity?.transport).toBe("usb");
+		expect(identity?.stable_id).toBe("card:usbaudio");
+		const label = resolveAudioLabels(
+			{ "USB audio": "usbaudio" },
+			generic,
+			new Map(),
+		).get("USB audio");
+		expect(label).toContain("RØDE");
+	});
+
 	test("resolveAudioLabels prefers the real product_name over the generic display_name", () => {
 		const engine: EngineAudioDevice[] = [
 			{

--- a/apps/backend/src/tests/audio-naming.test.ts
+++ b/apps/backend/src/tests/audio-naming.test.ts
@@ -8,6 +8,7 @@ import {
 	isHumanAudioName,
 	parseAsoundCards,
 	resetAudioNamingDiagnostics,
+	resolveAudioIdentities,
 	resolveAudioLabels,
 } from "../modules/streaming/audio-naming.ts";
 import {
@@ -351,6 +352,91 @@ describe("deriveAudioSources — label attachment", () => {
 			id: "USB audio",
 			kind: "device",
 		});
+	});
+});
+
+describe("device naming/identity (device-quality-wave2 Todo 22)", () => {
+	test("resolveAudioIdentities joins product_name/transport/stable_id on alsa_card_id", () => {
+		const engine: EngineAudioDevice[] = [
+			{
+				input_id: "audio:usbaudio",
+				display_name: "USB Audio",
+				alsa_card_id: "usbaudio",
+				product_name: "RØDE NT-USB",
+				transport: "usb",
+				stable_id: "card:usbaudio",
+			},
+		];
+		const identities = resolveAudioIdentities(
+			{ "USB audio": "usbaudio" },
+			engine,
+		);
+		expect(identities.get("USB audio")).toEqual({
+			product_name: "RØDE NT-USB",
+			transport: "usb",
+			stable_id: "card:usbaudio",
+		});
+	});
+
+	test("a card with no matching engine entry (or a pre-2026.7.3 pin) yields no identity", () => {
+		expect(resolveAudioIdentities({ "USB audio": "usbaudio" }, []).size).toBe(
+			0,
+		);
+		const legacy: EngineAudioDevice[] = [
+			{
+				input_id: "audio:usbaudio",
+				display_name: "USB Audio",
+				alsa_card_id: "usbaudio",
+			},
+		];
+		expect(
+			resolveAudioIdentities({ "USB audio": "usbaudio" }, legacy).size,
+		).toBe(0);
+	});
+
+	test("resolveAudioLabels prefers the real product_name over the generic display_name", () => {
+		const engine: EngineAudioDevice[] = [
+			{
+				input_id: "audio:usbaudio",
+				display_name: "USB Audio Device",
+				alsa_card_id: "usbaudio",
+				product_name: "RØDE NT-USB",
+			},
+		];
+		const labels = resolveAudioLabels(
+			{ "USB audio": "usbaudio" },
+			engine,
+			new Map(),
+		);
+		expect(labels.get("USB audio")).toBe("RØDE NT-USB");
+	});
+
+	test("deriveAudioSources attaches the identity fields onto device entries", () => {
+		const identities = new Map([
+			[
+				"USB audio",
+				{
+					product_name: "RØDE NT-USB",
+					transport: "usb" as const,
+					stable_id: "card:usbaudio",
+				},
+			],
+		]);
+		const sources = deriveAudioSources(
+			{ "USB audio": "usbaudio", "No audio": "No audio" },
+			new Map([["USB audio", "RØDE NT-USB"]]),
+			identities,
+		);
+		expect(sources.find((s) => s.id === "USB audio")).toEqual({
+			id: "USB audio",
+			kind: "device",
+			label: "RØDE NT-USB",
+			product_name: "RØDE NT-USB",
+			transport: "usb",
+			stable_id: "card:usbaudio",
+		});
+		// Pseudo-sources never carry identity fields.
+		expect(sources.find((s) => s.id === "No audio")?.stable_id).toBeUndefined();
 	});
 });
 

--- a/apps/backend/src/tests/cerastream-bindings-skew.test.ts
+++ b/apps/backend/src/tests/cerastream-bindings-skew.test.ts
@@ -96,6 +96,8 @@ describe("cerastream bindings version-skew guard", () => {
 	});
 
 	test("event topics + discriminated union stay in lockstep", () => {
+		// device-quality-wave2 Todo 22: the 2026.7.3 pin adds the additive 8th
+		// `audio-level` topic (ADR-0007) — the always-on level meter.
 		expect([...EVENT_TOPICS]).toEqual([
 			"status",
 			"switch",
@@ -104,6 +106,7 @@ describe("cerastream bindings version-skew guard", () => {
 			"srt-stats",
 			"error",
 			"preview",
+			"audio-level",
 		]);
 		expect(eventParamsSchema.options.length).toBe(EVENT_TOPICS.length);
 	});
@@ -117,8 +120,36 @@ describe("cerastream bindings version-skew guard", () => {
 		expect(processErrorCodeSchema.options.length).toBe(7);
 	});
 
-	test("SCHEMA_VERSION is pinned to 0.4.0", () => {
-		expect(SCHEMA_VERSION).toBe("0.4.0");
+	test("SCHEMA_VERSION is pinned to 0.8.0", () => {
+		// device-quality-wave2 Todo 22: the 2026.7.3 pin ships schema 0.8.0 (the
+		// additive Todo 20/21/30 batch), superseding the 0.4.0 the prior pin shipped.
+		expect(SCHEMA_VERSION).toBe("0.8.0");
+	});
+
+	test("audio-level topic + connect-error codes are on the surface (Todo 22)", () => {
+		const level = eventParamsSchema.parse({
+			type: "audio-level",
+			seq: 1,
+			source: { identity: "card:usbaudio", owner: "sidecar" },
+			channels: 2,
+			rms_db: [-18, -19],
+			peak_db: [-6, -7],
+		});
+		expect(level.type).toBe("audio-level");
+		const unavailable = eventParamsSchema.parse({
+			type: "audio-level",
+			seq: 2,
+			unavailable: true,
+			reason: "mode_none",
+		});
+		expect((unavailable as { unavailable?: boolean }).unavailable).toBe(true);
+		expect([...bindings.CERASTREAM_CONNECT_ERROR_CODES]).toEqual([
+			"absent",
+			"refused",
+			"unreachable",
+			"lost",
+			"closed",
+		]);
 	});
 
 	test("0.4.0 surface: startParamsSchema has additive optional fields", () => {
@@ -203,12 +234,12 @@ describe("cerastream bindings version-skew guard", () => {
 		expect(withEncode.active_encode?.decoder).toBe("mppvideodec");
 	});
 
-	test("SKEW: the binding statusEventSchema STRIPS active_encode.passthrough", () => {
-		// cerastream reports `active_encode.passthrough` (Todo 16, schema 0.5.0) but
-		// the published binding predates it and Zod-strips the field — which is why
-		// CeraUI reads it over the raw passthrough event bridge, not the typed
-		// subscribeEvents path. If a future binding bump adds the field this
-		// assertion flips and the raw bridge can be retired.
+	test("the binding statusEventSchema now RETAINS active_encode.passthrough", () => {
+		// The 2026.7.3 pin (schema 0.8.0) carries the 0.5.0 passthrough field, so
+		// the typed subscribeEvents path now surfaces it — the prior 0.4.0 pin
+		// Zod-stripped it (the reason CeraUI still reads it over the raw passthrough
+		// event bridge). This assertion flipped on the bump; retiring that raw
+		// bridge is a separate follow-up, out of scope here.
 		const parsed = bindings.statusEventSchema.parse({
 			type: "status",
 			seq: 1,
@@ -223,7 +254,7 @@ describe("cerastream bindings version-skew guard", () => {
 		});
 		expect(
 			(parsed.active_encode as { passthrough?: unknown }).passthrough,
-		).toBeUndefined();
+		).toBe(true);
 	});
 
 	test("0.4.0 surface: getCapabilitiesResultSchema has additive optional preview field", () => {

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -19,7 +19,7 @@ Svelte 5 PWA for CeraUI — the on-device control plane for CeraLive streaming h
 The `backend` app consumes both streaming bindings as pinned public npm packages:
 
 ```
-"@ceralive/cerastream": "2026.7.2"   (public npm, @ceralive scope)
+"@ceralive/cerastream": "2026.7.3"   (public npm, @ceralive scope)
 "@ceralive/srtla-send": "2026.6.2"   (public npm, @ceralive scope)
 ```
 

--- a/apps/frontend/src/lib/components/preview/AudioLevelMeter.svelte
+++ b/apps/frontend/src/lib/components/preview/AudioLevelMeter.svelte
@@ -9,6 +9,7 @@
   e-ink freeze stills them automatically (never JS-drive these).
 -->
 <script lang="ts">
+import type { AudioLevelUnavailableReason } from '@ceraui/rpc/schemas';
 import { LL } from '@ceraui/i18n/svelte';
 
 import { cn } from '$lib/utils';
@@ -16,10 +17,26 @@ import { cn } from '$lib/utils';
 interface Props {
 	rmsDb?: number[];
 	peakDb?: number[];
+	// ADR-0007: the engine emits an explicit `unavailable` marker (lease handoff
+	// gap, missing device, or audio.mode=none) — NEVER a fabricated silence level.
+	// When set, render the unavailable state instead of bars, so a dead meter is
+	// visibly distinct from real digital silence.
+	unavailable?: boolean;
+	reason?: AudioLevelUnavailableReason;
 	class?: string;
 }
 
-const { rmsDb = [], peakDb = [], class: className = undefined }: Props = $props();
+const {
+	rmsDb = [],
+	peakDb = [],
+	unavailable = false,
+	reason = undefined,
+	class: className = undefined,
+}: Props = $props();
+
+const reasonLabel = $derived(
+	reason !== undefined ? $LL.live.preview.audioUnavailableReason[reason]() : undefined,
+);
 
 // dBFS window mapped to the bar: -60 dBFS reads empty, 0 dBFS reads full.
 const FLOOR_DB = -60;
@@ -46,12 +63,23 @@ const silent = $derived(channels.length === 0 || channels.every((c) => c.peak ==
 <div
 	data-testid="audio-level-meter"
 	data-silent={silent ? 'true' : 'false'}
+	data-unavailable={unavailable ? 'true' : 'false'}
 	data-channels={channelCount}
 	class={cn('space-y-1.5', className)}
 	role="group"
 	aria-label={$LL.live.preview.audioLabel()}
 >
-	{#if silent}
+	{#if unavailable}
+		<p
+			class="text-muted-foreground font-mono text-[11px] tracking-wide"
+			data-testid="audio-unavailable"
+			role="status"
+		>
+			{$LL.live.preview.audioUnavailable()}{#if reasonLabel}<span class="opacity-70">
+					{' \u00b7 '}{reasonLabel}</span
+				>{/if}
+		</p>
+	{:else if silent}
 		<p class="text-muted-foreground font-mono text-[11px] tracking-wide" data-testid="audio-silent">
 			{$LL.live.preview.audioSilent()}
 		</p>

--- a/apps/frontend/src/lib/components/preview/AudioLevelMeter.test.ts
+++ b/apps/frontend/src/lib/components/preview/AudioLevelMeter.test.ts
@@ -55,3 +55,43 @@ describe("AudioLevelMeter (Task 33)", () => {
 		expect(meterOf(container).getAttribute("data-silent")).toBe("true");
 	});
 });
+
+describe("AudioLevelMeter — unavailable state (device-quality-wave2 Todo 22)", () => {
+	it("renders the unavailable state (not silence, not bars) when unavailable", () => {
+		const { container } = render(AudioLevelMeter, {
+			props: { unavailable: true, reason: "mode_none" },
+		});
+		const meter = meterOf(container);
+
+		expect(meter.getAttribute("data-unavailable")).toBe("true");
+		// The unavailable marker renders — NOT the silent floor, NOT channel bars.
+		expect(
+			meter.querySelector('[data-testid="audio-unavailable"]'),
+		).not.toBeNull();
+		expect(meter.querySelector('[data-testid="audio-silent"]')).toBeNull();
+		expect(
+			meter.querySelectorAll('[data-testid="audio-channel"]'),
+		).toHaveLength(0);
+	});
+
+	it("surfaces the reason label alongside the unavailable heading", () => {
+		const { container } = render(AudioLevelMeter, {
+			props: { unavailable: true, reason: "no_device" },
+		});
+		const marker = meterOf(container).querySelector(
+			'[data-testid="audio-unavailable"]',
+		);
+		expect(marker?.textContent).toContain("No audio device");
+	});
+
+	it("prefers unavailable over any stale rms/peak arrays (never fake silence)", () => {
+		const { container } = render(AudioLevelMeter, {
+			props: { unavailable: true, rmsDb: [-12], peakDb: [-6] },
+		});
+		const meter = meterOf(container);
+		expect(meter.getAttribute("data-unavailable")).toBe("true");
+		expect(
+			meter.querySelectorAll('[data-testid="audio-channel"]'),
+		).toHaveLength(0);
+	});
+});

--- a/apps/frontend/src/lib/rpc/subscriptions.svelte.ts
+++ b/apps/frontend/src/lib/rpc/subscriptions.svelte.ts
@@ -7,6 +7,7 @@
 
 import type {
 	AddonState,
+	AudioLevelMessage,
 	CapabilitiesMessage,
 	CaptureDevice,
 	ConfigMessage,
@@ -108,6 +109,12 @@ let linkTelemetryState = $state<LinkTelemetryMessage | null | undefined>(
 	undefined,
 );
 
+// Always-on audio level (device-quality-wave2 Todo 22). Fed by the main-WS
+// `audio-level` broadcast the backend audio-meter bridge re-emits from the engine
+// sidecar — drives the LiveView meter OUTSIDE a preview. `undefined` before the
+// first event; an `unavailable` variant renders the meter's unavailable state.
+let audioLevelState = $state<AudioLevelMessage | undefined>(undefined);
+
 // System state
 let deviceStatsState = $state<DeviceStats | undefined>(undefined);
 let sensorsState = $state<SensorsStatus | undefined>(undefined);
@@ -207,6 +214,10 @@ export function getModems() {
 
 export function getLinkTelemetry() {
 	return linkTelemetryState;
+}
+
+export function getAudioLevel() {
+	return audioLevelState;
 }
 
 export function getSensors() {
@@ -453,6 +464,10 @@ function handleMessage(type: string, data: unknown, seq?: number): void {
 			netifState = merged;
 			break;
 		}
+
+		case "audio-level":
+			audioLevelState = data as AudioLevelMessage;
+			break;
 
 		case "wifi": {
 			// WiFi responses carry several shapes. The connect/new RESULT frames are
@@ -830,6 +845,7 @@ export function resetState(): void {
 	wifiState = undefined;
 	modemsState = undefined;
 	linkTelemetryState = undefined;
+	audioLevelState = undefined;
 	sensorsState = undefined;
 	deviceStatsState = undefined;
 	revisionsState = undefined;

--- a/apps/frontend/src/lib/streaming/sourceSummary.test.ts
+++ b/apps/frontend/src/lib/streaming/sourceSummary.test.ts
@@ -13,12 +13,15 @@ import { describe, expect, it } from "vitest";
 
 import {
 	AUTO_AUDIO_SOURCE_ENTRY,
+	audioSelectionValue,
+	audioSelectionWireId,
 	audioSourceLabel,
 	type CapabilitySummary,
 	deriveActiveSummary,
 	deriveCapabilitySummary,
 	formatCodec,
 	groupAudioSources,
+	resolveAudioSelection,
 	resolveAudioSourceList,
 	resolveAudioSourceMode,
 	resolveDisplayedAudioSource,
@@ -886,5 +889,136 @@ describe("source×audio mixture matrix (M1–M6) — display derivation", () => 
 			t,
 		);
 		expect(r.current).toBe("Auto \u2014 currently: Pipeline default");
+	});
+});
+
+// device-quality-wave2 Todo 22 — device-naming label + saved-selection migration.
+const t = (key: string): string => key;
+
+describe("audioSourceLabel — <Product Name> · <Transport> (Todo 22)", () => {
+	it("composes the product name with the transport tag", () => {
+		const entry: AudioSource = {
+			id: "USB audio",
+			kind: "device",
+			label: "usbaudio",
+			product_name: "RØDE NT-USB",
+			transport: "usb",
+			stable_id: "card:usbaudio",
+		};
+		expect(audioSourceLabel(entry, t)).toBe("RØDE NT-USB \u00b7 USB");
+	});
+
+	it("renders the product name alone when no transport is present", () => {
+		const entry: AudioSource = {
+			id: "USB audio",
+			kind: "device",
+			product_name: "RØDE NT-USB",
+		};
+		expect(audioSourceLabel(entry, t)).toBe("RØDE NT-USB");
+	});
+
+	it("falls back to the legacy label for an entry with no product name", () => {
+		const entry: AudioSource = {
+			id: "USB audio",
+			kind: "device",
+			label: "usbaudio",
+		};
+		expect(audioSourceLabel(entry, t)).toBe("usbaudio");
+	});
+
+	it("abbreviates bluetooth to BT and names onboard", () => {
+		expect(
+			audioSourceLabel(
+				{
+					id: "a",
+					kind: "device",
+					product_name: "Buds",
+					transport: "bluetooth",
+				},
+				t,
+			),
+		).toBe("Buds \u00b7 BT");
+		expect(
+			audioSourceLabel(
+				{
+					id: "b",
+					kind: "device",
+					product_name: "Codec",
+					transport: "onboard",
+				},
+				t,
+			),
+		).toBe("Codec \u00b7 Onboard");
+	});
+});
+
+describe("resolveAudioSelection — saved-selection migration (Todo 22)", () => {
+	const SOURCES: AudioSource[] = [
+		{
+			id: "USB audio",
+			kind: "device",
+			product_name: "RØDE NT-USB",
+			transport: "usb",
+			stable_id: "card:usbaudio",
+		},
+		{ id: "HDMI audio", kind: "device", stable_id: "card:hdmi" },
+	];
+
+	it("resolves a PRE-UPGRADE saved identifier (the old asrc-key) to the current entry", () => {
+		// This is the red→green migration guard: an old stored `config.asrc` (the
+		// asrc-key, saved before the identity scheme existed) must still resolve
+		// after the update. A resolver that keyed ONLY on stable_id would return
+		// undefined here.
+		const resolved = resolveAudioSelection("USB audio", SOURCES);
+		expect(resolved?.id).toBe("USB audio");
+		expect(resolved?.stable_id).toBe("card:usbaudio");
+	});
+
+	it("resolves a stable_id to the same entry (selection binds to stable_id)", () => {
+		expect(resolveAudioSelection("card:usbaudio", SOURCES)?.id).toBe(
+			"USB audio",
+		);
+	});
+
+	it("returns undefined for a selection that matches no current entry", () => {
+		expect(resolveAudioSelection("card:gone", SOURCES)).toBeUndefined();
+		expect(resolveAudioSelection(undefined, SOURCES)).toBeUndefined();
+	});
+
+	it("prefers a stable_id match over an id match on collision", () => {
+		const collide: AudioSource[] = [
+			{ id: "x", kind: "device", stable_id: "shared" },
+			{ id: "shared", kind: "device", stable_id: "card:other" },
+		];
+		expect(resolveAudioSelection("shared", collide)?.id).toBe("x");
+	});
+});
+
+describe("audioSelectionValue / audioSelectionWireId — UI value ↔ wire id (Todo 22)", () => {
+	const SOURCES: AudioSource[] = [
+		{ id: "USB audio", kind: "device", stable_id: "card:usbaudio" },
+		{ id: "HDMI audio", kind: "device" },
+	];
+
+	it("binds the UI value to the stable_id when present, else the wire id", () => {
+		expect(
+			audioSelectionValue({
+				id: "USB audio",
+				kind: "device",
+				stable_id: "card:usbaudio",
+			}),
+		).toBe("card:usbaudio");
+		expect(audioSelectionValue({ id: "HDMI audio", kind: "device" })).toBe(
+			"HDMI audio",
+		);
+	});
+
+	it("maps a selected stable_id BACK to the persisted wire asrc id", () => {
+		expect(audioSelectionWireId("card:usbaudio", SOURCES)).toBe("USB audio");
+	});
+
+	it("passes a wire id or unknown value through unchanged (pseudo-sources)", () => {
+		expect(audioSelectionWireId("HDMI audio", SOURCES)).toBe("HDMI audio");
+		expect(audioSelectionWireId("No audio", SOURCES)).toBe("No audio");
 	});
 });

--- a/apps/frontend/src/lib/streaming/sourceSummary.ts
+++ b/apps/frontend/src/lib/streaming/sourceSummary.ts
@@ -103,19 +103,84 @@ export function groupAudioSources(list: readonly AudioSource[]): {
 	return { devices, pseudo };
 }
 
+// Uppercase transport tag rendered beside the product name (`RØDE NT-USB · USB`).
+// Bluetooth abbreviates to BT; onboard reads "Onboard".
+const AUDIO_TRANSPORT_TAG: Record<
+	NonNullable<AudioSource["transport"]>,
+	string
+> = {
+	usb: "USB",
+	hdmi: "HDMI",
+	bluetooth: "BT",
+	onboard: "Onboard",
+};
+
 /**
- * Display label for an audio-source entry. Preference order (T6):
- *   1. `entry.label` — the verbatim hardware name resolved by the backend (T4);
- *      wins when present, NEVER translated.
- *   2. `entry.labelKey` — the translated pseudo-source label (Auto / No audio /
+ * Display label for an audio-source entry. Preference order:
+ *   1. `<product_name> · <TRANSPORT>` (device-quality-wave2 Todo 22) — the real
+ *      engine product name + its transport tag; the transport is appended only
+ *      when a product name is present (a bare tag is meaningless).
+ *   2. `entry.label` — the verbatim hardware name resolved by the backend (T4);
+ *      NEVER translated.
+ *   3. `entry.labelKey` — the translated pseudo-source label (Auto / No audio /
  *      Pipeline default).
- *   3. `entry.id` — the raw wire id, for a legacy device entry with no label.
+ *   4. `entry.id` — the raw wire id, for a legacy device entry with no label.
  */
 export function audioSourceLabel(
 	entry: AudioSource,
 	t: (key: string) => string,
 ): string {
+	if (entry.product_name !== undefined && entry.product_name.length > 0) {
+		const tag =
+			entry.transport !== undefined
+				? AUDIO_TRANSPORT_TAG[entry.transport]
+				: undefined;
+		return tag !== undefined
+			? `${entry.product_name} \u00b7 ${tag}`
+			: entry.product_name;
+	}
 	return entry.label ?? (entry.labelKey ? t(entry.labelKey) : entry.id);
+}
+
+/**
+ * Resolve a SAVED audio selection (an old asrc-key OR the new `stable_id`) to the
+ * matching current entry — the migration shim (device-quality-wave2 Todo 22). A
+ * pre-upgrade `config.asrc` (the asrc-key id) keeps resolving after the identity
+ * scheme change, and a `stable_id` resolves once the UI binds selection to it.
+ * Match order: exact `stable_id` → exact `id`. Returns `undefined` when the saved
+ * selection matches no current entry (a device that is no longer present).
+ */
+export function resolveAudioSelection(
+	saved: string | undefined,
+	sources: readonly AudioSource[],
+): AudioSource | undefined {
+	if (saved === undefined) return undefined;
+	return (
+		sources.find((s) => s.stable_id !== undefined && s.stable_id === saved) ??
+		sources.find((s) => s.id === saved)
+	);
+}
+
+/**
+ * The value the audio-source `<Select>` binds to for an entry: the reboot-stable
+ * `stable_id` when present (device-quality-wave2 Todo 22), else the wire `id`. The
+ * persisted `config.asrc` stays the wire `id` — `audioSelectionWireId` maps a
+ * selected value back to it, so the engine ALSA path is unchanged.
+ */
+export function audioSelectionValue(entry: AudioSource): string {
+	return entry.stable_id ?? entry.id;
+}
+
+/**
+ * Map an audio `<Select>` value (a `stable_id` or a wire `id`) back to the wire
+ * `id` persisted as `config.asrc`. Falls back to the value itself when it matches
+ * no entry (a pseudo-source or a legacy id has no `stable_id`).
+ */
+export function audioSelectionWireId(
+	value: string,
+	sources: readonly AudioSource[],
+): string {
+	return resolveAudioSelection(value, sources)?.id ?? value;
 }
 
 /**

--- a/apps/frontend/src/main/LiveView.idle-order.test.ts
+++ b/apps/frontend/src/main/LiveView.idle-order.test.ts
@@ -30,6 +30,7 @@ vi.mock("$lib/rpc/subscriptions.svelte", () => ({
 	getIsStreaming: () => false,
 	getSensors: () => ({}),
 	getLinkTelemetry: () => null,
+	getAudioLevel: () => undefined,
 	getDevices: () => [],
 	getActiveInput: () => undefined,
 	getConnectionState: () => "connected",

--- a/apps/frontend/src/main/LiveView.summary-coherence.test.ts
+++ b/apps/frontend/src/main/LiveView.summary-coherence.test.ts
@@ -40,6 +40,7 @@ vi.mock("$lib/rpc/subscriptions.svelte", () => ({
 	getIsStreaming: () => false,
 	getSensors: () => ({}),
 	getLinkTelemetry: () => null,
+	getAudioLevel: () => undefined,
 	getDevices: () => [],
 	getActiveInput: () => undefined,
 	getConnectionState: () => "connected",

--- a/apps/frontend/src/main/LiveView.summary.test.ts
+++ b/apps/frontend/src/main/LiveView.summary.test.ts
@@ -44,6 +44,7 @@ vi.mock("$lib/rpc/subscriptions.svelte", async () => {
 		getIsStreaming: () => streamingFlag.value,
 		getSensors: () => ({}),
 		getLinkTelemetry: () => null,
+		getAudioLevel: () => undefined,
 		getDevices: () => [],
 		getActiveInput: () => undefined,
 		getConnectionState: () => "connected",

--- a/apps/frontend/src/main/LiveView.svelte
+++ b/apps/frontend/src/main/LiveView.svelte
@@ -52,8 +52,10 @@ import {
 	resolveReceiverKind,
 } from '$lib/streaming/receiver-experience';
 import {
+	audioSelectionWireId,
 	audioSourceLabel,
 	deriveActiveSummary,
+	resolveAudioSelection,
 	resolveAudioSourceList,
 	resolvedAudioLabel,
 } from '$lib/streaming/sourceSummary';
@@ -93,6 +95,7 @@ import EncoderDialog, { type EncoderConfig } from '$main/dialogs/EncoderDialog.s
 import ServerDialog from '$main/dialogs/ServerDialog.svelte';
 import CapabilityTierBanner from '$main/live/CapabilityTierBanner.svelte';
 import IdleCockpit from '$main/live/IdleCockpit.svelte';
+import LiveAudioMeter from '$main/live/LiveAudioMeter.svelte';
 import LiveCockpit from '$main/live/LiveCockpit.svelte';
 import LiveHeader from '$main/live/LiveHeader.svelte';
 import type { ConfigRow } from '$main/live/StreamSettingsCard.svelte';
@@ -512,6 +515,14 @@ const audioSources = $derived(getStatus()?.asrcs ?? []);
 // Typed audio-source model (status.audio_sources) beside the legacy asrcs — drives
 // the humanized picker; falls back to `audioSources` on an older backend.
 const audioSourceList = $derived(getStatus()?.audio_sources);
+// Resolved typed entries + the migration-shim selection (device-quality-wave2
+// Todo 22): a SAVED `config.asrc` — an old asrc-key OR a new stable_id — resolves
+// to the current entry's wire id, so a pre-upgrade selection keeps resolving after
+// the identity scheme change. The persisted wire value stays the asrc id.
+const audioEntries = $derived(resolveAudioSourceList(audioSourceList, audioSources));
+const resolvedAudioSource = $derived(
+	resolveAudioSelection(effectiveAudioSource, audioEntries)?.id ?? effectiveAudioSource,
+);
 
 function handleAudioSave(values: AudioConfigValues) {
 	audioOverride = values;
@@ -522,7 +533,11 @@ function handleAudioSave(values: AudioConfigValues) {
 // config reflect it immediately, then persists via setConfig (no stream restart)
 // — mirrors AudioDialog's asrc path. Live audio switching stays gated (Task 10):
 // the Source section only offers this control while idle.
-async function handleSelectAudioSource(asrc: string) {
+async function handleSelectAudioSource(selection: string) {
+	// The picker value may be a stable_id (Todo 22); map it back to the wire asrc
+	// id before persisting — the engine ALSA path is keyed on the asrc id, and the
+	// field-lock/echo must key on the same wire value the `config` broadcast echoes.
+	const asrc = audioSelectionWireId(selection, audioEntries);
 	audioOverride = {
 		asrc,
 		acodec: effectiveAudioCodec ?? 'aac',
@@ -930,7 +945,7 @@ const configRows = $derived<ConfigRow[]>([
 			{audioSources}
 			{audioSourceList}
 			audioStatus={getStatus()}
-			selectedAudioSource={effectiveAudioSource}
+			selectedAudioSource={resolvedAudioSource}
 			onSelectAudioSource={handleSelectAudioSource}
 			onOpenAudioDialog={() => (audioDialogOpen = true)}
 			selectedPipeline={config?.pipeline}
@@ -938,6 +953,11 @@ const configRows = $derived<ConfigRow[]>([
 			activeEncode={getStatus()?.active_encode ?? null}
 		/>
 	{/if}
+
+	<!-- Always-visible audio level meter (Todo 22): OUTSIDE the preview, so the
+	     bars move while idle with no preview open and continue across start/stop.
+	     Renders in both the idle and live cockpit states. -->
+	<LiveAudioMeter />
 </div>
 
 <ServerDialog bind:open={serverDialogOpen} onSaved={validateSavedDestination} />

--- a/apps/frontend/src/main/LiveView.test.ts
+++ b/apps/frontend/src/main/LiveView.test.ts
@@ -35,6 +35,7 @@ vi.mock("$lib/rpc/subscriptions.svelte", () => ({
 	getIsStreaming: () => state.isStreaming,
 	getSensors: () => ({}),
 	getLinkTelemetry: () => null,
+	getAudioLevel: () => undefined,
 	getDevices: () => [],
 	getActiveInput: () => undefined,
 	getConnectionState: () => "connected",

--- a/apps/frontend/src/main/live/LiveAudioMeter.svelte
+++ b/apps/frontend/src/main/live/LiveAudioMeter.svelte
@@ -17,23 +17,51 @@ import { LL } from '@ceraui/i18n/svelte';
 import AudioLevelMeter from '$lib/components/preview/AudioLevelMeter.svelte';
 import { getAudioLevel } from '$lib/rpc/subscriptions.svelte';
 
+// Staleness deadline: the engine sidecar emits at ≤10Hz (≥100ms). If no frame
+// arrives for this long the source has stalled (cerastream killed/crashed, the
+// bridge dropped) — fall to `unavailable`, NEVER frozen stale bars showing a
+// last-known level. Comfortably above the cadence so a normal gap never trips it.
+const STALE_MS = 2000;
+const TICK_MS = 500;
+
 const level = $derived(getAudioLevel());
+
+let lastAt = $state(0);
+let now = $state(0);
+
+// Record arrival time on every new frame (each broadcast is a fresh object, so the
+// `level` reference changes per event — the effect re-runs and stamps lastAt).
+$effect(() => {
+	if (level !== undefined) lastAt = Date.now();
+});
+
+// Independent clock so staleness resolves even while no frame arrives.
+$effect(() => {
+	now = Date.now();
+	const id = setInterval(() => {
+		now = Date.now();
+	}, TICK_MS);
+	return () => clearInterval(id);
+});
+
+const stale = $derived(level !== undefined && lastAt > 0 && now - lastAt > STALE_MS);
 </script>
 
 {#if level !== undefined}
 	<section
 		class="border-border/60 bg-card/40 rounded-lg border p-3"
 		data-testid="live-audio-meter"
+		data-stale={stale ? 'true' : 'false'}
 		aria-label={$LL.live.preview.audioLabel()}
 	>
 		<p class="text-muted-foreground mb-2 font-mono text-[10px] uppercase tracking-wider">
 			{$LL.live.preview.audioLabel()}
 		</p>
 		<AudioLevelMeter
-			rmsDb={level.rms_db ?? []}
-			peakDb={level.peak_db ?? []}
-			unavailable={level.unavailable === true}
-			reason={level.reason}
+			rmsDb={stale ? [] : (level.rms_db ?? [])}
+			peakDb={stale ? [] : (level.peak_db ?? [])}
+			unavailable={stale || level.unavailable === true}
+			reason={stale ? undefined : level.reason}
 		/>
 	</section>
 {/if}

--- a/apps/frontend/src/main/live/LiveAudioMeter.svelte
+++ b/apps/frontend/src/main/live/LiveAudioMeter.svelte
@@ -1,0 +1,39 @@
+<!--
+  LiveAudioMeter.svelte — the always-visible audio level meter (device-quality-wave2
+  Todo 22).
+
+  Reads the main-WS `audio-level` broadcast via `getAudioLevel()` (fed by the backend
+  audio-meter bridge from the engine's always-on sidecar) and renders the shared
+  `AudioLevelMeter`. Mounted in LiveView OUTSIDE the preview, so the bars move while
+  IDLE with no preview open (a clap near the mic reacts) and continue across
+  start/stop. The in-preview meter (PreviewCanvas) keeps its own preview-socket path.
+
+  Before the first event arrives it renders nothing (no fake silence). An
+  `unavailable` marker from the engine renders the meter's unavailable state.
+-->
+<script lang="ts">
+import { LL } from '@ceraui/i18n/svelte';
+
+import AudioLevelMeter from '$lib/components/preview/AudioLevelMeter.svelte';
+import { getAudioLevel } from '$lib/rpc/subscriptions.svelte';
+
+const level = $derived(getAudioLevel());
+</script>
+
+{#if level !== undefined}
+	<section
+		class="border-border/60 bg-card/40 rounded-lg border p-3"
+		data-testid="live-audio-meter"
+		aria-label={$LL.live.preview.audioLabel()}
+	>
+		<p class="text-muted-foreground mb-2 font-mono text-[10px] uppercase tracking-wider">
+			{$LL.live.preview.audioLabel()}
+		</p>
+		<AudioLevelMeter
+			rmsDb={level.rms_db ?? []}
+			peakDb={level.peak_db ?? []}
+			unavailable={level.unavailable === true}
+			reason={level.reason}
+		/>
+	</section>
+{/if}

--- a/apps/frontend/src/main/live/LiveAudioMeter.test.ts
+++ b/apps/frontend/src/main/live/LiveAudioMeter.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import type { AudioLevelMessage } from "@ceraui/rpc/schemas";
+import { render } from "@testing-library/svelte";
+import { flushSync } from "svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let currentLevel: AudioLevelMessage | undefined;
+
+vi.mock("$lib/rpc/subscriptions.svelte", () => ({
+	getAudioLevel: () => currentLevel,
+}));
+
+import LiveAudioMeter from "./LiveAudioMeter.svelte";
+
+function meter(container: HTMLElement): HTMLElement | null {
+	return container.querySelector<HTMLElement>(
+		'[data-testid="live-audio-meter"]',
+	);
+}
+function innerMeter(container: HTMLElement): HTMLElement | null {
+	return container.querySelector<HTMLElement>(
+		'[data-testid="audio-level-meter"]',
+	);
+}
+
+describe("LiveAudioMeter — always-visible slot + staleness watchdog (Todo 22)", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		currentLevel = undefined;
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("renders nothing before the first audio-level frame (no fake silence)", () => {
+		const { container } = render(LiveAudioMeter);
+		expect(meter(container)).toBeNull();
+	});
+
+	it("renders the meter live from a real level frame (not stale)", () => {
+		currentLevel = {
+			source: { owner: "sidecar" },
+			channels: 2,
+			rms_db: [-18, -19],
+			peak_db: [-6, -7],
+		};
+		const { container } = render(LiveAudioMeter);
+		expect(meter(container)?.getAttribute("data-stale")).toBe("false");
+		expect(innerMeter(container)?.getAttribute("data-unavailable")).toBe(
+			"false",
+		);
+		expect(
+			innerMeter(container)?.querySelectorAll('[data-testid="audio-channel"]'),
+		).toHaveLength(2);
+	});
+
+	it("falls to unavailable (NOT frozen bars) when frames stall past the deadline", () => {
+		currentLevel = { channels: 2, rms_db: [-12, -12], peak_db: [-6, -6] };
+		const { container } = render(LiveAudioMeter);
+		// Fresh at first.
+		expect(meter(container)?.getAttribute("data-stale")).toBe("false");
+
+		// No new frame arrives; advance past STALE_MS (2000ms). The watchdog clock
+		// ticks and the meter flips to unavailable with no stale bars retained.
+		vi.advanceTimersByTime(2600);
+		flushSync();
+
+		expect(meter(container)?.getAttribute("data-stale")).toBe("true");
+		expect(innerMeter(container)?.getAttribute("data-unavailable")).toBe(
+			"true",
+		);
+		expect(
+			innerMeter(container)?.querySelectorAll('[data-testid="audio-channel"]'),
+		).toHaveLength(0);
+	});
+
+	it("forwards an engine `unavailable` marker straight through", () => {
+		currentLevel = { unavailable: true, reason: "mode_none" };
+		const { container } = render(LiveAudioMeter);
+		expect(innerMeter(container)?.getAttribute("data-unavailable")).toBe(
+			"true",
+		);
+		expect(
+			innerMeter(container)?.querySelector('[data-testid="audio-unavailable"]'),
+		).not.toBeNull();
+	});
+});

--- a/apps/frontend/src/tests/live-start-failed-reason.test.ts
+++ b/apps/frontend/src/tests/live-start-failed-reason.test.ts
@@ -21,6 +21,7 @@ vi.mock("$lib/rpc/subscriptions.svelte", () => ({
 	getIsStreaming: () => false,
 	getSensors: () => ({}),
 	getLinkTelemetry: () => null,
+	getAudioLevel: () => undefined,
 	getDevices: () => [],
 	getActiveInput: () => undefined,
 	getConnectionState: () => "connected",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
       "name": "backend",
       "version": "2026.6.2",
       "dependencies": {
-        "@ceralive/cerastream": "2026.7.2",
+        "@ceralive/cerastream": "2026.7.3",
         "@ceralive/control-protocol": "2026.7.0",
         "@ceralive/srtla-send": "2026.6.2",
         "@ceraui/rpc": "workspace:*",
@@ -342,7 +342,7 @@
 
     "@ceralive/biome-config": ["@ceralive/biome-config@2026.6.2", "", {}, "sha512-LqDaJufxLOC3Rm38u/ocpUro/ub8llv1q9pcS3W/Ys7gBy+wLjS2TmcyhMjNMRg9c7pCQlPMI6eS8JkhpN+ecw=="],
 
-    "@ceralive/cerastream": ["@ceralive/cerastream@2026.7.2", "", { "dependencies": { "zod": "^4.3.5" } }, "sha512-5Zw7XJ7qhtAHSd1kZRUnBD8ZHQGjhhLwgZj2ZluXRqNBMoEieEp+9p4WrPDwJZluBc6pMbj6T+5zDSqdFxrLTw=="],
+    "@ceralive/cerastream": ["@ceralive/cerastream@2026.7.3", "", { "dependencies": { "zod": "^4.3.5" } }, "sha512-Re0aP5yxe0Nb/LDkyvLTIfwktsBnywLusADXTNSZvLuYCDWQ0C7m1nyW0viOUilq8uB++H/jPJaEcykPq+cEzA=="],
 
     "@ceralive/control-protocol": ["@ceralive/control-protocol@2026.7.0", "", { "dependencies": { "zod": "^4.3.5" } }, "sha512-/pLQpo3bTUzzxaQJK0zta4XKS6EJWr26p5jj2YST69ejxafQiCCjXKgdOkMWU9VjKm0XeMNQehxXOb6ylMGGHg=="],
 

--- a/packages/i18n/src/ar/index.ts
+++ b/packages/i18n/src/ar/index.ts
@@ -1213,6 +1213,13 @@ const ar = {
 			audioLabel: "مستويات الصوت",
 			audioSilent: "صامت",
 			channelAria: "مستوى القناة {n}",
+			audioUnavailable: "المقياس غير متوفر",
+			audioUnavailableReason: {
+				device_busy: "جهاز الصوت مشغول",
+				no_device: "لا يوجد جهاز صوت",
+				mode_none: "الصوت معطّل",
+				handoff: "جارٍ التبديل\u2026",
+			},
 			unavailable: {
 				engineStarting: {
 					title: "المحرك قيد التشغيل",

--- a/packages/i18n/src/de/index.ts
+++ b/packages/i18n/src/de/index.ts
@@ -506,6 +506,13 @@ const de = {
 			audioLabel: "Audiopegel",
 			audioSilent: "Stille",
 			channelAria: "Pegel Kanal {n}",
+			audioUnavailable: "Pegelanzeige nicht verfügbar",
+			audioUnavailableReason: {
+				device_busy: "Audiogerät belegt",
+				no_device: "Kein Audiogerät",
+				mode_none: "Audio deaktiviert",
+				handoff: "Wird umgeschaltet\u2026",
+			},
 			unavailable: {
 				engineStarting: {
 					title: "Engine startet",

--- a/packages/i18n/src/en/index.ts
+++ b/packages/i18n/src/en/index.ts
@@ -491,6 +491,13 @@ const en = {
 			audioLabel: "Audio levels",
 			audioSilent: "Silent",
 			channelAria: "Channel {n:number} level",
+			audioUnavailable: "Meter unavailable",
+			audioUnavailableReason: {
+				device_busy: "Audio device busy",
+				no_device: "No audio device",
+				mode_none: "Audio disabled",
+				handoff: "Switching\u2026",
+			},
 			unavailable: {
 				engineStarting: {
 					title: "Engine starting",

--- a/packages/i18n/src/es/index.ts
+++ b/packages/i18n/src/es/index.ts
@@ -508,6 +508,13 @@ const es = {
 			audioLabel: "Niveles de audio",
 			audioSilent: "Silencio",
 			channelAria: "Nivel del canal {n}",
+			audioUnavailable: "Medidor no disponible",
+			audioUnavailableReason: {
+				device_busy: "Dispositivo de audio ocupado",
+				no_device: "Sin dispositivo de audio",
+				mode_none: "Audio desactivado",
+				handoff: "Cambiando\u2026",
+			},
 			unavailable: {
 				engineStarting: {
 					title: "El motor se está iniciando",

--- a/packages/i18n/src/fr/index.ts
+++ b/packages/i18n/src/fr/index.ts
@@ -1272,6 +1272,13 @@ const fr = {
 			audioLabel: "Niveaux audio",
 			audioSilent: "Silence",
 			channelAria: "Niveau du canal {n}",
+			audioUnavailable: "Indicateur indisponible",
+			audioUnavailableReason: {
+				device_busy: "Périphérique audio occupé",
+				no_device: "Aucun périphérique audio",
+				mode_none: "Audio désactivé",
+				handoff: "Changement\u2026",
+			},
 			unavailable: {
 				engineStarting: {
 					title: "Démarrage du moteur",

--- a/packages/i18n/src/hi/index.ts
+++ b/packages/i18n/src/hi/index.ts
@@ -1076,6 +1076,13 @@ const hi = {
 			audioLabel: "ऑडियो स्तर",
 			audioSilent: "मौन",
 			channelAria: "चैनल {n} स्तर",
+			audioUnavailable: "मीटर उपलब्ध नहीं",
+			audioUnavailableReason: {
+				device_busy: "ऑडियो डिवाइस व्यस्त",
+				no_device: "कोई ऑडियो डिवाइस नहीं",
+				mode_none: "ऑडियो अक्षम",
+				handoff: "बदल रहा है\u2026",
+			},
 			unavailable: {
 				engineStarting: {
 					title: "इंजन शुरू हो रहा है",

--- a/packages/i18n/src/ja/index.ts
+++ b/packages/i18n/src/ja/index.ts
@@ -1113,6 +1113,13 @@ const ja = {
 			audioLabel: "音声レベル",
 			audioSilent: "無音",
 			channelAria: "チャンネル {n} レベル",
+			audioUnavailable: "メーターは利用できません",
+			audioUnavailableReason: {
+				device_busy: "オーディオデバイス使用中",
+				no_device: "オーディオデバイスなし",
+				mode_none: "オーディオ無効",
+				handoff: "切り替え中\u2026",
+			},
 			unavailable: {
 				engineStarting: {
 					title: "エンジン起動中",

--- a/packages/i18n/src/ko/index.ts
+++ b/packages/i18n/src/ko/index.ts
@@ -1090,6 +1090,13 @@ const ko = {
 			audioLabel: "오디오 레벨",
 			audioSilent: "무음",
 			channelAria: "채널 {n} 레벨",
+			audioUnavailable: "미터를 사용할 수 없음",
+			audioUnavailableReason: {
+				device_busy: "오디오 장치 사용 중",
+				no_device: "오디오 장치 없음",
+				mode_none: "오디오 비활성화",
+				handoff: "전환 중\u2026",
+			},
 			unavailable: {
 				engineStarting: {
 					title: "엔진 시작 중",

--- a/packages/i18n/src/pt-BR/index.ts
+++ b/packages/i18n/src/pt-BR/index.ts
@@ -1248,6 +1248,13 @@ const ptBR = {
 			audioLabel: "Níveis de áudio",
 			audioSilent: "Silêncio",
 			channelAria: "Nível do canal {n}",
+			audioUnavailable: "Medidor indisponível",
+			audioUnavailableReason: {
+				device_busy: "Dispositivo de áudio ocupado",
+				no_device: "Nenhum dispositivo de áudio",
+				mode_none: "Áudio desativado",
+				handoff: "Alternando\u2026",
+			},
 			unavailable: {
 				engineStarting: {
 					title: "Motor iniciando",

--- a/packages/i18n/src/zh/index.ts
+++ b/packages/i18n/src/zh/index.ts
@@ -1027,6 +1027,13 @@ const zh = {
 			audioLabel: "音频电平",
 			audioSilent: "静音",
 			channelAria: "频道 {n} 电平",
+			audioUnavailable: "电平表不可用",
+			audioUnavailableReason: {
+				device_busy: "音频设备忙",
+				no_device: "无音频设备",
+				mode_none: "音频已禁用",
+				handoff: "切换中\u2026",
+			},
 			unavailable: {
 				engineStarting: {
 					title: "引擎启动中",

--- a/packages/rpc/src/schemas/audio-level.schema.ts
+++ b/packages/rpc/src/schemas/audio-level.schema.ts
@@ -1,0 +1,46 @@
+/**
+ * Audio-level broadcast message schema.
+ *
+ * Mirrors the cerastream `audio-level` event topic (`@ceralive/cerastream`
+ * `audioLevelEventSchema`, ADR-0007) as it is re-broadcast over the MAIN
+ * authenticated backend WS — NOT the preview socket. The envelope `type`/`seq`
+ * are stripped by the broadcast layer, so this schema carries only the payload.
+ *
+ * Two mutually-exclusive shapes: a real per-channel level (`rms_db`/`peak_db`),
+ * or an `unavailable: true` marker with a `reason`. The engine NEVER fabricates
+ * a silence level for a missing device or a degenerate `audio.mode` — a gap is
+ * always the explicit `unavailable` variant.
+ */
+import { z } from 'zod';
+
+export const AUDIO_LEVEL_OWNERS = ['sidecar', 'streaming'] as const;
+export const audioLevelOwnerSchema = z.enum(AUDIO_LEVEL_OWNERS);
+export type AudioLevelOwner = z.infer<typeof audioLevelOwnerSchema>;
+
+export const AUDIO_LEVEL_UNAVAILABLE_REASONS = [
+	'device_busy',
+	'no_device',
+	'mode_none',
+	'handoff',
+] as const;
+export const audioLevelUnavailableReasonSchema = z.enum(AUDIO_LEVEL_UNAVAILABLE_REASONS);
+export type AudioLevelUnavailableReason = z.infer<typeof audioLevelUnavailableReasonSchema>;
+
+export const audioLevelMessageSchema = z.object({
+	source: z
+		.object({
+			// Reboot-stable device id (cerastream Todo 20 `stable_id`).
+			identity: z.string().optional(),
+			owner: audioLevelOwnerSchema,
+		})
+		.optional(),
+	channels: z.number().int().nonnegative().optional(),
+	// dBFS, range (-inf, 0]; digital silence serialises as the `floor_db` sentinel.
+	rms_db: z.array(z.number()).optional(),
+	peak_db: z.array(z.number()).optional(),
+	floor_db: z.number().optional(),
+	// The gap marker — present (and only present) when there is no real level.
+	unavailable: z.literal(true).optional(),
+	reason: audioLevelUnavailableReasonSchema.optional(),
+});
+export type AudioLevelMessage = z.infer<typeof audioLevelMessageSchema>;

--- a/packages/rpc/src/schemas/index.ts
+++ b/packages/rpc/src/schemas/index.ts
@@ -2,6 +2,7 @@
  * Export all Zod schemas
  */
 export * from './addons.schema';
+export * from './audio-level.schema';
 export * from './auth.schema';
 export * from './broadcast.schema';
 export * from './cloud-provider.schema';

--- a/packages/rpc/src/schemas/streaming.schema.ts
+++ b/packages/rpc/src/schemas/streaming.schema.ts
@@ -94,6 +94,12 @@ export const AUDIO_SOURCE_AUTO = 'Auto';
 export const audioSourceKindSchema = z.enum(['device', 'none', 'pipeline_default', 'auto']);
 export type AudioSourceKind = z.infer<typeof audioSourceKindSchema>;
 
+// Physical transport tag for a device source (cerastream Todo 20). Mirrors the
+// binding `deviceTransportSchema`; rendered beside the product name as
+// `<Product Name> · USB`.
+export const audioTransportSchema = z.enum(['usb', 'hdmi', 'bluetooth', 'onboard']);
+export type AudioTransport = z.infer<typeof audioTransportSchema>;
+
 export const audioSourceSchema = z.object({
 	id: z.string(),
 	kind: audioSourceKindSchema,
@@ -102,6 +108,16 @@ export const audioSourceSchema = z.object({
 	// optional: pseudo-sources (none/pipeline_default/auto) carry `labelKey`
 	// instead; a legacy device entry with no label still parses.
 	label: z.string().optional(),
+	// Real product name from the engine (cerastream Todo 20 `product_name`),
+	// deduped with a #N suffix upstream. Additive + optional — a legacy entry
+	// without it falls back to `label`.
+	product_name: z.string().optional(),
+	// Physical transport tag rendered beside the product name.
+	transport: audioTransportSchema.optional(),
+	// Reboot-stable hardware identity (cerastream Todo 20 `stable_id`). The UI
+	// selection binds to this; the persisted `config.asrc` wire value is
+	// unchanged (still the asrc key), so the engine ALSA path is untouched.
+	stable_id: z.string().optional(),
 });
 export type AudioSource = z.infer<typeof audioSourceSchema>;
 


### PR DESCRIPTION
## What

Consume the published `@ceralive/cerastream 2026.7.3` additive batch (device-quality-wave2 Todo 22) to add an **always-visible audio level meter** and **real audio-device naming** to the Live destination.

- **Pin bump** `@ceralive/cerastream 2026.7.2 → 2026.7.3` — an isolated commit touching only `apps/backend/package.json` + `bun.lock` (the first-party pin-bump lockfile exception; nothing else in the lockfile changes).
- **Always-on meter:** a persistent backend bridge (`audio-meter-bridge.ts`) holds one long-lived subscription to the engine's always-on `audio-level` sidecar topic and re-broadcasts it over the MAIN authenticated WS. `LiveAudioMeter` mounts the meter OUTSIDE the preview (always-visible LiveView slot) — the in-preview `PreviewCanvas` meter is kept. A staleness watchdog falls to `unavailable` (never frozen stale bars) when frames stall, and renders the ADR-0007 `unavailable` state.
- **Device naming:** the audio picker renders `<Product Name> · <Transport>`; a pure migration shim keeps a pre-upgrade `config.asrc` resolving (selection identity keys on `stable_id`; the persisted wire value — and the engine ALSA path — is unchanged). A generic engine `product_name` ("usbaudio", == the card id) is gated out so it never beats the real longname.

## Why

The engine now ships an always-on level sidecar and real device identity (cerastream Todo 20/21/30). Operators need to see audio activity while idle with no preview open, see real device names in the picker, and keep their saved audio selection working across the identity-scheme change.

## How to verify

- `bun run lint` (biome clean on changed files), `bun run --filter frontend check` (0 errors), backend `bun tsc --noEmit`, `bun run check:tech-debt` (OK).
- `bun run test`: frontend vitest 1734 pass / 0 fail; rpc 235 pass; backend 2132 pass / 6 fail (all pre-existing baseline — the two `cerastream-backend.ts untouched` full-clone git-diff guards + the `srtla ips-file writer` EACCES set, CI-green / local-only).
- Migration is red→green: keying `resolveAudioSelection` only on `stable_id` fails the PRE-UPGRADE test.
- **Board QA** (rk3588 + RØDE): engine `audio-level` events flow at ~5 Hz while idle; the meter renders outside the preview; killing cerastream flips it to "Meter unavailable" (not frozen bars) and restarting self-heals; the RØDE audio picker shows the real device name. Screenshots + transcripts in `.omo/evidence/device-quality-wave2/task-22-*`.

## Risks

Low. Additive: a new event topic + optional schema fields + a new always-visible component; no existing wire value or the engine ALSA path changes. The bridge is real-engine-only (mock-skipped) and never blocks boot. The `cerastream-bindings-skew` guard was updated to the reviewed 2026.7.3 surface.

## Notes / follow-ups

- The board's RØDE is an HDMI-audio capture (not a mic) with no HDMI source connected, so the sidecar reports genuine digital silence — the physical clap-to-move is operator/hardware-gated; the event flow + live-bar rendering + label composition are proven by IPC + unit/component tests.
- cerastream emits a generic `product_name` for that audio node (a cerastream Todo-20 derivation follow-up); CeraUI falls back to the real longname.
- Depends on `CERALIVE/cerastream#63` (merged) + `bindings-v2026.7.3` (published to npm).