### PR TITLE
fix(streaming): make stream launch transactional

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -914,7 +914,14 @@ the Todo-27 launch transaction. Initial IP-list preparation is awaited before
 sender spawn. Sender, telemetry, control client, subscription, and accepted
 engine start register cleanup immediately; failure unwinds them in reverse order
 and leaves lifecycle/status idle. The start response is emitted only after the
-engine's streaming result parses successfully.
+engine confirms PLAYING. A direct start reply with `state: "streaming"` is an
+authoritative confirmation; every other schema-valid reply (including
+`state: "starting"`) remains in `playing-wait` until a subscribed status heartbeat
+reports the concordant pair `state: "streaming"` plus `streaming: true`. If that
+heartbeat misses the 5-second phase deadline, start returns typed
+`start_timeout` and rolls back. Connect/subscription cleanup is attached to each
+acquisition promise before its deadline race, so a resource delivered after
+rollback is closed immediately and cannot become backend-owned.
 
 Connect and hello share the published binding's combined operation and are
 classified by machine-readable error shape; CeraUI does not simulate a separate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -907,6 +907,21 @@ modules/streaming/streamloop/
 `bcrptExec`, `checkAutoStartStream`, `setAutostart`, `srtlaSendExec`,
 `start`, `startStream`, `stop`. Adding or removing any of these is a breaking change.
 
+### Transactional start/stop lifecycle
+
+The Todo-25 start taxonomy is wired through one Todo-26 session orchestrator and
+the Todo-27 launch transaction. Initial IP-list preparation is awaited before
+sender spawn. Sender, telemetry, control client, subscription, and accepted
+engine start register cleanup immediately; failure unwinds them in reverse order
+and leaves lifecycle/status idle. The start response is emitted only after the
+engine's streaming result parses successfully.
+
+Connect and hello share the published binding's combined operation and are
+classified by machine-readable error shape; CeraUI does not simulate a separate
+hello I/O wait. Subscribe, start-RPC, PLAYING validation, and stop have explicit
+bounds. Stop confirms engine/process cleanup or returns typed `stop_failed` after
+12 seconds. Full contract and timeout values: `docs/START-LIFECYCLE.md`.
+
 ### timing-constants.ts
 
 `apps/backend/src/modules/streaming/timing-constants.ts` centralizes all hardcoded

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -26,6 +26,7 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 | srtla per-link telemetry → `status.linkTelemetry` | `modules/streaming/link-telemetry.ts` |
 | Stream lifecycle (spawn supervision, start/stop, autostart, exec paths) | `modules/streaming/streamloop/` (barrel: `modules/streaming/streamloop.ts`) |
 | Authoritative stream-session lifecycle (UI/autostart/remote arbitration, cancellation generations, boot adoption) | `modules/streaming/stream-session-orchestrator.ts` |
+| Transactional launch cleanup + phase/stop deadlines | `modules/streaming/launch-transaction.ts`, `start-lifecycle-timing.ts`, `streamloop/start-stream.ts`; contract in `../../docs/START-LIFECYCLE.md` |
 | WebSocket server wiring | `modules/ui/websocket-server.ts` + `rpc/server.ts` |
 | Auth token logic | `modules/ui/auth.ts` + `rpc/middleware/auth.middleware.ts` |
 | PASETO device-token verification (relay-config + device-control, ADR-0006) | `modules/pairing/device-token.ts` — `verifyDeviceControlToken`, `resolveControlChannelEndpoint` |

--- a/apps/backend/src/modules/remote-control/set-profile-wiring.ts
+++ b/apps/backend/src/modules/remote-control/set-profile-wiring.ts
@@ -35,9 +35,11 @@ import { RUNTIME_CONFIG_DEFAULTS } from "../../helpers/config-schemas.ts";
 import { logger } from "../../helpers/logger.ts";
 import { getConfig, saveConfig } from "../config.ts";
 import { getLastCapabilities } from "../streaming/capabilities.ts";
-import { classifyStartFailure } from "../streaming/start-failure-taxonomy.ts";
 import {
+	classifyStartFailure,
 	StreamStartFailure,
+} from "../streaming/start-failure-taxonomy.ts";
+import {
 	startStreamSession,
 	stopStreamSession,
 } from "../streaming/stream-session-orchestrator.ts";
