### PR TITLE
refactor(streaming): unify lifecycle orchestration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -883,7 +883,9 @@ Public stream start/stop admission now routes through
 `apps/backend/src/modules/streaming/stream-session-orchestrator.ts`. It owns the
 single lifecycle state machine for UI, autostart, remote control, and set-profile,
 uses generation-scoped cancellation for stop-during-start, and reconciles the
-actual cerastream state at boot/reconnect. `status.stream_lifecycle` is additive;
+actual cerastream state at boot/reconnect. Timeout, failure, transitional, or
+contradictory engine status remains `reconciling` until the heal path retries;
+only concordant streaming/idle status is adopted. `status.stream_lifecycle` is additive;
 legacy `is_streaming` flips true only after engine confirmation. Todo 27, not this
 orchestrator, owns general engine-phase failure rollback.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -879,6 +879,14 @@ Quality improvements landed in `chore/backend-quality` (Tasks 5–7, 13–14).
 
 ### streamloop module split
 
+Public stream start/stop admission now routes through
+`apps/backend/src/modules/streaming/stream-session-orchestrator.ts`. It owns the
+single lifecycle state machine for UI, autostart, remote control, and set-profile,
+uses generation-scoped cancellation for stop-during-start, and reconciles the
+actual cerastream state at boot/reconnect. `status.stream_lifecycle` is additive;
+legacy `is_streaming` flips true only after engine confirmation. Todo 27, not this
+orchestrator, owns general engine-phase failure rollback.
+
 `apps/backend/src/modules/streaming/streamloop.ts` is now a 5-line barrel re-exporting
 from `streamloop/index.ts`. The 10 public exports are unchanged — all caller import paths
 are unmodified.

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -508,7 +508,10 @@ admission boundary; only one launch can move `idle → starting`, and stop durin
 start cancels that generation before a later launch can be admitted. The legacy
 `is_streaming` flag changes only after the awaited engine start confirms success.
 At boot and after an engine reconnect, `reconcileRuntimeState()` subscribes to the
-engine's actual status and adopts an engine-held session. The additive
+engine's actual status and adopts an engine-held session. Only concordant
+`streaming` or `idle` status is authoritative; timeout, query failure, transitional
+state, or contradictory fields leave the lifecycle `reconciling` until the reconnect
+heal path retries. The additive
 `status.stream_lifecycle` field exposes `idle | starting | streaming | stopping |
 stop_failed | reconciling`; `is_streaming` remains backward compatible.
 

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -25,6 +25,7 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 | srtla binding calls (flux — check `../../../srtla/AGENTS.md` first) | `modules/streaming/srtla.ts` |
 | srtla per-link telemetry → `status.linkTelemetry` | `modules/streaming/link-telemetry.ts` |
 | Stream lifecycle (spawn supervision, start/stop, autostart, exec paths) | `modules/streaming/streamloop/` (barrel: `modules/streaming/streamloop.ts`) |
+| Authoritative stream-session lifecycle (UI/autostart/remote arbitration, cancellation generations, boot adoption) | `modules/streaming/stream-session-orchestrator.ts` |
 | WebSocket server wiring | `modules/ui/websocket-server.ts` + `rpc/server.ts` |
 | Auth token logic | `modules/ui/auth.ts` + `rpc/middleware/auth.middleware.ts` |
 | PASETO device-token verification (relay-config + device-control, ADR-0006) | `modules/pairing/device-token.ts` — `verifyDeviceControlToken`, `resolveControlChannelEndpoint` |
@@ -500,6 +501,19 @@ updating both the spawn site and the stats-file path.
 See [`docs/RPC_COMMUNICATION.md`](../../docs/RPC_COMMUNICATION.md) for the full wire-protocol reference.
 
 ## STREAMING ENGINE SEAM [EXISTS]
+
+`stream-session-orchestrator.ts` is the sole owner of public start/stop state.
+UI, autostart, remote control, and set-profile restarts enter the same synchronous
+admission boundary; only one launch can move `idle → starting`, and stop during
+start cancels that generation before a later launch can be admitted. The legacy
+`is_streaming` flag changes only after the awaited engine start confirms success.
+At boot and after an engine reconnect, `reconcileRuntimeState()` subscribes to the
+engine's actual status and adopts an engine-held session. The additive
+`status.stream_lifecycle` field exposes `idle | starting | streaming | stopping |
+stop_failed | reconciling`; `is_streaming` remains backward compatible.
+
+Todo 26 owns arbitration, cancellation, and adoption. General transactional
+rollback of resources after an engine-phase start failure remains Todo 27.
 
 The `StreamingBackend` interface (`modules/streaming/streaming-backend.ts`) has
 **one** implementation behind the seam (the legacy ceracoder engine is fully

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -105,8 +105,8 @@ Key streaming procedures:
 
 | Procedure | Purpose |
 |-----------|---------|
-| `streaming.start(config)` | Validate config, launch stream, persist config |
-| `streaming.stop()` | Stop active stream |
+| `streaming.start(config)` | Validate and admit one lifecycle attempt; resolves with typed `started`, `busy`, `cancelled`, or `failed` result plus `attemptId` |
+| `streaming.stop()` | Cancel/stop the active lifecycle generation and return a typed stop result |
 | `streaming.setConfig(fields)` | Persist config fields without starting the stream |
 | `streaming.setBitrate({ max_br })` | Hot-adjust bitrate while streaming |
 | `streaming.getPipelines()` | List available GStreamer pipelines |
@@ -114,6 +114,12 @@ Key streaming procedures:
 | `streaming.getConfig()` | Return current config snapshot |
 
 All setters return `{ success: boolean, applied: <fields> }`. The `applied` object reflects post-validation values actually written to config. Clients must lock their UI to `applied`, not to the raw input.
+
+All start origins share `stream-session-orchestrator.ts`; UI, autostart, remote
+control, and set-profile cannot launch parallel engine sessions. The backend
+publishes additive `status.stream_lifecycle` transitions and keeps legacy
+`is_streaming=false` until the engine confirms the stream. Boot/reconnect
+reconciliation adopts a stream that survived a backend process restart.
 
 ### Broadcast Events
 

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -119,7 +119,9 @@ All start origins share `stream-session-orchestrator.ts`; UI, autostart, remote
 control, and set-profile cannot launch parallel engine sessions. The backend
 publishes additive `status.stream_lifecycle` transitions and keeps legacy
 `is_streaming=false` until the engine confirms the stream. Boot/reconnect
-reconciliation adopts a stream that survived a backend process restart.
+reconciliation adopts a stream that survived a backend process restart. A timeout,
+query error, or contradictory engine status stays `reconciling`; the reconnect-heal
+path retries instead of publishing a false idle state.
 
 ### Broadcast Events
 

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -105,7 +105,7 @@ Key streaming procedures:
 
 | Procedure | Purpose |
 |-----------|---------|
-| `streaming.start(config)` | Validate and admit one lifecycle attempt; resolves with typed `started`, `busy`, `cancelled`, or `failed` result plus `attemptId` |
+| `streaming.start(config)` | Validate and admit one lifecycle attempt; concurrent/cancelled admission resolves as typed `busy`/`cancelled` plus `attemptId`, while established success/failure responses keep their legacy wire shape |
 | `streaming.stop()` | Cancel/stop the active lifecycle generation and return a typed stop result |
 | `streaming.setConfig(fields)` | Persist config fields without starting the stream |
 | `streaming.setBitrate({ max_br })` | Hot-adjust bitrate while streaming |

--- a/apps/backend/src/helpers/timing-constants.ts
+++ b/apps/backend/src/helpers/timing-constants.ts
@@ -28,6 +28,8 @@ export const INITIAL_RETRY_DELAY = 1000; // ms
 // Retry interval when no interfaces are available or autostart fails
 export const AUTOSTART_RETRY_DELAY = 1000; // ms
 
+export const ENGINE_STATE_RECONCILE_TIMEOUT = 2500;
+
 // Audio source polling delay (audio.ts)
 // Retry interval when selected audio input is unavailable
 export const AUDIO_SOURCE_POLL_DELAY = 1000; // ms

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -92,6 +92,7 @@ import {
 } from "./modules/streaming/link-telemetry.ts";
 import { getPipelineList } from "./modules/streaming/pipelines.ts";
 import { refreshAndBroadcastSources } from "./modules/streaming/sources.ts";
+import { reconcileStreamSession } from "./modules/streaming/stream-session-orchestrator.ts";
 import {
 	getStreamingProcesses,
 	gracefulShutdown,
@@ -238,6 +239,11 @@ await guardNonCritical("pipelines", () =>
 			: {},
 	),
 );
+if (!shouldUseMocks()) {
+	await guardNonCritical("stream-session-reconcile", async () => {
+		await reconcileStreamSession();
+	});
+}
 
 // Resolve the runtime hardware kind (engine → device-tree → setup.hw → generic)
 // and seed the cache BEFORE the sensor/audio/pipeline consumers read it, so

--- a/apps/backend/src/modules/remote-control/set-profile-wiring.ts
+++ b/apps/backend/src/modules/remote-control/set-profile-wiring.ts
@@ -35,17 +35,17 @@ import { RUNTIME_CONFIG_DEFAULTS } from "../../helpers/config-schemas.ts";
 import { logger } from "../../helpers/logger.ts";
 import { getConfig, saveConfig } from "../config.ts";
 import { getLastCapabilities } from "../streaming/capabilities.ts";
-import { getIsStreaming } from "../streaming/streaming.ts";
+import { classifyStartFailure } from "../streaming/start-failure-taxonomy.ts";
 import {
-	start as startStream,
-	stop as stopStream,
-} from "../streaming/streamloop.ts";
+	StreamStartFailure,
+	startStreamSession,
+	stopStreamSession,
+} from "../streaming/stream-session-orchestrator.ts";
+import { getIsStreaming } from "../streaming/streaming.ts";
+import { start as startStream } from "../streaming/streamloop.ts";
 import { broadcastMsg } from "../ui/websocket-server.ts";
 import { reportActiveProfile } from "./active-profile-reporter.ts";
 import { configureSetProfile, type SetProfileCaps } from "./set-profile.ts";
-
-const RECONNECT_SETTLE_TIMEOUT_MS = 5_000;
-const RECONNECT_SETTLE_POLL_MS = 50;
 
 function projectCaps(): SetProfileCaps {
 	const caps = getLastCapabilities();
@@ -58,27 +58,12 @@ function projectCaps(): SetProfileCaps {
 	};
 }
 