@@ -78,10 +80,10 @@ async function reconnect(): Promise<void> {
 	const started = await startStreamSession({
 		origin: "set-profile",
 		launch: async ({ attemptId, generation }) => {
-			const result = await startStream(stubConn, {}, generation);
+			const result = await startStream(stubConn, {}, generation, attemptId);
 			if (!result.success) {
 				throw new StreamStartFailure(
-					classifyStartFailure("spawn-sender", result.error, attemptId),
+					classifyStartFailure(result.phase, result.error, attemptId),
 				);
 			}
 		},

--- a/apps/backend/src/modules/streaming/cerastream-backend.ts
+++ b/apps/backend/src/modules/streaming/cerastream-backend.ts
@@ -487,18 +487,33 @@ export class CerastreamBackend implements StreamingBackend {
 			transaction ?? createLaunchTransaction("backend-start");
 		try {
 			await this.enqueue(async () => {
-				const client = await launchTransaction.runPhase(
+				let confirmStreaming: (() => void) | undefined;
+				const streamingStatus = new Promise<void>((resolve) => {
+					confirmStreaming = resolve;
+				});
+				const client = await launchTransaction.acquirePhase(
 					"connect",
 					() => this.deps.connect(this.deps.connectOptions),
+					(client) => client.close(),
 					classifyConnectHandshakePhase,
 				);
 				this.client = client;
-				launchTransaction.register(() => client.close());
-				const subscription = await launchTransaction.runPhase("subscribe", () =>
-					client.subscribeEvents({}, (event) => this.handleEvent(event)),
+				const subscription = await launchTransaction.acquirePhase(
+					"subscribe",
+					() =>
+						client.subscribeEvents({}, (event) => {
+							this.handleEvent(event);
+							if (
+								event.type === "status" &&
+								classifyRuntimeState(event.state, event.streaming) ===
+									"streaming"
+							) {
+								confirmStreaming?.();
+							}
+						}),
+					(subscription) => subscription.close(),
 				);
 				this.subscription = subscription;
-				launchTransaction.register(() => subscription.close());
 				launchTransaction.register(async () => {
 					try {
 						await client.stop();
@@ -515,11 +530,15 @@ export class CerastreamBackend implements StreamingBackend {
 					this.dispatchStart(client, params),
 				);
 				await launchTransaction.runPhase("playing-wait", async () => {
-					startResultSchema.parse(result);
+					const parsed = startResultSchema.parse(result);
+					if (parsed.state !== "streaming") await streamingStatus;
 				});
 			}, "start");
 		} catch (error) {
 			await launchTransaction.rollback();
+			this.active = false;
+			this.client = undefined;
+			this.subscription = undefined;
 			throw error;
 		}
 	}

--- a/apps/backend/src/modules/streaming/cerastream-backend.ts
+++ b/apps/backend/src/modules/streaming/cerastream-backend.ts
@@ -61,6 +61,7 @@ import {
 	type SwitchInputParams,
 	type SwitchInputResult,
 	startParamsSchema,
+	startResultSchema,
 	switchAudioParamsSchema,
 	switchAudioResultSchema,
 	writeCerastreamConfig,
@@ -83,6 +84,10 @@ import { SRTLA_LISTEN_PORT } from "./constants.ts";
 import { deviceRegistry } from "./devices.ts";
 import { isEmbeddedAudioPipeline } from "./embedded-audio.ts";
 import { validateBitrate } from "./encoder.ts";
+import {
+	createLaunchTransaction,
+	type LaunchTransaction,
+} from "./launch-transaction.ts";
 import type {
 	BackendErrorListener,
 	BitrateParams,
@@ -381,6 +386,19 @@ function isZodLikeError(err: unknown): boolean {
 	);
 }
 
+export function classifyConnectHandshakePhase(
+	error: unknown,
+): "connect" | "hello" {
+	if (
+		error instanceof CerastreamTimeoutError ||
+		error instanceof CerastreamRpcError ||
+		isZodLikeError(error)
+	) {
+		return "hello";
+	}
+	return "connect";
+}
+
 /** Classify a failed `connect()`/handshake into an {@link EngineProbe}. */
 export function classifyEngineProbeError(err: unknown): EngineProbe {
 	if (err instanceof CerastreamRpcError) {
@@ -458,17 +476,52 @@ export class CerastreamBackend implements StreamingBackend {
 		return ["--config", this.deps.configPath];
 	}
 
-	async start(config: RuntimeConfig, opts: StreamRunOptions): Promise<void> {
+	async start(
+		config: RuntimeConfig,
+		opts: StreamRunOptions,
+		transaction?: LaunchTransaction,
+	): Promise<void> {
 		this.active = true;
 		const params = this.buildStartParams(config, opts);
-		await this.enqueue(async () => {
-			const client = await this.deps.connect(this.deps.connectOptions);
-			this.client = client;
-			this.subscription = await client.subscribeEvents({}, (event) =>
-				this.handleEvent(event),
-			);
-			await this.dispatchStart(client, params);
-		}, "start");
+		const launchTransaction =
+			transaction ?? createLaunchTransaction("backend-start");
+		try {
+			await this.enqueue(async () => {
+				const client = await launchTransaction.runPhase(
+					"connect",
+					() => this.deps.connect(this.deps.connectOptions),
+					classifyConnectHandshakePhase,
+				);
+				this.client = client;
+				launchTransaction.register(() => client.close());
+				const subscription = await launchTransaction.runPhase("subscribe", () =>
+					client.subscribeEvents({}, (event) => this.handleEvent(event)),
+				);
+				this.subscription = subscription;
+				launchTransaction.register(() => subscription.close());
+				launchTransaction.register(async () => {
+					try {
+						await client.stop();
+					} catch (error) {
+						this.deps.logger.debug(
+							"cerastream: rollback stop best-effort failed",
+							{
+								error,
+							},
+						);
+					}
+				});
+				const result = await launchTransaction.runPhase("start-rpc", () =>
+					this.dispatchStart(client, params),
+				);
+				await launchTransaction.runPhase("playing-wait", async () => {
+					startResultSchema.parse(result);
+				});
+			}, "start");
+		} catch (error) {
+			await launchTransaction.rollback();
+			throw error;
+		}
 	}
 
 	// Send `start` so `audio.mode` / `video_passthrough` survive: an engine that
@@ -478,16 +531,15 @@ export class CerastreamBackend implements StreamingBackend {
 	private async dispatchStart(
 		client: CerastreamClient,
 		params: StartParamsWithAudioMode,
-	): Promise<void> {
+	): Promise<unknown> {
 		const version = client.hello.schema_version;
 		if (supportsAudioMode(version) || supportsVideoPassthrough(version)) {
 			const raw = client as unknown as {
 				rawRequest(method: string, params?: unknown): Promise<unknown>;
 			};
-			await raw.rawRequest("start", params);
-			return;
+			return raw.rawRequest("start", params);
 		}
-		await client.start(params as StartParams);
+		return client.start(params as StartParams);
 	}
 
 	stop(onStopped: () => void): boolean {

--- a/apps/backend/src/modules/streaming/launch-transaction.ts
+++ b/apps/backend/src/modules/streaming/launch-transaction.ts
@@ -17,6 +17,12 @@ export type LaunchDeadlineTimers = {
 
 export type LaunchTransaction = {
 	readonly register: (cleanup: () => void | Promise<void>) => void;
+	readonly acquirePhase: <Resource>(
+		phase: StartDeadlinePhase,
+		operation: () => Promise<Resource>,
+		cleanup: (resource: Resource) => void | Promise<void>,
+		errorPhase?: (error: unknown) => StartDeadlinePhase,
+	) => Promise<Resource>;
 	readonly runPhase: <Result>(
 		phase: StartDeadlinePhase,
 		operation: () => Promise<Result>,
@@ -54,45 +60,57 @@ export function createLaunchTransaction(
 			});
 		}
 	};
+	const register = (cleanup: () => void | Promise<void>): void => {
+		if (rolledBack) {
+			void runCleanup(cleanup);
+			return;
+		}
+		cleanups.push(cleanup);
+	};
+	const runPhase = async <Result>(
+		phase: StartDeadlinePhase,
+		operation: () => Promise<Result>,
+		errorPhase: (error: unknown) => StartDeadlinePhase = () => phase,
+	): Promise<Result> => {
+		let timer: LaunchTimer | undefined;
+		let deadlineExpired = false;
+		const timeout = new Promise<never>((_resolve, reject) => {
+			timer = timers.schedule(() => {
+				deadlineExpired = true;
+				reject(
+					new CerastreamTimeoutError(phase, START_PHASE_DEADLINES_MS[phase]),
+				);
+			}, START_PHASE_DEADLINES_MS[phase]);
+		});
+		try {
+			return await Promise.race([operation(), timeout]);
+		} catch (error) {
+			throw new StreamStartFailure(
+				classifyStartFailure(
+					deadlineExpired ? phase : errorPhase(error),
+					error,
+					attemptId,
+					{ warn },
+				),
+			);
+		} finally {
+			if (timer !== undefined) timers.cancel(timer);
+		}
+	};
 
 	return {
-		register: (cleanup) => {
-			if (rolledBack) {
-				void runCleanup(cleanup);
-				return;
-			}
-			cleanups.push(cleanup);
-		},
-		runPhase: async <Result>(
-			phase: StartDeadlinePhase,
-			operation: () => Promise<Result>,
-			errorPhase: (error: unknown) => StartDeadlinePhase = () => phase,
-		): Promise<Result> => {
-			let timer: LaunchTimer | undefined;
-			let deadlineExpired = false;
-			const timeout = new Promise<never>((_resolve, reject) => {
-				timer = timers.schedule(() => {
-					deadlineExpired = true;
-					reject(
-						new CerastreamTimeoutError(phase, START_PHASE_DEADLINES_MS[phase]),
-					);
-				}, START_PHASE_DEADLINES_MS[phase]);
-			});
-			try {
-				return await Promise.race([operation(), timeout]);
-			} catch (error) {
-				throw new StreamStartFailure(
-					classifyStartFailure(
-						deadlineExpired ? phase : errorPhase(error),
-						error,
-						attemptId,
-						{ warn },
-					),
-				);
-			} finally {
-				if (timer !== undefined) timers.cancel(timer);
-			}
-		},
+		register,
+		acquirePhase: (phase, operation, cleanup, errorPhase) =>
+			runPhase(
+				phase,
+				() =>
+					operation().then((resource) => {
+						register(() => cleanup(resource));
+						return resource;
+					}),
+				errorPhase,
+			),
+		runPhase,
 		rollback: () => {
 			if (rollbackPromise !== undefined) return rollbackPromise;
 			rolledBack = true;

--- a/apps/backend/src/modules/streaming/launch-transaction.ts
+++ b/apps/backend/src/modules/streaming/launch-transaction.ts
@@ -1,0 +1,106 @@
+import { CerastreamTimeoutError } from "@ceralive/cerastream";
+import {
+	classifyStartFailure,
+	StreamStartFailure,
+} from "./start-failure-taxonomy.ts";
+import {
+	START_PHASE_DEADLINES_MS,
+	type StartDeadlinePhase,
+} from "./start-lifecycle-timing.ts";
+
+type LaunchTimer = ReturnType<typeof globalThis.setTimeout> | number;
+
+export type LaunchDeadlineTimers = {
+	readonly schedule: (callback: () => void, delayMs: number) => LaunchTimer;
+	readonly cancel: (timer: LaunchTimer) => void;
+};
+
+export type LaunchTransaction = {
+	readonly register: (cleanup: () => void | Promise<void>) => void;
+	readonly runPhase: <Result>(
+		phase: StartDeadlinePhase,
+		operation: () => Promise<Result>,
+		errorPhase?: (error: unknown) => StartDeadlinePhase,
+	) => Promise<Result>;
+	readonly rollback: () => Promise<void>;
+};
+
+const realTimers: LaunchDeadlineTimers = {
+	schedule: (callback, delayMs) => globalThis.setTimeout(callback, delayMs),
+	cancel: (timer) => globalThis.clearTimeout(timer),
+};
+
+export function createLaunchTransaction(
+	attemptId: string,
+	options: {
+		readonly timers?: LaunchDeadlineTimers;
+		readonly warn?: (message: string, meta?: Record<string, unknown>) => void;
+	} = {},
+): LaunchTransaction {
+	const timers = options.timers ?? realTimers;
+	const cleanups: Array<() => void | Promise<void>> = [];
+	let rolledBack = false;
+	let rollbackPromise: Promise<void> | undefined;
+	const warn = options.warn ?? (() => undefined);
+
+	const runCleanup = async (
+		cleanup: () => void | Promise<void>,
+	): Promise<void> => {
+		try {
+			await cleanup();
+		} catch (error) {
+			warn("stream launch cleanup failed", {
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	};
+
+	return {
+		register: (cleanup) => {
+			if (rolledBack) {
+				void runCleanup(cleanup);
+				return;
+			}
+			cleanups.push(cleanup);
+		},
+		runPhase: async <Result>(
+			phase: StartDeadlinePhase,
+			operation: () => Promise<Result>,
+			errorPhase: (error: unknown) => StartDeadlinePhase = () => phase,
+		): Promise<Result> => {
+			let timer: LaunchTimer | undefined;
+			let deadlineExpired = false;
+			const timeout = new Promise<never>((_resolve, reject) => {
+				timer = timers.schedule(() => {
+					deadlineExpired = true;
+					reject(
+						new CerastreamTimeoutError(phase, START_PHASE_DEADLINES_MS[phase]),
+					);
+				}, START_PHASE_DEADLINES_MS[phase]);
+			});
+			try {
+				return await Promise.race([operation(), timeout]);
+			} catch (error) {
+				throw new StreamStartFailure(
+					classifyStartFailure(
+						deadlineExpired ? phase : errorPhase(error),
+						error,
+						attemptId,
+						{ warn },
+					),
+				);
+			} finally {
+				if (timer !== undefined) timers.cancel(timer);
+			}
+		},
+		rollback: () => {
+			if (rollbackPromise !== undefined) return rollbackPromise;
+			rolledBack = true;
+			rollbackPromise = (async () => {
+				for (const cleanup of cleanups.reverse()) await runCleanup(cleanup);
+				cleanups.length = 0;
+			})();
+			return rollbackPromise;
+		},
+	};
+}

--- a/apps/backend/src/modules/streaming/start-failure-taxonomy.ts
+++ b/apps/backend/src/modules/streaming/start-failure-taxonomy.ts
@@ -48,6 +48,14 @@ import {
 
 import { randomBase64 } from "../../helpers/crypto.ts";
 
+export class StreamStartFailure extends Error {
+	override readonly name = "StreamStartFailure";
+
+	constructor(readonly failure: StartFailure) {
+		super(`${failure.phase}:${failure.class}`);
+	}
+}
+
 // ─── (b) Attempt-ID generation at the public start boundary ──────────────────
 
 // Monotonic-ish component so ids sort roughly by creation time in logs, plus a

--- a/apps/backend/src/modules/streaming/start-lifecycle-timing.ts
+++ b/apps/backend/src/modules/streaming/start-lifecycle-timing.ts
@@ -1,0 +1,18 @@
+import type { StartFailurePhase } from "@ceraui/rpc/schemas";
+
+export type StartDeadlinePhase = Exclude<
+	StartFailurePhase,
+	"params" | "spawn-sender"
+>;
+
+export const START_PHASE_DEADLINES_MS: Readonly<
+	Record<StartDeadlinePhase, number>
+> = {
+	connect: 10_000,
+	hello: 10_000,
+	subscribe: 10_000,
+	"start-rpc": 10_000,
+	"playing-wait": 5_000,
+};
+
+export const STOP_DEADLINE_MS = 12_000;

--- a/apps/backend/src/modules/streaming/stream-session-orchestrator.ts
+++ b/apps/backend/src/modules/streaming/stream-session-orchestrator.ts
@@ -1,7 +1,6 @@
 import {
 	isLegalLifecycleTransition,
 	type LifecycleState,
-	type StartFailure,
 	type StartResult,
 	type StopResult,
 } from "@ceraui/rpc/schemas";
@@ -12,7 +11,9 @@ import { queryEngineRuntimeStreaming } from "./engine-runtime-state.ts";
 import {
 	classifyStartFailure,
 	newAttemptId,
+	StreamStartFailure,
 } from "./start-failure-taxonomy.ts";
+import { STOP_DEADLINE_MS } from "./start-lifecycle-timing.ts";
 import { updateStreamLifecycleState } from "./stream-lifecycle-status.ts";
 import { getIsStreaming, updateStatus } from "./streaming.ts";
 import type { EngineRuntimeState } from "./streaming-backend.ts";
@@ -54,6 +55,14 @@ export type StreamSessionOrchestratorDeps = {
 		from: LifecycleState,
 		to: LifecycleState,
 	) => void;
+	readonly stopDeadlineMs?: number;
+	readonly scheduleTimeout?: (
+		callback: () => void,
+		delayMs: number,
+	) => ReturnType<typeof globalThis.setTimeout> | number;
+	readonly cancelTimeout?: (
+		timer: ReturnType<typeof globalThis.setTimeout> | number,
+	) => void;
 };
 
 type ActiveAttempt = {
@@ -76,6 +85,30 @@ export function createStreamSessionOrchestrator(
 	let generation = 0;
 	let active: ActiveAttempt | undefined;
 	let reconciliationEpoch = 0;
+	const stopDeadlineMs = deps.stopDeadlineMs ?? STOP_DEADLINE_MS;
+	const scheduleTimeout =
+		deps.scheduleTimeout ??
+		((callback: () => void, delayMs: number) =>
+			globalThis.setTimeout(callback, delayMs));
+	const cancelTimeout =
+		deps.cancelTimeout ??
+		((timer: ReturnType<typeof globalThis.setTimeout> | number) =>
+			globalThis.clearTimeout(timer));
+
+	const stopWithinDeadline = (generationToStop: number): Promise<void> => {
+		let timer: ReturnType<typeof globalThis.setTimeout> | number | undefined;
+		const timeout = new Promise<never>((_resolve, reject) => {
+			timer = scheduleTimeout(
+				() => reject(new Error("stop_timeout")),
+				stopDeadlineMs,
+			);
+		});
+		return Promise.race([deps.stopRuntime(generationToStop), timeout]).finally(
+			() => {
+				if (timer !== undefined) cancelTimeout(timer);
+			},
+		);
+	};
 
 	const transition = (next: LifecycleState): boolean => {
 		if (state === next) return true;
@@ -91,7 +124,7 @@ export function createStreamSessionOrchestrator(
 	const finishCancelled = async (
 		attempt: ActiveAttempt,
 	): Promise<StartResult> => {
-		await deps.stopRuntime(attempt.generation);
+		await stopWithinDeadline(attempt.generation);
 		if (active === attempt) {
 			transition("idle");
 			active = undefined;
@@ -175,7 +208,7 @@ export function createStreamSessionOrchestrator(
 		}
 
 		try {
-			await deps.stopRuntime(stoppedGeneration);
+			await stopWithinDeadline(stoppedGeneration);
 			if (!cancellingStart) {
 				active = undefined;
 				transition("idle");
@@ -210,14 +243,6 @@ export function createStreamSessionOrchestrator(
 		reconcile,
 		snapshot: () => ({ state, generation }),
 	};
-}
-
-export class StreamStartFailure extends Error {
-	override readonly name = "StreamStartFailure";
-
-	constructor(readonly failure: StartFailure) {
-		super(`${failure.phase}:${failure.class}`);
-	}
 }
 
 const productionOrchestrator = createStreamSessionOrchestrator({

--- a/apps/backend/src/modules/streaming/streaming-backend.ts
+++ b/apps/backend/src/modules/streaming/streaming-backend.ts
@@ -36,6 +36,7 @@
 //          supervised process; its telemetry is owned by `link-telemetry.ts`.
 
 import type { RuntimeConfig } from "../../helpers/config-schemas.ts";
+import type { LaunchTransaction } from "./launch-transaction.ts";
 
 /** Per-field bitrate input — mirrors the RPC bitrate setter payload. */
 export type BitrateParams = { max_br?: number | undefined };
@@ -88,7 +89,11 @@ export interface StreamingBackend {
 	buildRunArgs(config: RuntimeConfig, opts: StreamRunOptions): Array<string>;
 
 	/** Launch the engine process and resolve after the engine confirms PLAYING. */
-	start(config: RuntimeConfig, opts: StreamRunOptions): Promise<void>;
+	start(
+		config: RuntimeConfig,
+		opts: StreamRunOptions,
+		transaction?: LaunchTransaction,
+	): Promise<void>;
 	/**
 	 * Stop the engine process. `onStopped` fires once the engine has terminated
 	 * (synchronously if it was already dead). Returns whether an engine process

--- a/apps/backend/src/modules/streaming/streamloop/autostart.ts
+++ b/apps/backend/src/modules/streaming/streamloop/autostart.ts
@@ -28,11 +28,11 @@ import { isUpdating } from "../../system/software-updates.ts";
 import { broadcastMsg } from "../../ui/websocket-server.ts";
 import type { Pipeline } from "../pipelines.ts";
 import { genSrtlaIpList, resolveSrtla } from "../srtla.ts";
-import { classifyStartFailure } from "../start-failure-taxonomy.ts";
 import {
+	classifyStartFailure,
 	StreamStartFailure,
-	startStreamSession,
-} from "../stream-session-orchestrator.ts";
+} from "../start-failure-taxonomy.ts";
+import { startStreamSession } from "../stream-session-orchestrator.ts";
 import { getIsStreaming, validateConfig } from "../streaming.ts";
 import { startStream } from "./start-stream.ts";
 
@@ -92,10 +92,12 @@ export async function autoStartStream(): Promise<void> {
 				srtlaAddr,
 				c.srtlaPort,
 				c.streamid,
+				{},
+				attemptId,
 			);
 			if (!launched.success) {
 				throw new StreamStartFailure(
-					classifyStartFailure("spawn-sender", launched.error, attemptId),
+					classifyStartFailure(launched.phase, launched.error, attemptId),
 				);
 			}
 		},

--- a/apps/backend/src/modules/streaming/streamloop/process-runner.ts
+++ b/apps/backend/src/modules/streaming/streamloop/process-runner.ts
@@ -56,7 +56,7 @@ export function spawnStreamingLoop(
 	command: string,
 	args: Array<string>,
 	errCallback: (data: string) => void,
-) {
+): StreamingProcess {
 	const proc = Bun.spawn([command, ...args], {
 		stdin: "inherit",
 		stdout: "inherit",
@@ -119,6 +119,7 @@ export function spawnStreamingLoop(
 		reportStreamProcessExit();
 		broadcastHealthIfChanged();
 	});
+	return streamingProcess;
 }
 
 function removeProc(streamingProcess: StreamingProcess) {
@@ -141,6 +142,32 @@ export function stopProcess(streamingProcess: StreamingProcess) {
 
 	removeProc(streamingProcess);
 	return true;
+}
+
+export async function stopProcessAndWait(
+	streamingProcess: StreamingProcess,
+): Promise<void> {
+	if (stopProcess(streamingProcess)) return;
+	let killTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
+	try {
+		await Promise.race([
+			streamingProcess.proc.exited.then(() => undefined),
+			new Promise<void>((resolve) => {
+				killTimer = globalThis.setTimeout(() => {
+					if (
+						streamingProcess.proc.exitCode === null &&
+						streamingProcess.proc.signalCode === null
+					) {
+						streamingProcess.proc.kill("SIGKILL");
+					}
+					resolve();
+				}, SHUTDOWN_SIGKILL_TIMEOUT_MS);
+			}),
+		]);
+		await streamingProcess.proc.exited;
+	} finally {
+		if (killTimer !== undefined) globalThis.clearTimeout(killTimer);
+	}
 }
 
 const stopCheckInterval = 50;

--- a/apps/backend/src/modules/streaming/streamloop/session.ts
+++ b/apps/backend/src/modules/streaming/streamloop/session.ts
@@ -39,6 +39,10 @@ import {
 	setSrtlaIpList,
 } from "../srtla.ts";
 import {
+	classifyStartFailure,
+	StreamStartFailure,
+} from "../start-failure-taxonomy.ts";
+import {
 	type ConfigParameters,
 	getIsStreaming,
 	startError,
@@ -46,7 +50,7 @@ import {
 	updateStatus,
 } from "../streaming.ts";
 import { getStreamingBackend } from "../streaming-engine.ts";
-import { getStreamingProcesses, stopAll } from "./process-runner.ts";
+import { getStreamingProcesses, stopProcessAndWait } from "./process-runner.ts";
 import { type StartStreamResult, startStream } from "./start-stream.ts";
 
 type SessionResources = {
@@ -56,10 +60,38 @@ type SessionResources = {
 
 let sessionResources: SessionResources | undefined;
 
+export type SrtlaIpPreparationDeps = {
+	readonly isLocal: (address: string) => boolean;
+	readonly localList: (address: string) => string[];
+	readonly bondedList: () => string[];
+	readonly writeList: (addresses: string[]) => Promise<void>;
+};
+
+const defaultSrtlaIpPreparationDeps: SrtlaIpPreparationDeps = {
+	isLocal: isLocalIp,
+	localList: genSrtlaIpListForLocalIpAddress,
+	bondedList: genSrtlaIpList,
+	writeList: setSrtlaIpList,
+};
+
+export async function prepareSrtlaIpAddresses(
+	srtlaAddr: string,
+	deps: SrtlaIpPreparationDeps = defaultSrtlaIpPreparationDeps,
+): Promise<void> {
+	const srtlaIpList = deps.isLocal(srtlaAddr)
+		? deps.localList(srtlaAddr)
+		: deps.bondedList();
+	if (srtlaIpList.length === 0) {
+		throw new Error("no_available_network_connections");
+	}
+	await deps.writeList(srtlaIpList);
+}
+
 export async function start(
 	conn: WebSocket,
 	params: ConfigParameters,
 	generation = 0,
+	attemptId = "legacy-start",
 ): Promise<StartStreamResult> {
 	if (getIsStreaming() || isUpdating()) {
 		sendStatus(conn);
@@ -67,6 +99,7 @@ export async function start(
 			success: false,
 			error: "stream_start_unavailable",
 			reason: "stream_start_unavailable",
+			phase: "params",
 		};
 	}
 
@@ -91,6 +124,7 @@ export async function start(
 			success: false,
 			error: typeof err === "string" ? err : "start_invalid",
 			reason: typeof err === "string" ? err : "start_invalid",
+			phase: "params",
 		};
 	}
 
@@ -102,31 +136,27 @@ export async function start(
 		sessionResources.removeNetworkInterfacesChangeListener();
 	}
 
-	const handleSrtlaIpAddresses = async () => {
-		const srtlaIpList = isLocalIp(c.srtlaAddr)
-			? genSrtlaIpListForLocalIpAddress(c.srtlaAddr)
-			: genSrtlaIpList();
-		if (!srtlaIpList.length) {
-			startError(
-				conn,
-				"Failed to start, no available network connections",
-				senderId,
-			);
-			return;
-		}
-
-		await setSrtlaIpList(srtlaIpList);
-
-		if (getIsStreaming()) {
-			restartSrtla();
+	try {
+		await prepareSrtlaIpAddresses(c.srtlaAddr);
+	} catch (error) {
+		throw new StreamStartFailure(
+			classifyStartFailure("params", error, attemptId, {
+				warn: (message, meta) => logger.warn(message, meta),
+			}),
+		);
+	}
+	const refreshSrtlaIpAddresses = async () => {
+		try {
+			await prepareSrtlaIpAddresses(c.srtlaAddr);
+			if (getIsStreaming()) restartSrtla();
+		} catch (error) {
+			logger.warn("Failed to refresh SRTLA IP addresses", { error });
 		}
 	};
-
-	void handleSrtlaIpAddresses();
 	sessionResources = {
 		generation,
 		removeNetworkInterfacesChangeListener: onNetworkInterfacesChange(
-			handleSrtlaIpAddresses,
+			refreshSrtlaIpAddresses,
 		),
 	};
 
@@ -137,8 +167,15 @@ export async function start(
 			c.srtlaAddr,
 			c.srtlaPort,
 			c.streamid,
+			{},
+			attemptId,
 		);
 	} catch (err) {
+		if (sessionResources?.generation === generation) {
+			sessionResources.removeNetworkInterfacesChangeListener();
+			sessionResources = undefined;
+		}
+		if (err instanceof StreamStartFailure) throw err;
 		if (typeof err === "string") {
 			startError(conn, err, senderId);
 		} else {
@@ -149,6 +186,7 @@ export async function start(
 			success: false,
 			error: typeof err === "string" ? err : "engine_internal",
 			reason: typeof err === "string" ? err : "engine_internal",
+			phase: "spawn-sender",
 		};
 	}
 
@@ -173,22 +211,31 @@ export function stopGeneration(generation: number): Promise<void> {
 	setPendingAudioFollowAsrc(null);
 
 	return new Promise((resolve) => {
+		let finishPromise: Promise<void> | undefined;
 		const finish = () => {
-			if (sessionResources?.generation === generation) {
-				sessionResources.removeNetworkInterfacesChangeListener();
-				sessionResources = undefined;
-			}
-			stopAll();
-			stopLinkTelemetry();
-			updateStatus(false);
-			resolve();
+			if (finishPromise !== undefined) return finishPromise;
+			finishPromise = (async () => {
+				if (sessionResources?.generation === generation) {
+					sessionResources.removeNetworkInterfacesChangeListener();
+					sessionResources = undefined;
+				}
+				await Promise.all(
+					[...getStreamingProcesses()].map((process) =>
+						stopProcessAndWait(process),
+					),
+				);
+				stopLinkTelemetry();
+				updateStatus(false);
+				resolve();
+			})();
+			return finishPromise;
 		};
 
 		if (isAsrcProbeRejectResolved()) {
 			clearAsrcProbeReject();
 
 			if (getStreamingProcesses().length === 0) {
-				finish();
+				void finish();
 				return;
 			}
 
@@ -200,7 +247,9 @@ export function stopGeneration(generation: number): Promise<void> {
 
 		// Bring the engine down first (it owns the engine-first shutdown ordering),
 		// then sweep the rest once it has exited.
-		const foundEngine = getStreamingBackend().stop(finish);
+		const foundEngine = getStreamingBackend().stop(() => {
+			void finish();
+		});
 
 		if (!foundEngine) {
 			if (
@@ -212,7 +261,7 @@ export function stopGeneration(generation: number): Promise<void> {
 					"engine session missing while generation-owned resources remained",
 				);
 			}
-			finish();
+			void finish();
 		}
 	});
 }

--- a/apps/backend/src/modules/streaming/streamloop/start-stream.ts
+++ b/apps/backend/src/modules/streaming/streamloop/start-stream.ts
@@ -41,12 +41,17 @@ import { getLastCapabilities } from "../capabilities.ts";
 import { SRTLA_LISTEN_PORT } from "../constants.ts";
 import { embeddedAudioActive } from "../embedded-audio.ts";
 import { clearStreamProcessExit } from "../health.ts";
-import { srtlaStatsFile, startLinkTelemetry } from "../link-telemetry.ts";
+import { createLaunchTransaction } from "../launch-transaction.ts";
+import {
+	srtlaStatsFile,
+	startLinkTelemetry,
+	stopLinkTelemetry,
+} from "../link-telemetry.ts";
 import type { Pipeline } from "../pipelines.ts";
 import { getStreamingBackend } from "../streaming-engine.ts";
 import { srtlaSendExec } from "./exec-paths.ts";
 import { resolveProcessError } from "./process-error-patterns.ts";
-import { spawnStreamingLoop } from "./process-runner.ts";
+import { spawnStreamingLoop, stopProcessAndWait } from "./process-runner.ts";
 
 export interface AudioProbeDeps {
 	probe?: (asrc: string) => Promise<string>;
@@ -54,10 +59,16 @@ export interface AudioProbeDeps {
 }
 
 export const AUDIO_SOURCE_PROBE_FAILED = "audio_source_probe_failed";
+export const IP_LIST_READ_FAILED = "ip_list_read_failed";
 
 export type StartStreamResult =
 	| { success: true }
-	| { success: false; error: string; reason: string };
+	| {
+			success: false;
+			error: string;
+			reason: string;
+			phase: "params" | "spawn-sender";
+	  };
 
 export async function maybeProbeAudioSource(
 	pipeline: Pipeline,
@@ -100,6 +111,7 @@ export async function startStream(
 	srtlaPort: number,
 	streamid: string,
 	audioDeps: AudioProbeDeps = {},
+	attemptId = "legacy-start",
 ): Promise<StartStreamResult> {
 	const config = getConfig();
 	const launchConfig = resolveLaunchConfig(config);
@@ -117,54 +129,77 @@ export async function startStream(
 			success: false,
 			error: AUDIO_SOURCE_PROBE_FAILED,
 			reason: AUDIO_SOURCE_PROBE_FAILED,
+			phase: "params",
 		};
 	}
 	const statsFile = srtlaStatsFile();
 	// ADR-001 control socket: telemetry rides the JSON-RPC subscription when the
 	// sender advertises it, with --stats-file as the airtight fallback poll.
 	const controlSocket = controlSocketPath(SRTLA_LISTEN_PORT);
-	spawnStreamingLoop(
-		srtlaSendExec,
-		buildSrtlaSendArgs({
-			listenPort: SRTLA_LISTEN_PORT,
-			srtlaHost: srtlaAddr,
-			srtlaPort,
-			ipsFile: setup.ips_file,
-			statsFile,
-			controlSocket,
-			execPath: setup.srtla_path,
-		}),
-		(err) => {
-			const resolved = resolveProcessError("srtla", err);
-			if (resolved) {
-				notificationBroadcast(
-					"srtla",
-					"error",
-					resolved.message,
-					5,
-					true,
-					false,
-				);
-			}
-		},
-	);
-
-	// Begin ingesting srtla_send's per-uplink telemetry. Seed the conn_id->iface
-	// registry from the exact file srtla_send reads at spawn so tlm_id (file
-	// order) maps back to interface names.
-	const ipsContent = await Bun.file(setup.ips_file ?? "")
-		.text()
-		.catch(() => "");
-	startLinkTelemetry(statsFile, ipsContent.split("\n"), { controlSocket });
-
-	// Engine launch (session start over structured IPC) is behind the seam.
-	await getStreamingBackend().start(launchConfig, {
-		pipeline: pipeline.source,
-		host: "127.0.0.1",
-		port: SRTLA_LISTEN_PORT,
-		streamid,
-		reducedPacketSize: hasLowMtu(),
+	let ipsContent: string;
+	try {
+		ipsContent = await Bun.file(setup.ips_file ?? "").text();
+	} catch (error) {
+		logger.warn("startStream: IP list read failed; aborting start", { error });
+		return {
+			success: false,
+			error: IP_LIST_READ_FAILED,
+			reason: IP_LIST_READ_FAILED,
+			phase: "params",
+		};
+	}
+	const transaction = createLaunchTransaction(attemptId, {
+		warn: (message, meta) => logger.warn(message, meta),
 	});
+	try {
+		const sender = spawnStreamingLoop(
+			srtlaSendExec,
+			buildSrtlaSendArgs({
+				listenPort: SRTLA_LISTEN_PORT,
+				srtlaHost: srtlaAddr,
+				srtlaPort,
+				ipsFile: setup.ips_file,
+				statsFile,
+				controlSocket,
+				execPath: setup.srtla_path,
+			}),
+			(err) => {
+				const resolved = resolveProcessError("srtla", err);
+				if (resolved) {
+					notificationBroadcast(
+						"srtla",
+						"error",
+						resolved.message,
+						5,
+						true,
+						false,
+					);
+				}
+			},
+		);
+		transaction.register(() => stopProcessAndWait(sender));
+
+		// Begin ingesting srtla_send's per-uplink telemetry. Seed the conn_id->iface
+		// registry from the exact file srtla_send reads at spawn so tlm_id (file
+		// order) maps back to interface names.
+		startLinkTelemetry(statsFile, ipsContent.split("\n"), { controlSocket });
+		transaction.register(() => stopLinkTelemetry());
+
+		await getStreamingBackend().start(
+			launchConfig,
+			{
+				pipeline: pipeline.source,
+				host: "127.0.0.1",
+				port: SRTLA_LISTEN_PORT,
+				streamid,
+				reducedPacketSize: hasLowMtu(),
+			},
+			transaction,
+		);
+	} catch (error) {
+		await transaction.rollback();
+		throw error;
+	}
 
 	return { success: true };
 }

--- a/apps/backend/src/rpc/procedures/streaming.procedure.ts
+++ b/apps/backend/src/rpc/procedures/streaming.procedure.ts
@@ -88,9 +88,11 @@ import {
 	type ResolveSourceRoutingResult,
 	resolveSourceRouting,
 } from "../../modules/streaming/sources.ts";
-import { classifyStartFailure } from "../../modules/streaming/start-failure-taxonomy.ts";
 import {
+	classifyStartFailure,
 	StreamStartFailure,
+} from "../../modules/streaming/start-failure-taxonomy.ts";
+import {
 	startStreamSession,
 	stopStreamSession,
 } from "../../modules/streaming/stream-session-orchestrator.ts";
@@ -301,11 +303,12 @@ export const streamingStartProcedure = authedProcedure
 					context.ws as unknown as import("ws").default,
 					applied,
 					generation,
+					attemptId,
 				);
 				if (!startResult.success) {
 					legacyError = startResult.error;
 					throwStartFailure(
-						"spawn-sender",
+						startResult.phase,
 						new Error(startResult.error),
 						attemptId,
 					);

--- a/apps/backend/src/tests/audio-probe-failure-reason.test.ts
+++ b/apps/backend/src/tests/audio-probe-failure-reason.test.ts
@@ -60,6 +60,7 @@ describe("startStream — audio-source probe failure surfaces a structured reaso
 			success: false,
 			error: AUDIO_SOURCE_PROBE_FAILED,
 			reason: AUDIO_SOURCE_PROBE_FAILED,
+			phase: "params",
 		});
 		expect(AUDIO_SOURCE_PROBE_FAILED).toBe("audio_source_probe_failed");
 	});

--- a/apps/backend/src/tests/edge-cases/streamloop-process-runner.test.ts
+++ b/apps/backend/src/tests/edge-cases/streamloop-process-runner.test.ts
@@ -37,19 +37,12 @@ async function waitUntil(
 	return predicate();
 }
 
-// spawnStreamingLoop does not return the process it creates, so identify "ours"
-// as the single entry that appeared in the supervised list after the call.
 function spawnAndCapture(
 	command: string,
 	args: string[],
 	cb: (data: string) => void,
 ): StreamingProcess {
-	const before = new Set(getStreamingProcesses());
-	spawnStreamingLoop(command, args, cb);
-	const mine = getStreamingProcesses().find((p) => !before.has(p));
-	if (!mine)
-		throw new Error("spawned process was not registered in the supervisor");
-	return mine;
+	return spawnStreamingLoop(command, args, cb);
 }
 
 describe("process-runner: stderr is drained into the error callback", () => {

--- a/apps/backend/src/tests/launch-transaction.test.ts
+++ b/apps/backend/src/tests/launch-transaction.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+
+import { CerastreamConnectionError } from "@ceralive/cerastream";
+import type { StartFailurePhase } from "@ceraui/rpc/schemas";
+import {
+	createLaunchTransaction,
+	type LaunchDeadlineTimers,
+} from "../modules/streaming/launch-transaction.ts";
+import { StreamStartFailure } from "../modules/streaming/start-failure-taxonomy.ts";
+import { START_PHASE_DEADLINES_MS } from "../modules/streaming/start-lifecycle-timing.ts";
+
+type Deferred = {
+	readonly promise: Promise<void>;
+	readonly resolve: () => void;
+};
+
+function deferred(): Deferred {
+	let resolvePromise: (() => void) | undefined;
+	const promise = new Promise<void>((resolve) => {
+		resolvePromise = resolve;
+	});
+	return { promise, resolve: () => resolvePromise?.() };
+}
+
+function fakeTimers(): {
+	readonly timers: LaunchDeadlineTimers;
+	readonly fire: () => void;
+	readonly delay: () => number | undefined;
+} {
+	let callback: (() => void) | undefined;
+	let delayMs: number | undefined;
+	return {
+		timers: {
+			schedule: (next: () => void, delay: number) => {
+				callback = next;
+				delayMs = delay;
+				return 1;
+			},
+			cancel: () => {},
+		},
+		fire: () => callback?.(),
+		delay: () => delayMs,
+	};
+}
+
+describe("transactional stream launch", () => {
+	test("connect refusal after sender spawn rolls every owned resource back", async () => {
+		const resources = {
+			sender: false,
+			telemetry: false,
+			client: false,
+			subscription: false,
+		};
+		const transaction = createLaunchTransaction("attempt-1");
+		transaction.register(() => {
+			resources.sender = false;
+		});
+		resources.sender = true;
+		transaction.register(() => {
+			resources.telemetry = false;
+		});
+		resources.telemetry = true;
+		transaction.register(() => {
+			resources.client = false;
+		});
+		resources.client = true;
+		transaction.register(() => {
+			resources.subscription = false;
+		});
+		resources.subscription = true;
+
+		try {
+			await transaction.runPhase("connect", async () => {
+				throw new CerastreamConnectionError("refused", undefined, "refused");
+			});
+		} catch (error) {
+			expect(error).toBeInstanceOf(StreamStartFailure);
+			if (error instanceof StreamStartFailure) {
+				expect(error.failure).toMatchObject({
+					attemptId: "attempt-1",
+					phase: "connect",
+					class: "engine_unavailable",
+				});
+			}
+		}
+		await transaction.rollback();
+
+		expect(resources).toEqual({
+			sender: false,
+			telemetry: false,
+			client: false,
+			subscription: false,
+		});
+	});
+
+	for (const phase of [
+		"connect",
+		"hello",
+		"subscribe",
+		"start-rpc",
+		"playing-wait",
+	] as const satisfies readonly StartFailurePhase[]) {
+		test(`${phase} hang times out and rolls back in reverse order`, async () => {
+			const clock = fakeTimers();
+			const cleanupOrder: string[] = [];
+			const transaction = createLaunchTransaction("attempt-timeout", {
+				timers: clock.timers,
+			});
+			transaction.register(() => {
+				cleanupOrder.push("sender");
+			});
+			transaction.register(() => {
+				cleanupOrder.push("telemetry");
+			});
+			transaction.register(() => {
+				cleanupOrder.push("client");
+			});
+			const hanging = deferred();
+
+			const result = transaction.runPhase(phase, () => hanging.promise);
+			expect(clock.delay()).toBe(START_PHASE_DEADLINES_MS[phase]);
+			clock.fire();
+			await expect(result).rejects.toMatchObject({
+				failure: {
+					attemptId: "attempt-timeout",
+					phase,
+					class: "start_timeout",
+				},
+			});
+			await transaction.rollback();
+			await transaction.rollback();
+			let staleResource = true;
+			transaction.register(() => {
+				staleResource = false;
+			});
+			await Promise.resolve();
+
+			expect(cleanupOrder).toEqual(["client", "telemetry", "sender"]);
+			expect(staleResource).toBe(false);
+		});
+	}
+});

--- a/apps/backend/src/tests/srtla-ip-preparation.test.ts
+++ b/apps/backend/src/tests/srtla-ip-preparation.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+
+import { prepareSrtlaIpAddresses } from "../modules/streaming/streamloop/session.ts";
+
+function deferred(): {
+	readonly promise: Promise<void>;
+	readonly resolve: () => void;
+} {
+	let resolvePromise: (() => void) | undefined;
+	const promise = new Promise<void>((resolve) => {
+		resolvePromise = resolve;
+	});
+	return { promise, resolve: () => resolvePromise?.() };
+}
+
+describe("SRTLA IP-list launch preparation", () => {
+	test("does not resolve until the IP list has been written", async () => {
+		const writeBarrier = deferred();
+		let settled = false;
+		const preparation = prepareSrtlaIpAddresses("relay.example", {
+			isLocal: () => false,
+			localList: () => [],
+			bondedList: () => ["10.0.0.2"],
+			writeList: () => writeBarrier.promise,
+		}).then(() => {
+			settled = true;
+		});
+
+		await Promise.resolve();
+		expect(settled).toBe(false);
+		writeBarrier.resolve();
+		await preparation;
+		expect(settled).toBe(true);
+	});
+
+	test("rejects launch preparation when no network address is available", async () => {
+		let writes = 0;
+		await expect(
+			prepareSrtlaIpAddresses("relay.example", {
+				isLocal: () => false,
+				localList: () => [],
+				bondedList: () => [],
+				writeList: async () => {
+					writes += 1;
+				},
+			}),
+		).rejects.toThrow("no_available_network_connections");
+		expect(writes).toBe(0);
+	});
+});

--- a/apps/backend/src/tests/stream-session-orchestrator.test.ts
+++ b/apps/backend/src/tests/stream-session-orchestrator.test.ts
@@ -110,6 +110,33 @@ describe("stream session orchestrator", () => {
 		expect(orchestrator.snapshot().state).toBe("idle");
 	});
 
+	test("a stuck runtime stop returns stop_failed after the configured bound", async () => {
+		const stopBarrier = deferred();
+		let deadlineCallback: (() => void) | undefined;
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: attemptIds(),
+			setStreamingStatus: () => {},
+			stopRuntime: () => stopBarrier.promise,
+			queryRuntime: async () => "idle",
+			stopDeadlineMs: 12_000,
+			scheduleTimeout: (callback) => {
+				deadlineCallback = callback;
+				return 1;
+			},
+			cancelTimeout: () => {},
+		});
+		await orchestrator.start({ origin: "ui", launch: async () => {} });
+
+		const stopping = orchestrator.stop();
+		deadlineCallback?.();
+
+		expect(await stopping).toEqual({
+			result: "stop_failed",
+			reason: "stop_timeout",
+		});
+		expect(orchestrator.snapshot().state).toBe("stop_failed");
+	});
+
 	test("a cancelled generation cannot cancel the next start", async () => {
 		// Given generation one cancelled before its engine confirmation.
 		const firstBarrier = deferred();

--- a/apps/backend/src/tests/streaming-backend-contract.test.ts
+++ b/apps/backend/src/tests/streaming-backend-contract.test.ts
@@ -5,11 +5,17 @@ import type {
 	CerastreamClient,
 	EventParams,
 } from "@ceralive/cerastream";
+import {
+	CerastreamConnectionError,
+	CerastreamRpcError,
+	CerastreamTimeoutError,
+} from "@ceralive/cerastream";
 import type { RuntimeConfig } from "../helpers/config-schemas.ts";
 import {
 	CerastreamBackend,
 	type CerastreamBackendDeps,
 	cerastreamBackend,
+	classifyConnectHandshakePhase,
 } from "../modules/streaming/cerastream-backend.ts";
 import type {
 	StreamingBackend,
@@ -602,16 +608,85 @@ describe("CerastreamBackend RPC passthroughs", () => {
 // ---------------------------------------------------------------------------
 
 describe("CerastreamBackend engine crash", () => {
+	test("successful start resolves only after the engine confirms streaming", async () => {
+		const { backend, fake } = makeBackend();
+		let confirmStart: (() => void) | undefined;
+		let markStartEntered: (() => void) | undefined;
+		const startEntered = new Promise<void>((resolve) => {
+			markStartEntered = resolve;
+		});
+		let settled = false;
+		fake.client.start = (params) => {
+			fake.calls.push({ op: "start", params });
+			markStartEntered?.();
+			return new Promise((resolve) => {
+				confirmStart = () => resolve({ session_id: "s1", state: "streaming" });
+			});
+		};
+		const starting = backend.start(STREAM_CONFIG, RUN_OPTS).then(() => {
+			settled = true;
+		});
+		await startEntered;
+
+		expect(settled).toBe(false);
+		confirmStart?.();
+		await starting;
+		expect(settled).toBe(true);
+	});
+
+	test("a close between hello and start RPC returns one failure and closes the client", async () => {
+		const { backend, fake } = makeBackend();
+		fake.client.subscribeEvents = async () => {
+			throw new CerastreamConnectionError(
+				"connection lost before subscription",
+				undefined,
+				"lost",
+			);
+		};
+
+		await expect(backend.start(STREAM_CONFIG, RUN_OPTS)).rejects.toMatchObject({
+			failure: { phase: "subscribe", class: "engine_unavailable" },
+		});
+		await backend.settle();
+
+		expect(fake.calls.map((call) => call.op)).not.toContain("start");
+		expect(fake.calls.filter((call) => call.op === "close")).toHaveLength(1);
+	});
+
+	test("a post-subscribe start failure closes the subscription and client", async () => {
+		// Given the current backend has connected and subscribed before start fails.
+		const { backend, fake } = makeBackend();
+		fake.client.start = async (params) => {
+			fake.calls.push({ op: "start", params });
+			throw new Error("engine refused start after subscribe");
+		};
+
+		// When the engine rejects the start RPC.
+		await expect(backend.start(STREAM_CONFIG, RUN_OPTS)).rejects.toMatchObject({
+			failure: { phase: "start-rpc", class: "engine_internal" },
+		});
+		await backend.settle();
+
+		// Then rollback releases both acquired IPC resources.
+		expect(fake.calls.map((call) => call.op)).toContain("unsubscribe");
+		expect(fake.calls.map((call) => call.op)).toContain("close");
+		expect(backend.stop(() => {})).toBe(false);
+	});
+
 	test("a connect failure on start surfaces a notification and clears the session", async () => {
 		const { backend, bridgeH } = makeBackend({
 			connect: async () => {
-				throw new Error("cerastream control socket unreachable");
+				throw new CerastreamConnectionError(
+					"cerastream control socket unreachable",
+					undefined,
+					"refused",
+				);
 			},
 		});
 
-		await expect(backend.start(STREAM_CONFIG, RUN_OPTS)).rejects.toThrow(
-			"cerastream control socket unreachable",
-		);
+		await expect(backend.start(STREAM_CONFIG, RUN_OPTS)).rejects.toMatchObject({
+			failure: { phase: "connect", class: "engine_unavailable" },
+		});
 		await backend.settle();
 
 		expect(
@@ -622,6 +697,29 @@ describe("CerastreamBackend engine crash", () => {
 
 		const found = backend.stop(() => {});
 		expect(found).toBe(false);
+	});
+
+	test("combined binding errors classify transport as connect and handshake as hello", () => {
+		expect(
+			classifyConnectHandshakePhase(
+				new CerastreamConnectionError("refused", undefined, "refused"),
+			),
+		).toBe("connect");
+		expect(
+			classifyConnectHandshakePhase(
+				new CerastreamRpcError(
+					-32000,
+					"unsupported",
+					"cerastream.protocol.unsupported_version",
+					null,
+				),
+			),
+		).toBe("hello");
+		expect(
+			classifyConnectHandshakePhase(
+				new CerastreamTimeoutError("hello", 10_000),
+			),
+		).toBe("hello");
 	});
 });
 

--- a/apps/backend/src/tests/streaming-backend-contract.test.ts
+++ b/apps/backend/src/tests/streaming-backend-contract.test.ts
@@ -4,6 +4,7 @@ import type {
 	CaptureDevice,
 	CerastreamClient,
 	EventParams,
+	StartResult,
 } from "@ceralive/cerastream";
 import {
 	CerastreamConnectionError,
@@ -17,6 +18,11 @@ import {
 	cerastreamBackend,
 	classifyConnectHandshakePhase,
 } from "../modules/streaming/cerastream-backend.ts";
+import {
+	createLaunchTransaction,
+	type LaunchDeadlineTimers,
+} from "../modules/streaming/launch-transaction.ts";
+import { START_PHASE_DEADLINES_MS } from "../modules/streaming/start-lifecycle-timing.ts";
 import type {
 	StreamingBackend,
 	StreamRunOptions,
@@ -66,15 +72,25 @@ interface FakeClientHarness {
 	client: CerastreamClient;
 	calls: Array<{ op: string; params?: unknown }>;
 	readonly subscribed: Promise<void>;
+	readonly started: Promise<void>;
 	emit(event: EventParams): void;
 }
 
-function makeFakeClient(): FakeClientHarness {
+interface FakeClientOptions {
+	readonly startResult?: StartResult;
+	readonly subscribeGate?: Promise<void>;
+}
+
+function makeFakeClient(options: FakeClientOptions = {}): FakeClientHarness {
 	const calls: Array<{ op: string; params?: unknown }> = [];
 	let listener: ((event: EventParams) => void) | undefined;
 	let resolveSubscribed: (() => void) | undefined;
+	let resolveStarted: (() => void) | undefined;
 	const subscribed = new Promise<void>((resolve) => {
 		resolveSubscribed = resolve;
+	});
+	const started = new Promise<void>((resolve) => {
+		resolveStarted = resolve;
 	});
 	const client: CerastreamClient = {
 		hello: {
@@ -84,7 +100,8 @@ function makeFakeClient(): FakeClientHarness {
 		},
 		start: async (params) => {
 			calls.push({ op: "start", params });
-			return { session_id: "s1", state: "streaming" };
+			resolveStarted?.();
+			return options.startResult ?? { session_id: "s1", state: "streaming" };
 		},
 		stop: async (params) => {
 			calls.push({ op: "stop", params });
@@ -122,6 +139,9 @@ function makeFakeClient(): FakeClientHarness {
 			calls.push({ op: "subscribe-events", params });
 			listener = eventListener;
 			resolveSubscribed?.();
+			if (options.subscribeGate !== undefined) {
+				await options.subscribeGate;
+			}
 			return {
 				result: {
 					subscribed: [
@@ -170,8 +190,51 @@ function makeFakeClient(): FakeClientHarness {
 		client,
 		calls,
 		subscribed,
+		started,
 		emit: (event) => listener?.(event),
 	};
+}
+
+interface Deferred<Value> {
+	readonly promise: Promise<Value>;
+	readonly resolve: (value: Value) => void;
+}
+
+function deferred<Value>(): Deferred<Value> {
+	let resolvePromise: (value: Value) => void = () => undefined;
+	const promise = new Promise<Value>((resolve) => {
+		resolvePromise = resolve;
+	});
+	return { promise, resolve: resolvePromise };
+}
+
+function fakeDeadlineTimers(): {
+	readonly timers: LaunchDeadlineTimers;
+	readonly fire: () => void;
+	readonly delay: () => number | undefined;
+} {
+	let callback: (() => void) | undefined;
+	let delayMs: number | undefined;
+	return {
+		timers: {
+			schedule: (next, delay) => {
+				callback = next;
+				delayMs = delay;
+				return 1;
+			},
+			cancel: () => undefined,
+		},
+		fire: () => callback?.(),
+		delay: () => delayMs,
+	};
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+	for (let attempt = 0; attempt < 50; attempt += 1) {
+		if (predicate()) return;
+		await Bun.sleep(0);
+	}
+	expect(predicate()).toBe(true);
 }
 
 interface BridgeHarness {
@@ -214,11 +277,12 @@ function makeBackend(
 	opts: {
 		connect?: CerastreamBackendDeps["connect"];
 		config?: Partial<RuntimeConfig>;
+		fakeOptions?: FakeClientOptions;
 		scheduleTimeout?: CerastreamBackendDeps["scheduleTimeout"];
 		cancelTimeout?: CerastreamBackendDeps["cancelTimeout"];
 	} = {},
 ): BackendHarness {
-	const fake = makeFakeClient();
+	const fake = makeFakeClient(opts.fakeOptions);
 	const bridgeH = makeBridge();
 	const config: RuntimeConfig = { ...STREAM_CONFIG, ...opts.config };
 	let saves = 0;
@@ -365,6 +429,123 @@ describe("CerastreamBackend behavioural contract", () => {
 		expect(params.srt.streamid).toBe("stream-1");
 		expect(params.bitrate.max_bitrate).toBe(8000);
 		expect(params.pipeline).toBe("h264_hdmi_1080p");
+	});
+
+	test("a starting reply remains pending until an authoritative streaming status event", async () => {
+		const { backend, fake } = makeBackend({
+			fakeOptions: {
+				startResult: { session_id: "s-starting", state: "starting" },
+			},
+		});
+		const start = backend.start(STREAM_CONFIG, RUN_OPTS);
+		await fake.started;
+		let settled = false;
+		void start.then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			},
+		);
+		await Bun.sleep(0);
+
+		expect(settled).toBe(false);
+		fake.emit({ type: "status", seq: 1, state: "streaming", streaming: true });
+		await start;
+		expect(settled).toBe(true);
+	});
+
+	test("a starting reply without a streaming heartbeat times out in playing-wait and rolls back", async () => {
+		const clock = fakeDeadlineTimers();
+		const { backend, fake } = makeBackend({
+			fakeOptions: {
+				startResult: { session_id: "s-starting", state: "starting" },
+			},
+		});
+		const transaction = createLaunchTransaction("attempt-playing-timeout", {
+			timers: clock.timers,
+		});
+		const start = backend.start(STREAM_CONFIG, RUN_OPTS, transaction);
+		await fake.started;
+		await waitFor(
+			() => clock.delay() === START_PHASE_DEADLINES_MS["playing-wait"],
+		);
+		clock.fire();
+
+		await expect(start).rejects.toMatchObject({
+			failure: {
+				attemptId: "attempt-playing-timeout",
+				phase: "playing-wait",
+				class: "start_timeout",
+			},
+		});
+		expect(
+			fake.calls
+				.map((call) => call.op)
+				.filter((op) => ["stop", "unsubscribe", "close"].includes(op)),
+		).toEqual(["stop", "unsubscribe", "close"]);
+		expect(fake.calls.filter((call) => call.op === "close")).toHaveLength(1);
+		expect(fake.calls.filter((call) => call.op === "unsubscribe")).toHaveLength(
+			1,
+		);
+		expect(backend.stop(() => undefined)).toBe(false);
+	});
+
+	test("a client acquired after the connect deadline is immediately closed with no ownership residue", async () => {
+		const clock = fakeDeadlineTimers();
+		const lateClient = deferred<CerastreamClient>();
+		const harness = makeBackend({ connect: () => lateClient.promise });
+		const transaction = createLaunchTransaction("attempt-late-connect", {
+			timers: clock.timers,
+		});
+		const start = harness.backend.start(STREAM_CONFIG, RUN_OPTS, transaction);
+		await waitFor(() => clock.delay() === START_PHASE_DEADLINES_MS.connect);
+		clock.fire();
+		await expect(start).rejects.toMatchObject({
+			failure: { phase: "connect", class: "start_timeout" },
+		});
+
+		lateClient.resolve(harness.fake.client);
+		await waitFor(() => harness.fake.calls.some((call) => call.op === "close"));
+		expect(
+			harness.fake.calls.filter((call) => call.op === "close"),
+		).toHaveLength(1);
+		expect(
+			harness.fake.calls.some((call) => call.op === "subscribe-events"),
+		).toBe(false);
+		expect(harness.backend.stop(() => undefined)).toBe(false);
+	});
+
+	test("a subscription acquired after its deadline is immediately closed with no ownership residue", async () => {
+		const clock = fakeDeadlineTimers();
+		const subscribeGate = deferred<void>();
+		const harness = makeBackend({
+			fakeOptions: { subscribeGate: subscribeGate.promise },
+		});
+		const transaction = createLaunchTransaction("attempt-late-subscribe", {
+			timers: clock.timers,
+		});
+		const start = harness.backend.start(STREAM_CONFIG, RUN_OPTS, transaction);
+		await harness.fake.subscribed;
+		await waitFor(() => clock.delay() === START_PHASE_DEADLINES_MS.subscribe);
+		clock.fire();
+		await expect(start).rejects.toMatchObject({
+			failure: { phase: "subscribe", class: "start_timeout" },
+		});
+
+		subscribeGate.resolve(undefined);
+		await waitFor(() =>
+			harness.fake.calls.some((call) => call.op === "unsubscribe"),
+		);
+		expect(
+			harness.fake.calls.filter((call) => call.op === "close"),
+		).toHaveLength(1);
+		expect(
+			harness.fake.calls.filter((call) => call.op === "unsubscribe"),
+		).toHaveLength(1);
+		expect(harness.fake.calls.some((call) => call.op === "start")).toBe(false);
+		expect(harness.backend.stop(() => undefined)).toBe(false);
 	});
 
 	test("setBitrate persists and pushes the value over IPC while streaming", async () => {

--- a/docs/START-LIFECYCLE.md
+++ b/docs/START-LIFECYCLE.md
@@ -1,10 +1,9 @@
 # Start-Lifecycle Contract
 
-> **Status: DESIGN + SCHEMA ONLY** (device-quality-wave2 Todo 25).
-> This document and its two typed modules are the deliverable. Nothing here is
-> wired into a runtime path — the start/stop RPC handlers, the retry loop, the
-> suppression signals, and the frontend rendering are Todos 26-29. This contract
-> is the thing those todos build against.
+> **Status: RUNTIME THROUGH TRANSACTIONAL LAUNCH** (device-quality-wave2 Todos
+> 25-27). The typed contract, unified session orchestrator, cleanup transaction,
+> phase deadlines, and bounded stop result are wired. Retry/suppression and
+> frontend rendering remain Todos 28-29.
 
 The streaming **start** is a multi-phase pipeline that can fail at any of several
 sites, in several ways, with very different correct responses (retry vs. surface
@@ -134,19 +133,12 @@ require — each row is a site that was found and mapped.
 **Notes on sites the plan assumed but the codebase does NOT currently have as
 literal code:**
 
-- **PLAYING wait timeout (row 21).** There is **no dedicated 5s PLAYING wait** in
-  CeraUI's start path today. The `@ceralive/cerastream` client's `start` call
-  resolves only when the engine confirms PLAYING, bounded by the SAME 10s
-  `requestTimeoutMs` — surfacing as a `CerastreamTimeoutError`. The `playing-wait`
-  phase and its `start_timeout → not-retriable` mapping are therefore reserved
-  for Todo 27, which introduces an explicit awaited PLAYING wait with a per-phase
-  deadline. (`health.ts:39` `FRAMES_FRESHNESS_MS = 5000` is a frame-freshness
-  value for the health rollup, NOT a start-time wait — do not conflate them.)
-- **`spawn-sender` phase.** The `srtla_send` spawn (`start-stream.ts`) has no
-  typed failure today (Todo 27 adds the transactional rollback). The phase is
-  reserved so a spawn failure has a home when that wiring lands. It maps to
-  `start_invalid`/`engine_internal` via the generic `Error` fallback in the
-  interim.
+- **PLAYING confirmation (row 21).** CeraUI awaits the binding's `start` result,
+  then validates its streaming state inside the 5s `playing-wait` deadline.
+  `started` is impossible before both awaits finish. The second checkpoint
+  validates the response; it does not invent another engine operation.
+- **`spawn-sender` phase.** A local sender spawn/setup failure maps here. Any
+  later engine-phase failure unwinds the exact sender handle.
 - **`-32001` (not_streaming), `-32004` (bitrate), `-32005` (preview),
   `-32006` (audio device)** exist in the client's `RPC_ERROR_NUMERIC`
   (`errors.js:76-81`) but are not START-path outcomes (they belong to stop /
@@ -262,6 +254,34 @@ reconciling → idle          (engine was idle — adopt)
 | Todo | Uses from this contract |
 |------|-------------------------|
 | 26 (unified lock + boot reconciliation) | `busy`/`cancelled` results, `attemptId`, the state set + transitions, `reconciling` |
-| 27 (transactional launch + phase deadlines + honest stop) | per-phase `StartFailure`, `start_timeout`, `StopResult` |
+| 27 (implemented) | idempotent LIFO rollback, per-phase `start_timeout`, bounded `StopResult` |
 | 28 (bounded retry + suppression + truthful copy) | retry policy, retriability table, suppression predicate, `code`/`class` for copy |
 | 29 (frontend watchdog + generation identity + typed rendering) | `attemptId` fencing, `phase`+`class` → i18n rendering |
+
+---
+
+## Transactional runtime (Todo 27)
+
+Each acquired launch resource registers cleanup immediately. Failure unwinds in
+strict reverse order: engine stop, event subscription, control client, link
+telemetry, then the exact `srtla_send` process. Rollback is idempotent; one
+cleanup failure is logged and cannot prevent the remaining entries from running.
+
+The public binding's `connect()` combines the UDS connect and mandatory hello
+request, so CeraUI does not simulate a separate hello I/O operation.
+Machine-readable classification is:
+
+| Binding failure | Reported phase |
+|---|---|
+| `CerastreamConnectionError` (`absent`/`refused`/`unreachable`) | `connect` |
+| hello RPC error, hello-response Zod error, or hello request timeout | `hello` |
+| outer combined-operation deadline without a binding error | `connect` |
+
+Application-owned awaits stay separate and bounded: subscribe (10s), start RPC
+(10s), and PLAYING-result validation (5s). Stop is bounded at 12s and returns
+`stop_failed(reason: "stop_timeout")` when cleanup does not settle. Sender
+termination retains the existing 10s SIGTERM-to-SIGKILL policy.
+
+IP-list preparation completes before sender launch. Initial read/write or
+no-interface failures are launch-critical typed failures. Network-change refresh
+failures after launch are logged separately and cannot rewrite the start result.

--- a/docs/START-LIFECYCLE.md
+++ b/docs/START-LIFECYCLE.md
@@ -133,10 +133,12 @@ require — each row is a site that was found and mapped.
 **Notes on sites the plan assumed but the codebase does NOT currently have as
 literal code:**
 
-- **PLAYING confirmation (row 21).** CeraUI awaits the binding's `start` result,
-  then validates its streaming state inside the 5s `playing-wait` deadline.
-  `started` is impossible before both awaits finish. The second checkpoint
-  validates the response; it does not invent another engine operation.
+- **PLAYING confirmation (row 21).** CeraUI parses the binding's `start` result
+  inside the 5s `playing-wait` deadline. A direct `state: "streaming"` result
+  completes the phase. A valid transitional result such as `state: "starting"`
+  keeps the phase pending until the existing event subscription receives a
+  concordant runtime status (`state: "streaming"`, `streaming: true`). No polling
+  loop or second engine operation is introduced.
 - **`spawn-sender` phase.** A local sender spawn/setup failure maps here. Any
   later engine-phase failure unwinds the exact sender handle.
 - **`-32001` (not_streaming), `-32004` (bitrate), `-32005` (preview),
@@ -278,9 +280,20 @@ Machine-readable classification is:
 | outer combined-operation deadline without a binding error | `connect` |
 
 Application-owned awaits stay separate and bounded: subscribe (10s), start RPC
-(10s), and PLAYING-result validation (5s). Stop is bounded at 12s and returns
+(10s), and PLAYING confirmation (5s). The direct start reply is authoritative
+only when it reports `state: "streaming"`; any other valid state, including
+`state: "starting"`, waits for a subscribed status heartbeat whose state is
+`streaming` and whose `streaming` flag is true. Missing that confirmation returns
+typed `start_timeout` in `playing-wait`. Stop is bounded at 12s and returns
 `stop_failed(reason: "stop_timeout")` when cleanup does not settle. Sender
 termination retains the existing 10s SIGTERM-to-SIGKILL policy.
+
+Connect and subscription are acquisition phases: their cleanup is registered on
+the acquisition promise before it enters the deadline race. If either promise
+resolves after timeout and rollback, transaction registration observes the
+rolled-back state and closes the late resource immediately. The race retains a
+rejection observer as well, so a late failed acquisition cannot become an
+unhandled rejection.
 
 IP-list preparation completes before sender launch. Initial read/write or
 no-interface failures are launch-critical typed failures. Network-change refresh


### PR DESCRIPTION
## What

- Make stream launch an idempotent LIFO transaction covering the exact sender process, telemetry watcher, cerastream client, subscription, and accepted engine start.
- Await IP-list preparation and engine streaming confirmation before reporting `started`.
- Bound connect/handshake, subscribe, start RPC, playing validation, and stop; return typed `stop_failed` when stop cleanup times out.

## Why

A failure after acquiring only part of the media path could leave a sender, telemetry watcher, or IPC resource alive, while start could report success before all launch-critical work had settled. Stop also did not honestly report a cleanup hang.

## How to verify

- `bun test apps/backend/src/tests/launch-transaction.test.ts apps/backend/src/tests/srtla-ip-preparation.test.ts apps/backend/src/tests/stream-session-orchestrator.test.ts apps/backend/src/tests/streaming-backend-contract.test.ts`
- `bun run --filter @ceraui/rpc check`
- `bun run --filter backend check`
- `bun run check:tech-debt`
- `BUILD_ARCH=arm64 bun run build`
- `bunx playwright test ./tests/e2e/stream-start-failure.spec.ts --project=desktop --workers=1`

## Risks

The published cerastream binding combines socket connect and hello. Machine-readable binding failures are classified as `connect` or `hello`, but an outer combined-operation deadline is conservatively reported as `connect`; CeraUI does not simulate a second hello I/O operation. Sender shutdown retains the existing 10-second SIGTERM-to-SIGKILL policy inside the 12-second session stop bound.