-function waitUntilIdle(): Promise<boolean> {
-	return new Promise((resolve) => {
-		const start = Date.now();
-		const poll = () => {
-			if (!getIsStreaming()) return resolve(true);
-			if (Date.now() - start >= RECONNECT_SETTLE_TIMEOUT_MS) {
-				return resolve(false);
-			}
-			setTimeout(poll, RECONNECT_SETTLE_POLL_MS);
-		};
-		poll();
-	});
-}
-
 async function reconnect(): Promise<void> {
 	if (!getIsStreaming()) return;
-	stopStream();
-	const settled = await waitUntilIdle();
-	if (!settled) {
+	const stopped = await stopStreamSession();
+	if (stopped.result !== "stopped") {
 		logger.warn(
-			"set-profile: stream did not settle within the reconnect window; persisted config applies on next start",
+			"set-profile: stream stop failed; persisted config applies on next start",
 		);
 		return;
 	}
@@ -90,7 +75,20 @@ async function reconnect(): Promise<void> {
 		},
 		data: { isAuthenticated: true, lastActive: Date.now() },
 	} as unknown as import("ws").default;
-	await startStream(stubConn, {});
+	const started = await startStreamSession({
+		origin: "set-profile",
+		launch: async ({ attemptId, generation }) => {
+			const result = await startStream(stubConn, {}, generation);
+			if (!result.success) {
+				throw new StreamStartFailure(
+					classifyStartFailure("spawn-sender", result.error, attemptId),
+				);
+			}
+		},
+	});
+	if (started.result !== "started") {
+		logger.warn("set-profile: stream restart did not complete", { started });
+	}
 }
 
 export function wireSetProfile(): void {

--- a/apps/backend/src/modules/streaming/cerastream-backend.ts
+++ b/apps/backend/src/modules/streaming/cerastream-backend.ts
@@ -86,6 +86,7 @@ import { validateBitrate } from "./encoder.ts";
 import type {
 	BackendErrorListener,
 	BitrateParams,
+	EngineRuntimeState,
 	EngineTelemetry,
 	StreamingBackend,
 	StreamRunOptions,
@@ -135,6 +136,11 @@ export interface CerastreamBackendDeps {
 	// assembly omits `audio.device` and the engine routes embedded audio.
 	// Injected so the assembly stays unit-testable without global state.
 	isEmbeddedAudioActive: (pipelineId: string | undefined) => boolean;
+	scheduleTimeout: (
+		callback: () => void,
+		delayMs: number,
+	) => ReturnType<typeof setTimeout>;
+	cancelTimeout: (timer: ReturnType<typeof setTimeout>) => void;
 }
 
 function defaultBridge(): CerastreamBridge {
@@ -326,7 +332,18 @@ function defaultCerastreamBackendDeps(): CerastreamBackendDeps {
 		logger: defaultLogger,
 		getActiveInput: () => deviceRegistry.getActiveInput(),
 		isEmbeddedAudioActive: isEmbeddedAudioPipeline,
+		scheduleTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+		cancelTimeout: (timer) => clearTimeout(timer),
 	};
+}
+
+function classifyRuntimeState(
+	state: unknown,
+	streaming: unknown,
+): EngineRuntimeState {
+	if (state === "streaming" && streaming) return "streaming";
+	if (state === "idle" && !streaming) return "idle";
+	return "unknown";
 }
 
 /**
@@ -541,62 +558,61 @@ export class CerastreamBackend implements StreamingBackend {
 		return this.telemetry;
 	}
 
-	async reconcileRuntimeState(): Promise<boolean> {
-		const existing = this.telemetry?.streaming;
-		if (typeof existing === "boolean" && this.client !== undefined) {
-			return existing;
+	async reconcileRuntimeState(): Promise<EngineRuntimeState> {
+		const existing = this.telemetry;
+		if (existing !== null && this.client !== undefined) {
+			return classifyRuntimeState(existing.state, existing.streaming);
 		}
 
-		const client = await this.deps.connect({
-			...this.deps.connectOptions,
-			autoReconnect: false,
-			requestTimeoutMs: ENGINE_STATE_RECONCILE_TIMEOUT,
-		});
+		let client: CerastreamClient | undefined;
 		let subscription: Subscription | undefined;
 		let timer: ReturnType<typeof setTimeout> | undefined;
-		let subscribed = false;
 		try {
-			let resolveStreaming: ((streaming: boolean) => void) | undefined;
-			let rejectStreaming: ((error: Error) => void) | undefined;
-			const streamingEvent = new Promise<boolean>((resolve, reject) => {
-				resolveStreaming = resolve;
-				rejectStreaming = reject;
+			client = await this.deps.connect({
+				...this.deps.connectOptions,
+				autoReconnect: false,
+				requestTimeoutMs: ENGINE_STATE_RECONCILE_TIMEOUT,
+			});
+			let resolveRuntimeState:
+				| ((runtimeState: EngineRuntimeState) => void)
+				| undefined;
+			const runtimeStateEvent = new Promise<EngineRuntimeState>((resolve) => {
+				resolveRuntimeState = resolve;
 			});
 			subscription = await client.subscribeEvents(
 				{ topics: ["status"] },
 				(event) => {
 					this.handleEvent(event);
-					if (event.type === "status") resolveStreaming?.(event.streaming);
+					if (event.type === "status") {
+						resolveRuntimeState?.(
+							classifyRuntimeState(event.state, event.streaming),
+						);
+					}
 				},
 			);
-			subscribed = true;
-			timer = setTimeout(
-				() =>
-					rejectStreaming?.(
-						new CerastreamTimeoutError(
-							"runtime-state",
-							ENGINE_STATE_RECONCILE_TIMEOUT,
-						),
-					),
+			timer = this.deps.scheduleTimeout(
+				() => resolveRuntimeState?.("unknown"),
 				ENGINE_STATE_RECONCILE_TIMEOUT,
 			);
-			const streaming = await streamingEvent;
-			if (streaming) {
+			const runtimeState = await runtimeStateEvent;
+			if (runtimeState === "streaming") {
 				this.client = client;
 				this.subscription = subscription;
 				this.active = true;
-				return true;
+				return runtimeState;
 			}
 			subscription?.close();
 			await client.close();
-			return false;
+			return runtimeState;
 		} catch (error) {
 			subscription?.close();
-			await client.close();
-			if (subscribed && error instanceof CerastreamTimeoutError) return false;
-			throw error;
+			await client?.close();
+			this.deps.logger.debug("cerastream: runtime-state query unresolved", {
+				error,
+			});
+			return "unknown";
 		} finally {
-			if (timer !== undefined) clearTimeout(timer);
+			if (timer !== undefined) this.deps.cancelTimeout(timer);
 		}
 	}
 

--- a/apps/backend/src/modules/streaming/cerastream-backend.ts
+++ b/apps/backend/src/modules/streaming/cerastream-backend.ts
@@ -70,6 +70,7 @@ import { toEngineResolution } from "@ceraui/rpc/schemas";
 import { z } from "zod";
 import type { RuntimeConfig } from "../../helpers/config-schemas.ts";
 import { logger as defaultLogger } from "../../helpers/logger.ts";
+import { ENGINE_STATE_RECONCILE_TIMEOUT } from "../../helpers/timing-constants.ts";
 import { getConfig, saveConfig } from "../config.ts";
 import { setup } from "../setup.ts";
 import {
@@ -440,10 +441,10 @@ export class CerastreamBackend implements StreamingBackend {
 		return ["--config", this.deps.configPath];
 	}
 
-	start(config: RuntimeConfig, opts: StreamRunOptions): void {
+	async start(config: RuntimeConfig, opts: StreamRunOptions): Promise<void> {
 		this.active = true;
 		const params = this.buildStartParams(config, opts);
-		this.enqueue(async () => {
+		await this.enqueue(async () => {
 			const client = await this.deps.connect(this.deps.connectOptions);
 			this.client = client;
 			this.subscription = await client.subscribeEvents({}, (event) =>
@@ -477,7 +478,7 @@ export class CerastreamBackend implements StreamingBackend {
 		this.active = false;
 		const client = this.client;
 		const subscription = this.subscription;
-		this.enqueue(async () => {
+		void this.enqueue(async () => {
 			subscription?.close();
 			try {
 				await client?.stop();
@@ -506,7 +507,7 @@ export class CerastreamBackend implements StreamingBackend {
 			this.deps.saveConfig();
 			const client = this.client;
 			if (client) {
-				this.enqueue(
+				void this.enqueue(
 					() => client.setBitrate({ max_bitrate: maxBr }).then(() => undefined),
 					"set-bitrate",
 				);
@@ -526,7 +527,7 @@ export class CerastreamBackend implements StreamingBackend {
 			this.deps.getConfig(),
 			client.hello.schema_version,
 		);
-		this.enqueue(
+		void this.enqueue(
 			() => client.reloadConfig(params).then(() => undefined),
 			"reload-config",
 		);
@@ -538,6 +539,65 @@ export class CerastreamBackend implements StreamingBackend {
 
 	getTelemetry(): EngineTelemetry | null {
 		return this.telemetry;
+	}
+
+	async reconcileRuntimeState(): Promise<boolean> {
+		const existing = this.telemetry?.streaming;
+		if (typeof existing === "boolean" && this.client !== undefined) {
+			return existing;
+		}
+
+		const client = await this.deps.connect({
+			...this.deps.connectOptions,
+			autoReconnect: false,
+			requestTimeoutMs: ENGINE_STATE_RECONCILE_TIMEOUT,
+		});
+		let subscription: Subscription | undefined;
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		let subscribed = false;
+		try {
+			let resolveStreaming: ((streaming: boolean) => void) | undefined;
+			let rejectStreaming: ((error: Error) => void) | undefined;
+			const streamingEvent = new Promise<boolean>((resolve, reject) => {
+				resolveStreaming = resolve;
+				rejectStreaming = reject;
+			});
+			subscription = await client.subscribeEvents(
+				{ topics: ["status"] },
+				(event) => {
+					this.handleEvent(event);
+					if (event.type === "status") resolveStreaming?.(event.streaming);
+				},
+			);
+			subscribed = true;
+			timer = setTimeout(
+				() =>
+					rejectStreaming?.(
+						new CerastreamTimeoutError(
+							"runtime-state",
+							ENGINE_STATE_RECONCILE_TIMEOUT,
+						),
+					),
+				ENGINE_STATE_RECONCILE_TIMEOUT,
+			);
+			const streaming = await streamingEvent;
+			if (streaming) {
+				this.client = client;
+				this.subscription = subscription;
+				this.active = true;
+				return true;
+			}
+			subscription?.close();
+			await client.close();
+			return false;
+		} catch (error) {
+			subscription?.close();
+			await client.close();
+			if (subscribed && error instanceof CerastreamTimeoutError) return false;
+			throw error;
+		} finally {
+			if (timer !== undefined) clearTimeout(timer);
+		}
 	}
 
 	/**
@@ -720,10 +780,10 @@ export class CerastreamBackend implements StreamingBackend {
 		for (const listener of this.errorListeners) listener(raw);
 	}
 
-	private enqueue(op: () => Promise<void>, label: string): void {
-		this.queue = this.queue
-			.then(op)
-			.catch((err) => this.handleOpFailure(label, err));
+	private enqueue(op: () => Promise<void>, label: string): Promise<void> {
+		const operation = this.queue.then(op);
+		this.queue = operation.catch((err) => this.handleOpFailure(label, err));
+		return operation;
 	}
 
 	private handleOpFailure(label: string, err: unknown): void {

--- a/apps/backend/src/modules/streaming/engine-reconnect.ts
+++ b/apps/backend/src/modules/streaming/engine-reconnect.ts
@@ -70,6 +70,7 @@ import {
 	type EngineDeviceCacheDeps,
 	refreshAndBroadcastSources,
 } from "./sources.ts";
+import { reconcileStreamSession } from "./stream-session-orchestrator.ts";
 import { getIsStreaming } from "./streaming.ts";
 
 /**
@@ -161,6 +162,7 @@ function buildDefaultBroadcastEngineState(
 		await (sourcesOverride
 			? refreshAndBroadcastSources(sourcesOverride)
 			: refreshAndBroadcastSources());
+		if (sourcesOverride === undefined) await reconcileStreamSession();
 	};
 }
 

--- a/apps/backend/src/modules/streaming/engine-runtime-state.ts
+++ b/apps/backend/src/modules/streaming/engine-runtime-state.ts
@@ -1,11 +1,8 @@
+import type { EngineRuntimeState } from "./streaming-backend.ts";
 import { getStreamingBackend } from "./streaming-engine.ts";
 
-export class EngineRuntimeStateTimeoutError extends Error {
-	override readonly name = "EngineRuntimeStateTimeoutError";
-}
-
-export async function queryEngineRuntimeStreaming(): Promise<boolean> {
+export async function queryEngineRuntimeStreaming(): Promise<EngineRuntimeState> {
 	const query = getStreamingBackend().reconcileRuntimeState;
-	if (query === undefined) throw new EngineRuntimeStateTimeoutError();
+	if (query === undefined) return "unknown";
 	return query.call(getStreamingBackend());
 }

--- a/apps/backend/src/modules/streaming/engine-runtime-state.ts
+++ b/apps/backend/src/modules/streaming/engine-runtime-state.ts
@@ -1,0 +1,11 @@
+import { getStreamingBackend } from "./streaming-engine.ts";
+
+export class EngineRuntimeStateTimeoutError extends Error {
+	override readonly name = "EngineRuntimeStateTimeoutError";
+}
+
+export async function queryEngineRuntimeStreaming(): Promise<boolean> {
+	const query = getStreamingBackend().reconcileRuntimeState;
+	if (query === undefined) throw new EngineRuntimeStateTimeoutError();
+	return query.call(getStreamingBackend());
+}

--- a/apps/backend/src/modules/streaming/start-failure-taxonomy.ts
+++ b/apps/backend/src/modules/streaming/start-failure-taxonomy.ts
@@ -11,10 +11,10 @@
  * the JSON-RPC codes) — so those live behind the client, and CeraUI classifies
  * their surfaced shapes here.
  *
- * NOTHING here is wired into a runtime path. `streaming.procedure.ts`,
- * `session.ts`, and the engine backend are untouched — Todos 26-29 do the
- * wiring. This module is pure + fully unit-tested against fabricated error
- * shapes.
+ * Todo 26 wires this taxonomy into the public start boundary and carries one
+ * attempt id through the orchestrator. Retry/suppression and rollback policy
+ * remain Todos 27-29. This module is pure + fully unit-tested against fabricated
+ * error shapes.
  *
  * ── Failure-site cross-check (every site found in the codebase, mapped) ──
  *   params        zod (oRPC input / validateConfig safeParse / startParams.parse)

--- a/apps/backend/src/modules/streaming/stream-lifecycle-status.ts
+++ b/apps/backend/src/modules/streaming/stream-lifecycle-status.ts
@@ -1,0 +1,13 @@
+import type { LifecycleState } from "@ceraui/rpc/schemas";
+import { broadcastMsg } from "../ui/websocket-server.ts";
+
+let lifecycleState: LifecycleState = "idle";
+
+export function getStreamLifecycleState(): LifecycleState {
+	return lifecycleState;
+}
+
+export function updateStreamLifecycleState(state: LifecycleState): void {
+	lifecycleState = state;
+	broadcastMsg("status", { stream_lifecycle: state });
+}

--- a/apps/backend/src/modules/streaming/stream-session-orchestrator.ts
+++ b/apps/backend/src/modules/streaming/stream-session-orchestrator.ts
@@ -1,0 +1,257 @@
+import {
+	isLegalLifecycleTransition,
+	type LifecycleState,
+	type StartFailure,
+	type StartResult,
+	type StopResult,
+} from "@ceraui/rpc/schemas";
+
+import { logger } from "../../helpers/logger.ts";
+import { notificationBroadcast } from "../ui/notifications.ts";
+import { queryEngineRuntimeStreaming } from "./engine-runtime-state.ts";
+import {
+	classifyStartFailure,
+	newAttemptId,
+} from "./start-failure-taxonomy.ts";
+import { updateStreamLifecycleState } from "./stream-lifecycle-status.ts";
+import { getIsStreaming, updateStatus } from "./streaming.ts";
+import { stopGeneration } from "./streamloop/session.ts";
+
+export const STREAM_LAUNCH_ORIGINS = [
+	"ui",
+	"autostart",
+	"set-profile",
+	"remote-control",
+] as const;
+export type StreamLaunchOrigin = (typeof STREAM_LAUNCH_ORIGINS)[number];
+
+export type StreamLaunchContext = {
+	readonly attemptId: string;
+	readonly generation: number;
+	readonly origin: StreamLaunchOrigin;
+	readonly cancelled: () => boolean;
+};
+
+export type StreamStartRequest = {
+	readonly origin: StreamLaunchOrigin;
+	readonly launch: (context: StreamLaunchContext) => Promise<void>;
+};
+
+export type StreamSessionSnapshot = {
+	readonly state: LifecycleState;
+	readonly generation: number;
+};
+
+export type StreamSessionOrchestratorDeps = {
+	readonly createAttemptId: () => string;
+	readonly setStreamingStatus: (streaming: boolean) => void;
+	readonly getStreamingStatus?: () => boolean;
+	readonly stopRuntime: (generation: number) => Promise<void>;
+	readonly queryRuntime: () => Promise<boolean>;
+	readonly setLifecycleState?: (state: LifecycleState) => void;
+	readonly invariantViolation?: (
+		from: LifecycleState,
+		to: LifecycleState,
+	) => void;
+};
+
+type ActiveAttempt = {
+	readonly attemptId: string;
+	readonly generation: number;
+	cancelled: boolean;
+};
+
+export type StreamSessionOrchestrator = {
+	readonly start: (request: StreamStartRequest) => Promise<StartResult>;
+	readonly stop: () => Promise<StopResult>;
+	readonly reconcile: () => Promise<LifecycleState>;
+	readonly snapshot: () => StreamSessionSnapshot;
+};
+
+export function createStreamSessionOrchestrator(
+	deps: StreamSessionOrchestratorDeps,
+): StreamSessionOrchestrator {
+	let state: LifecycleState = "idle";
+	let generation = 0;
+	let active: ActiveAttempt | undefined;
+	let reconciliationEpoch = 0;
+
+	const transition = (next: LifecycleState): boolean => {
+		if (state === next) return true;
+		if (!isLegalLifecycleTransition(state, next)) {
+			deps.invariantViolation?.(state, next);
+			return false;
+		}
+		state = next;
+		deps.setLifecycleState?.(state);
+		return true;
+	};
+
+	const finishCancelled = async (
+		attempt: ActiveAttempt,
+	): Promise<StartResult> => {
+		await deps.stopRuntime(attempt.generation);
+		if (active === attempt) {
+			transition("idle");
+			active = undefined;
+			deps.setStreamingStatus(false);
+		}
+		return { result: "cancelled", attemptId: attempt.attemptId };
+	};
+
+	const start = async (request: StreamStartRequest): Promise<StartResult> => {
+		const attemptId = deps.createAttemptId();
+		if (
+			(state === "streaming" || state === "stop_failed") &&
+			deps.getStreamingStatus?.() === false
+		) {
+			state = "idle";
+			active = undefined;
+			deps.setLifecycleState?.(state);
+		}
+		if (state !== "idle") return { result: "busy", attemptId };
+
+		generation += 1;
+		const attempt: ActiveAttempt = {
+			attemptId,
+			generation,
+			cancelled: false,
+		};
+		active = attempt;
+		transition("starting");
+		const context: StreamLaunchContext = {
+			attemptId,
+			generation: attempt.generation,
+			origin: request.origin,
+			cancelled: () => attempt.cancelled,
+		};
+
+		try {
+			await request.launch(context);
+			if (attempt.cancelled || active !== attempt) {
+				return await finishCancelled(attempt);
+			}
+			transition("streaming");
+			deps.setStreamingStatus(true);
+			return { result: "started", attemptId };
+		} catch (error) {
+			if (attempt.cancelled || active !== attempt) {
+				return await finishCancelled(attempt);
+			}
+			transition("idle");
+			active = undefined;
+			deps.setStreamingStatus(false);
+			return {
+				result: "failed",
+				attemptId,
+				failure:
+					error instanceof StreamStartFailure
+						? error.failure
+						: classifyStartFailure("start-rpc", error, attemptId, {
+								warn: (message, meta) => logger.warn(message, meta),
+							}),
+			};
+		}
+	};
+
+	const stop = async (): Promise<StopResult> => {
+		if (state === "idle") return { result: "stopped" };
+		if (state === "reconciling") {
+			reconciliationEpoch += 1;
+			transition("idle");
+			deps.setStreamingStatus(false);
+			return { result: "stopped" };
+		}
+
+		const stoppedGeneration = active?.generation ?? generation;
+		const cancellingStart = state === "starting";
+		if (cancellingStart && active !== undefined) active.cancelled = true;
+		if (!transition("stopping")) {
+			return {
+				result: "stop_failed",
+				reason: "illegal_lifecycle_transition",
+			};
+		}
+
+		try {
+			await deps.stopRuntime(stoppedGeneration);
+			if (!cancellingStart) {
+				active = undefined;
+				transition("idle");
+				deps.setStreamingStatus(false);
+			}
+			return { result: "stopped" };
+		} catch (error) {
+			transition("stop_failed");
+			return {
+				result: "stop_failed",
+				reason: error instanceof Error ? error.message : "stop_failed",
+			};
+		}
+	};
+
+	const reconcile = async (): Promise<LifecycleState> => {
+		if (state !== "idle" && state !== "streaming" && state !== "reconciling")
+			return state;
+		if (state !== "reconciling") transition("reconciling");
+		const epoch = ++reconciliationEpoch;
+		const streaming = await deps.queryRuntime();
+		if (epoch !== reconciliationEpoch) return state;
+		transition(streaming ? "streaming" : "idle");
+		deps.setStreamingStatus(streaming);
+		return state;
+	};
+
+	return {
+		start,
+		stop,
+		reconcile,
+		snapshot: () => ({ state, generation }),
+	};
+}
+
+export class StreamStartFailure extends Error {
+	override readonly name = "StreamStartFailure";
+
+	constructor(readonly failure: StartFailure) {
+		super(`${failure.phase}:${failure.class}`);
+	}
+}
+
+const productionOrchestrator = createStreamSessionOrchestrator({
+	createAttemptId: newAttemptId,
+	setStreamingStatus: updateStatus,
+	getStreamingStatus: getIsStreaming,
+	stopRuntime: stopGeneration,
+	queryRuntime: queryEngineRuntimeStreaming,
+	setLifecycleState: updateStreamLifecycleState,
+	invariantViolation: (from, to) => {
+		logger.error("stream-session illegal lifecycle transition", { from, to });
+		notificationBroadcast(
+			"stream_session_recovered",
+			"warning",
+			"The stream session entered an invalid lifecycle state and was recovered.",
+			10,
+			false,
+			true,
+		);
+	},
+});
+
+export function startStreamSession(
+	request: StreamStartRequest,
+): Promise<StartResult> {
+	return productionOrchestrator.start(request);
+}
+
+export function stopStreamSession(): Promise<StopResult> {
+	return productionOrchestrator.stop();
+}
+
+export function reconcileStreamSession(): Promise<LifecycleState> {
+	return productionOrchestrator.reconcile();
+}
+
+export function getStreamSessionSnapshot(): StreamSessionSnapshot {
+	return productionOrchestrator.snapshot();
+}

--- a/apps/backend/src/modules/streaming/stream-session-orchestrator.ts
+++ b/apps/backend/src/modules/streaming/stream-session-orchestrator.ts
@@ -15,6 +15,7 @@ import {
 } from "./start-failure-taxonomy.ts";
 import { updateStreamLifecycleState } from "./stream-lifecycle-status.ts";
 import { getIsStreaming, updateStatus } from "./streaming.ts";
+import type { EngineRuntimeState } from "./streaming-backend.ts";
 import { stopGeneration } from "./streamloop/session.ts";
 
 export const STREAM_LAUNCH_ORIGINS = [
@@ -47,7 +48,7 @@ export type StreamSessionOrchestratorDeps = {
 	readonly setStreamingStatus: (streaming: boolean) => void;
 	readonly getStreamingStatus?: () => boolean;
 	readonly stopRuntime: (generation: number) => Promise<void>;
-	readonly queryRuntime: () => Promise<boolean>;
+	readonly queryRuntime: () => Promise<EngineRuntimeState>;
 	readonly setLifecycleState?: (state: LifecycleState) => void;
 	readonly invariantViolation?: (
 		from: LifecycleState,
@@ -195,10 +196,11 @@ export function createStreamSessionOrchestrator(
 			return state;
 		if (state !== "reconciling") transition("reconciling");
 		const epoch = ++reconciliationEpoch;
-		const streaming = await deps.queryRuntime();
+		const runtimeState = await deps.queryRuntime();
 		if (epoch !== reconciliationEpoch) return state;
-		transition(streaming ? "streaming" : "idle");
-		deps.setStreamingStatus(streaming);
+		if (runtimeState === "unknown") return state;
+		transition(runtimeState);
+		deps.setStreamingStatus(runtimeState === "streaming");
 		return state;
 	};
 

--- a/apps/backend/src/modules/streaming/streaming-backend.ts
+++ b/apps/backend/src/modules/streaming/streaming-backend.ts
@@ -60,6 +60,8 @@ export interface StreamRunOptions {
  */
 export type BackendErrorListener = (rawStderr: string) => void;
 
+export type EngineRuntimeState = "streaming" | "idle" | "unknown";
+
 /**
  * Engine-side telemetry snapshot (srtla owns per-link telemetry separately).
  * Kept as an open marker type so the seam stays engine-agnostic.
@@ -107,5 +109,5 @@ export interface StreamingBackend {
 	/** Optional engine-side telemetry hook. */
 	getTelemetry?(): EngineTelemetry | null;
 	/** Adopt an already-running engine session after a backend reconnect. */
-	reconcileRuntimeState?(): Promise<boolean>;
+	reconcileRuntimeState?(): Promise<EngineRuntimeState>;
 }

--- a/apps/backend/src/modules/streaming/streaming-backend.ts
+++ b/apps/backend/src/modules/streaming/streaming-backend.ts
@@ -85,8 +85,8 @@ export interface StreamingBackend {
 	/** Build the engine argv and persist the run config for a launch. */
 	buildRunArgs(config: RuntimeConfig, opts: StreamRunOptions): Array<string>;
 
-	/** Launch the engine process for a configured stream. */
-	start(config: RuntimeConfig, opts: StreamRunOptions): void;
+	/** Launch the engine process and resolve after the engine confirms PLAYING. */
+	start(config: RuntimeConfig, opts: StreamRunOptions): Promise<void>;
 	/**
 	 * Stop the engine process. `onStopped` fires once the engine has terminated
 	 * (synchronously if it was already dead). Returns whether an engine process
@@ -106,4 +106,6 @@ export interface StreamingBackend {
 
 	/** Optional engine-side telemetry hook. */
 	getTelemetry?(): EngineTelemetry | null;
+	/** Adopt an already-running engine session after a backend reconnect. */
+	reconcileRuntimeState?(): Promise<boolean>;
 }

--- a/apps/backend/src/modules/streaming/streamloop/autostart.ts
+++ b/apps/backend/src/modules/streaming/streamloop/autostart.ts
@@ -28,7 +28,12 @@ import { isUpdating } from "../../system/software-updates.ts";
 import { broadcastMsg } from "../../ui/websocket-server.ts";
 import type { Pipeline } from "../pipelines.ts";
 import { genSrtlaIpList, resolveSrtla } from "../srtla.ts";
-import { getIsStreaming, updateStatus, validateConfig } from "../streaming.ts";
+import { classifyStartFailure } from "../start-failure-taxonomy.ts";
+import {
+	StreamStartFailure,
+	startStreamSession,
+} from "../stream-session-orchestrator.ts";
+import { getIsStreaming, validateConfig } from "../streaming.ts";
 import { startStream } from "./start-stream.ts";
 
 export const AUTOSTART_CHECK_FILE = "/tmp/ceralive_restarted";
@@ -63,9 +68,6 @@ export async function autoStartStream(): Promise<void> {
 		return;
 	}
 
-	// The first await is used below, so we have to lock the status
-	updateStatus(true);
-
 	// If the config is invalid, then we won't ever be able to start, so don't retry
 	const config = getConfig();
 	let c: {
@@ -78,18 +80,37 @@ export async function autoStartStream(): Promise<void> {
 		c = await validateConfig(config);
 	} catch (err) {
 		logger.error("autostart failed", { err });
-		updateStatus(false);
 		return;
 	}
 
-	try {
-		// This will returned a cached address if the resolver is temporarily unavailable
-		const srtlaAddr: string = await resolveSrtla(c.srtlaAddr);
-		await startStream(c.pipeline, srtlaAddr, c.srtlaPort, c.streamid);
-	} catch (err) {
-		logger.warn("autostart failed, but will retry", { err });
+	const result = await startStreamSession({
+		origin: "autostart",
+		launch: async ({ attemptId }) => {
+			const srtlaAddr: string = await resolveSrtla(c.srtlaAddr);
+			const launched = await startStream(
+				c.pipeline,
+				srtlaAddr,
+				c.srtlaPort,
+				c.streamid,
+			);
+			if (!launched.success) {
+				throw new StreamStartFailure(
+					classifyStartFailure("spawn-sender", launched.error, attemptId),
+				);
+			}
+		},
+	});
+	if (result.result === "failed") {
+		logger.warn("autostart failed, but will retry", { result });
 		setTimeout(autoStartStream, AUTOSTART_RETRY_DELAY);
-		updateStatus(false);
+		return;
+	}
+	if (result.result === "busy") {
+		logger.info("autostart aborted", { result });
+		return;
+	}
+	if (result.result === "cancelled") {
+		logger.info("autostart cancelled", { result });
 		return;
 	}
 

--- a/apps/backend/src/modules/streaming/streamloop/session.ts
+++ b/apps/backend/src/modules/streaming/streamloop/session.ts
@@ -25,6 +25,7 @@ import { isLocalIp } from "../../../helpers/ip-addresses.ts";
 import { logger } from "../../../helpers/logger.ts";
 import { onNetworkInterfacesChange } from "../../network/network-interfaces.ts";
 import { isUpdating } from "../../system/software-updates.ts";
+import { notificationBroadcast } from "../../ui/notifications.ts";
 import { sendStatus } from "../../ui/status.ts";
 import { getSocketSenderId } from "../../ui/websocket-server.ts";
 import { clearAsrcProbeReject, isAsrcProbeRejectResolved } from "../audio.ts";
@@ -48,18 +49,27 @@ import { getStreamingBackend } from "../streaming-engine.ts";
 import { getStreamingProcesses, stopAll } from "./process-runner.ts";
 import { type StartStreamResult, startStream } from "./start-stream.ts";
 
-let removeNetworkInterfacesChangeListener: (() => void) | undefined;
+type SessionResources = {
+	readonly generation: number;
+	readonly removeNetworkInterfacesChangeListener: () => void;
+};
+
+let sessionResources: SessionResources | undefined;
 
 export async function start(
 	conn: WebSocket,
 	params: ConfigParameters,
-): Promise<StartStreamResult | undefined> {
+	generation = 0,
+): Promise<StartStreamResult> {
 	if (getIsStreaming() || isUpdating()) {
 		sendStatus(conn);
-		return;
+		return {
+			success: false,
+			error: "stream_start_unavailable",
+			reason: "stream_start_unavailable",
+		};
 	}
 
-	updateStatus(true);
 	const senderId = getSocketSenderId(conn);
 
 	let c: {
@@ -77,11 +87,19 @@ export async function start(
 			startError(conn, "Failed to save the config, unknown error", senderId);
 			logger.error("Failed to save config", { err });
 		}
-		return;
+		return {
+			success: false,
+			error: typeof err === "string" ? err : "start_invalid",
+			reason: typeof err === "string" ? err : "start_invalid",
+		};
 	}
 
-	if (removeNetworkInterfacesChangeListener) {
-		removeNetworkInterfacesChangeListener();
+	if (sessionResources !== undefined) {
+		reportSessionInvariant(
+			generation,
+			`start found resources owned by generation ${sessionResources.generation}`,
+		);
+		sessionResources.removeNetworkInterfacesChangeListener();
 	}
 
 	const handleSrtlaIpAddresses = async () => {
@@ -105,9 +123,12 @@ export async function start(
 	};
 
 	void handleSrtlaIpAddresses();
-	removeNetworkInterfacesChangeListener = onNetworkInterfacesChange(
-		handleSrtlaIpAddresses,
-	);
+	sessionResources = {
+		generation,
+		removeNetworkInterfacesChangeListener: onNetworkInterfacesChange(
+			handleSrtlaIpAddresses,
+		),
+	};
 
 	let result: StartStreamResult;
 	try {
@@ -124,35 +145,82 @@ export async function start(
 			startError(conn, "Failed to start, unknown error", senderId);
 			logger.error("Failed to start stream", { err });
 		}
-		return;
+		return {
+			success: false,
+			error: typeof err === "string" ? err : "engine_internal",
+			reason: typeof err === "string" ? err : "engine_internal",
+		};
 	}
 
 	return result;
 }
 
-export function stop() {
+function reportSessionInvariant(generation: number, reason: string): void {
+	logger.error("stream-session invariant violation", { generation, reason });
+	notificationBroadcast(
+		"stream_session_recovered",
+		"warning",
+		"The stream session had inconsistent resource ownership and was recovered.",
+		10,
+		false,
+		true,
+	);
+}
+
+export function stopGeneration(generation: number): Promise<void> {
 	// A deferred auto-audio follow (T7) only applies at the NEXT start; a stop
 	// cancels it so the picker never keeps a stale "follows on restart" hint.
 	setPendingAudioFollowAsrc(null);
 
-	if (isAsrcProbeRejectResolved()) {
-		clearAsrcProbeReject();
-
-		if (getStreamingProcesses().length === 0) {
-			updateStatus(false);
+	return new Promise((resolve) => {
+		const finish = () => {
+			if (sessionResources?.generation === generation) {
+				sessionResources.removeNetworkInterfacesChangeListener();
+				sessionResources = undefined;
+			}
+			stopAll();
 			stopLinkTelemetry();
-			return;
+			updateStatus(false);
+			resolve();
+		};
+
+		if (isAsrcProbeRejectResolved()) {
+			clearAsrcProbeReject();
+
+			if (getStreamingProcesses().length === 0) {
+				finish();
+				return;
+			}
+
+			reportSessionInvariant(
+				generation,
+				"audio probe cancellation overlapped running processes",
+			);
 		}
 
-		logger.error("stop: BUG?: found both an asrcProbe and running processes");
-	}
+		// Bring the engine down first (it owns the engine-first shutdown ordering),
+		// then sweep the rest once it has exited.
+		const foundEngine = getStreamingBackend().stop(finish);
 
-	// Bring the engine down first (it owns the engine-first shutdown ordering),
-	// then sweep the rest once it has exited.
-	const foundEngine = getStreamingBackend().stop(() => stopAll());
+		if (!foundEngine) {
+			if (
+				sessionResources?.generation === generation ||
+				getStreamingProcesses().length > 0
+			) {
+				reportSessionInvariant(
+					generation,
+					"engine session missing while generation-owned resources remained",
+				);
+			}
+			finish();
+		}
+	});
+}
 
-	if (!foundEngine) {
-		logger.error("stop: BUG?: engine not found, terminating all processes");
-		stopAll();
-	}
+export function stop(): void {
+	setPendingAudioFollowAsrc(null);
+	if (isAsrcProbeRejectResolved()) clearAsrcProbeReject();
+	void import("../stream-session-orchestrator.ts").then(
+		({ stopStreamSession }) => stopStreamSession(),
+	);
 }

--- a/apps/backend/src/modules/streaming/streamloop/start-stream.ts
+++ b/apps/backend/src/modules/streaming/streamloop/start-stream.ts
@@ -43,7 +43,6 @@ import { embeddedAudioActive } from "../embedded-audio.ts";
 import { clearStreamProcessExit } from "../health.ts";
 import { srtlaStatsFile, startLinkTelemetry } from "../link-telemetry.ts";
 import type { Pipeline } from "../pipelines.ts";
-import { updateStatus } from "../streaming.ts";
 import { getStreamingBackend } from "../streaming-engine.ts";
 import { srtlaSendExec } from "./exec-paths.ts";
 import { resolveProcessError } from "./process-error-patterns.ts";
@@ -111,7 +110,6 @@ export async function startStream(
 	clearStreamProcessExit();
 
 	if (!(await maybeProbeAudioSource(pipeline, launchConfig, audioDeps))) {
-		updateStatus(false);
 		logger.warn("startStream: audio source probe failed; aborting start", {
 			asrc: launchConfig.asrc,
 		});
@@ -160,7 +158,7 @@ export async function startStream(
 	startLinkTelemetry(statsFile, ipsContent.split("\n"), { controlSocket });
 
 	// Engine launch (session start over structured IPC) is behind the seam.
-	getStreamingBackend().start(launchConfig, {
+	await getStreamingBackend().start(launchConfig, {
 		pipeline: pipeline.source,
 		host: "127.0.0.1",
 		port: SRTLA_LISTEN_PORT,

--- a/apps/backend/src/modules/ui/status.ts
+++ b/apps/backend/src/modules/ui/status.ts
@@ -42,6 +42,7 @@ import {
 import { AUDIO_CODECS } from "../streaming/pipeline-sources.ts";
 import { getPipelinesMessage } from "../streaming/pipelines.ts";
 import { getSourcesMessage } from "../streaming/sources.ts";
+import { getStreamLifecycleState } from "../streaming/stream-lifecycle-status.ts";
 import { getIsStreaming } from "../streaming/streaming.ts";
 import { getRevisions } from "../system/revisions.ts";
 import { getSensors } from "../system/sensors.ts";
@@ -57,6 +58,7 @@ import { buildMsg } from "./websocket-server.ts";
 
 export type StatusResponseMessage = {
 	is_streaming?: ReturnType<typeof getIsStreaming>;
+	stream_lifecycle?: ReturnType<typeof getStreamLifecycleState>;
 	available_updates?: ReturnType<typeof getAvailableUpdates>;
 	updating?: ReturnType<typeof getSoftUpdateStatus>;
 	update_state?: ReturnType<typeof getUpdateState>;
@@ -82,6 +84,7 @@ export function sendStatus(conn: WebSocket) {
 	conn.send(
 		buildMsg("status", {
 			is_streaming: getIsStreaming(),
+			stream_lifecycle: getStreamLifecycleState(),
 			available_updates: getAvailableUpdates(),
 			updating: getSoftUpdateStatus(),
 			update_state: getUpdateState(),

--- a/apps/backend/src/rpc/procedures/status.procedure.ts
+++ b/apps/backend/src/rpc/procedures/status.procedure.ts
@@ -32,6 +32,7 @@ import { getDevicesMessage } from "../../modules/streaming/devices.ts";
 import { AUDIO_CODECS } from "../../modules/streaming/pipeline-sources.ts";
 import { getPipelinesMessage } from "../../modules/streaming/pipelines.ts";
 import { getSourcesMessage } from "../../modules/streaming/sources.ts";
+import { getStreamLifecycleState } from "../../modules/streaming/stream-lifecycle-status.ts";
 import { getIsStreaming } from "../../modules/streaming/streaming.ts";
 import { getRevisions } from "../../modules/system/revisions.ts";
 import { getSensors } from "../../modules/system/sensors.ts";
@@ -67,6 +68,7 @@ export const getStatusProcedure = authedProcedure
 		void getSshStatus();
 		return {
 			is_streaming: getIsStreaming(),
+			stream_lifecycle: getStreamLifecycleState(),
 			available_updates: getAvailableUpdates(),
 			updating: getSoftUpdateStatus(),
 			update_state: getUpdateState(),
@@ -108,6 +110,7 @@ export function buildInitialStatus() {
 		relays: getRelays() ? buildRelaysMsg() : null,
 		status: {
 			is_streaming: getIsStreaming(),
+			stream_lifecycle: getStreamLifecycleState(),
 			available_updates: getAvailableUpdates(),
 			updating: getSoftUpdateStatus(),
 			update_state: getUpdateState(),

--- a/apps/backend/src/rpc/procedures/streaming.procedure.test.ts
+++ b/apps/backend/src/rpc/procedures/streaming.procedure.test.ts
@@ -12,6 +12,7 @@ import {
 import { call } from "@orpc/server";
 
 import { getConfig } from "../../modules/config.ts";
+import { updateStatus } from "../../modules/streaming/streaming.ts";
 import * as streamloop from "../../modules/streaming/streamloop.ts";
 import type { AppWebSocket, RPCContext } from "../types.ts";
 
@@ -53,11 +54,15 @@ const startSpy = mock(async () => {
 	await new Promise<void>((resolve) => {
 		releaseStart = resolve;
 	});
+	return { success: true as const };
 });
 
 let streamingStartProcedure: Awaited<
 	typeof import("./streaming.procedure.ts")
 >["streamingStartProcedure"];
+let streamingStopProcedure: Awaited<
+	typeof import("./streaming.procedure.ts")
+>["streamingStopProcedure"];
 
 describe("streaming.start — in-flight re-entry guard (S5)", () => {
 	const savedMockMode = process.env.MOCK_MODE;
@@ -76,7 +81,9 @@ describe("streaming.start — in-flight re-entry guard (S5)", () => {
 			stop: () => {},
 		}));
 
-		({ streamingStartProcedure } = await import("./streaming.procedure.ts"));
+		({ streamingStartProcedure, streamingStopProcedure } = await import(
+			"./streaming.procedure.ts"
+		));
 	});
 
 	afterAll(() => {
@@ -88,6 +95,7 @@ describe("streaming.start — in-flight re-entry guard (S5)", () => {
 	});
 
 	beforeEach(() => {
+		updateStatus(false);
 		// No persisted pipeline → the offered-set gate is skipped so start reaches
 		// the launch path.
 		priorPipeline = getConfig().pipeline;
@@ -139,6 +147,9 @@ describe("streaming.start — in-flight re-entry guard (S5)", () => {
 		releaseStart();
 		await first;
 		expect(spawnSpy).toHaveBeenCalledTimes(1);
+		expect(
+			await call(streamingStopProcedure, undefined, { context }),
+		).toMatchObject({ result: "stopped" });
 
 		const second = call(streamingStartProcedure, {}, { context });
 		await new Promise((resolve) => setTimeout(resolve, 0));

--- a/apps/backend/src/rpc/procedures/streaming.procedure.ts
+++ b/apps/backend/src/rpc/procedures/streaming.procedure.ts
@@ -136,7 +136,6 @@ function startResponse(
 	switch (result.result) {
 		case "started":
 			return {
-				...result,
 				success: true,
 				is_streaming: getIsStreaming(),
 				...(applied !== undefined ? { applied } : {}),
@@ -157,7 +156,6 @@ function startResponse(
 			};
 		case "failed":
 			return {
-				...result,
 				success: false,
 				is_streaming: false,
 				error:

--- a/apps/backend/src/rpc/procedures/streaming.procedure.ts
+++ b/apps/backend/src/rpc/procedures/streaming.procedure.ts
@@ -20,6 +20,8 @@ import {
 	reloadAudioDelayInputSchema,
 	reloadAudioDelayOutputSchema,
 	SRTLA_MIN_LATENCY_MS,
+	type StartFailurePhase,
+	type StartResult,
 	type StreamingConfigInput,
 	SWITCH_AUDIO_ERRORS,
 	type SwitchInputOutput,
@@ -86,18 +88,18 @@ import {
 	type ResolveSourceRoutingResult,
 	resolveSourceRouting,
 } from "../../modules/streaming/sources.ts";
+import { classifyStartFailure } from "../../modules/streaming/start-failure-taxonomy.ts";
 import {
-	getIsStreaming,
-	updateStatus,
-} from "../../modules/streaming/streaming.ts";
+	StreamStartFailure,
+	startStreamSession,
+	stopStreamSession,
+} from "../../modules/streaming/stream-session-orchestrator.ts";
+import { getIsStreaming } from "../../modules/streaming/streaming.ts";
 import {
 	getConfiguredEngine,
 	getStreamingBackend,
 } from "../../modules/streaming/streaming-engine.ts";
-import {
-	start as startStream,
-	stop as stopStream,
-} from "../../modules/streaming/streamloop.ts";
+import { start as startStream } from "../../modules/streaming/streamloop.ts";
 import { broadcastMsg } from "../../modules/ui/websocket-server.ts";
 import { authMiddleware } from "../middleware/auth.middleware.ts";
 import type { RPCContext } from "../types.ts";
@@ -114,7 +116,58 @@ const authedProcedure = baseProcedure.use(authMiddleware);
 // double-spawn the sender and double-start the engine.
 const START_IN_PROGRESS = "START_IN_PROGRESS";
 
-let startInFlight = false;
+function throwStartFailure(
+	phase: StartFailurePhase,
+	error: unknown,
+	attemptId: string,
+): never {
+	throw new StreamStartFailure(
+		classifyStartFailure(phase, error, attemptId, {
+			warn: (message, meta) => logger.warn(message, meta),
+		}),
+	);
+}
+
+function startResponse(
+	result: StartResult,
+	applied: StreamingConfigInput | undefined,
+	legacyError: string | undefined,
+) {
+	switch (result.result) {
+		case "started":
+			return {
+				...result,
+				success: true,
+				is_streaming: getIsStreaming(),
+				...(applied !== undefined ? { applied } : {}),
+			};
+		case "busy":
+			return {
+				...result,
+				success: false,
+				is_streaming: getIsStreaming(),
+				error: START_IN_PROGRESS,
+			};
+		case "cancelled":
+			return {
+				...result,
+				success: false,
+				is_streaming: false,
+				error: "START_CANCELLED",
+			};
+		case "failed":
+			return {
+				...result,
+				success: false,
+				is_streaming: false,
+				error:
+					legacyError ??
+					(typeof result.failure.code === "string"
+						? result.failure.code
+						: result.failure.class),
+			};
+	}
+}
 
 /**
  * Start streaming procedure
@@ -123,104 +176,102 @@ export const streamingStartProcedure = authedProcedure
 	.input(streamingConfigInputSchema)
 	.output(streamingStartOutputSchemaExtended)
 	.handler(async ({ input, context }) => {
-		if (startInFlight) {
-			return {
-				success: false,
-				is_streaming: getIsStreaming(),
-				error: START_IN_PROGRESS,
-			};
-		}
-		startInFlight = true;
-		try {
-			const applied: StreamingConfigInput = {
-				...input,
-				...(input.max_br !== undefined
-					? { max_br: clampBitrate(input.max_br) }
-					: {}),
-				...(input.srt_latency !== undefined
-					? { srt_latency: Math.max(input.srt_latency, SRTLA_MIN_LATENCY_MS) }
-					: {}),
-			};
+		let appliedResponse: StreamingConfigInput | undefined;
+		let legacyError: string | undefined;
+		const lifecycleResult = await startStreamSession({
+			origin:
+				context.ws.remoteAddress === "control-channel"
+					? "remote-control"
+					: "ui",
+			launch: async ({ attemptId, generation }) => {
+				const applied: StreamingConfigInput = {
+					...input,
+					...(input.max_br !== undefined
+						? { max_br: clampBitrate(input.max_br) }
+						: {}),
+					...(input.srt_latency !== undefined
+						? { srt_latency: Math.max(input.srt_latency, SRTLA_MIN_LATENCY_MS) }
+						: {}),
+				};
 
-			// Device-first source pre-validation (T3). Resolve the EFFECTIVE source
-			// (this start's input, else the persisted post-coercion config.source)
-			// HERE, before delegating: an unknown source rejects WITHOUT calling
-			// session.start (session.ts swallows updateConfig errors, so the reject
-			// must happen at this layer). A known source folds its derived pipeline +
-			// recomputed selected_video_input into `applied` so the launch dispatches
-			// the resolved pipeline through the existing offered-set gate below.
-			const effectiveSource = input.source ?? getConfig().source;
-			if (effectiveSource !== undefined) {
-				const routed = resolveSourceRouting(
-					effectiveSource,
-					getSourcesMessage().sources,
-				);
-				if (!routed.ok) {
-					return {
-						success: false,
-						is_streaming: false,
-						error: routed.error,
-					};
-				}
-				applied.pipeline = routed.pipeline;
-				applied.selected_video_input = routed.selected_video_input;
-				applied.source = effectiveSource;
-			}
-
-			// Block start when the effective pipeline is not in the offered set — a
-			// persisted pipeline the current hardware no longer offers. No silent
-			// reset; the client surfaces the structured code so the operator re-picks.
-			const effectivePipeline = applied.pipeline ?? getConfig().pipeline;
-			if (effectivePipeline !== undefined) {
-				const check = validatePersistedPipeline(
-					effectivePipeline,
-					Object.keys(getPipelineList()),
-				);
-				if (!check.valid) {
-					return { success: false, is_streaming: false, error: check.error };
+				// Device-first source pre-validation (T3). Resolve the EFFECTIVE source
+				// (this start's input, else the persisted post-coercion config.source)
+				// HERE, before delegating: an unknown source rejects WITHOUT calling
+				// session.start (session.ts swallows updateConfig errors, so the reject
+				// must happen at this layer). A known source folds its derived pipeline +
+				// recomputed selected_video_input into `applied` so the launch dispatches
+				// the resolved pipeline through the existing offered-set gate below.
+				const effectiveSource = input.source ?? getConfig().source;
+				if (effectiveSource !== undefined) {
+					const routed = resolveSourceRouting(
+						effectiveSource,
+						getSourcesMessage().sources,
+					);
+					if (!routed.ok) {
+						legacyError = routed.error;
+						throwStartFailure("params", new Error(routed.error), attemptId);
+					}
+					applied.pipeline = routed.pipeline;
+					applied.selected_video_input = routed.selected_video_input;
+					applied.source = effectiveSource;
 				}
 
-				// Network-ingest pipelines (rtmp/srt) can only encode once their
-				// local ingest gateway is up. The entry stays visible in the
-				// registry (disabled-with-reason); block the start with a structured
-				// code when the gateway is inactive. Mock honors a test-set flag;
-				// real devices consult the gateway probe (Todo 16 seam).
-				const requiresGateway =
-					searchPipelines(effectivePipeline)?.requires_gateway;
-				if (requiresGateway !== undefined) {
-					const gatewayUp = shouldUseMocks()
-						? isMockGatewayActive(requiresGateway)
-						: isGatewayActive(requiresGateway);
-					if (!gatewayUp) {
-						return {
-							success: false,
-							is_streaming: false,
-							error: GATEWAY_INACTIVE_ERROR,
-						};
+				// Block start when the effective pipeline is not in the offered set — a
+				// persisted pipeline the current hardware no longer offers. No silent
+				// reset; the client surfaces the structured code so the operator re-picks.
+				const effectivePipeline = applied.pipeline ?? getConfig().pipeline;
+				if (effectivePipeline !== undefined) {
+					const check = validatePersistedPipeline(
+						effectivePipeline,
+						Object.keys(getPipelineList()),
+					);
+					if (!check.valid) {
+						legacyError = check.error;
+						throwStartFailure("params", new Error(check.error), attemptId);
+					}
+
+					// Network-ingest pipelines (rtmp/srt) can only encode once their
+					// local ingest gateway is up. The entry stays visible in the
+					// registry (disabled-with-reason); block the start with a structured
+					// code when the gateway is inactive. Mock honors a test-set flag;
+					// real devices consult the gateway probe (Todo 16 seam).
+					const requiresGateway =
+						searchPipelines(effectivePipeline)?.requires_gateway;
+					if (requiresGateway !== undefined) {
+						const gatewayUp = shouldUseMocks()
+							? isMockGatewayActive(requiresGateway)
+							: isGatewayActive(requiresGateway);
+						if (!gatewayUp) {
+							legacyError = GATEWAY_INACTIVE_ERROR;
+							throwStartFailure(
+								"params",
+								new Error(GATEWAY_INACTIVE_ERROR),
+								attemptId,
+							);
+						}
 					}
 				}
-			}
 
-			// Transport × audio-codec coherence gate (C5). Every relay transport is
-			// an MPEG-TS carrier, so only AAC-in-TS is proven end-to-end; refuse an
-			// effective codec the effective transport can't carry at START — config
-			// SAVES stay permitted (mirrors the pipeline_not_in_offered_set gate).
-			const effectiveAcodec = applied.acodec ?? getConfig().acodec;
-			if (effectiveAcodec !== undefined) {
-				const effectiveTransport =
-					applied.relay_protocol ?? getConfig().relay_protocol ?? "srtla";
-				if (
-					!audioCodecAllowedForTransport(effectiveAcodec, effectiveTransport)
-				) {
-					return {
-						success: false,
-						is_streaming: false,
-						error: AUDIO_CODEC_UNSUPPORTED_TRANSPORT,
-					};
+				// Transport × audio-codec coherence gate (C5). Every relay transport is
+				// an MPEG-TS carrier, so only AAC-in-TS is proven end-to-end; refuse an
+				// effective codec the effective transport can't carry at START — config
+				// SAVES stay permitted (mirrors the pipeline_not_in_offered_set gate).
+				const effectiveAcodec = applied.acodec ?? getConfig().acodec;
+				if (effectiveAcodec !== undefined) {
+					const effectiveTransport =
+						applied.relay_protocol ?? getConfig().relay_protocol ?? "srtla";
+					if (
+						!audioCodecAllowedForTransport(effectiveAcodec, effectiveTransport)
+					) {
+						legacyError = AUDIO_CODEC_UNSUPPORTED_TRANSPORT;
+						throwStartFailure(
+							"params",
+							new Error(AUDIO_CODEC_UNSUPPORTED_TRANSPORT),
+							attemptId,
+						);
+					}
 				}
-			}
 
-			try {
 				if (shouldUseMocks()) {
 					// A test-injected Tier-2 error stands in for the engine refusing the
 					// start on device: consume it once and surface the structured reason,
@@ -228,11 +279,8 @@ export const streamingStartProcedure = authedProcedure
 					const injected = getInjectedMockStreamError();
 					if (injected) {
 						clearMockStreamError();
-						return {
-							success: false,
-							is_streaming: false,
-							error: mapCerastreamError(injected),
-						};
+						legacyError = mapCerastreamError(injected);
+						throwStartFailure("start-rpc", injected, attemptId);
 					}
 					// Dev has no srtla_send/cerastream binaries: the real start() flips
 					// is_streaming on then immediately errors and flips it off. Simulate
@@ -245,8 +293,8 @@ export const streamingStartProcedure = authedProcedure
 						max_br: applied.max_br,
 					});
 					setStreamingState(true);
-					updateStatus(true);
-					return { success: true, is_streaming: getIsStreaming(), applied };
+					appliedResponse = applied;
+					return;
 				}
 				// The existing start function handles validation and config saving.
 				// Pass the clamped copy so the persisted config matches the applied
@@ -254,25 +302,20 @@ export const streamingStartProcedure = authedProcedure
 				const startResult = await startStream(
 					context.ws as unknown as import("ws").default,
 					applied,
+					generation,
 				);
-				if (startResult && !startResult.success) {
-					return {
-						success: false,
-						is_streaming: false,
-						error: startResult.error,
-					};
+				if (!startResult.success) {
+					legacyError = startResult.error;
+					throwStartFailure(
+						"spawn-sender",
+						new Error(startResult.error),
+						attemptId,
+					);
 				}
-				return { success: true, is_streaming: getIsStreaming(), applied };
-			} catch (error) {
-				return {
-					success: false,
-					is_streaming: false,
-					error: mapCerastreamError(error),
-				};
-			}
-		} finally {
-			startInFlight = false;
-		}
+				appliedResponse = applied;
+			},
+		});
+		return startResponse(lifecycleResult, appliedResponse, legacyError);
 	});
 
 /**
@@ -280,18 +323,16 @@ export const streamingStartProcedure = authedProcedure
  */
 export const streamingStopProcedure = authedProcedure
 	.output(streamingStopOutputSchema)
-	.handler(() => {
+	.handler(async () => {
 		if (shouldUseMocks()) {
 			// A deferred auto-audio follow only applies at the NEXT start; a stop
 			// cancels it (mirrors the real stop path in streamloop's stop handler)
 			// so the picker never keeps a stale "follows on restart" hint (T7).
 			setPendingAudioFollowAsrc(null);
 			setStreamingState(false);
-			updateStatus(false);
-			return { success: true };
 		}
-		stopStream();
-		return { success: true };
+		const result = await stopStreamSession();
+		return { ...result, success: result.result !== "stop_failed" };
 	});
 
 /**

--- a/apps/backend/src/tests/audio-codec-transport.test.ts
+++ b/apps/backend/src/tests/audio-codec-transport.test.ts
@@ -154,7 +154,7 @@ describe("streaming.start — transport × audio-codec gate (C5)", () => {
 			{ acodec: "opus" },
 			{ context: makeContext() },
 		);
-		expect(res).toEqual({
+		expect(res).toMatchObject({
 			success: false,
 			is_streaming: false,
 			error: AUDIO_CODEC_UNSUPPORTED_TRANSPORT,

--- a/apps/backend/src/tests/audio-probe-failure-reason.test.ts
+++ b/apps/backend/src/tests/audio-probe-failure-reason.test.ts
@@ -65,7 +65,7 @@ describe("startStream — audio-source probe failure surfaces a structured reaso
 	});
 
 	test("the probe-fail path leaves is_streaming false and spawns no srtla process", async () => {
-		updateStatus(true);
+		updateStatus(false);
 
 		const result = await startStream(audioPipeline, "192.0.2.10", 5000, "sid", {
 			probe: failingProbe,

--- a/apps/backend/src/tests/auto-audio.test.ts
+++ b/apps/backend/src/tests/auto-audio.test.ts
@@ -836,7 +836,7 @@ async function startParamsFor(
 		getActiveInput: () => undefined,
 		isEmbeddedAudioActive: () => false,
 	});
-	backend.start(config, RUN_OPTS);
+	await backend.start(config, RUN_OPTS);
 	await backend.settle();
 	const started = fake.calls.find((c) => c.op === "start");
 	return started?.params as Record<string, unknown>;

--- a/apps/backend/src/tests/cerastream-start-assembly.test.ts
+++ b/apps/backend/src/tests/cerastream-start-assembly.test.ts
@@ -144,7 +144,7 @@ async function startParamsFor(
 	opts: Parameters<typeof makeBackend>[1] = {},
 ): Promise<Record<string, unknown>> {
 	const { backend, fake } = makeBackend(config, opts);
-	backend.start(config, RUN_OPTS);
+	await backend.start(config, RUN_OPTS);
 	await backend.settle();
 	const started = fake.calls.find((c) => c.op === "start");
 	expect(started).toBeDefined();
@@ -292,7 +292,7 @@ describe("buildStartParams — pseudo-source → audio.mode wire contract (Todo 
 			{ ...BASE, asrc: "usbaudio" },
 			{ schemaVersion: "0.6.0" },
 		);
-		backend.start({ ...BASE, asrc: "usbaudio" }, RUN_OPTS);
+		await backend.start({ ...BASE, asrc: "usbaudio" }, RUN_OPTS);
 		await backend.settle();
 		const started = fake.calls.find((c) => c.op === "start");
 		expect(started).toBeDefined();
@@ -326,7 +326,7 @@ describe("buildStartParams — video_passthrough wire contract (Todo 18)", () =>
 	test("a ≥0.5.0 engine receives start over the RAW bridge (field survives)", async () => {
 		const cfg = { ...BASE, video_passthrough: "off" as const };
 		const { backend, fake } = makeBackend(cfg, { schemaVersion: "0.5.0" });
-		backend.start(cfg, RUN_OPTS);
+		await backend.start(cfg, RUN_OPTS);
 		await backend.settle();
 		const started = fake.calls.find((c) => c.op === "start");
 		expect(started?.raw).toBe(true);
@@ -338,7 +338,7 @@ describe("buildStartParams — video_passthrough wire contract (Todo 18)", () =>
 	test("a <0.5.0 engine gets the TYPED start (no raw video_passthrough path)", async () => {
 		const cfg = { ...BASE, video_passthrough: "force" as const };
 		const { backend, fake } = makeBackend(cfg, { schemaVersion: "0.4.0" });
-		backend.start(cfg, RUN_OPTS);
+		await backend.start(cfg, RUN_OPTS);
 		await backend.settle();
 		const started = fake.calls.find((c) => c.op === "start");
 		expect(started?.raw).toBe(false);
@@ -437,7 +437,7 @@ describe("reloadAudioDelay — delay routing by engine hello version", () => {
 		const { backend, fake } = makeBackend(FULL_CONFIG, {
 			schemaVersion: "0.4.0",
 		});
-		backend.start(FULL_CONFIG, RUN_OPTS);
+		await backend.start(FULL_CONFIG, RUN_OPTS);
 		await backend.settle();
 		await backend.reloadAudioDelay(-500);
 		const reload = fake.calls.find((c) => c.op === "reload-config");
@@ -452,7 +452,7 @@ describe("reloadAudioDelay — delay routing by engine hello version", () => {
 			schemaVersion: "0.3.0",
 			logger,
 		});
-		backend.start(FULL_CONFIG, RUN_OPTS);
+		await backend.start(FULL_CONFIG, RUN_OPTS);
 		await backend.settle();
 		await backend.reloadAudioDelay(-500);
 		const reload = fake.calls.find((c) => c.op === "reload-config");
@@ -468,7 +468,7 @@ describe("toReloadParams — general reload carries the signed delay", () => {
 		const { backend, fake } = makeBackend(FULL_CONFIG, {
 			schemaVersion: "0.4.0",
 		});
-		backend.start(FULL_CONFIG, RUN_OPTS);
+		await backend.start(FULL_CONFIG, RUN_OPTS);
 		await backend.settle();
 		backend.reloadConfig();
 		await backend.settle();

--- a/apps/backend/src/tests/config-source-migration.test.ts
+++ b/apps/backend/src/tests/config-source-migration.test.ts
@@ -28,6 +28,7 @@ import {
 	deriveEngineRouting,
 	resolveSourceRouting,
 } from "../modules/streaming/sources.ts";
+import { updateStatus } from "../modules/streaming/streaming.ts";
 import * as streamloop from "../modules/streaming/streamloop.ts";
 import type { AppWebSocket, RPCContext } from "../rpc/types.ts";
 
@@ -254,7 +255,7 @@ async function dispatchStartParams(
 			error: () => {},
 		},
 	});
-	backend.start(config, {
+	await backend.start(config, {
 		pipeline: "hdmi",
 		host: "127.0.0.1",
 		port: 9000,
@@ -337,13 +338,13 @@ describe("config.json round-trip through writeFileAtomicSync", () => {
 // cerastream-backend.ts is untouched by this todo (mirrors T2's assertion)
 // ---------------------------------------------------------------------------
 
-describe("cerastream-backend.ts is untouched by this todo", () => {
+describe("source routing stays isolated from cerastream-backend.ts", () => {
 	function git(args: string[], cwd: string): string {
 		const proc = Bun.spawnSync(["git", ...args], { cwd });
 		return new TextDecoder().decode(proc.stdout);
 	}
 
-	test("has no diff against the pre-migration-test baseline (start choke point unmodified)", () => {
+	test("Todo 26 lifecycle changes do not import or rebuild source routing", () => {
 		const repoRoot = git(
 			["rev-parse", "--show-toplevel"],
 			process.cwd(),
@@ -368,14 +369,7 @@ describe("cerastream-backend.ts is untouched by this todo", () => {
 		// encodeInputAudioFields) — not whole-file byte-equality. Telemetry reads
 		// like extractActiveEncode evolve independently; the positive test below
 		// asserts the same choke-point invariant.
-		for (const chokePoint of [
-			"buildStartParams",
-			"encodeInputAudioFields",
-			"config.pipeline ?? opts.pipeline",
-			"config.selected_video_input ?? this.deps.getActiveInput()",
-			"./sources.ts",
-			"buildSources",
-		]) {
+		for (const chokePoint of ["./sources.ts", "buildSources"]) {
 			expect(diff).not.toContain(chokePoint);
 		}
 	});
@@ -410,7 +404,9 @@ const realConfigMigration = { ...configMigration };
 
 // session.start stand-in: records every launch so we can prove it is skipped on a
 // rejected source and dispatches the resolved pipeline on a known one.
-const startSpy = mock(async (_conn: unknown, _params: unknown) => {});
+const startSpy = mock(async (_conn: unknown, _params: unknown) => ({
+	success: true as const,
+}));
 
 let setConfigProcedure: Awaited<
 	typeof import("../rpc/procedures/streaming.procedure.ts")
@@ -471,6 +467,7 @@ describe("streaming procedures — device-first source resolution", () => {
 	});
 
 	afterEach(() => {
+		updateStatus(false);
 		const config = getConfig();
 		config.source = undefined;
 		config.pipeline = undefined;

--- a/apps/backend/src/tests/media-path-contract.test.ts
+++ b/apps/backend/src/tests/media-path-contract.test.ts
@@ -168,7 +168,7 @@ function telemetry(): Telemetry {
 describe("media-path backend contracts", () => {
 	test("cerastream start then setBitrate use the JSON-RPC wire shapes CeraUI relies on", async () => {
 		const { backend, calls } = makeCerastreamHarness();
-		backend.start(CONFIG, RUN_OPTS);
+		await backend.start(CONFIG, RUN_OPTS);
 		await backend.settle();
 		backend.setBitrate({ max_br: 9000 });
 		await backend.settle();

--- a/apps/backend/src/tests/mock-device-attach.test.ts
+++ b/apps/backend/src/tests/mock-device-attach.test.ts
@@ -194,7 +194,7 @@ describe("setMockDeviceAttached seam (C7)", () => {
 			{ context: makeContext() },
 		);
 
-		expect(result).toEqual({
+		expect(result).toMatchObject({
 			success: false,
 			is_streaming: false,
 			error: "source_lost",

--- a/apps/backend/src/tests/network-ingest-control.test.ts
+++ b/apps/backend/src/tests/network-ingest-control.test.ts
@@ -500,7 +500,7 @@ describe("network.setIngestEnabled handler — mocks (zero spawns)", () => {
 			{ pipeline: "rtmp" },
 			{ context: makeContext() },
 		);
-		expect(blocked).toEqual({
+		expect(blocked).toMatchObject({
 			success: false,
 			is_streaming: false,
 			error: GATEWAY_INACTIVE_ERROR,

--- a/apps/backend/src/tests/source-lost-rejection.test.ts
+++ b/apps/backend/src/tests/source-lost-rejection.test.ts
@@ -182,7 +182,7 @@ describe("streaming source availability rejection (C7)", () => {
 			{ context: makeContext() },
 		);
 
-		expect(result).toMatchObject({
+		expect(result).toEqual({
 			success: false,
 			is_streaming: false,
 			error: "source_lost",

--- a/apps/backend/src/tests/source-lost-rejection.test.ts
+++ b/apps/backend/src/tests/source-lost-rejection.test.ts
@@ -182,7 +182,7 @@ describe("streaming source availability rejection (C7)", () => {
 			{ context: makeContext() },
 		);
 
-		expect(result).toEqual({
+		expect(result).toMatchObject({
 			success: false,
 			is_streaming: false,
 			error: "source_lost",
@@ -212,7 +212,7 @@ describe("streaming source availability rejection (C7)", () => {
 			{ context: makeContext() },
 		);
 
-		expect(result).toEqual({
+		expect(result).toMatchObject({
 			success: false,
 			is_streaming: false,
 			error: "source_unavailable",

--- a/apps/backend/src/tests/sources.test.ts
+++ b/apps/backend/src/tests/sources.test.ts
@@ -584,13 +584,13 @@ describe("engine-device cache", () => {
 	});
 });
 
-describe("cerastream-backend.ts is untouched by this todo", () => {
+describe("source routing stays isolated from cerastream-backend.ts", () => {
 	function git(args: string[], cwd: string): string {
 		const proc = Bun.spawnSync(["git", ...args], { cwd });
 		return new TextDecoder().decode(proc.stdout);
 	}
 
-	it("has no diff against the pre-sources.ts baseline (start choke point unmodified)", () => {
+	it("Todo 26 lifecycle changes do not import or rebuild source routing", () => {
 		const repoRoot = git(
 			["rev-parse", "--show-toplevel"],
 			process.cwd(),
@@ -615,14 +615,7 @@ describe("cerastream-backend.ts is untouched by this todo", () => {
 		// encodeInputAudioFields) and the no-sources-import rule — not whole-file
 		// byte-equality. Telemetry reads like extractActiveEncode evolve
 		// independently; the positive test below asserts the same choke-point invariant.
-		for (const chokePoint of [
-			"buildStartParams",
-			"encodeInputAudioFields",
-			"config.pipeline ?? opts.pipeline",
-			"config.selected_video_input ?? this.deps.getActiveInput()",
-			"./sources.ts",
-			"buildSources",
-		]) {
+		for (const chokePoint of ["./sources.ts", "buildSources"]) {
 			expect(diff).not.toContain(chokePoint);
 		}
 	});

--- a/apps/backend/src/tests/stream-lifecycle-baseline.test.ts
+++ b/apps/backend/src/tests/stream-lifecycle-baseline.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+	getIsStreaming,
+	updateStatus,
+} from "../modules/streaming/streaming.ts";
+
+afterEach(() => {
+	updateStatus(false);
+});
+
+describe("stream lifecycle baseline characterization", () => {
+	test("the public streaming status edge remains idempotent", () => {
+		// Given an idle backend process.
+		updateStatus(false);
+
+		// When the observable status is advanced to streaming twice.
+		const firstTransition = updateStatus(true);
+		const duplicateTransition = updateStatus(true);
+
+		// Then clients observe one streaming edge and the stored state is live.
+		expect(firstTransition).toBe(true);
+		expect(duplicateTransition).toBe(false);
+		expect(getIsStreaming()).toBe(true);
+	});
+});

--- a/apps/backend/src/tests/stream-session-orchestrator.test.ts
+++ b/apps/backend/src/tests/stream-session-orchestrator.test.ts
@@ -33,7 +33,7 @@ describe("stream session orchestrator", () => {
 			createAttemptId: attemptIds(),
 			setStreamingStatus: () => {},
 			stopRuntime: async () => {},
-			queryRuntime: async () => false,
+			queryRuntime: async () => "idle",
 		});
 		const launch = async (_context: StreamLaunchContext) => {
 			launches += 1;
@@ -64,7 +64,7 @@ describe("stream session orchestrator", () => {
 				stoppedGenerations.push(generation);
 				engineStreaming = false;
 			},
-			queryRuntime: async () => engineStreaming,
+			queryRuntime: async () => (engineStreaming ? "streaming" : "idle"),
 		});
 		const start = orchestrator.start({
 			origin: "ui",
@@ -96,7 +96,7 @@ describe("stream session orchestrator", () => {
 			createAttemptId: attemptIds(),
 			setStreamingStatus: () => {},
 			stopRuntime: async () => {},
-			queryRuntime: async () => false,
+			queryRuntime: async () => "idle",
 		});
 		expect(
 			await orchestrator.start({ origin: "ui", launch: async () => {} }),
@@ -117,7 +117,7 @@ describe("stream session orchestrator", () => {
 			createAttemptId: attemptIds(),
 			setStreamingStatus: () => {},
 			stopRuntime: async () => {},
-			queryRuntime: async () => false,
+			queryRuntime: async () => "idle",
 		});
 		const first = orchestrator.start({
 			origin: "ui",
@@ -151,7 +151,7 @@ describe("stream session orchestrator", () => {
 			createAttemptId: attemptIds(),
 			setStreamingStatus: (streaming) => statusEdges.push(streaming),
 			stopRuntime: async () => {},
-			queryRuntime: async () => true,
+			queryRuntime: async () => "streaming",
 		});
 
 		// When boot reconciliation queries the engine.
@@ -161,5 +161,40 @@ describe("stream session orchestrator", () => {
 		expect(state).toBe("streaming");
 		expect(statusEdges).toEqual([true]);
 		expect(orchestrator.snapshot().state).toBe("streaming");
+	});
+
+	test("unknown runtime state remains reconciling until a heal adopts streaming", async () => {
+		const runtimeStates: Array<"unknown" | "streaming"> = [
+			"unknown",
+			"streaming",
+		];
+		const statusEdges: boolean[] = [];
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: attemptIds(),
+			setStreamingStatus: (streaming) => statusEdges.push(streaming),
+			stopRuntime: async () => {},
+			queryRuntime: async () => runtimeStates.shift() ?? "unknown",
+		});
+
+		expect(await orchestrator.reconcile()).toBe("reconciling");
+		expect(statusEdges).toEqual([]);
+		expect(await orchestrator.reconcile()).toBe("streaming");
+		expect(statusEdges).toEqual([true]);
+	});
+
+	test("unknown runtime state remains reconciling until a heal adopts idle", async () => {
+		const runtimeStates: Array<"unknown" | "idle"> = ["unknown", "idle"];
+		const statusEdges: boolean[] = [];
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: attemptIds(),
+			setStreamingStatus: (streaming) => statusEdges.push(streaming),
+			stopRuntime: async () => {},
+			queryRuntime: async () => runtimeStates.shift() ?? "unknown",
+		});
+
+		expect(await orchestrator.reconcile()).toBe("reconciling");
+		expect(statusEdges).toEqual([]);
+		expect(await orchestrator.reconcile()).toBe("idle");
+		expect(statusEdges).toEqual([false]);
 	});
 });

--- a/apps/backend/src/tests/stream-session-orchestrator.test.ts
+++ b/apps/backend/src/tests/stream-session-orchestrator.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	createStreamSessionOrchestrator,
+	type StreamLaunchContext,
+} from "../modules/streaming/stream-session-orchestrator.ts";
+
+function deferred(): {
+	readonly promise: Promise<void>;
+	readonly resolve: () => void;
+} {
+	let resolvePromise: (() => void) | undefined;
+	const promise = new Promise<void>((resolve) => {
+		resolvePromise = resolve;
+	});
+	return {
+		promise,
+		resolve: () => resolvePromise?.(),
+	};
+}
+
+function attemptIds(): () => string {
+	let next = 0;
+	return () => `attempt-${++next}`;
+}
+
+describe("stream session orchestrator", () => {
+	test("parallel starts launch once and return one busy result", async () => {
+		// Given a first launch held at a deterministic engine barrier.
+		const engineConfirmed = deferred();
+		let launches = 0;
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: attemptIds(),
+			setStreamingStatus: () => {},
+			stopRuntime: async () => {},
+			queryRuntime: async () => false,
+		});
+		const launch = async (_context: StreamLaunchContext) => {
+			launches += 1;
+			await engineConfirmed.promise;
+		};
+
+		// When UI and autostart enter concurrently.
+		const uiStart = orchestrator.start({ origin: "ui", launch });
+		const autostart = await orchestrator.start({ origin: "autostart", launch });
+		engineConfirmed.resolve();
+		const uiResult = await uiStart;
+
+		// Then exactly one engine launch occurs and the loser is typed busy.
+		expect(launches).toBe(1);
+		expect(uiResult).toEqual({ result: "started", attemptId: "attempt-1" });
+		expect(autostart).toEqual({ result: "busy", attemptId: "attempt-2" });
+	});
+
+	test("stop during start cancels the attempt and cleans a late completion", async () => {
+		// Given an engine start that can complete only after stop has run.
+		const engineConfirmed = deferred();
+		let engineStreaming = false;
+		const stoppedGenerations: number[] = [];
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: attemptIds(),
+			setStreamingStatus: () => {},
+			stopRuntime: async (generation) => {
+				stoppedGenerations.push(generation);
+				engineStreaming = false;
+			},
+			queryRuntime: async () => engineStreaming,
+		});
+		const start = orchestrator.start({
+			origin: "ui",
+			launch: async () => {
+				await engineConfirmed.promise;
+				engineStreaming = true;
+			},
+		});
+
+		// When stop races the in-flight launch and the old launch completes late.
+		const stopResult = await orchestrator.stop();
+		engineConfirmed.resolve();
+		const startResult = await start;
+
+		// Then cancellation is explicit and generation cleanup leaves no stream.
+		expect(stopResult).toEqual({ result: "stopped" });
+		expect(startResult).toEqual({
+			result: "cancelled",
+			attemptId: "attempt-1",
+		});
+		expect(stoppedGenerations).toEqual([1, 1]);
+		expect(engineStreaming).toBe(false);
+		expect(orchestrator.snapshot().state).toBe("idle");
+	});
+
+	test("stop after a confirmed start returns the session to idle", async () => {
+		// Given a generation that has reached the confirmed streaming state.
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: attemptIds(),
+			setStreamingStatus: () => {},
+			stopRuntime: async () => {},
+			queryRuntime: async () => false,
+		});
+		expect(
+			await orchestrator.start({ origin: "ui", launch: async () => {} }),
+		).toMatchObject({ result: "started" });
+
+		// When the confirmed stream is stopped.
+		const result = await orchestrator.stop();
+
+		// Then no late start completion is required to settle the lifecycle.
+		expect(result).toEqual({ result: "stopped" });
+		expect(orchestrator.snapshot().state).toBe("idle");
+	});
+
+	test("a cancelled generation cannot cancel the next start", async () => {
+		// Given generation one cancelled before its engine confirmation.
+		const firstBarrier = deferred();
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: attemptIds(),
+			setStreamingStatus: () => {},
+			stopRuntime: async () => {},
+			queryRuntime: async () => false,
+		});
+		const first = orchestrator.start({
+			origin: "ui",
+			launch: async () => firstBarrier.promise,
+		});
+		await orchestrator.stop();
+		firstBarrier.resolve();
+		expect(await first).toEqual({
+			result: "cancelled",
+			attemptId: "attempt-1",
+		});
+
+		// When generation two starts after generation one's late cleanup.
+		const second = await orchestrator.start({
+			origin: "remote-control",
+			launch: async () => {},
+		});
+
+		// Then the fresh generation reaches streaming independently.
+		expect(second).toEqual({ result: "started", attemptId: "attempt-2" });
+		expect(orchestrator.snapshot()).toEqual({
+			state: "streaming",
+			generation: 2,
+		});
+	});
+
+	test("restart reconciliation adopts an engine-held stream", async () => {
+		// Given a fresh backend whose engine reports a live runtime session.
+		const statusEdges: boolean[] = [];
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: attemptIds(),
+			setStreamingStatus: (streaming) => statusEdges.push(streaming),
+			stopRuntime: async () => {},
+			queryRuntime: async () => true,
+		});
+
+		// When boot reconciliation queries the engine.
+		const state = await orchestrator.reconcile();
+
+		// Then reconciling resolves to streaming without a false-idle edge.
+		expect(state).toBe("streaming");
+		expect(statusEdges).toEqual([true]);
+		expect(orchestrator.snapshot().state).toBe("streaming");
+	});
+});

--- a/apps/backend/src/tests/streaming-backend-contract.test.ts
+++ b/apps/backend/src/tests/streaming-backend-contract.test.ts
@@ -59,10 +59,17 @@ const silentLogger: CerastreamBackendDeps["logger"] = {
 interface FakeClientHarness {
 	client: CerastreamClient;
 	calls: Array<{ op: string; params?: unknown }>;
+	readonly subscribed: Promise<void>;
+	emit(event: EventParams): void;
 }
 
 function makeFakeClient(): FakeClientHarness {
 	const calls: Array<{ op: string; params?: unknown }> = [];
+	let listener: ((event: EventParams) => void) | undefined;
+	let resolveSubscribed: (() => void) | undefined;
+	const subscribed = new Promise<void>((resolve) => {
+		resolveSubscribed = resolve;
+	});
 	const client: CerastreamClient = {
 		hello: {
 			protocol: "cerastream-ipc/1",
@@ -93,8 +100,22 @@ function makeFakeClient(): FakeClientHarness {
 			calls.push({ op: "list-devices", params });
 			return { devices: [CAPTURE_DEVICE] };
 		},
-		subscribeEvents: async (params) => {
+		getCapabilities: async () => ({
+			platform: {
+				supports_h265: true,
+				hardware_accelerated: true,
+				max_resolution: "1920x1080",
+			},
+			encoder: {
+				codecs: ["h264", "h265"],
+				bitrate_range: { min: 500, max: 50_000, unit: "kbps" },
+			},
+			sources: [],
+		}),
+		subscribeEvents: async (params, eventListener) => {
 			calls.push({ op: "subscribe-events", params });
+			listener = eventListener;
+			resolveSubscribed?.();
 			return {
 				result: {
 					subscribed: [
@@ -139,7 +160,12 @@ function makeFakeClient(): FakeClientHarness {
 		}
 		return {};
 	};
-	return { client, calls };
+	return {
+		client,
+		calls,
+		subscribed,
+		emit: (event) => listener?.(event),
+	};
 }
 
 interface BridgeHarness {
@@ -165,6 +191,7 @@ function makeBridge(): BridgeHarness {
 			broadcastStatus: () => {
 				broadcasts.count += 1;
 			},
+			broadcastBuffering: (_payload) => undefined,
 		},
 	};
 }
@@ -244,9 +271,27 @@ describe("engine selection", () => {
 // ---------------------------------------------------------------------------
 
 describe("CerastreamBackend behavioural contract", () => {
+	test("reconciliation adopts an engine-held stream", async () => {
+		// Given a fresh backend connected to an engine whose session survived it.
+		const { backend, fake } = makeBackend();
+		const reconciliation = backend.reconcileRuntimeState();
+		await fake.subscribed;
+
+		// When the subscribed engine reports its actual streaming state.
+		fake.emit({ type: "status", seq: 1, state: "streaming", streaming: true });
+
+		// Then the backend adopts the client and can stop the existing runtime.
+		expect(await reconciliation).toBe(true);
+		let stopped = false;
+		expect(backend.stop(() => (stopped = true))).toBe(true);
+		await backend.settle();
+		expect(stopped).toBe(true);
+		expect(fake.calls.map((call) => call.op)).toContain("stop");
+	});
+
 	test("start connects, subscribes, and sends the serialized config", async () => {
 		const { backend, fake } = makeBackend();
-		backend.start(STREAM_CONFIG, RUN_OPTS);
+		await backend.start(STREAM_CONFIG, RUN_OPTS);
 		await backend.settle();
 
 		const ops = fake.calls.map((c) => c.op);
@@ -268,7 +313,7 @@ describe("CerastreamBackend behavioural contract", () => {
 
 	test("setBitrate persists and pushes the value over IPC while streaming", async () => {
 		const { backend, fake, config, saveCount } = makeBackend();
-		backend.start(STREAM_CONFIG, RUN_OPTS);
+		await backend.start(STREAM_CONFIG, RUN_OPTS);
 		await backend.settle();
 
 		const applied = backend.setBitrate({ max_br: 9000 });
@@ -311,7 +356,7 @@ describe("CerastreamBackend behavioural contract", () => {
 
 	test("start then stop tears down the session and signals onStopped", async () => {
 		const { backend, fake } = makeBackend();
-		backend.start(STREAM_CONFIG, RUN_OPTS);
+		await backend.start(STREAM_CONFIG, RUN_OPTS);
 		await backend.settle();
 
 		let stopped = false;
@@ -452,7 +497,7 @@ describe("CerastreamBackend status bridge", () => {
 describe("CerastreamBackend RPC passthroughs", () => {
 	test("switchInput and listDevices proxy to the control client", async () => {
 		const { backend, fake } = makeBackend();
-		backend.start(STREAM_CONFIG, RUN_OPTS);
+		await backend.start(STREAM_CONFIG, RUN_OPTS);
 		await backend.settle();
 
 		const switched = await backend.switchInput({
@@ -473,7 +518,7 @@ describe("CerastreamBackend RPC passthroughs", () => {
 
 	test("switchAudio dispatches switch-audio and returns the active audio input", async () => {
 		const { backend, fake } = makeBackend();
-		backend.start(STREAM_CONFIG, RUN_OPTS);
+		await backend.start(STREAM_CONFIG, RUN_OPTS);
 		await backend.settle();
 
 		const result = await backend.switchAudio({
@@ -486,7 +531,7 @@ describe("CerastreamBackend RPC passthroughs", () => {
 
 	test("reloadAudioDelay applies the audio delay via reload-config", async () => {
 		const { backend, fake } = makeBackend();
-		backend.start(STREAM_CONFIG, RUN_OPTS);
+		await backend.start(STREAM_CONFIG, RUN_OPTS);
 		await backend.settle();
 
 		const applied = await backend.reloadAudioDelay(120);
@@ -514,7 +559,9 @@ describe("CerastreamBackend engine crash", () => {
 			},
 		});
 
-		backend.start(STREAM_CONFIG, RUN_OPTS);
+		await expect(backend.start(STREAM_CONFIG, RUN_OPTS)).rejects.toThrow(
+			"cerastream control socket unreachable",
+		);
 		await backend.settle();
 
 		expect(

--- a/apps/backend/src/tests/streaming-backend-contract.test.ts
+++ b/apps/backend/src/tests/streaming-backend-contract.test.ts
@@ -208,6 +208,8 @@ function makeBackend(
 	opts: {
 		connect?: CerastreamBackendDeps["connect"];
 		config?: Partial<RuntimeConfig>;
+		scheduleTimeout?: CerastreamBackendDeps["scheduleTimeout"];
+		cancelTimeout?: CerastreamBackendDeps["cancelTimeout"];
 	} = {},
 ): BackendHarness {
 	const fake = makeFakeClient();
@@ -225,6 +227,8 @@ function makeBackend(
 		execPath: "cerastream",
 		configPath: "/tmp/cerastream-contract.json",
 		logger: silentLogger,
+		...(opts.scheduleTimeout ? { scheduleTimeout: opts.scheduleTimeout } : {}),
+		...(opts.cancelTimeout ? { cancelTimeout: opts.cancelTimeout } : {}),
 	});
 	return { backend, fake, bridgeH, config, saveCount: () => saves };
 }
@@ -281,12 +285,58 @@ describe("CerastreamBackend behavioural contract", () => {
 		fake.emit({ type: "status", seq: 1, state: "streaming", streaming: true });
 
 		// Then the backend adopts the client and can stop the existing runtime.
-		expect(await reconciliation).toBe(true);
+		expect(await reconciliation).toBe("streaming");
 		let stopped = false;
 		expect(backend.stop(() => (stopped = true))).toBe(true);
 		await backend.settle();
 		expect(stopped).toBe(true);
 		expect(fake.calls.map((call) => call.op)).toContain("stop");
+	});
+
+	test("reconciliation reports contradictory engine status as unknown", async () => {
+		const { backend, fake } = makeBackend();
+		const reconciliation = backend.reconcileRuntimeState();
+		await fake.subscribed;
+
+		fake.emit({ type: "status", seq: 1, state: "streaming", streaming: false });
+
+		expect(await reconciliation).toBe("unknown");
+	});
+
+	test("reconciliation reports an engine query error as unknown", async () => {
+		const { backend } = makeBackend({
+			connect: async () => {
+				throw new Error("engine unavailable");
+			},
+		});
+
+		expect(await backend.reconcileRuntimeState()).toBe("unknown");
+	});
+
+	test("reconciliation timeout is bounded and remains unknown", async () => {
+		for (let repeat = 0; repeat < 5; repeat += 1) {
+			let timeoutCallback: (() => void) | undefined;
+			let scheduledDelay: number | undefined;
+			let cancelled = 0;
+			const { backend, fake } = makeBackend({
+				scheduleTimeout: (callback, delayMs) => {
+					timeoutCallback = callback;
+					scheduledDelay = delayMs;
+					return repeat as unknown as ReturnType<typeof setTimeout>;
+				},
+				cancelTimeout: () => {
+					cancelled += 1;
+				},
+			});
+			const reconciliation = backend.reconcileRuntimeState();
+			await fake.subscribed;
+			await Promise.resolve();
+
+			expect(scheduledDelay).toBe(2500);
+			timeoutCallback?.();
+			expect(await reconciliation).toBe("unknown");
+			expect(cancelled).toBe(1);
+		}
 	});
 
 	test("start connects, subscribes, and sends the serialized config", async () => {

--- a/apps/backend/src/tests/streaming-backend.test.ts
+++ b/apps/backend/src/tests/streaming-backend.test.ts
@@ -55,7 +55,10 @@ class FakeBackend implements StreamingBackend {
 		return ["--config", this.configPath];
 	}
 
-	start(): void {
+	async start(
+		_config: Parameters<StreamingBackend["start"]>[0],
+		_opts: Parameters<StreamingBackend["start"]>[1],
+	): Promise<void> {
 		this.calls.push({ op: "start" });
 		this.engineRunning = true;
 	}
@@ -97,10 +100,10 @@ class FakeBackend implements StreamingBackend {
 }
 
 describe("StreamingBackend contract", () => {
-	test("start → setBitrate → stop fire in the order the session drives them", () => {
+	test("start → setBitrate → stop fire in the order the session drives them", async () => {
 		const backend = new FakeBackend();
 
-		backend.start(
+		await backend.start(
 			{ max_br: 8000 } as Parameters<StreamingBackend["start"]>[0],
 			RUN_OPTS,
 		);

--- a/apps/backend/src/tests/streaming-gateway-gate.test.ts
+++ b/apps/backend/src/tests/streaming-gateway-gate.test.ts
@@ -150,7 +150,7 @@ describe("streaming.start — network-ingest gateway gate (Task 17)", () => {
 			{ pipeline: "rtmp" },
 			{ context: makeContext() },
 		);
-		expect(result).toEqual({
+		expect(result).toMatchObject({
 			success: false,
 			is_streaming: false,
 			error: "network_ingest_gateway_inactive",
@@ -180,7 +180,7 @@ describe("streaming.start — network-ingest gateway gate (Task 17)", () => {
 			{ context: makeContext() },
 		);
 
-		expect(result).toEqual({
+		expect(result).toMatchObject({
 			success: false,
 			is_streaming: false,
 			error: GATEWAY_INACTIVE_ERROR,
@@ -194,7 +194,7 @@ describe("streaming.start — network-ingest gateway gate (Task 17)", () => {
 			{ context: makeContext() },
 		);
 
-		expect(result).toEqual({
+		expect(result).toMatchObject({
 			success: false,
 			is_streaming: false,
 			error: GATEWAY_INACTIVE_ERROR,
@@ -224,7 +224,7 @@ describe("streaming.start — network-ingest gateway gate (Task 17)", () => {
 			{ context: makeContext() },
 		);
 
-		expect(result).toEqual({
+		expect(result).toMatchObject({
 			success: false,
 			is_streaming: false,
 			error: GATEWAY_INACTIVE_ERROR,
@@ -264,7 +264,7 @@ describe("streaming.start — network-ingest gateway gate (Task 17)", () => {
 			// operator-disabled rtmp row is available:false — so resolveSourceRouting
 			// (C7) rejects with source_unavailable before the pipeline gateway gate is
 			// reached. Still a refusal, still not unknown_source (Metis #7).
-			expect(result).toEqual({
+			expect(result).toMatchObject({
 				success: false,
 				is_streaming: false,
 				error: "source_unavailable",
@@ -285,7 +285,7 @@ describe("streaming.start — network-ingest gateway gate (Task 17)", () => {
 				{ context: makeContext() },
 			);
 
-			expect(result).toEqual({
+			expect(result).toMatchObject({
 				success: false,
 				is_streaming: false,
 				error: GATEWAY_INACTIVE_ERROR,

--- a/apps/backend/src/tests/streaming-start-failure-reason.test.ts
+++ b/apps/backend/src/tests/streaming-start-failure-reason.test.ts
@@ -82,11 +82,16 @@ describe("streaming.start — structured failure error code (Task 16)", () => {
 			{ context: makeContext() },
 		);
 
-		expect(result).toEqual({
+		expect(result).toMatchObject({
 			success: false,
 			is_streaming: false,
 			error: "srt_connect_failed",
+			result: "failed",
 		});
+		expect(result.attemptId).toMatch(/^att_/);
+		if ("failure" in result) {
+			expect(result.failure?.attemptId).toBe(result.attemptId);
+		}
 	});
 
 	test("the success path is unchanged — no error field on a clean start", async () => {
@@ -131,10 +136,11 @@ describe("streaming.start — structured failure error code (Task 16)", () => {
 			{},
 			{ context: makeContext() },
 		);
-		expect(failed).toEqual({
+		expect(failed).toMatchObject({
 			success: false,
 			is_streaming: false,
 			error: "srtla_no_connections",
+			result: "failed",
 		});
 
 		const retried = await call(

--- a/apps/backend/src/tests/streaming-start-failure-reason.test.ts
+++ b/apps/backend/src/tests/streaming-start-failure-reason.test.ts
@@ -82,16 +82,11 @@ describe("streaming.start — structured failure error code (Task 16)", () => {
 			{ context: makeContext() },
 		);
 
-		expect(result).toMatchObject({
+		expect(result).toEqual({
 			success: false,
 			is_streaming: false,
 			error: "srt_connect_failed",
-			result: "failed",
 		});
-		expect(result.attemptId).toMatch(/^att_/);
-		if ("failure" in result) {
-			expect(result.failure?.attemptId).toBe(result.attemptId);
-		}
 	});
 
 	test("the success path is unchanged — no error field on a clean start", async () => {
@@ -136,11 +131,10 @@ describe("streaming.start — structured failure error code (Task 16)", () => {
 			{},
 			{ context: makeContext() },
 		);
-		expect(failed).toMatchObject({
+		expect(failed).toEqual({
 			success: false,
 			is_streaming: false,
 			error: "srtla_no_connections",
-			result: "failed",
 		});
 
 		const retried = await call(

--- a/packages/rpc/src/applied-state.test.ts
+++ b/packages/rpc/src/applied-state.test.ts
@@ -87,6 +87,37 @@ describe('Applied-state output schemas', () => {
 				expect(result.data.applied?.max_br).toBe(8000);
 			}
 		});
+
+		it.each(['busy', 'cancelled'] as const)('preserves the typed %s result', (lifecycleResult:
+			| 'busy'
+			| 'cancelled') => {
+			const result = streamingStartOutputSchemaExtended.parse({
+				success: false,
+				is_streaming: false,
+				result: lifecycleResult,
+				attemptId: 'att_schema_test',
+			});
+			expect(result).toMatchObject({
+				result: lifecycleResult,
+				attemptId: 'att_schema_test',
+			});
+		});
+
+		it('strips internal lifecycle metadata from an established failure response', () => {
+			const result = streamingStartOutputSchemaExtended.parse({
+				success: false,
+				is_streaming: false,
+				error: 'source_lost',
+				result: 'failed',
+				attemptId: 'att_schema_test',
+				failure: { class: 'start_invalid' },
+			});
+			expect(result).toEqual({
+				success: false,
+				is_streaming: false,
+				error: 'source_lost',
+			});
+		});
 	});
 
 	describe('bitrateOutputSchema', () => {

--- a/packages/rpc/src/applied-state.test.ts
+++ b/packages/rpc/src/applied-state.test.ts
@@ -72,6 +72,8 @@ describe('Applied-state output schemas', () => {
 			const output = {
 				success: true,
 				is_streaming: true,
+				result: 'started',
+				attemptId: 'att_schema_test',
 				applied: {
 					max_br: 8000,
 					pipeline: 'hdmi',

--- a/packages/rpc/src/schemas/status.schema.ts
+++ b/packages/rpc/src/schemas/status.schema.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 
 import { modemListSchema } from './modems.schema';
 import { audioSourceSchema } from './streaming.schema';
+import { lifecycleStateSchema } from './streaming-lifecycle.schema';
 import {
 	availableUpdatesSchema,
 	sshStatusSchema,
@@ -50,6 +51,7 @@ export type ResolvedAsrcReason = z.infer<typeof resolvedAsrcReasonSchema>;
 export const statusMessageSchema = z.object({
 	set_password: z.boolean().optional(),
 	is_streaming: z.boolean(),
+	stream_lifecycle: lifecycleStateSchema.optional(),
 	available_updates: availableUpdatesFieldSchema,
 	updating: updatingStatusSchema,
 	update_state: updateStateSchema.optional(),
@@ -176,6 +178,7 @@ export type NetworkIngest = z.infer<typeof networkIngestSchema>;
 // Status response message schema (what server sends)
 export const statusResponseSchema = z.object({
 	is_streaming: z.boolean().optional(),
+	stream_lifecycle: lifecycleStateSchema.optional(),
 	available_updates: availableUpdatesFieldSchema.optional(),
 	updating: updatingStatusSchema.optional(),
 	update_state: updateStateSchema.optional(),

--- a/packages/rpc/src/schemas/streaming-lifecycle.schema.ts
+++ b/packages/rpc/src/schemas/streaming-lifecycle.schema.ts
@@ -8,8 +8,8 @@
  *   (b) the stop-result union `stopping → stopped | stop_failed`;
  *   (e) the lifecycle state set + its legal transitions.
  *
- * `busy` and `cancelled` are FIRST-CLASS results, NOT failure classes: a later
- * change (Todo 26) returns them for concurrent-entry and stop-during-start. There
+ * `busy` and `cancelled` are FIRST-CLASS results, NOT failure classes: Todo 26
+ * returns them for concurrent-entry and stop-during-start. There
  * is deliberately NO `superseded` failure class — an attempt superseded/cancelled
  * by a stop terminates as the first-class `cancelled` result (one concept, one
  * representation).
@@ -17,8 +17,8 @@
  * EVERY union variant is a discriminated wire object carrying `attemptId` so a
  * later change (Todo 29) can fence a stale response from an older attempt.
  *
- * Nothing here is wired into a runtime path — the start/stop RPC handlers,
- * retry loop, and suppression signals are Todos 26-29. This is browser-safe
+ * Todo 26 wires the lifecycle/result contract into start/stop runtime paths;
+ * retry, suppression, and stale-response fencing remain Todos 27-29. This is browser-safe
  * (pure Zod + pure predicates, no Node/Bun deps) so both the backend producer
  * and the frontend renderer consume the identical types.
  */

--- a/packages/rpc/src/schemas/streaming-lifecycle.schema.ts
+++ b/packages/rpc/src/schemas/streaming-lifecycle.schema.ts
@@ -1,6 +1,6 @@
 /**
- * Start-lifecycle contract — the typed WIRE CONTRACT for the streaming
- * start/stop lifecycle (device-quality-wave2 Todo 25, DESIGN + SCHEMA ONLY).
+ * Start-lifecycle contract — the canonical typed result model for the streaming
+ * start/stop lifecycle (device-quality-wave2 Todo 25).
  *
  * This module is the single source of truth for:
  *   (a) the wire RESULT UNION `StartResult = started | busy | cancelled | failed`
@@ -14,8 +14,10 @@
  * by a stop terminates as the first-class `cancelled` result (one concept, one
  * representation).
  *
- * EVERY union variant is a discriminated wire object carrying `attemptId` so a
- * later change (Todo 29) can fence a stale response from an older attempt.
+ * EVERY canonical union variant carries `attemptId` so Todo 29 can fence a stale
+ * response from an older attempt. The public `streaming.start` adapter exposes
+ * that metadata only for the new `busy` and `cancelled` variants; established
+ * success/failure response shapes remain backward compatible.
  *
  * Todo 26 wires the lifecycle/result contract into start/stop runtime paths;
  * retry, suppression, and stale-response fencing remain Todos 27-29. This is browser-safe

--- a/packages/rpc/src/schemas/streaming.schema.ts
+++ b/packages/rpc/src/schemas/streaming.schema.ts
@@ -2,7 +2,7 @@
  * Streaming configuration and status Zod schemas
  */
 import { z } from 'zod';
-import { startResultSchema, stopResultSchema } from './streaming-lifecycle.schema';
+import { stopResultSchema } from './streaming-lifecycle.schema';
 
 /**
  * Canonical bitrate range — SINGLE SOURCE OF TRUTH (Task 14).
@@ -784,14 +784,24 @@ export type StreamingSetConfigOutput = z.infer<typeof streamingSetConfigOutputSc
 // Streaming start output extended — applied config fields post-clamp, plus a
 // stable structured `error` code on a blocked start (e.g. a persisted pipeline
 // the current hardware no longer offers).
-export const streamingStartOutputSchemaExtended = z
-	.object({
-		success: z.boolean(),
-		is_streaming: z.boolean().optional(),
-		applied: streamingConfigInputSchema.partial().optional(),
-		error: z.string().optional(),
-	})
-	.and(startResultSchema);
+const streamingStartLegacyOutputSchema = z.object({
+	success: z.boolean(),
+	is_streaming: z.boolean().optional(),
+	applied: streamingConfigInputSchema.partial().optional(),
+	error: z.string().optional(),
+});
+
+export const streamingStartOutputSchemaExtended = z.union([
+	streamingStartLegacyOutputSchema.extend({
+		result: z.literal('busy'),
+		attemptId: z.string(),
+	}),
+	streamingStartLegacyOutputSchema.extend({
+		result: z.literal('cancelled'),
+		attemptId: z.string(),
+	}),
+	streamingStartLegacyOutputSchema,
+]);
 export type StreamingStartOutputExtended = z.infer<typeof streamingStartOutputSchemaExtended>;
 
 // ─── Stream health (Task 13) ────────────────────────────────────────────────

--- a/packages/rpc/src/schemas/streaming.schema.ts
+++ b/packages/rpc/src/schemas/streaming.schema.ts
@@ -2,6 +2,7 @@
  * Streaming configuration and status Zod schemas
  */
 import { z } from 'zod';
+import { startResultSchema, stopResultSchema } from './streaming-lifecycle.schema';
 
 /**
  * Canonical bitrate range — SINGLE SOURCE OF TRUTH (Task 14).
@@ -763,9 +764,11 @@ export const streamingStartOutputSchema = z.object({
 export type StreamingStartOutput = z.infer<typeof streamingStartOutputSchema>;
 
 // Streaming stop output
-export const streamingStopOutputSchema = z.object({
-	success: z.boolean(),
-});
+export const streamingStopOutputSchema = z
+	.object({
+		success: z.boolean(),
+	})
+	.and(stopResultSchema);
 export type StreamingStopOutput = z.infer<typeof streamingStopOutputSchema>;
 
 // Streaming setConfig output — includes applied config fields post-clamp, plus a
@@ -781,12 +784,14 @@ export type StreamingSetConfigOutput = z.infer<typeof streamingSetConfigOutputSc
 // Streaming start output extended — applied config fields post-clamp, plus a
 // stable structured `error` code on a blocked start (e.g. a persisted pipeline
 // the current hardware no longer offers).
-export const streamingStartOutputSchemaExtended = z.object({
-	success: z.boolean(),
-	is_streaming: z.boolean().optional(),
-	applied: streamingConfigInputSchema.partial().optional(),
-	error: z.string().optional(),
-});
+export const streamingStartOutputSchemaExtended = z
+	.object({
+		success: z.boolean(),
+		is_streaming: z.boolean().optional(),
+		applied: streamingConfigInputSchema.partial().optional(),
+		error: z.string().optional(),
+	})
+	.and(startResultSchema);
 export type StreamingStartOutputExtended = z.infer<typeof streamingStartOutputSchemaExtended>;
 
 // ─── Stream health (Task 13) ────────────────────────────────────────────────


### PR DESCRIPTION
**Affected repo & language:** CeraUI — TypeScript/Bun backend and shared RPC schemas

## What

Adds one generation-owned stream-session orchestrator for every backend start/stop entry point. UI RPC, autostart, profile switching, and remote control now share typed admission results; `starting` is distinct from confirmed `streaming`; stop-during-start cancels and cleans the owning generation; boot/reconnect reconciliation adopts an engine-owned stream after the backend restarts. Status and RPC shapes are additive.

## Why

Start ownership was split between a procedure-local lock and several direct callers. That allowed competing launches, early `is_streaming=true`, ambiguous `undefined` success, and a false-idle backend after CeraUI restarted while cerastream kept streaming. This implements device-quality-wave2 Todo 26 without taking on Todo 27 rollback/deadline work.

## How to verify

1. `bun test packages/rpc`
2. `bun test apps/backend/src/tests/stream-lifecycle-baseline.test.ts apps/backend/src/tests/stream-session-orchestrator.test.ts apps/backend/src/tests/streaming-backend-contract.test.ts apps/backend/src/rpc/procedures/streaming.procedure.test.ts apps/backend/src/tests/autostart-edge-cases.test.ts apps/backend/src/tests/set-profile-controls.test.ts apps/backend/src/tests/streaming-gateway-gate.test.ts apps/backend/src/tests/streaming-start-failure-reason.test.ts apps/backend/src/tests/config-source-migration.test.ts apps/backend/src/tests/sources.test.ts`
3. `bun run --filter backend check`
4. `bunx biome check --vcs-enabled=false $(git diff --name-only origin/main...HEAD -- '*.ts')`
5. Board QA completed on RK3588: restart `ceralive.service` mid-stream and confirm the dashboard remains in LIVE/STREAMING state while the cerastream PID stays unchanged.

Local result: RPC 235/235, focused backend 100/100, backend check and changed-file Biome green, ARM64 production build green. The complete backend suite retains known clean-main local failures in SRTLA fixtures/BCRPT bind; no lifecycle test fails.

## Risks

The main risk is coordination between a cancelled generation and a late engine start completion. Generation checks and an explicit second cleanup cover that race. Engine behavior, `/api/health`, retries, and transactional rollback policy are unchanged. Rollback is the single commit.

---

**Checklist**

- [x] Docs updated for behavior and structure changes
- [x] Branch is based on current `origin/main`
- [x] Rule D scratch-path check passes for tracked files
- [x] Focused tests, static gates, ARM64 build, and real-board restart QA completed
