### PR TITLE
fix(streaming): bounded start retry and truthful failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -931,6 +931,15 @@ bounds. Stop confirms engine/process cleanup or returns typed `stop_failed` afte
 12 seconds. Full contract and timeout values: `docs/START-LIFECYCLE.md`.
 
 Todo 28 adds a 5-attempt/60-second exponential retry bound around that transaction.
+Each individual launch is also capped at 10 seconds; expiry cancels that launch's
+generation, awaits bounded cleanup, and classifies the attempt as a retriable
+connect-phase `start_timeout` so a hung engine call cannot hold the lifecycle slot.
+The prior launch must settle after cleanup before backoff is armed; if it does not
+settle within the cleanup bound, `start_cleanup_timeout` is terminal and no later
+attempt is launched.
+Cerastream stop is the deliberate exception to the backend IPC queue: it is sent
+immediately through the active client so cleanup cannot wait behind the launch it
+must interrupt.
 Suppression reads only existing update, engine capability, and boot-uptime signals;
 suppressed attempts remain `starting` and emit no error toast. Structured retry and
 terminal records carry attempt id, phase, class, optional engine code, and retry

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -886,8 +886,9 @@ uses generation-scoped cancellation for stop-during-start, and reconciles the
 actual cerastream state at boot/reconnect. Timeout, failure, transitional, or
 contradictory engine status remains `reconciling` until the heal path retries;
 only concordant streaming/idle status is adopted. `status.stream_lifecycle` is additive;
-legacy `is_streaming` flips true only after engine confirmation. Todo 27, not this
-orchestrator, owns general engine-phase failure rollback.
+legacy `is_streaming` flips true only after engine confirmation. The bounded retry
+runner retries only connect-phase transient classes, after transactional rollback,
+and stop cancels a pending backoff without notification.
 
 `apps/backend/src/modules/streaming/streamloop.ts` is now a 5-line barrel re-exporting
 from `streamloop/index.ts`. The 10 public exports are unchanged — all caller import paths
@@ -928,6 +929,14 @@ classified by machine-readable error shape; CeraUI does not simulate a separate
 hello I/O wait. Subscribe, start-RPC, PLAYING validation, and stop have explicit
 bounds. Stop confirms engine/process cleanup or returns typed `stop_failed` after
 12 seconds. Full contract and timeout values: `docs/START-LIFECYCLE.md`.
+
+Todo 28 adds a 5-attempt/60-second exponential retry bound around that transaction.
+Suppression reads only existing update, engine capability, and boot-uptime signals;
+suppressed attempts remain `starting` and emit no error toast. Structured retry and
+terminal records carry attempt id, phase, class, optional engine code, and retry
+state. User copy is keyed across all 10 locales, and terminal copy points to the
+cerastream journal. Autostart's no-link loop is capped at five checks; permanent
+configuration/engine failures stop immediately with a visible reason.
 
 ### timing-constants.ts
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -883,9 +883,11 @@ Public stream start/stop admission now routes through
 `apps/backend/src/modules/streaming/stream-session-orchestrator.ts`. It owns the
 single lifecycle state machine for UI, autostart, remote control, and set-profile,
 uses generation-scoped cancellation for stop-during-start, and reconciles the
-actual cerastream state at boot/reconnect. Timeout, failure, transitional, or
-contradictory engine status remains `reconciling` until the heal path retries;
-only concordant streaming/idle status is adopted. `status.stream_lifecycle` is additive;
+actual cerastream state at boot/reconnect. Query/subscription failure or a
+transitional/contradictory status remains `reconciling` until the heal path retries.
+After a successful status subscription, a full 2.5-second window with no event is
+authoritative idle because active streams emit a 2-second heartbeat; late events
+from that closed probe are fenced. `status.stream_lifecycle` is additive;
 legacy `is_streaming` flips true only after engine confirmation. The bounded retry
 runner retries only connect-phase transient classes, after transactional rollback,
 and stop cancels a pending backoff without notification.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -939,7 +939,9 @@ settle within the cleanup bound, `start_cleanup_timeout` is terminal and no late
 attempt is launched.
 Cerastream stop is the deliberate exception to the backend IPC queue: it is sent
 immediately through the active client so cleanup cannot wait behind the launch it
-must interrupt.
+must interrupt. The client is then closed without waiting for a stop reply; this
+settles pending start/stop requests and releases the serialized queue even when a
+crashed engine can no longer answer.
 Suppression reads only existing update, engine capability, and boot-uptime signals;
 suppressed attempts remain `starting` and emit no error toast. Structured retry and
 terminal records carry attempt id, phase, class, optional engine code, and retry

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -511,9 +511,10 @@ start cancels that generation before a later launch can be admitted. The legacy
 `is_streaming` flag changes only after the awaited engine start confirms success.
 At boot and after an engine reconnect, `reconcileRuntimeState()` subscribes to the
 engine's actual status and adopts an engine-held session. Only concordant
-`streaming` or `idle` status is authoritative; timeout, query failure, transitional
-state, or contradictory fields leave the lifecycle `reconciling` until the reconnect
-heal path retries. The additive
+`streaming` or `idle` status is authoritative. A successful subscription that sees
+no event for 2.5 seconds resolves idle because an active stream emits status every
+2 seconds; query/subscription failure, transitional state, or contradictory fields
+remain `reconciling`, and late events from a completed probe are fenced. The additive
 `status.stream_lifecycle` field exposes `idle | starting | streaming | stopping |
 stop_failed | reconciling`; `is_streaming` remains backward compatible.
 

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -27,6 +27,7 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 | Stream lifecycle (spawn supervision, start/stop, autostart, exec paths) | `modules/streaming/streamloop/` (barrel: `modules/streaming/streamloop.ts`) |
 | Authoritative stream-session lifecycle (UI/autostart/remote arbitration, cancellation generations, boot adoption) | `modules/streaming/stream-session-orchestrator.ts` |
 | Transactional launch cleanup + phase/stop deadlines | `modules/streaming/launch-transaction.ts`, `start-lifecycle-timing.ts`, `streamloop/start-stream.ts`; contract in `../../docs/START-LIFECYCLE.md` |
+| Bounded start retry + suppression + diagnostics | `modules/streaming/stream-start-retry.ts`, `stream-start-retry-reporting.ts` |
 | WebSocket server wiring | `modules/ui/websocket-server.ts` + `rpc/server.ts` |
 | Auth token logic | `modules/ui/auth.ts` + `rpc/middleware/auth.middleware.ts` |
 | PASETO device-token verification (relay-config + device-control, ADR-0006) | `modules/pairing/device-token.ts` — `verifyDeviceControlToken`, `resolveControlChannelEndpoint` |
@@ -516,8 +517,11 @@ heal path retries. The additive
 `status.stream_lifecycle` field exposes `idle | starting | streaming | stopping |
 stop_failed | reconciling`; `is_streaming` remains backward compatible.
 
-Todo 26 owns arbitration, cancellation, and adoption. General transactional
-rollback of resources after an engine-phase start failure remains Todo 27.
+The launch transaction owns rollback and phase deadlines. The retry runner starts
+the next connect attempt only after rollback resolves, caps attempts and elapsed
+time, and exposes a cancellable timer to the same generation. Reporting suppresses
+transient toasts only during existing update/restart/boot windows; terminal
+failures are never suppressed and carry keyed 10-locale copy plus journal guidance.
 
 The `StreamingBackend` interface (`modules/streaming/streaming-backend.ts`) has
 **one** implementation behind the seam (the legacy ceracoder engine is fully

--- a/apps/backend/src/modules/streaming/audio.ts
+++ b/apps/backend/src/modules/streaming/audio.ts
@@ -90,7 +90,18 @@ export function resolveAudioMode(
 	if (asrc === NO_AUDIO_ID) return { mode: "none" };
 	if (asrc === DEFAULT_AUDIO_ID) return { mode: "default" };
 	if (embeddedAudioActive) return { mode: "default" };
-	return { mode: "device", device: getAudioSrcId(asrc) };
+	return { mode: "device", device: toAlsaCaptureDevice(getAudioSrcId(asrc)) };
+}
+
+// The engine passes `audio.device` straight to `alsasrc device=`, which needs a
+// real ALSA device string, not a bare card id: `alsasrc device="usbaudio"` never
+// opens and the engine rejects the start with `-32602 audio-device-unavailable`.
+// Wrap a bare card id as `hw:CARD=<id>` (the engine's own per-source default form);
+// a value that already carries an ALSA selector (`hw:0`, `hw:CARD=x`, `plughw:…`)
+// is passed through unchanged, so the transform is idempotent.
+function toAlsaCaptureDevice(cardId: string): string {
+	if (cardId.includes(":") || cardId.includes("=")) return cardId;
+	return `hw:CARD=${cardId}`;
 }
 const BASE_AUDIO_SRC_ALIASES: Readonly<Record<string, string>> = {
 	C4K: "Cam Link 4K",

--- a/apps/backend/src/modules/streaming/cerastream-backend.ts
+++ b/apps/backend/src/modules/streaming/cerastream-backend.ts
@@ -433,8 +433,9 @@ export class CerastreamBackend implements StreamingBackend {
 	private subscription: Subscription | undefined;
 	private active = false;
 	private telemetry: EngineTelemetry | null = null;
-	// Serializes async IPC ops so they never interleave; `settle()` awaits the tail.
+	// Serializes non-stop IPC ops; stop interrupts a pending start through its client.
 	private queue: Promise<void> = Promise.resolve();
+	private interrupt: Promise<void> = Promise.resolve();
 
 	constructor(deps: Partial<CerastreamBackendDeps> = {}) {
 		this.deps = { ...defaultCerastreamBackendDeps(), ...deps };
@@ -566,7 +567,7 @@ export class CerastreamBackend implements StreamingBackend {
 		this.active = false;
 		const client = this.client;
 		const subscription = this.subscription;
-		void this.enqueue(async () => {
+		const operation = (async () => {
 			subscription?.close();
 			try {
 				await client?.stop();
@@ -576,11 +577,14 @@ export class CerastreamBackend implements StreamingBackend {
 				} catch {
 					// already closing
 				}
-				this.client = undefined;
-				this.subscription = undefined;
+				if (this.client === client) this.client = undefined;
+				if (this.subscription === subscription) this.subscription = undefined;
 				onStopped();
 			}
-		}, "stop");
+		})();
+		this.interrupt = operation.catch((error) =>
+			this.handleOpFailure("stop", error),
+		);
 		return true;
 	}
 
@@ -783,8 +787,8 @@ export class CerastreamBackend implements StreamingBackend {
 	}
 
 	/** Test seam: resolve once every queued IPC op has settled. */
-	settle(): Promise<void> {
-		return this.queue;
+	async settle(): Promise<void> {
+		await Promise.all([this.queue, this.interrupt]);
 	}
 
 	/** Bridge one engine event onto notifications / telemetry / status. */

--- a/apps/backend/src/modules/streaming/cerastream-backend.ts
+++ b/apps/backend/src/modules/streaming/cerastream-backend.ts
@@ -879,14 +879,6 @@ export class CerastreamBackend implements StreamingBackend {
 			this.active = false;
 			this.client = undefined;
 			this.subscription = undefined;
-			this.deps.bridge.notify(
-				"cerastream",
-				"error",
-				"The streaming engine failed to start. Retrying...",
-				5,
-				true,
-				false,
-			);
 		}
 	}
 

--- a/apps/backend/src/modules/streaming/cerastream-backend.ts
+++ b/apps/backend/src/modules/streaming/cerastream-backend.ts
@@ -569,14 +569,16 @@ export class CerastreamBackend implements StreamingBackend {
 		const subscription = this.subscription;
 		const operation = (async () => {
 			subscription?.close();
+			void client?.stop().catch((error) => {
+				this.deps.logger.debug("cerastream: stop request interrupted", {
+					error,
+				});
+			});
 			try {
-				await client?.stop();
+				await client?.close();
+			} catch {
+				// already closing
 			} finally {
-				try {
-					await client?.close();
-				} catch {
-					// already closing
-				}
 				if (this.client === client) this.client = undefined;
 				if (this.subscription === subscription) this.subscription = undefined;
 				onStopped();

--- a/apps/backend/src/modules/streaming/cerastream-backend.ts
+++ b/apps/backend/src/modules/streaming/cerastream-backend.ts
@@ -644,6 +644,7 @@ export class CerastreamBackend implements StreamingBackend {
 		let client: CerastreamClient | undefined;
 		let subscription: Subscription | undefined;
 		let timer: ReturnType<typeof setTimeout> | undefined;
+		let acceptingEvents = true;
 		try {
 			client = await this.deps.connect({
 				...this.deps.connectOptions,
@@ -659,6 +660,7 @@ export class CerastreamBackend implements StreamingBackend {
 			subscription = await client.subscribeEvents(
 				{ topics: ["status"] },
 				(event) => {
+					if (!acceptingEvents) return;
 					this.handleEvent(event);
 					if (event.type === "status") {
 						resolveRuntimeState?.(
@@ -668,10 +670,11 @@ export class CerastreamBackend implements StreamingBackend {
 				},
 			);
 			timer = this.deps.scheduleTimeout(
-				() => resolveRuntimeState?.("unknown"),
+				() => resolveRuntimeState?.("idle"),
 				ENGINE_STATE_RECONCILE_TIMEOUT,
 			);
 			const runtimeState = await runtimeStateEvent;
+			acceptingEvents = false;
 			if (runtimeState === "streaming") {
 				this.client = client;
 				this.subscription = subscription;
@@ -682,6 +685,7 @@ export class CerastreamBackend implements StreamingBackend {
 			await client.close();
 			return runtimeState;
 		} catch (error) {
+			acceptingEvents = false;
 			subscription?.close();
 			await client?.close();
 			this.deps.logger.debug("cerastream: runtime-state query unresolved", {

--- a/apps/backend/src/modules/streaming/cerastream-error-mapping.ts
+++ b/apps/backend/src/modules/streaming/cerastream-error-mapping.ts
@@ -88,7 +88,7 @@ function messageFor(code: ProcessErrorCode, reason?: string): string {
 	// <reason>; the structured event carries it as a field instead of stderr text.
 	if (code === PROCESS_ERROR_CODES.SRT_CONNECT_FAILED) {
 		const detail = reason ? ` (${reason})` : "";
-		return `Failed to connect to the SRT server${detail}. Retrying...`;
+		return `Failed to connect to the SRT server${detail}. No automatic retry is scheduled.`;
 	}
 
 	return `Engine error: ${code}`;

--- a/apps/backend/src/modules/streaming/start-failure-taxonomy.ts
+++ b/apps/backend/src/modules/streaming/start-failure-taxonomy.ts
@@ -181,6 +181,8 @@ export interface RetryPolicy {
 	maxAttempts: number;
 	/** Total wall-clock budget across all attempts, in ms. */
 	totalBudgetMs: number;
+	/** Deadline for one in-flight launch before its generation is cancelled. */
+	attemptTimeoutMs?: number;
 	/** First backoff delay, in ms. */
 	baseDelayMs: number;
 	/** Backoff ceiling, in ms. */
@@ -193,6 +195,7 @@ export interface RetryPolicy {
 export const DEFAULT_START_RETRY_POLICY: RetryPolicy = {
 	maxAttempts: 5,
 	totalBudgetMs: 60_000,
+	attemptTimeoutMs: 10_000,
 	baseDelayMs: 2_000,
 	maxDelayMs: 16_000,
 };

--- a/apps/backend/src/modules/streaming/start-failure-taxonomy.ts
+++ b/apps/backend/src/modules/streaming/start-failure-taxonomy.ts
@@ -11,10 +11,10 @@
  * the JSON-RPC codes) — so those live behind the client, and CeraUI classifies
  * their surfaced shapes here.
  *
- * Todo 26 wires this taxonomy into the public start boundary and carries one
- * attempt id through the orchestrator. Retry/suppression and rollback policy
- * remain Todos 27-29. This module is pure + fully unit-tested against fabricated
- * error shapes.
+ * Todo 26 wired this taxonomy into the public start boundary and carries one
+ * attempt id through the orchestrator. Todo 28 consumes the policy below for
+ * bounded retries and suppression. This module stays pure and fully unit-tested
+ * against fabricated error shapes.
  *
  * ── Failure-site cross-check (every site found in the codebase, mapped) ──
  *   params        zod (oRPC input / validateConfig safeParse / startParams.parse)
@@ -189,7 +189,7 @@ export interface RetryPolicy {
 
 // Defaults chosen against the supervision windows (systemd RestartSec=5,
 // crash-loop 5/60s): a few short retries that comfortably span one restart
-// window, then escalate. Not yet consumed by any runtime loop (Todo 28 wires it).
+// window, then escalate.
 export const DEFAULT_START_RETRY_POLICY: RetryPolicy = {
 	maxAttempts: 5,
 	totalBudgetMs: 60_000,

--- a/apps/backend/src/modules/streaming/stream-session-orchestrator.ts
+++ b/apps/backend/src/modules/streaming/stream-session-orchestrator.ts
@@ -11,10 +11,20 @@ import { queryEngineRuntimeStreaming } from "./engine-runtime-state.ts";
 import {
 	classifyStartFailure,
 	newAttemptId,
-	StreamStartFailure,
+	type RetryPolicy,
+	type SuppressionContext,
 } from "./start-failure-taxonomy.ts";
 import { STOP_DEADLINE_MS } from "./start-lifecycle-timing.ts";
 import { updateStreamLifecycleState } from "./stream-lifecycle-status.ts";
+import {
+	runStartWithRetry,
+	type StartRetryDiagnostic,
+} from "./stream-start-retry.ts";
+import {
+	getStartSuppressionContext,
+	reportStartRetry,
+	reportStartTerminalFailure,
+} from "./stream-start-retry-reporting.ts";
 import { getIsStreaming, updateStatus } from "./streaming.ts";
 import type { EngineRuntimeState } from "./streaming-backend.ts";
 import { stopGeneration } from "./streamloop/session.ts";
@@ -44,6 +54,8 @@ export type StreamSessionSnapshot = {
 	readonly generation: number;
 };
 
+export type { StartRetryDiagnostic } from "./stream-start-retry.ts";
+
 export type StreamSessionOrchestratorDeps = {
 	readonly createAttemptId: () => string;
 	readonly setStreamingStatus: (streaming: boolean) => void;
@@ -63,12 +75,18 @@ export type StreamSessionOrchestratorDeps = {
 	readonly cancelTimeout?: (
 		timer: ReturnType<typeof globalThis.setTimeout> | number,
 	) => void;
+	readonly retryPolicy?: RetryPolicy;
+	readonly now?: () => number;
+	readonly suppressionContext?: () => SuppressionContext;
+	readonly reportRetry?: (diagnostic: StartRetryDiagnostic) => void;
+	readonly reportTerminalFailure?: (diagnostic: StartRetryDiagnostic) => void;
 };
 
 type ActiveAttempt = {
 	readonly attemptId: string;
 	readonly generation: number;
 	cancelled: boolean;
+	cancelRetryWait?: () => void;
 };
 
 export type StreamSessionOrchestrator = {
@@ -160,32 +178,50 @@ export function createStreamSessionOrchestrator(
 			cancelled: () => attempt.cancelled,
 		};
 
-		try {
-			await request.launch(context);
-			if (attempt.cancelled || active !== attempt) {
-				return await finishCancelled(attempt);
-			}
-			transition("streaming");
-			deps.setStreamingStatus(true);
-			return { result: "started", attemptId };
-		} catch (error) {
-			if (attempt.cancelled || active !== attempt) {
-				return await finishCancelled(attempt);
-			}
+		const launchResult = await runStartWithRetry({
+			attemptId,
+			launch: () => request.launch(context),
+			classifyUnknown: (error) =>
+				classifyStartFailure("start-rpc", error, attemptId, {
+					warn: (message, meta) => logger.warn(message, meta),
+				}),
+			cancelled: () => attempt.cancelled || active !== attempt,
+			setCancelWait: (cancel) => {
+				if (cancel === undefined) delete attempt.cancelRetryWait;
+				else attempt.cancelRetryWait = cancel;
+			},
+			schedule: scheduleTimeout,
+			cancelTimer: cancelTimeout,
+			...(deps.retryPolicy !== undefined
+				? { retryPolicy: deps.retryPolicy }
+				: {}),
+			...(deps.now !== undefined ? { now: deps.now } : {}),
+			...(deps.suppressionContext !== undefined
+				? { suppressionContext: deps.suppressionContext }
+				: {}),
+			...(deps.reportRetry !== undefined
+				? { reportRetry: deps.reportRetry }
+				: {}),
+			...(deps.reportTerminalFailure !== undefined
+				? { reportTerminalFailure: deps.reportTerminalFailure }
+				: {}),
+		});
+		if (launchResult.result === "cancelled") {
+			return await finishCancelled(attempt);
+		}
+		if (launchResult.result === "failed") {
 			transition("idle");
 			active = undefined;
 			deps.setStreamingStatus(false);
 			return {
 				result: "failed",
 				attemptId,
-				failure:
-					error instanceof StreamStartFailure
-						? error.failure
-						: classifyStartFailure("start-rpc", error, attemptId, {
-								warn: (message, meta) => logger.warn(message, meta),
-							}),
+				failure: launchResult.failure,
 			};
 		}
+		transition("streaming");
+		deps.setStreamingStatus(true);
+		return { result: "started", attemptId };
 	};
 
 	const stop = async (): Promise<StopResult> => {
@@ -199,7 +235,10 @@ export function createStreamSessionOrchestrator(
 
 		const stoppedGeneration = active?.generation ?? generation;
 		const cancellingStart = state === "starting";
-		if (cancellingStart && active !== undefined) active.cancelled = true;
+		if (cancellingStart && active !== undefined) {
+			active.cancelled = true;
+			active.cancelRetryWait?.();
+		}
 		if (!transition("stopping")) {
 			return {
 				result: "stop_failed",
@@ -263,6 +302,9 @@ const productionOrchestrator = createStreamSessionOrchestrator({
 			true,
 		);
 	},
+	suppressionContext: getStartSuppressionContext,
+	reportRetry: reportStartRetry,
+	reportTerminalFailure: reportStartTerminalFailure,
 });
 
 export function startStreamSession(

--- a/apps/backend/src/modules/streaming/stream-session-orchestrator.ts
+++ b/apps/backend/src/modules/streaming/stream-session-orchestrator.ts
@@ -75,6 +75,13 @@ export type StreamSessionOrchestratorDeps = {
 	readonly cancelTimeout?: (
 		timer: ReturnType<typeof globalThis.setTimeout> | number,
 	) => void;
+	readonly scheduleLaunchDeadline?: (
+		callback: () => void,
+		delayMs: number,
+	) => ReturnType<typeof globalThis.setTimeout> | number;
+	readonly cancelLaunchDeadline?: (
+		timer: ReturnType<typeof globalThis.setTimeout> | number,
+	) => void;
 	readonly retryPolicy?: RetryPolicy;
 	readonly now?: () => number;
 	readonly suppressionContext?: () => SuppressionContext;
@@ -110,6 +117,14 @@ export function createStreamSessionOrchestrator(
 			globalThis.setTimeout(callback, delayMs));
 	const cancelTimeout =
 		deps.cancelTimeout ??
+		((timer: ReturnType<typeof globalThis.setTimeout> | number) =>
+			globalThis.clearTimeout(timer));
+	const scheduleLaunchDeadline =
+		deps.scheduleLaunchDeadline ??
+		((callback: () => void, delayMs: number) =>
+			globalThis.setTimeout(callback, delayMs));
+	const cancelLaunchDeadline =
+		deps.cancelLaunchDeadline ??
 		((timer: ReturnType<typeof globalThis.setTimeout> | number) =>
 			globalThis.clearTimeout(timer));
 
@@ -171,27 +186,46 @@ export function createStreamSessionOrchestrator(
 		};
 		active = attempt;
 		transition("starting");
-		const context: StreamLaunchContext = {
-			attemptId,
-			generation: attempt.generation,
-			origin: request.origin,
-			cancelled: () => attempt.cancelled,
-		};
+		const deadlineCancelledLaunches = new Set<number>();
 
 		const launchResult = await runStartWithRetry({
 			attemptId,
-			launch: () => request.launch(context),
+			launch: (launchNumber) =>
+				request.launch({
+					attemptId,
+					generation: attempt.generation,
+					origin: request.origin,
+					cancelled: () =>
+						attempt.cancelled || deadlineCancelledLaunches.has(launchNumber),
+				}),
 			classifyUnknown: (error) =>
 				classifyStartFailure("start-rpc", error, attemptId, {
 					warn: (message, meta) => logger.warn(message, meta),
 				}),
 			cancelled: () => attempt.cancelled || active !== attempt,
+			onLaunchTimeout: async (launchNumber) => {
+				deadlineCancelledLaunches.add(launchNumber);
+				try {
+					await stopWithinDeadline(attempt.generation);
+				} catch (error) {
+					logger.error("Timed-out stream launch cleanup failed", {
+						attemptId,
+						generation: attempt.generation,
+						launchNumber,
+						error,
+					});
+					throw error;
+				}
+			},
 			setCancelWait: (cancel) => {
 				if (cancel === undefined) delete attempt.cancelRetryWait;
 				else attempt.cancelRetryWait = cancel;
 			},
 			schedule: scheduleTimeout,
 			cancelTimer: cancelTimeout,
+			scheduleDeadline: scheduleLaunchDeadline,
+			cancelDeadline: cancelLaunchDeadline,
+			cleanupDeadlineMs: stopDeadlineMs,
 			...(deps.retryPolicy !== undefined
 				? { retryPolicy: deps.retryPolicy }
 				: {}),

--- a/apps/backend/src/modules/streaming/stream-start-retry-reporting.ts
+++ b/apps/backend/src/modules/streaming/stream-start-retry-reporting.ts
@@ -1,0 +1,139 @@
+import type { StartFailureClass } from "@ceraui/rpc/schemas";
+
+import { logger } from "../../helpers/logger.ts";
+import { isUpdating } from "../system/software-updates.ts";
+import {
+	notificationBroadcast,
+	notificationRemove,
+} from "../ui/notifications.ts";
+import {
+	type CapabilitiesResult,
+	getLastCapabilities,
+} from "./capabilities.ts";
+import {
+	DEFAULT_START_RETRY_POLICY,
+	type SuppressionContext,
+} from "./start-failure-taxonomy.ts";
+import type { StartRetryDiagnostic } from "./stream-start-retry.ts";
+
+const RETRY_NOTIFICATION_KEYS = {
+	engine_unavailable: "notifications.streamStartEngineUnavailableRetrying",
+	engine_restarting: "notifications.streamStartEngineRestartingRetrying",
+	start_timeout: "notifications.streamStartTimeoutRetrying",
+} as const;
+
+const RETRY_FALLBACK_MESSAGES = {
+	engine_unavailable: "Streaming engine unavailable",
+	engine_restarting: "Streaming engine is restarting",
+	start_timeout: "Streaming engine did not answer in time",
+} as const;
+
+type RetryableStartClass = keyof typeof RETRY_NOTIFICATION_KEYS;
+
+function isRetryableStartClass(
+	failureClass: StartFailureClass,
+): failureClass is RetryableStartClass {
+	return failureClass in RETRY_NOTIFICATION_KEYS;
+}
+
+const TERMINAL_NOTIFICATION_KEYS: Readonly<Record<StartFailureClass, string>> =
+	{
+		engine_unavailable: "notifications.streamStartEngineUnavailableFailed",
+		engine_restarting: "notifications.streamStartEngineRestartingFailed",
+		start_timeout: "notifications.streamStartTimeoutFailed",
+		start_invalid: "notifications.streamStartInvalidFailed",
+		protocol_incompatible: "notifications.streamStartProtocolFailed",
+		engine_internal: "notifications.streamStartInternalFailed",
+	};
+
+function notificationParams(
+	diagnostic: StartRetryDiagnostic,
+): Record<string, unknown> {
+	return {
+		attemptId: diagnostic.attemptId,
+		phase: diagnostic.phase,
+		class: diagnostic.class,
+		...(diagnostic.code !== undefined ? { code: diagnostic.code } : {}),
+		retryState: diagnostic.retry.state,
+		attempt: diagnostic.retry.attempt,
+		maxAttempts: diagnostic.retry.maxAttempts,
+		...(diagnostic.retry.state === "scheduled"
+			? {
+					nextAttempt: diagnostic.retry.nextAttempt,
+					delayMs: diagnostic.retry.delayMs,
+					suppressed: diagnostic.retry.suppressed,
+				}
+			: { suppressed: false }),
+	};
+}
+
+export function reportStartRetry(diagnostic: StartRetryDiagnostic): void {
+	logger.warn("stream start retry scheduled", diagnostic);
+	if (diagnostic.retry.state !== "scheduled" || diagnostic.retry.suppressed)
+		return;
+	if (!isRetryableStartClass(diagnostic.class)) {
+		logger.error("stream start retry invariant violated", diagnostic);
+		return;
+	}
+	const key = RETRY_NOTIFICATION_KEYS[diagnostic.class];
+	notificationBroadcast(
+		"stream_start_retry",
+		"warning",
+		`${RETRY_FALLBACK_MESSAGES[diagnostic.class]}; retrying (${diagnostic.retry.nextAttempt}/${diagnostic.retry.maxAttempts}).`,
+		5,
+		false,
+		true,
+		true,
+		key,
+		notificationParams(diagnostic),
+	);
+}
+
+export function reportStartTerminalFailure(
+	diagnostic: StartRetryDiagnostic,
+): void {
+	logger.error("stream start failed", diagnostic);
+	notificationRemove("stream_start_retry");
+	notificationBroadcast(
+		"stream_start_failed",
+		"error",
+		`Stream failed to start (${diagnostic.class}) after ${diagnostic.retry.attempt}/${diagnostic.retry.maxAttempts} attempts. Check journalctl -u cerastream.service.`,
+		0,
+		false,
+		true,
+		true,
+		TERMINAL_NOTIFICATION_KEYS[diagnostic.class],
+		notificationParams(diagnostic),
+	);
+}
+
+type StartSuppressionSignals = {
+	readonly softwareUpdateActive: boolean;
+	readonly capabilities:
+		| Pick<CapabilitiesResult, "engineUnavailable" | "engineStarting">
+		| undefined;
+	readonly uptimeMs: number;
+};
+
+export function deriveStartSuppressionContext(
+	signals: StartSuppressionSignals,
+): SuppressionContext {
+	return {
+		softwareUpdateActive: signals.softwareUpdateActive,
+		engineRestartWindow:
+			signals.capabilities?.engineUnavailable === true &&
+			signals.capabilities.engineStarting !== true,
+		bootWindow:
+			signals.capabilities?.engineStarting === true ||
+			signals.uptimeMs < DEFAULT_START_RETRY_POLICY.totalBudgetMs,
+		cancelledByStop: false,
+	};
+}
+
+export function getStartSuppressionContext(): SuppressionContext {
+	return deriveStartSuppressionContext({
+		softwareUpdateActive: isUpdating(),
+		capabilities: getLastCapabilities(),
+		uptimeMs: process.uptime() * 1_000,
+	});
+}

--- a/apps/backend/src/modules/streaming/stream-start-retry.ts
+++ b/apps/backend/src/modules/streaming/stream-start-retry.ts
@@ -45,12 +45,19 @@ export type StartRetryRunResult =
 
 export type StartRetryRunDeps = {
 	readonly attemptId: string;
-	readonly launch: () => Promise<void>;
+	readonly launch: (attempt: number) => Promise<void>;
 	readonly classifyUnknown: (error: unknown) => StartFailure;
 	readonly cancelled: () => boolean;
+	readonly onLaunchTimeout: (attempt: number) => Promise<void>;
 	readonly setCancelWait: (cancel: (() => void) | undefined) => void;
 	readonly schedule: (callback: () => void, delayMs: number) => RetryTimer;
 	readonly cancelTimer: (timer: RetryTimer) => void;
+	readonly scheduleDeadline: (
+		callback: () => void,
+		delayMs: number,
+	) => RetryTimer;
+	readonly cancelDeadline: (timer: RetryTimer) => void;
+	readonly cleanupDeadlineMs: number;
 	readonly retryPolicy?: RetryPolicy;
 	readonly now?: () => number;
 	readonly suppressionContext?: () => SuppressionContext;
@@ -64,6 +71,71 @@ const NO_SUPPRESSION: SuppressionContext = {
 	bootWindow: false,
 	cancelledByStop: false,
 };
+
+type LaunchOutcome =
+	| { readonly result: "started" }
+	| { readonly result: "failed"; readonly error: unknown }
+	| { readonly result: "timed_out" }
+	| { readonly result: "cleanup_failed" }
+	| { readonly result: "cancelled" };
+
+function runLaunchWithinDeadline(
+	deps: StartRetryRunDeps,
+	attempt: number,
+	deadlineMs: number,
+): Promise<LaunchOutcome> {
+	return new Promise((resolve) => {
+		let settled = false;
+		let deadlineExpired = false;
+		let timer: RetryTimer | undefined;
+		let cleanupTimer: RetryTimer | undefined;
+		const finish = (outcome: LaunchOutcome): void => {
+			if (settled) return;
+			settled = true;
+			if (timer !== undefined) deps.cancelDeadline(timer);
+			if (cleanupTimer !== undefined) deps.cancelDeadline(cleanupTimer);
+			deps.setCancelWait(undefined);
+			resolve(outcome);
+		};
+		const launch = deps.launch(attempt).then<LaunchOutcome, LaunchOutcome>(
+			() => ({ result: "started" }),
+			(error: unknown) => ({ result: "failed", error }),
+		);
+		void launch.then((outcome) => {
+			if (!deadlineExpired) finish(outcome);
+		});
+		timer = deps.scheduleDeadline(() => {
+			if (settled) return;
+			deadlineExpired = true;
+			deps.setCancelWait(undefined);
+			const cleanup = deps.onLaunchTimeout(attempt).then(
+				async () => {
+					await launch;
+					return true;
+				},
+				() => false,
+			);
+			const cleanupDeadline = new Promise<false>((resolveDeadline) => {
+				cleanupTimer = deps.scheduleDeadline(
+					() => resolveDeadline(false),
+					deps.cleanupDeadlineMs,
+				);
+			});
+			void Promise.race([cleanup, cleanupDeadline]).then(
+				(cleaned) =>
+					finish({
+						result: cleaned ? "timed_out" : "cleanup_failed",
+					}),
+				() => finish({ result: "cleanup_failed" }),
+			);
+		}, deadlineMs);
+		deps.setCancelWait(() => {
+			if (settled) return;
+			if (timer !== undefined) deps.cancelDeadline(timer);
+			deps.setCancelWait(undefined);
+		});
+	});
+}
 
 function waitForRetry(
 	deps: StartRetryRunDeps,
@@ -108,10 +180,38 @@ export async function runStartWithRetry(
 
 	while (true) {
 		attempts += 1;
-		try {
-			await deps.launch();
-			return deps.cancelled() ? { result: "cancelled" } : { result: "started" };
-		} catch (error) {
+		const remainingBeforeLaunch = Math.max(
+			0,
+			policy.totalBudgetMs - Math.max(0, now() - startedAt),
+		);
+		const launch = await runLaunchWithinDeadline(
+			deps,
+			attempts,
+			Math.min(
+				policy.attemptTimeoutMs ??
+					DEFAULT_START_RETRY_POLICY.attemptTimeoutMs ??
+					policy.totalBudgetMs,
+				remainingBeforeLaunch,
+			),
+		);
+		if (launch.result === "cancelled" || deps.cancelled()) {
+			return { result: "cancelled" };
+		}
+		if (launch.result === "started") return { result: "started" };
+		{
+			const error =
+				launch.result === "timed_out" || launch.result === "cleanup_failed"
+					? new StreamStartFailure({
+							attemptId: deps.attemptId,
+							phase: "connect",
+							class: "start_timeout",
+							code:
+								launch.result === "timed_out"
+									? "start_attempt_deadline"
+									: "start_cleanup_timeout",
+							retriable: launch.result === "timed_out",
+						})
+					: launch.error;
 			if (deps.cancelled()) return { result: "cancelled" };
 			const classified =
 				error instanceof StreamStartFailure

--- a/apps/backend/src/modules/streaming/stream-start-retry.ts
+++ b/apps/backend/src/modules/streaming/stream-start-retry.ts
@@ -1,0 +1,161 @@
+import type {
+	StartFailure,
+	StartFailureClass,
+	StartFailurePhase,
+} from "@ceraui/rpc/schemas";
+
+import {
+	DEFAULT_START_RETRY_POLICY,
+	nextBackoffDelayMs,
+	type RetryPolicy,
+	StreamStartFailure,
+	type SuppressionContext,
+	shouldRetryStart,
+	shouldSuppressTransientFailure,
+} from "./start-failure-taxonomy.ts";
+
+type RetryTimer = ReturnType<typeof globalThis.setTimeout> | number;
+
+export type StartRetryDiagnostic = {
+	readonly attemptId: string;
+	readonly phase: StartFailurePhase;
+	readonly class: StartFailureClass;
+	readonly code?: number | string;
+	readonly retry:
+		| {
+				readonly state: "scheduled";
+				readonly attempt: number;
+				readonly nextAttempt: number;
+				readonly maxAttempts: number;
+				readonly delayMs: number;
+				readonly suppressed: boolean;
+		  }
+		| {
+				readonly state: "exhausted" | "not_retriable";
+				readonly attempt: number;
+				readonly maxAttempts: number;
+				readonly suppressed: false;
+		  };
+};
+
+export type StartRetryRunResult =
+	| { readonly result: "started" }
+	| { readonly result: "cancelled" }
+	| { readonly result: "failed"; readonly failure: StartFailure };
+
+export type StartRetryRunDeps = {
+	readonly attemptId: string;
+	readonly launch: () => Promise<void>;
+	readonly classifyUnknown: (error: unknown) => StartFailure;
+	readonly cancelled: () => boolean;
+	readonly setCancelWait: (cancel: (() => void) | undefined) => void;
+	readonly schedule: (callback: () => void, delayMs: number) => RetryTimer;
+	readonly cancelTimer: (timer: RetryTimer) => void;
+	readonly retryPolicy?: RetryPolicy;
+	readonly now?: () => number;
+	readonly suppressionContext?: () => SuppressionContext;
+	readonly reportRetry?: (diagnostic: StartRetryDiagnostic) => void;
+	readonly reportTerminalFailure?: (diagnostic: StartRetryDiagnostic) => void;
+};
+
+const NO_SUPPRESSION: SuppressionContext = {
+	softwareUpdateActive: false,
+	engineRestartWindow: false,
+	bootWindow: false,
+	cancelledByStop: false,
+};
+
+function waitForRetry(
+	deps: StartRetryRunDeps,
+	delayMs: number,
+): Promise<boolean> {
+	return new Promise((resolve) => {
+		let settled = false;
+		const finish = (elapsed: boolean): void => {
+			if (settled) return;
+			settled = true;
+			deps.setCancelWait(undefined);
+			resolve(elapsed);
+		};
+		const timer = deps.schedule(() => finish(true), delayMs);
+		deps.setCancelWait(() => {
+			deps.cancelTimer(timer);
+			finish(false);
+		});
+	});
+}
+
+function diagnostic(
+	failure: StartFailure,
+	retry: StartRetryDiagnostic["retry"],
+): StartRetryDiagnostic {
+	return {
+		attemptId: failure.attemptId,
+		phase: failure.phase,
+		class: failure.class,
+		...(failure.code !== undefined ? { code: failure.code } : {}),
+		retry,
+	};
+}
+
+export async function runStartWithRetry(
+	deps: StartRetryRunDeps,
+): Promise<StartRetryRunResult> {
+	const policy = deps.retryPolicy ?? DEFAULT_START_RETRY_POLICY;
+	const now = deps.now ?? Date.now;
+	const startedAt = now();
+	let attempts = 0;
+
+	while (true) {
+		attempts += 1;
+		try {
+			await deps.launch();
+			return deps.cancelled() ? { result: "cancelled" } : { result: "started" };
+		} catch (error) {
+			if (deps.cancelled()) return { result: "cancelled" };
+			const classified =
+				error instanceof StreamStartFailure
+					? error.failure
+					: deps.classifyUnknown(error);
+			const suppression = deps.suppressionContext?.() ?? NO_SUPPRESSION;
+			const failure: StartFailure =
+				suppression.engineRestartWindow &&
+				classified.class === "engine_unavailable"
+					? { ...classified, class: "engine_restarting" }
+					: classified;
+			const elapsedMs = Math.max(0, now() - startedAt);
+			const delayMs = nextBackoffDelayMs(attempts - 1, policy);
+			const remainingMs = policy.totalBudgetMs - elapsedMs;
+
+			if (
+				shouldRetryStart(failure, { attempts, elapsedMs }, policy) &&
+				delayMs < remainingMs
+			) {
+				deps.reportRetry?.(
+					diagnostic(failure, {
+						state: "scheduled",
+						attempt: attempts,
+						nextAttempt: attempts + 1,
+						maxAttempts: policy.maxAttempts,
+						delayMs,
+						suppressed: shouldSuppressTransientFailure(suppression),
+					}),
+				);
+				if (!(await waitForRetry(deps, delayMs))) {
+					return { result: "cancelled" };
+				}
+				continue;
+			}
+
+			deps.reportTerminalFailure?.(
+				diagnostic(failure, {
+					state: failure.retriable ? "exhausted" : "not_retriable",
+					attempt: attempts,
+					maxAttempts: policy.maxAttempts,
+					suppressed: false,
+				}),
+			);
+			return { result: "failed", failure };
+		}
+	}
+}

--- a/apps/backend/src/modules/streaming/streamloop/autostart.ts
+++ b/apps/backend/src/modules/streaming/streamloop/autostart.ts
@@ -25,6 +25,7 @@ import { logger } from "../../../helpers/logger.ts";
 import { AUTOSTART_RETRY_DELAY } from "../../../helpers/timing-constants.ts";
 import { getConfig, saveConfig } from "../../config.ts";
 import { isUpdating } from "../../system/software-updates.ts";
+import { notificationBroadcast } from "../../ui/notifications.ts";
 import { broadcastMsg } from "../../ui/websocket-server.ts";
 import type { Pipeline } from "../pipelines.ts";
 import { genSrtlaIpList, resolveSrtla } from "../srtla.ts";
@@ -37,6 +38,7 @@ import { getIsStreaming, validateConfig } from "../streaming.ts";
 import { startStream } from "./start-stream.ts";
 
 export const AUTOSTART_CHECK_FILE = "/tmp/ceralive_restarted";
+export const AUTOSTART_MAX_LINK_ATTEMPTS = 5;
 
 export function setAutostart(value: boolean): boolean {
 	const config = getConfig();
@@ -55,7 +57,7 @@ export async function checkAutoStartStream() {
 	fs.writeFileSync(AUTOSTART_CHECK_FILE, "");
 }
 
-export async function autoStartStream(): Promise<void> {
+export async function autoStartStream(linkAttempt = 1): Promise<void> {
 	if (getIsStreaming() || isUpdating()) {
 		logger.info("autostart aborted");
 		return;
@@ -64,7 +66,35 @@ export async function autoStartStream(): Promise<void> {
 	/* Populate the connections list file for srtla_send
        If no interfaces are available, retry later as we won't be able to stream yet */
 	if (genSrtlaIpList().length < 1) {
-		setTimeout(autoStartStream, AUTOSTART_RETRY_DELAY);
+		if (linkAttempt < AUTOSTART_MAX_LINK_ATTEMPTS) {
+			setTimeout(
+				() => void autoStartStream(linkAttempt + 1),
+				AUTOSTART_RETRY_DELAY,
+			);
+			return;
+		}
+		logger.error("autostart failed", {
+			class: "network_links_unavailable",
+			attempt: linkAttempt,
+			maxAttempts: AUTOSTART_MAX_LINK_ATTEMPTS,
+			retryState: "exhausted",
+		});
+		notificationBroadcast(
+			"stream_autostart_failed",
+			"error",
+			`Automatic stream start failed: no network links became available after ${linkAttempt}/${AUTOSTART_MAX_LINK_ATTEMPTS} checks. Check journalctl -u ceralive.service.`,
+			0,
+			false,
+			true,
+			true,
+			"notifications.streamAutostartNoLinksFailed",
+			{
+				attempt: linkAttempt,
+				maxAttempts: AUTOSTART_MAX_LINK_ATTEMPTS,
+				class: "network_links_unavailable",
+				retryState: "exhausted",
+			},
+		);
 		return;
 	}
 
@@ -80,6 +110,21 @@ export async function autoStartStream(): Promise<void> {
 		c = await validateConfig(config);
 	} catch (err) {
 		logger.error("autostart failed", { err });
+		notificationBroadcast(
+			"stream_autostart_failed",
+			"error",
+			"Automatic stream start failed: configuration or device is invalid. Check journalctl -u ceralive.service.",
+			0,
+			false,
+			true,
+			true,
+			"notifications.streamStartInvalidFailed",
+			{
+				phase: "params",
+				class: "start_invalid",
+				retryState: "not_retriable",
+			},
+		);
 		return;
 	}
 
@@ -103,8 +148,15 @@ export async function autoStartStream(): Promise<void> {
 		},
 	});
 	if (result.result === "failed") {
-		logger.warn("autostart failed, but will retry", { result });
-		setTimeout(autoStartStream, AUTOSTART_RETRY_DELAY);
+		logger.error("autostart failed", {
+			attemptId: result.attemptId,
+			phase: result.failure.phase,
+			class: result.failure.class,
+			...(result.failure.code !== undefined
+				? { code: result.failure.code }
+				: {}),
+			retryState: result.failure.retriable ? "exhausted" : "not_retriable",
+		});
 		return;
 	}
 	if (result.result === "busy") {

--- a/apps/backend/src/modules/streaming/streamloop/process-error-patterns.ts
+++ b/apps/backend/src/modules/streaming/streamloop/process-error-patterns.ts
@@ -65,23 +65,24 @@ export const PROCESS_ERROR_MESSAGES: Record<
 	ProcessErrorMessageEntry
 > = {
 	[PROCESS_ERROR_CODES.SRTLA_INITIAL_CONNECT_FAILED]: {
-		message: "Failed to connect to the SRTLA server. Retrying...",
+		message:
+			"The SRTLA sender exhausted its initial connection attempts and stopped.",
 		suppressIfSrtlaNotified: false,
 	},
 	[PROCESS_ERROR_CODES.SRTLA_NO_CONNECTIONS]: {
-		message: "All SRTLA connections failed. Trying to reconnect...",
+		message: "All SRTLA links are down. The sender is reconnecting its links.",
 		suppressIfSrtlaNotified: false,
 	},
 	[PROCESS_ERROR_CODES.CAPTURE_AUDIO_ERROR]: {
-		message: "Capture card error (audio). Trying to restart...",
+		message: "Capture card error (audio). No automatic restart is scheduled.",
 		suppressIfSrtlaNotified: false,
 	},
 	[PROCESS_ERROR_CODES.CAPTURE_VIDEO_ERROR]: {
-		message: "Capture card error (video). Trying to restart...",
+		message: "Capture card error (video). No automatic restart is scheduled.",
 		suppressIfSrtlaNotified: false,
 	},
 	[PROCESS_ERROR_CODES.PIPELINE_STALL]: {
-		message: "The input source has stalled. Trying to restart...",
+		message: "The input source has stalled. No automatic restart is scheduled.",
 		suppressIfSrtlaNotified: false,
 	},
 	[PROCESS_ERROR_CODES.SRT_CONNECT_FAILED]: {
@@ -89,7 +90,7 @@ export const PROCESS_ERROR_MESSAGES: Record<
 		suppressIfSrtlaNotified: true,
 	},
 	[PROCESS_ERROR_CODES.SRT_CONNECTION_LOST]: {
-		message: "The SRT connection failed. Trying to reconnect...",
+		message: "The SRT connection failed. No automatic reconnect is scheduled.",
 		suppressIfSrtlaNotified: true,
 	},
 };

--- a/apps/backend/src/modules/streaming/streamloop/session.ts
+++ b/apps/backend/src/modules/streaming/streamloop/session.ts
@@ -93,7 +93,7 @@ export async function start(
 	generation = 0,
 	attemptId = "legacy-start",
 ): Promise<StartStreamResult> {
-	if (getIsStreaming() || isUpdating()) {
+	if (getIsStreaming()) {
 		sendStatus(conn);
 		return {
 			success: false,
@@ -101,6 +101,16 @@ export async function start(
 			reason: "stream_start_unavailable",
 			phase: "params",
 		};
+	}
+	if (isUpdating()) {
+		sendStatus(conn);
+		throw new StreamStartFailure({
+			attemptId,
+			phase: "connect",
+			class: "engine_restarting",
+			code: "stream_start_suppressed_update",
+			retriable: true,
+		});
 	}
 
 	const senderId = getSocketSenderId(conn);
@@ -190,6 +200,10 @@ export async function start(
 		};
 	}
 
+	if (!result.success && sessionResources?.generation === generation) {
+		sessionResources.removeNetworkInterfacesChangeListener();
+		sessionResources = undefined;
+	}
 	return result;
 }
 

--- a/apps/backend/src/tests/auto-audio.test.ts
+++ b/apps/backend/src/tests/auto-audio.test.ts
@@ -859,10 +859,13 @@ describe("Auto launch → engine start assembly", () => {
 			{ asrcKey: "HDMI", cardId: "rockchiphdmiin", reason: "hdmi" },
 		);
 		// The launch copy carries the asrcKey "HDMI"; the engine maps it via
-		// getAudioSrcId → the card id (rk3588 test host).
+		// getAudioSrcId → the card id, wrapped as an alsasrc `hw:CARD=<id>` string
+		// (rk3588 test host).
 		expect(launch.asrc).toBe("HDMI");
 		const params = await startParamsFor(launch);
-		expect((params.audio as { device: string }).device).toBe("rockchiphdmiin");
+		expect((params.audio as { device: string }).device).toBe(
+			"hw:CARD=rockchiphdmiin",
+		);
 	});
 
 	test("Pipeline-default resolution → engine start params carry NO audio.device", async () => {

--- a/apps/backend/src/tests/cerastream-start-assembly.test.ts
+++ b/apps/backend/src/tests/cerastream-start-assembly.test.ts
@@ -271,12 +271,31 @@ describe("buildStartParams — pseudo-source → audio.mode wire contract (Todo 
 		expect(params.audio).not.toHaveProperty("device");
 	});
 
-	test('a real device ⇒ mode:"device" + its ALSA id', async () => {
+	test('a real device ⇒ mode:"device" + a hw:CARD= ALSA device string', async () => {
 		const params = await startParamsFor(
 			{ ...BASE, asrc: "usbaudio" },
 			{ schemaVersion: "0.6.0" },
 		);
-		expect(params.audio).toEqual({ mode: "device", device: "usbaudio" });
+		// The engine feeds audio.device straight to `alsasrc device=`, which needs a
+		// real ALSA device string — a bare card id ("usbaudio") never opens and the
+		// engine rejects the start with -32602 audio-device-unavailable. CeraUI must
+		// send the engine's own `hw:CARD=<id>` form.
+		expect(params.audio).toEqual({
+			mode: "device",
+			device: "hw:CARD=usbaudio",
+		});
+	});
+
+	test("a real device audio.device is a valid alsasrc string, never a bare card id (regression: -32602 audio-device-unavailable)", async () => {
+		const params = await startParamsFor(
+			{ ...BASE, asrc: "usbaudio" },
+			{ schemaVersion: "0.6.0" },
+		);
+		const device = (params.audio as { device: string }).device;
+		// Must carry an ALSA selector (`hw:CARD=`); a bare card id is exactly what
+		// produced the board's `-32602 start_invalid` UI-happy-path failure.
+		expect(device.startsWith("hw:CARD=")).toBe(true);
+		expect(device).not.toBe("usbaudio");
 	});
 
 	test("a legacy caller that omits asrc sends NO audio section (compat)", async () => {

--- a/apps/backend/src/tests/edge-cases/streamloop-autostart.test.ts
+++ b/apps/backend/src/tests/edge-cases/streamloop-autostart.test.ts
@@ -23,9 +23,12 @@ import {
 	getIsStreaming,
 	updateStatus,
 } from "../../modules/streaming/streaming.ts";
-import { autoStartStream } from "../../modules/streaming/streamloop/autostart.ts";
+import {
+	AUTOSTART_MAX_LINK_ATTEMPTS,
+	autoStartStream,
+} from "../../modules/streaming/streamloop/autostart.ts";
 
-type Scheduled = { fn: unknown; delay: unknown };
+type Scheduled = { fn: () => unknown; delay: number | undefined };
 
 // Replace setTimeout with a recorder so retries are observed, never armed.
 function captureTimers(): {
@@ -93,26 +96,30 @@ describe("autostart: abort when a stream is already running", () => {
 });
 
 describe("autostart: no links available yet (transient boot state)", () => {
-	test("arms exactly one self-rescheduling retry, never a synchronous loop", async () => {
+	test("bounds self-rescheduling retries without a synchronous loop", async () => {
 		const restoreLinks = withNoLinks();
 		const timers = captureTimers();
+		const observed: Scheduled[] = [];
 		try {
 			expect(getIsStreaming()).toBe(false);
 			expect(genSrtlaIpList().length).toBe(0);
 			await autoStartStream();
+			while (timers.scheduled.length > 0) {
+				const scheduled = timers.scheduled.shift();
+				if (scheduled === undefined) break;
+				observed.push(scheduled);
+				await scheduled.fn();
+			}
 		} finally {
 			timers.restore();
 			restoreLinks();
 		}
 
-		// Exactly one timer: the no-links path must back off once and return, not
-		// recurse synchronously (which would wedge the event loop on a device that
-		// boots before any interface is up).
-		expect(timers.scheduled.length).toBe(1);
-		const retry = timers.scheduled[0];
-		expect(retry?.delay).toBe(AUTOSTART_RETRY_DELAY);
-		// It re-arms with autoStartStream itself (self-rescheduling backoff).
-		expect(retry?.fn).toBe(autoStartStream);
+		expect(observed).toHaveLength(AUTOSTART_MAX_LINK_ATTEMPTS - 1);
+		expect(observed.every(({ delay }) => delay === AUTOSTART_RETRY_DELAY)).toBe(
+			true,
+		);
+		expect(timers.scheduled).toEqual([]);
 	});
 });
 

--- a/apps/backend/src/tests/mock-cerastream-errors.test.ts
+++ b/apps/backend/src/tests/mock-cerastream-errors.test.ts
@@ -67,6 +67,7 @@ function makeBackend(): BackendHarness {
 			},
 			notificationExists: () => false,
 			broadcastStatus: () => {},
+			broadcastBuffering: () => {},
 		},
 		execPath: "cerastream",
 		configPath: "/tmp/cerastream-mock-errors.json",
@@ -83,31 +84,31 @@ const EXPECTED: Record<
 > = {
 	srtla_initial_connect_failed: {
 		channel: "srtla",
-		msg: "Failed to connect to the SRTLA server. Retrying...",
+		msg: "The SRTLA sender exhausted its initial connection attempts and stopped.",
 	},
 	srtla_no_connections: {
 		channel: "srtla",
-		msg: "All SRTLA connections failed. Trying to reconnect...",
+		msg: "All SRTLA links are down. The sender is reconnecting its links.",
 	},
 	capture_audio_error: {
 		channel: "cerastream",
-		msg: "Capture card error (audio). Trying to restart...",
+		msg: "Capture card error (audio). No automatic restart is scheduled.",
 	},
 	capture_video_error: {
 		channel: "cerastream",
-		msg: "Capture card error (video). Trying to restart...",
+		msg: "Capture card error (video). No automatic restart is scheduled.",
 	},
 	pipeline_stall: {
 		channel: "cerastream",
-		msg: "The input source has stalled. Trying to restart...",
+		msg: "The input source has stalled. No automatic restart is scheduled.",
 	},
 	srt_connect_failed: {
 		channel: "cerastream",
-		msg: "Failed to connect to the SRT server. Retrying...",
+		msg: "Failed to connect to the SRT server. No automatic retry is scheduled.",
 	},
 	srt_connection_lost: {
 		channel: "cerastream",
-		msg: "The SRT connection failed. Trying to reconnect...",
+		msg: "The SRT connection failed. No automatic reconnect is scheduled.",
 	},
 };
 
@@ -169,7 +170,7 @@ describe("mock cerastream Tier-2 error injection → backend mapping", () => {
 
 		expect(notifications[0]?.name).toBe("cerastream");
 		expect(notifications[0]?.msg).toBe(
-			"Failed to connect to the SRT server (Connection timed out). Retrying...",
+			"Failed to connect to the SRT server (Connection timed out). No automatic retry is scheduled.",
 		);
 	});
 

--- a/apps/backend/src/tests/process-error-patterns.test.ts
+++ b/apps/backend/src/tests/process-error-patterns.test.ts
@@ -4,6 +4,7 @@ import { resolveCerastreamError } from "../modules/streaming/cerastream-error-ma
 import {
 	PROCESS_ERROR_CODES,
 	PROCESS_ERROR_MESSAGES,
+	type ProcessErrorCode,
 	type ProcessSource,
 	resolveProcessError,
 } from "../modules/streaming/streamloop/process-error-patterns.ts";
@@ -12,7 +13,7 @@ describe("srtla stderr pattern table lookup", () => {
 	const cases: Array<{
 		source: ProcessSource;
 		stderr: string;
-		code: string;
+		code: ProcessErrorCode;
 		message: string;
 		suppressIfSrtlaNotified: boolean;
 	}> = [
@@ -20,14 +21,16 @@ describe("srtla stderr pattern table lookup", () => {
 			source: "srtla",
 			stderr: "srtla_send: Failed to establish any initial connections",
 			code: PROCESS_ERROR_CODES.SRTLA_INITIAL_CONNECT_FAILED,
-			message: "Failed to connect to the SRTLA server. Retrying...",
+			message:
+				"The SRTLA sender exhausted its initial connection attempts and stopped.",
 			suppressIfSrtlaNotified: false,
 		},
 		{
 			source: "srtla",
 			stderr: "srtla_send: no available connections, dropping packet",
 			code: PROCESS_ERROR_CODES.SRTLA_NO_CONNECTIONS,
-			message: "All SRTLA connections failed. Trying to reconnect...",
+			message:
+				"All SRTLA links are down. The sender is reconnecting its links.",
 			suppressIfSrtlaNotified: false,
 		},
 	];
@@ -63,19 +66,21 @@ describe("shared code → message catalog (Task-7 table)", () => {
 	const staticMessages: Array<{ code: string; message: string }> = [
 		{
 			code: PROCESS_ERROR_CODES.CAPTURE_AUDIO_ERROR,
-			message: "Capture card error (audio). Trying to restart...",
+			message: "Capture card error (audio). No automatic restart is scheduled.",
 		},
 		{
 			code: PROCESS_ERROR_CODES.CAPTURE_VIDEO_ERROR,
-			message: "Capture card error (video). Trying to restart...",
+			message: "Capture card error (video). No automatic restart is scheduled.",
 		},
 		{
 			code: PROCESS_ERROR_CODES.PIPELINE_STALL,
-			message: "The input source has stalled. Trying to restart...",
+			message:
+				"The input source has stalled. No automatic restart is scheduled.",
 		},
 		{
 			code: PROCESS_ERROR_CODES.SRT_CONNECTION_LOST,
-			message: "The SRT connection failed. Trying to reconnect...",
+			message:
+				"The SRT connection failed. No automatic reconnect is scheduled.",
 		},
 	];
 
@@ -113,7 +118,7 @@ describe("SRT connect failure — dynamic reason message (structured path)", () 
 		);
 		expect(resolved.code).toBe(PROCESS_ERROR_CODES.SRT_CONNECT_FAILED);
 		expect(resolved.message).toBe(
-			"Failed to connect to the SRT server (connection refused). Retrying...",
+			"Failed to connect to the SRT server (connection refused). No automatic retry is scheduled.",
 		);
 		expect(resolved.suppressIfSrtlaNotified).toBe(true);
 	});
@@ -121,7 +126,7 @@ describe("SRT connect failure — dynamic reason message (structured path)", () 
 	test("omits the parenthetical when no reason is present", () => {
 		const resolved = resolveCerastreamError("srt_connect_failed", "engine");
 		expect(resolved.message).toBe(
-			"Failed to connect to the SRT server. Retrying...",
+			"Failed to connect to the SRT server. No automatic retry is scheduled.",
 		);
 	});
 });

--- a/apps/backend/src/tests/stream-session-orchestrator.test.ts
+++ b/apps/backend/src/tests/stream-session-orchestrator.test.ts
@@ -4,6 +4,7 @@ import {
 	createStreamSessionOrchestrator,
 	type StreamLaunchContext,
 } from "../modules/streaming/stream-session-orchestrator.ts";
+import { StreamStartFailure } from "../modules/streaming/start-failure-taxonomy.ts";
 
 function deferred(): {
 	readonly promise: Promise<void>;
@@ -25,6 +26,44 @@ function attemptIds(): () => string {
 }
 
 describe("stream session orchestrator", () => {
+	test("characterizes merged one-shot behavior for a retriable connect failure", async () => {
+		// Given merged Todo 27 behavior and a connect-phase engine outage.
+		let launches = 0;
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: attemptIds(),
+			setStreamingStatus: () => {},
+			stopRuntime: async () => {},
+			queryRuntime: async () => "idle",
+		});
+
+		// When the only launch attempt reports a retriable typed failure.
+		const result = await orchestrator.start({
+			origin: "ui",
+			launch: async ({ attemptId }) => {
+				launches += 1;
+				throw new StreamStartFailure({
+					attemptId,
+					phase: "connect",
+					class: "engine_unavailable",
+					retriable: true,
+				});
+			},
+		});
+
+		// Then the merged baseline is one-shot and immediately terminal.
+		expect(launches).toBe(1);
+		expect(result).toEqual({
+			result: "failed",
+			attemptId: "attempt-1",
+			failure: {
+				attemptId: "attempt-1",
+				phase: "connect",
+				class: "engine_unavailable",
+				retriable: true,
+			},
+		});
+	});
+
 	test("parallel starts launch once and return one busy result", async () => {
 		// Given a first launch held at a deterministic engine barrier.
 		const engineConfirmed = deferred();

--- a/apps/backend/src/tests/stream-session-orchestrator.test.ts
+++ b/apps/backend/src/tests/stream-session-orchestrator.test.ts
@@ -194,6 +194,186 @@ describe("stream session orchestrator", () => {
 		});
 	});
 
+	test("deadlines an in-flight launch, cleans its generation, and releases the start slot", async () => {
+		// Given a launch that never settles on its own and a deterministic deadline.
+		const launchBarrier = deferred();
+		const timers: Array<{ callback: () => void; delayMs: number }> = [];
+		const events: string[] = [];
+		const terminal: StartRetryDiagnostic[] = [];
+		let nowMs = 0;
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: attemptIds(),
+			setStreamingStatus: () => {},
+			stopRuntime: async (generation) => {
+				events.push(`cleanup-${generation}`);
+			},
+			queryRuntime: async () => "idle",
+			retryPolicy: {
+				maxAttempts: 5,
+				totalBudgetMs: 10,
+				baseDelayMs: 5,
+				maxDelayMs: 10,
+				attemptTimeoutMs: 10,
+			},
+			now: () => nowMs,
+			scheduleLaunchDeadline: (callback, delayMs) => {
+				timers.push({ callback, delayMs });
+				return timers.length;
+			},
+			cancelTimeout: () => {},
+			reportTerminalFailure: (diagnostic) => terminal.push(diagnostic),
+		});
+		const firstStart = orchestrator.start({
+			origin: "ui",
+			launch: async ({ cancelled }) => {
+				await launchBarrier.promise;
+				events.push(`launch-settled-cancelled-${cancelled()}`);
+			},
+		});
+		let resultSettled = false;
+		void firstStart.then(() => {
+			resultSettled = true;
+		});
+
+		await settleMicrotasks();
+		const deadline = timers.find((timer) => timer.delayMs === 10);
+		try {
+			// When the per-attempt deadline expires.
+			expect(deadline).toBeDefined();
+			nowMs = 10;
+			deadline?.callback();
+			await Bun.sleep(0);
+			expect(resultSettled).toBe(false);
+			launchBarrier.resolve();
+			const result = await firstStart;
+
+			// Then cleanup precedes one terminal timeout and the slot is reusable.
+			expect(result).toMatchObject({
+				result: "failed",
+				failure: {
+					phase: "connect",
+					class: "start_timeout",
+					code: "start_attempt_deadline",
+				},
+			});
+			expect(events).toEqual(["cleanup-1", "launch-settled-cancelled-true"]);
+			expect(terminal).toHaveLength(1);
+			expect(terminal[0]?.retry).toMatchObject({
+				state: "exhausted",
+				attempt: 1,
+			});
+			expect(
+				await orchestrator.start({ origin: "ui", launch: async () => {} }),
+			).toMatchObject({ result: "started" });
+		} finally {
+			launchBarrier.resolve();
+			await firstStart;
+		}
+		await settleMicrotasks();
+		expect(events).toEqual(["cleanup-1", "launch-settled-cancelled-true"]);
+	});
+
+	test("does not retry when a timed-out launch remains unsettled after cleanup", async () => {
+		// Given an in-flight launch that survives both generation cleanup and its bound.
+		const launchBarrier = deferred();
+		const deadlineTimers: Array<{ callback: () => void; delayMs: number }> = [];
+		const retryDelays: number[] = [];
+		const terminal: StartRetryDiagnostic[] = [];
+		let nowMs = 0;
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: attemptIds(),
+			setStreamingStatus: () => {},
+			stopRuntime: async () => {},
+			queryRuntime: async () => "idle",
+			stopDeadlineMs: 12,
+			retryPolicy: {
+				maxAttempts: 5,
+				totalBudgetMs: 60,
+				baseDelayMs: 5,
+				maxDelayMs: 10,
+				attemptTimeoutMs: 10,
+			},
+			now: () => nowMs,
+			scheduleTimeout: (_callback, delayMs) => {
+				retryDelays.push(delayMs);
+				return retryDelays.length;
+			},
+			cancelTimeout: () => {},
+			scheduleLaunchDeadline: (callback, delayMs) => {
+				deadlineTimers.push({ callback, delayMs });
+				return deadlineTimers.length;
+			},
+			cancelLaunchDeadline: () => {},
+			reportTerminalFailure: (diagnostic) => terminal.push(diagnostic),
+		});
+		const starting = orchestrator.start({
+			origin: "ui",
+			launch: async () => launchBarrier.promise,
+		});
+
+		try {
+			// When the launch deadline and the subsequent cleanup-settlement bound expire.
+			await settleMicrotasks();
+			nowMs = 10;
+			deadlineTimers.find((timer) => timer.delayMs === 10)?.callback();
+			await settleMicrotasks();
+			nowMs = 22;
+			deadlineTimers.find((timer) => timer.delayMs === 12)?.callback();
+			const result = await starting;
+
+			// Then cleanup incompleteness is terminal and no retry backoff is armed.
+			expect(result).toMatchObject({
+				result: "failed",
+				failure: {
+					class: "start_timeout",
+					code: "start_cleanup_timeout",
+					retriable: false,
+				},
+			});
+			expect(retryDelays).not.toContain(5);
+			expect(terminal).toHaveLength(1);
+			expect(terminal[0]?.retry).toMatchObject({
+				state: "not_retriable",
+				attempt: 1,
+			});
+		} finally {
+			launchBarrier.resolve();
+			await starting;
+		}
+	});
+
+	test("ignores a stale launch deadline after its generation has started", async () => {
+		// Given a successful launch whose cancelled deadline callback is retained.
+		let deadlineCallback: (() => void) | undefined;
+		let cleanups = 0;
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: attemptIds(),
+			setStreamingStatus: () => {},
+			stopRuntime: async () => {
+				cleanups += 1;
+			},
+			queryRuntime: async () => "idle",
+			scheduleLaunchDeadline: (callback) => {
+				deadlineCallback = callback;
+				return 1;
+			},
+			cancelLaunchDeadline: () => {},
+		});
+		const result = await orchestrator.start({
+			origin: "ui",
+			launch: async () => {},
+		});
+
+		// When the stale timer callback fires after the start has settled.
+		deadlineCallback?.();
+		await settleMicrotasks();
+
+		// Then it cannot cancel or clean the active generation.
+		expect(result).toMatchObject({ result: "started" });
+		expect(orchestrator.snapshot()).toMatchObject({ state: "streaming" });
+		expect(cleanups).toBe(0);
+	});
+
 	test("a deterministic start error is terminal without scheduling a retry", async () => {
 		// Given a non-retriable engine rejection.
 		const retryDiagnostics: StartRetryDiagnostic[] = [];
@@ -296,8 +476,8 @@ describe("stream session orchestrator", () => {
 				}
 			},
 		});
-		await Promise.resolve();
-		await Promise.resolve();
+		await settleMicrotasks();
+		expect(retryCallback).toBeDefined();
 		retryCallback?.();
 		expect(await start).toMatchObject({ result: "started" });
 

--- a/apps/backend/src/tests/stream-session-orchestrator.test.ts
+++ b/apps/backend/src/tests/stream-session-orchestrator.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
-
+import { StreamStartFailure } from "../modules/streaming/start-failure-taxonomy.ts";
 import {
 	createStreamSessionOrchestrator,
+	type StartRetryDiagnostic,
 	type StreamLaunchContext,
 } from "../modules/streaming/stream-session-orchestrator.ts";
-import { StreamStartFailure } from "../modules/streaming/start-failure-taxonomy.ts";
 
 function deferred(): {
 	readonly promise: Promise<void>;
@@ -25,6 +25,19 @@ function attemptIds(): () => string {
 	return () => `attempt-${++next}`;
 }
 
+function retriableFailure(attemptId: string): StreamStartFailure {
+	return new StreamStartFailure({
+		attemptId,
+		phase: "connect",
+		class: "engine_unavailable",
+		retriable: true,
+	});
+}
+
+async function settleMicrotasks(): Promise<void> {
+	for (let index = 0; index < 5; index += 1) await Promise.resolve();
+}
+
 describe("stream session orchestrator", () => {
 	test("characterizes merged one-shot behavior for a retriable connect failure", async () => {
 		// Given merged Todo 27 behavior and a connect-phase engine outage.
@@ -34,6 +47,12 @@ describe("stream session orchestrator", () => {
 			setStreamingStatus: () => {},
 			stopRuntime: async () => {},
 			queryRuntime: async () => "idle",
+			retryPolicy: {
+				maxAttempts: 1,
+				totalBudgetMs: 60_000,
+				baseDelayMs: 2_000,
+				maxDelayMs: 16_000,
+			},
 		});
 
 		// When the only launch attempt reports a retriable typed failure.
@@ -62,6 +81,233 @@ describe("stream session orchestrator", () => {
 				retriable: true,
 			},
 		});
+	});
+
+	test("retries a refused connect until the socket appears and succeeds without a terminal report", async () => {
+		// Given an engine boot window and deterministic retry timers.
+		const retryCallbacks: Array<() => void> = [];
+		const diagnostics: StartRetryDiagnostic[] = [];
+		const terminal: StartRetryDiagnostic[] = [];
+		let launches = 0;
+		let nowMs = 0;
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: attemptIds(),
+			setStreamingStatus: () => {},
+			stopRuntime: async () => {},
+			queryRuntime: async () => "idle",
+			now: () => nowMs,
+			scheduleTimeout: (callback) => {
+				retryCallbacks.push(callback);
+				return retryCallbacks.length;
+			},
+			cancelTimeout: () => {},
+			suppressionContext: () => ({
+				softwareUpdateActive: false,
+				engineRestartWindow: false,
+				bootWindow: true,
+				cancelledByStop: false,
+			}),
+			reportRetry: (diagnostic) => diagnostics.push(diagnostic),
+			reportTerminalFailure: (diagnostic) => terminal.push(diagnostic),
+		});
+
+		// When two refused connects are followed by a successful socket connection.
+		const resultPromise = orchestrator.start({
+			origin: "ui",
+			launch: async ({ attemptId }) => {
+				launches += 1;
+				if (launches < 3) throw retriableFailure(attemptId);
+			},
+		});
+		await settleMicrotasks();
+		nowMs = 2_000;
+		retryCallbacks.shift()?.();
+		await settleMicrotasks();
+		nowMs = 6_000;
+		retryCallbacks.shift()?.();
+		const result = await resultPromise;
+
+		// Then retrying remains calm and the eventual start has no terminal alert.
+		expect(result).toEqual({ result: "started", attemptId: "attempt-1" });
+		expect(launches).toBe(3);
+		expect(diagnostics.map((entry) => entry.retry.state)).toEqual([
+			"scheduled",
+			"scheduled",
+		]);
+		expect(diagnostics.every((entry) => entry.retry.suppressed)).toBe(true);
+		expect(terminal).toEqual([]);
+	});
+
+	test("budget exhaustion reports one terminal diagnostic with the attempt count", async () => {
+		// Given a three-attempt policy and an engine that remains unavailable.
+		const retryCallbacks: Array<() => void> = [];
+		const terminal: StartRetryDiagnostic[] = [];
+		let nowMs = 0;
+		let launches = 0;
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: attemptIds(),
+			setStreamingStatus: () => {},
+			stopRuntime: async () => {},
+			queryRuntime: async () => "idle",
+			now: () => nowMs,
+			retryPolicy: {
+				maxAttempts: 3,
+				totalBudgetMs: 20,
+				baseDelayMs: 5,
+				maxDelayMs: 10,
+			},
+			scheduleTimeout: (callback) => {
+				retryCallbacks.push(callback);
+				return retryCallbacks.length;
+			},
+			cancelTimeout: () => {},
+			reportTerminalFailure: (diagnostic) => terminal.push(diagnostic),
+		});
+
+		// When every bounded attempt fails.
+		const resultPromise = orchestrator.start({
+			origin: "ui",
+			launch: async ({ attemptId }) => {
+				launches += 1;
+				throw retriableFailure(attemptId);
+			},
+		});
+		await settleMicrotasks();
+		nowMs = 5;
+		retryCallbacks.shift()?.();
+		await settleMicrotasks();
+		nowMs = 15;
+		retryCallbacks.shift()?.();
+		const result = await resultPromise;
+
+		// Then one truthful exhausted diagnostic carries the final class and count.
+		expect(result).toMatchObject({
+			result: "failed",
+			failure: { class: "engine_unavailable" },
+		});
+		expect(launches).toBe(3);
+		expect(terminal).toHaveLength(1);
+		expect(terminal[0]?.retry).toMatchObject({
+			state: "exhausted",
+			attempt: 3,
+			maxAttempts: 3,
+		});
+	});
+
+	test("a deterministic start error is terminal without scheduling a retry", async () => {
+		// Given a non-retriable engine rejection.
+		const retryDiagnostics: StartRetryDiagnostic[] = [];
+		const terminal: StartRetryDiagnostic[] = [];
+		let launches = 0;
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: attemptIds(),
+			setStreamingStatus: () => {},
+			stopRuntime: async () => {},
+			queryRuntime: async () => "idle",
+			reportRetry: (diagnostic) => retryDiagnostics.push(diagnostic),
+			reportTerminalFailure: (diagnostic) => terminal.push(diagnostic),
+		});
+
+		// When start parameters are rejected.
+		const result = await orchestrator.start({
+			origin: "ui",
+			launch: async ({ attemptId }) => {
+				launches += 1;
+				throw new StreamStartFailure({
+					attemptId,
+					phase: "start-rpc",
+					class: "start_invalid",
+					code: -32602,
+					retriable: false,
+				});
+			},
+		});
+
+		// Then the failure is immediate and its diagnostic says no retry.
+		expect(result).toMatchObject({
+			result: "failed",
+			failure: { class: "start_invalid", code: -32602 },
+		});
+		expect(launches).toBe(1);
+		expect(retryDiagnostics).toEqual([]);
+		expect(terminal[0]?.retry.state).toBe("not_retriable");
+	});
+
+	test("stop cancels a scheduled retry without a terminal notification", async () => {
+		// Given a failed first attempt waiting on its retry timer.
+		const terminal: StartRetryDiagnostic[] = [];
+		let launches = 0;
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: attemptIds(),
+			setStreamingStatus: () => {},
+			stopRuntime: async () => {},
+			queryRuntime: async () => "idle",
+			scheduleTimeout: () => 1,
+			cancelTimeout: () => {},
+			reportTerminalFailure: (diagnostic) => terminal.push(diagnostic),
+		});
+		const start = orchestrator.start({
+			origin: "ui",
+			launch: async ({ attemptId }) => {
+				launches += 1;
+				throw retriableFailure(attemptId);
+			},
+		});
+		await Promise.resolve();
+
+		// When stop interrupts the pending backoff.
+		expect(await orchestrator.stop()).toEqual({ result: "stopped" });
+		const result = await start;
+
+		// Then no stale timer launches again and cancellation notifies nothing.
+		expect(result).toEqual({ result: "cancelled", attemptId: "attempt-1" });
+		expect(launches).toBe(1);
+		expect(terminal).toEqual([]);
+	});
+
+	test("awaits failed-attempt rollback before scheduling the next launch", async () => {
+		// Given a launch whose rejection follows an observable rollback barrier.
+		const events: string[] = [];
+		let retryCallback: (() => void) | undefined;
+		let launches = 0;
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: attemptIds(),
+			setStreamingStatus: () => {},
+			stopRuntime: async () => {},
+			queryRuntime: async () => "idle",
+			scheduleTimeout: (callback) => {
+				retryCallback = callback;
+				events.push("scheduled");
+				return 1;
+			},
+			cancelTimeout: () => {},
+		});
+
+		// When attempt one rolls back and attempt two succeeds.
+		const start = orchestrator.start({
+			origin: "ui",
+			launch: async ({ attemptId }) => {
+				launches += 1;
+				events.push(`launch-${launches}`);
+				if (launches === 1) {
+					await Promise.resolve();
+					events.push("rollback-complete");
+					throw retriableFailure(attemptId);
+				}
+			},
+		});
+		await Promise.resolve();
+		await Promise.resolve();
+		retryCallback?.();
+		expect(await start).toMatchObject({ result: "started" });
+
+		// Then cleanup completion precedes both scheduling and the next launch.
+		expect(events).toEqual([
+			"launch-1",
+			"rollback-complete",
+			"scheduled",
+			"launch-2",
+		]);
 	});
 
 	test("parallel starts launch once and return one busy result", async () => {

--- a/apps/backend/src/tests/stream-start-retry-reporting.test.ts
+++ b/apps/backend/src/tests/stream-start-retry-reporting.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+import { deriveStartSuppressionContext } from "../modules/streaming/stream-start-retry-reporting.ts";
+
+describe("stream start suppression signal derivation", () => {
+	test("a healthy live capability snapshot is not a restart window", () => {
+		expect(
+			deriveStartSuppressionContext({
+				softwareUpdateActive: false,
+				capabilities: {
+					engineUnavailable: false,
+				},
+				uptimeMs: 120_000,
+			}),
+		).toEqual({
+			softwareUpdateActive: false,
+			engineRestartWindow: false,
+			bootWindow: false,
+			cancelledByStop: false,
+		});
+	});
+
+	test("a cached unavailable snapshot is a known restart window", () => {
+		expect(
+			deriveStartSuppressionContext({
+				softwareUpdateActive: false,
+				capabilities: {
+					engineUnavailable: true,
+				},
+				uptimeMs: 120_000,
+			}),
+		).toMatchObject({
+			engineRestartWindow: true,
+			bootWindow: false,
+		});
+	});
+
+	test("an engine-starting snapshot keeps the boot window calm", () => {
+		expect(
+			deriveStartSuppressionContext({
+				softwareUpdateActive: false,
+				capabilities: {
+					engineUnavailable: true,
+					engineStarting: true,
+				},
+				uptimeMs: 120_000,
+			}),
+		).toMatchObject({
+			engineRestartWindow: false,
+			bootWindow: true,
+		});
+	});
+});

--- a/apps/backend/src/tests/streaming-backend-contract.test.ts
+++ b/apps/backend/src/tests/streaming-backend-contract.test.ts
@@ -18,6 +18,7 @@ import {
 	cerastreamBackend,
 	classifyConnectHandshakePhase,
 } from "../modules/streaming/cerastream-backend.ts";
+import { deriveStreamHealth } from "../modules/streaming/health.ts";
 import {
 	createLaunchTransaction,
 	type LaunchDeadlineTimers,
@@ -371,6 +372,62 @@ describe("engine selection", () => {
 // ---------------------------------------------------------------------------
 
 describe("CerastreamBackend behavioural contract", () => {
+	test("a silent idle engine terminalizes reconciliation and admits start", async () => {
+		// Given a connected, subscribed production backend whose idle engine emits
+		// no status heartbeat, matching the board's active-engine/idle-health state.
+		let reconcileTimeout: (() => void) | undefined;
+		const { backend, fake } = makeBackend({
+			scheduleTimeout: (callback) => {
+				reconcileTimeout = callback;
+				return 1 as unknown as ReturnType<typeof setTimeout>;
+			},
+			cancelTimeout: () => undefined,
+		});
+		let streaming = false;
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: () => "attempt-after-idle-reconcile",
+			setStreamingStatus: (next) => {
+				streaming = next;
+			},
+			getStreamingStatus: () => streaming,
+			stopRuntime: async () => undefined,
+			queryRuntime: () => backend.reconcileRuntimeState(),
+		});
+		const reconciling = orchestrator.reconcile();
+		await fake.subscribed;
+		await waitFor(() => reconcileTimeout !== undefined);
+
+		// When the bounded observation window expires without a status event.
+		reconcileTimeout?.();
+		const reconciled = await reconciling;
+		const health = deriveStreamHealth({
+			isStreaming: streaming,
+			processAlive: null,
+			framesAdvancing: null,
+			frameCount: null,
+			reconnecting: null,
+			reconnectCount: 0,
+			linkCount: 0,
+			activeLinks: 0,
+		});
+		const started = await orchestrator.start({
+			origin: "ui",
+			launch: async () => undefined,
+		});
+
+		// Then idle is authoritative, health agrees, and Start owns generation one.
+		expect(reconciled).toBe("idle");
+		expect(health.state).toBe("idle");
+		expect(started).toEqual({
+			result: "started",
+			attemptId: "attempt-after-idle-reconcile",
+		});
+		expect(orchestrator.snapshot()).toEqual({
+			state: "streaming",
+			generation: 1,
+		});
+	});
+
 	test("a dead engine cannot retain the backend queue after lifecycle cleanup", async () => {
 		// Production-wired reproduction of the board failure: generation one owns
 		// the real CerastreamBackend queue while both start and stop replies hang.
@@ -500,12 +557,26 @@ describe("CerastreamBackend behavioural contract", () => {
 
 	test("reconciliation reports contradictory engine status as unknown", async () => {
 		const { backend, fake } = makeBackend();
-		const reconciliation = backend.reconcileRuntimeState();
+		let streaming = false;
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: () => "attempt-disagreement",
+			setStreamingStatus: (next) => {
+				streaming = next;
+			},
+			getStreamingStatus: () => streaming,
+			stopRuntime: async () => undefined,
+			queryRuntime: () => backend.reconcileRuntimeState(),
+		});
+		const reconciliation = orchestrator.reconcile();
 		await fake.subscribed;
 
 		fake.emit({ type: "status", seq: 1, state: "streaming", streaming: false });
 
-		expect(await reconciliation).toBe("unknown");
+		expect(await reconciliation).toBe("reconciling");
+		expect(streaming).toBe(false);
+		expect(
+			await orchestrator.start({ origin: "ui", launch: async () => undefined }),
+		).toMatchObject({ result: "busy" });
 	});
 
 	test("reconciliation reports an engine query error as unknown", async () => {
@@ -518,7 +589,7 @@ describe("CerastreamBackend behavioural contract", () => {
 		expect(await backend.reconcileRuntimeState()).toBe("unknown");
 	});
 
-	test("reconciliation timeout is bounded and remains unknown", async () => {
+	test("a silent subscribed reconciliation is bounded and resolves idle", async () => {
 		for (let repeat = 0; repeat < 5; repeat += 1) {
 			let timeoutCallback: (() => void) | undefined;
 			let scheduledDelay: number | undefined;
@@ -539,9 +610,30 @@ describe("CerastreamBackend behavioural contract", () => {
 
 			expect(scheduledDelay).toBe(2500);
 			timeoutCallback?.();
-			expect(await reconciliation).toBe("unknown");
+			expect(await reconciliation).toBe("idle");
 			expect(cancelled).toBe(1);
 		}
+	});
+
+	test("a status event arriving after idle reconciliation cannot become owned", async () => {
+		let timeoutCallback: (() => void) | undefined;
+		const { backend, fake } = makeBackend({
+			scheduleTimeout: (callback) => {
+				timeoutCallback = callback;
+				return 1 as unknown as ReturnType<typeof setTimeout>;
+			},
+			cancelTimeout: () => undefined,
+		});
+		const reconciliation = backend.reconcileRuntimeState();
+		await fake.subscribed;
+		await waitFor(() => timeoutCallback !== undefined);
+
+		timeoutCallback?.();
+		expect(await reconciliation).toBe("idle");
+		fake.emit({ type: "status", seq: 2, state: "streaming", streaming: true });
+
+		expect(backend.getTelemetry()).toBeNull();
+		expect(backend.stop(() => undefined)).toBe(false);
 	});
 
 	test("start connects, subscribes, and sends the serialized config", async () => {

--- a/apps/backend/src/tests/streaming-backend-contract.test.ts
+++ b/apps/backend/src/tests/streaming-backend-contract.test.ts
@@ -646,7 +646,7 @@ describe("CerastreamBackend error mapping", () => {
 		expect(bridgeH.notifications).toHaveLength(1);
 		expect(bridgeH.notifications[0]).toEqual({
 			name: "cerastream",
-			msg: "The input source has stalled. Trying to restart...",
+			msg: "The input source has stalled. No automatic restart is scheduled.",
 		});
 	});
 
@@ -656,7 +656,7 @@ describe("CerastreamBackend error mapping", () => {
 
 		expect(bridgeH.notifications[0]).toEqual({
 			name: "srtla",
-			msg: "All SRTLA connections failed. Trying to reconnect...",
+			msg: "All SRTLA links are down. The sender is reconnecting its links.",
 		});
 	});
 
@@ -671,7 +671,7 @@ describe("CerastreamBackend error mapping", () => {
 		});
 
 		expect(bridgeH.notifications[0]?.msg).toBe(
-			"Failed to connect to the SRT server (Connection timed out). Retrying...",
+			"Failed to connect to the SRT server (Connection timed out). No automatic retry is scheduled.",
 		);
 	});
 
@@ -854,7 +854,7 @@ describe("CerastreamBackend engine crash", () => {
 		expect(backend.stop(() => {})).toBe(false);
 	});
 
-	test("a connect failure on start surfaces a notification and clears the session", async () => {
+	test("a connect failure defers notification policy to the session orchestrator", async () => {
 		const { backend, bridgeH } = makeBackend({
 			connect: async () => {
 				throw new CerastreamConnectionError(
@@ -870,11 +870,7 @@ describe("CerastreamBackend engine crash", () => {
 		});
 		await backend.settle();
 
-		expect(
-			bridgeH.notifications.some(
-				(n) => n.name === "cerastream" && n.msg.includes("failed to start"),
-			),
-		).toBe(true);
+		expect(bridgeH.notifications).toEqual([]);
 
 		const found = backend.stop(() => {});
 		expect(found).toBe(false);

--- a/apps/backend/src/tests/streaming-backend-contract.test.ts
+++ b/apps/backend/src/tests/streaming-backend-contract.test.ts
@@ -23,6 +23,7 @@ import {
 	type LaunchDeadlineTimers,
 } from "../modules/streaming/launch-transaction.ts";
 import { START_PHASE_DEADLINES_MS } from "../modules/streaming/start-lifecycle-timing.ts";
+import { createStreamSessionOrchestrator } from "../modules/streaming/stream-session-orchestrator.ts";
 import type {
 	StreamingBackend,
 	StreamRunOptions,
@@ -79,6 +80,7 @@ interface FakeClientHarness {
 interface FakeClientOptions {
 	readonly startResult?: StartResult;
 	readonly startGate?: Promise<StartResult>;
+	readonly stopGate?: Promise<{ state: "idle" }>;
 	readonly subscribeGate?: Promise<void>;
 }
 
@@ -88,11 +90,18 @@ function makeFakeClient(options: FakeClientOptions = {}): FakeClientHarness {
 	let resolveSubscribed: (() => void) | undefined;
 	let resolveStarted: (() => void) | undefined;
 	let rejectStartOnClose: ((error: Error) => void) | undefined;
+	let rejectStopOnClose: ((error: Error) => void) | undefined;
 	const startClosed =
 		options.startGate === undefined
 			? undefined
 			: new Promise<never>((_resolve, reject) => {
 					rejectStartOnClose = reject;
+				});
+	const stopClosed =
+		options.stopGate === undefined
+			? undefined
+			: new Promise<never>((_resolve, reject) => {
+					rejectStopOnClose = reject;
 				});
 	const subscribed = new Promise<void>((resolve) => {
 		resolveSubscribed = resolve;
@@ -116,6 +125,9 @@ function makeFakeClient(options: FakeClientOptions = {}): FakeClientHarness {
 		},
 		stop: async (params) => {
 			calls.push({ op: "stop", params });
+			if (options.stopGate !== undefined && stopClosed !== undefined) {
+				return await Promise.race([options.stopGate, stopClosed]);
+			}
 			return { state: "idle" };
 		},
 		reloadConfig: async (params) => {
@@ -181,7 +193,9 @@ function makeFakeClient(options: FakeClientOptions = {}): FakeClientHarness {
 		},
 		close: async () => {
 			calls.push({ op: "close" });
-			rejectStartOnClose?.(new Error("client_closed"));
+			const closed = new Error("client_closed");
+			rejectStartOnClose?.(closed);
+			rejectStopOnClose?.(closed);
 		},
 	};
 	// `switch-audio` is dispatched by the backend through the client's raw
@@ -357,6 +371,115 @@ describe("engine selection", () => {
 // ---------------------------------------------------------------------------
 
 describe("CerastreamBackend behavioural contract", () => {
+	test("a dead engine cannot retain the backend queue after lifecycle cleanup", async () => {
+		// Production-wired reproduction of the board failure: generation one owns
+		// the real CerastreamBackend queue while both start and stop replies hang.
+		const deadStart = deferred<StartResult>();
+		const deadStop = deferred<{ state: "idle" }>();
+		const dead = makeFakeClient({
+			startGate: deadStart.promise,
+			stopGate: deadStop.promise,
+		});
+		const recovered = makeFakeClient();
+		const bridgeH = makeBridge();
+		const config: RuntimeConfig = { ...STREAM_CONFIG };
+		let connections = 0;
+		const backend = new CerastreamBackend({
+			connect: async () => {
+				connections += 1;
+				if (connections === 1) return dead.client;
+				if (connections === 2) throw new Error("engine_restart_window");
+				return recovered.client;
+			},
+			connectOptions: {},
+			getConfig: () => config,
+			saveConfig: () => undefined,
+			bridge: bridgeH.bridge,
+			execPath: "cerastream",
+			configPath: "/tmp/cerastream-contract.json",
+			logger: silentLogger,
+		});
+		const stopTimers: Array<() => void> = [];
+		const launchTimers: Array<{ callback: () => void; delayMs: number }> = [];
+		let streaming = false;
+		let nextAttempt = 0;
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: () => {
+				nextAttempt += 1;
+				return `attempt-${nextAttempt}`;
+			},
+			setStreamingStatus: (next) => {
+				streaming = next;
+			},
+			getStreamingStatus: () => streaming,
+			stopRuntime: (generation) =>
+				new Promise<void>((resolve) => {
+					if (!backend.stop(resolve)) resolve();
+					expect(generation).toBeGreaterThan(0);
+				}),
+			queryRuntime: async () => "idle",
+			stopDeadlineMs: 12,
+			retryPolicy: {
+				maxAttempts: 1,
+				totalBudgetMs: 10,
+				attemptTimeoutMs: 10,
+				baseDelayMs: 1,
+				maxDelayMs: 1,
+			},
+			now: () => 10,
+			scheduleTimeout: (callback) => {
+				stopTimers.push(callback);
+				return stopTimers.length;
+			},
+			cancelTimeout: () => undefined,
+			scheduleLaunchDeadline: (callback, delayMs) => {
+				launchTimers.push({ callback, delayMs });
+				return launchTimers.length;
+			},
+			cancelLaunchDeadline: () => undefined,
+		});
+		const launch = () => backend.start(STREAM_CONFIG, RUN_OPTS);
+
+		const first = orchestrator.start({ origin: "ui", launch });
+		await dead.started;
+		launchTimers.find(({ delayMs }) => delayMs === 10)?.callback();
+		await Bun.sleep(0);
+		stopTimers.shift()?.();
+		expect(await first).toMatchObject({ result: "failed" });
+		expect(streaming).toBe(false);
+		expect(orchestrator.snapshot()).toEqual({
+			state: "idle",
+			generation: 1,
+		});
+		const deadOps = dead.calls.map(({ op }) => op);
+		expect(deadOps.filter((op) => op === "start")).toHaveLength(1);
+		expect(deadOps.filter((op) => op === "stop")).toHaveLength(2);
+		expect(deadOps.filter((op) => op === "close")).toHaveLength(2);
+		expect(deadOps.filter((op) => op === "unsubscribe")).toHaveLength(2);
+
+		// A second owner must reach the recovered connect path and terminate; it
+		// must not park behind generation one's dead queue and make a third RPC busy.
+		const second = orchestrator.start({ origin: "ui", launch });
+		for (let tick = 0; tick < 10; tick += 1) await Bun.sleep(0);
+		expect(await second).toMatchObject({ result: "failed" });
+		expect(streaming).toBe(false);
+		expect(orchestrator.snapshot()).toEqual({
+			state: "idle",
+			generation: 2,
+		});
+		const third = await orchestrator.start({ origin: "ui", launch });
+		expect(third).toMatchObject({ result: "started" });
+		expect(connections).toBe(3);
+		expect(streaming).toBe(true);
+		expect(orchestrator.snapshot()).toEqual({
+			state: "streaming",
+			generation: 3,
+		});
+
+		await orchestrator.stop();
+		await backend.settle();
+	});
+
 	test("reconciliation adopts an engine-held stream", async () => {
 		// Given a fresh backend connected to an engine whose session survived it.
 		const { backend, fake } = makeBackend();

--- a/apps/backend/src/tests/streaming-backend-contract.test.ts
+++ b/apps/backend/src/tests/streaming-backend-contract.test.ts
@@ -78,6 +78,7 @@ interface FakeClientHarness {
 
 interface FakeClientOptions {
 	readonly startResult?: StartResult;
+	readonly startGate?: Promise<StartResult>;
 	readonly subscribeGate?: Promise<void>;
 }
 
@@ -86,6 +87,13 @@ function makeFakeClient(options: FakeClientOptions = {}): FakeClientHarness {
 	let listener: ((event: EventParams) => void) | undefined;
 	let resolveSubscribed: (() => void) | undefined;
 	let resolveStarted: (() => void) | undefined;
+	let rejectStartOnClose: ((error: Error) => void) | undefined;
+	const startClosed =
+		options.startGate === undefined
+			? undefined
+			: new Promise<never>((_resolve, reject) => {
+					rejectStartOnClose = reject;
+				});
 	const subscribed = new Promise<void>((resolve) => {
 		resolveSubscribed = resolve;
 	});
@@ -101,6 +109,9 @@ function makeFakeClient(options: FakeClientOptions = {}): FakeClientHarness {
 		start: async (params) => {
 			calls.push({ op: "start", params });
 			resolveStarted?.();
+			if (options.startGate !== undefined && startClosed !== undefined) {
+				return await Promise.race([options.startGate, startClosed]);
+			}
 			return options.startResult ?? { session_id: "s1", state: "streaming" };
 		},
 		stop: async (params) => {
@@ -170,6 +181,7 @@ function makeFakeClient(options: FakeClientOptions = {}): FakeClientHarness {
 		},
 		close: async () => {
 			calls.push({ op: "close" });
+			rejectStartOnClose?.(new Error("client_closed"));
 		},
 	};
 	// `switch-audio` is dispatched by the backend through the client's raw
@@ -429,6 +441,31 @@ describe("CerastreamBackend behavioural contract", () => {
 		expect(params.srt.streamid).toBe("stream-1");
 		expect(params.bitrate.max_bitrate).toBe(8000);
 		expect(params.pipeline).toBe("h264_hdmi_1080p");
+	});
+
+	test("stop interrupts an in-flight start instead of waiting behind its queue", async () => {
+		// Given an accepted start request whose reply remains in flight.
+		const startGate = deferred<StartResult>();
+		const { backend, fake } = makeBackend({
+			fakeOptions: { startGate: startGate.promise },
+		});
+		const starting = backend.start(STREAM_CONFIG, RUN_OPTS);
+		const startFailure = starting.catch((error: unknown) => error);
+		await fake.started;
+		let stopped = false;
+
+		// When lifecycle cleanup requests a stop before that start reply settles.
+		expect(backend.stop(() => (stopped = true))).toBe(true);
+		await waitFor(() => stopped);
+
+		// Then stop reaches the engine immediately instead of joining behind start.
+		expect(fake.calls.map((call) => call.op)).toContain("stop");
+		expect(stopped).toBe(true);
+		expect(await startFailure).toMatchObject({
+			failure: { phase: "start-rpc", class: "engine_internal" },
+		});
+		await backend.settle();
+		expect(backend.stop(() => undefined)).toBe(false);
 	});
 
 	test("a starting reply remains pending until an authoritative streaming status event", async () => {

--- a/apps/backend/src/tests/streamloop-modules.test.ts
+++ b/apps/backend/src/tests/streamloop-modules.test.ts
@@ -131,7 +131,6 @@ describe("autostart.ts backoff seam", () => {
 		const retry = scheduled.find((s) => s.delay === AUTOSTART_RETRY_DELAY);
 		expect(retry).toBeDefined();
 		expect(typeof retry?.fn).toBe("function");
-		// It must retry with autoStartStream itself (self-rescheduling backoff).
-		expect(retry?.fn).toBe(autostartFn);
+		expect(retry?.fn).not.toBe(autostartFn);
 	});
 });

--- a/docs/START-LIFECYCLE.md
+++ b/docs/START-LIFECYCLE.md
@@ -207,8 +207,9 @@ per-attempt launch deadline, AND a total-time budget
   fenced to that cancelled launch and cannot declare the session started.
 - Engine stop bypasses `CerastreamBackend`'s ordinary IPC queue and uses the active
   client immediately. This lets deadline cleanup interrupt the in-flight start
-  instead of deadlocking behind it; the client is closed after the stop response,
-  which releases the queued start operation before a retry is admitted.
+  instead of deadlocking behind it. After dispatching stop, CeraUI closes the
+  client without waiting for a reply; closure settles pending start/stop requests
+  and releases the serialized queue before another generation is admitted.
 - A scheduled retry logs `attemptId`, phase, class, engine code when present, and
   retry state. It emits a class-keyed localized warning only outside a suppression
   window. Terminal exhaustion/non-retriable failure emits exactly one keyed error

--- a/docs/START-LIFECYCLE.md
+++ b/docs/START-LIFECYCLE.md
@@ -1,9 +1,9 @@
 # Start-Lifecycle Contract
 
-> **Status: RUNTIME THROUGH TRANSACTIONAL LAUNCH** (device-quality-wave2 Todos
-> 25-27). The typed contract, unified session orchestrator, cleanup transaction,
-> phase deadlines, and bounded stop result are wired. Retry/suppression and
-> frontend rendering remain Todos 28-29.
+> **Status: RUNTIME THROUGH BOUNDED RETRY** (device-quality-wave2 Todos 25-28).
+> The typed contract, unified session orchestrator, cleanup transaction, phase
+> deadlines, bounded stop, retry/suppression, and truthful notification
+> diagnostics are wired. Frontend generation fencing/rendering remains Todo 29.
 
 The streaming **start** is a multi-phase pipeline that can fail at any of several
 sites, in several ways, with very different correct responses (retry vs. surface
@@ -19,6 +19,8 @@ Typed modules:
 |---------|--------|
 | Wire contract (`StartResult`, `StartFailure`, `StopResult`, state set, transitions, retriability) | `packages/rpc/src/schemas/streaming-lifecycle.schema.ts` |
 | Mapping table + attempt-id + retry policy + suppression predicate | `apps/backend/src/modules/streaming/start-failure-taxonomy.ts` |
+| Bounded retry runner + cancellation | `apps/backend/src/modules/streaming/stream-start-retry.ts` |
+| Suppression signals + keyed notifications/logs | `apps/backend/src/modules/streaming/stream-start-retry-reporting.ts` |
 | Contract tests (schema) | `packages/rpc/src/schemas/streaming-lifecycle.schema.test.ts` |
 | Contract tests (table-driven mapping) | `apps/backend/src/tests/start-failure-taxonomy.test.ts` |
 
@@ -169,13 +171,13 @@ per public start entry; Todo 29 uses it to fence stale responses.
 A transient (retriable) failure inside a KNOWN window should show a calm "engine
 starting…" state, not an error notification. `shouldSuppressTransientFailure(ctx)`
 is the pure predicate; each input is sourced from an **existing** backend signal
-(Todo 28 binds them — this contract defines the shape + the source map):
+(Todo 28 binding):
 
 | Window | `SuppressionContext` field | Existing signal source |
 |--------|----------------------------|------------------------|
 | Software update active | `softwareUpdateActive` | `isUpdating()` (software-updates module) |
-| Known engine restart (systemd `RestartSec=5`) | `engineRestartWindow` | engine-reconnect capability state (`engineUnavailable`/`engineStarting`) |
-| Boot window | `bootWindow` | boot-readiness/health module |
+| Known engine restart (systemd `RestartSec=5`) | `engineRestartWindow` | a prior capability snapshot plus the current retriable connect failure (the engine was reachable this run and is now absent/refused) |
+| Boot window | `bootWindow` | initial `engineStarting` capability or process uptime within the 60-second start budget |
 | Cancelled by stop | `cancelledByStop` | the attempt ended as the first-class `cancelled` result — it notifies nothing |
 
 A **real terminal** failure (budget exhausted, or a non-retriable class) is NEVER
@@ -193,6 +195,13 @@ AND a total-time budget (`DEFAULT_START_RETRY_POLICY`: 5 attempts / 60s budget /
 - `nextBackoffDelayMs(attempt, policy)` — `base·2^attempt`, capped at `maxDelayMs`.
 - `shouldRetryStart(failure, {attempts, elapsedMs}, policy)` — retries iff the
   failure is `retriable` AND both budgets remain.
+- Every failed launch finishes its transactional rollback before the backoff timer
+  is armed. Stop cancels that timer by generation and produces `cancelled` with no
+  notification.
+- A scheduled retry logs `attemptId`, phase, class, engine code when present, and
+  retry state. It emits a class-keyed localized warning only outside a suppression
+  window. Terminal exhaustion/non-retriable failure emits exactly one keyed error
+  with attempt count and `journalctl -u cerastream.service`.
 
 Retriability is **phase-scoped** (see the retriability table below): only failures
 in the connection-establishment phases (`connect`, and `hello` for the
@@ -257,7 +266,7 @@ reconciling → idle          (engine was idle — adopt)
 |------|-------------------------|
 | 26 (unified lock + boot reconciliation) | `busy`/`cancelled` results, `attemptId`, the state set + transitions, `reconciling` |
 | 27 (implemented) | idempotent LIFO rollback, per-phase `start_timeout`, bounded `StopResult` |
-| 28 (bounded retry + suppression + truthful copy) | retry policy, retriability table, suppression predicate, `code`/`class` for copy |
+| 28 (implemented) | bounded retry, suppression binding, keyed copy, diagnostic payloads, bounded autostart |
 | 29 (frontend watchdog + generation identity + typed rendering) | `attemptId` fencing, `phase`+`class` → i18n rendering |
 
 ---

--- a/docs/START-LIFECYCLE.md
+++ b/docs/START-LIFECYCLE.md
@@ -187,8 +187,9 @@ suppressed — that gating lives in the retry loop (Todo 28), not in this predic
 
 ## (d) Retry policy
 
-Bounded exponential backoff, for **retriable classes only**, with a max-attempts
-AND a total-time budget (`DEFAULT_START_RETRY_POLICY`: 5 attempts / 60s budget /
+Bounded exponential backoff, for **retriable classes only**, with a max-attempts,
+per-attempt launch deadline, AND a total-time budget
+(`DEFAULT_START_RETRY_POLICY`: 5 attempts / 10s launch deadline / 60s budget /
 2s base / 16s ceiling — chosen against the supervision windows: systemd
 `RestartSec=5`, crash-loop 5/60s).
 
@@ -198,6 +199,16 @@ AND a total-time budget (`DEFAULT_START_RETRY_POLICY`: 5 attempts / 60s budget /
 - Every failed launch finishes its transactional rollback before the backoff timer
   is armed. Stop cancels that timer by generation and produces `cancelled` with no
   notification.
+- A launch that remains in flight for 10 seconds has its generation cancelled and
+  bounded cleanup awaited before it becomes a retriable connect-phase
+  `start_timeout`. The launch itself must then settle before backoff is armed. If
+  cleanup cannot make it settle within the stop bound, the result is terminal
+  `start_cleanup_timeout` and no next attempt launches. A late completion remains
+  fenced to that cancelled launch and cannot declare the session started.
+- Engine stop bypasses `CerastreamBackend`'s ordinary IPC queue and uses the active
+  client immediately. This lets deadline cleanup interrupt the in-flight start
+  instead of deadlocking behind it; the client is closed after the stop response,
+  which releases the queued start operation before a retry is admitted.
 - A scheduled retry logs `attemptId`, phase, class, engine code when present, and
   retry state. It emits a class-keyed localized warning only outside a suppression
   window. Terminal exhaustion/non-retriable failure emits exactly one keyed error

--- a/docs/START-LIFECYCLE.md
+++ b/docs/START-LIFECYCLE.md
@@ -244,7 +244,11 @@ State set: `idle | starting | streaming | stopping | stop_failed | reconciling`.
   after engine confirmation).
 - `reconciling` is the boot/reconnect state where the backend queries the
   engine's actual runtime state and adopts it (the engine may be streaming while
-  CeraUI restarted).
+  CeraUI restarted). A successfully subscribed probe observes status for 2.5
+  seconds: concordant streaming/idle is adopted immediately, silence resolves
+  idle because live sessions heartbeat every 2 seconds, and query failure or a
+  contradictory/transitional event remains unknown. Events arriving after the
+  probe closes are fenced.
 - `stop_failed` is a terminal-until-retried state a stop can land in.
 
 Legal transitions (anything else is an invariant violation → structured recovery,

--- a/packages/i18n/src/ar/index.ts
+++ b/packages/i18n/src/ar/index.ts
@@ -1470,6 +1470,26 @@ const ar = {
 		bitrateRange: "يجب أن يكون معدل البت بين 2000 و12000 كيلوبت/ثانية",
 	},
 	notifications: {
+		streamAutostartNoLinksFailed:
+			"فشل بدء البث التلقائي: لم تتوفر روابط شبكة بعد {attempt}/{maxAttempts} فحوصات. افحص journalctl -u ceralive.service.",
+		streamStartEngineUnavailableRetrying:
+			"محرك البث غير متاح — إعادة المحاولة ({nextAttempt}/{maxAttempts})…",
+		streamStartEngineRestartingRetrying:
+			"تتم إعادة تشغيل محرك البث — إعادة المحاولة ({nextAttempt}/{maxAttempts})…",
+		streamStartTimeoutRetrying:
+			"لم يستجب محرك البث في الوقت المحدد — إعادة المحاولة ({nextAttempt}/{maxAttempts})…",
+		streamStartEngineUnavailableFailed:
+			"فشل بدء البث: المحرك غير متاح ({attempt}/{maxAttempts} محاولات). افحص journalctl -u cerastream.service.",
+		streamStartEngineRestartingFailed:
+			"فشل بدء البث: استمر المحرك في إعادة التشغيل ({attempt}/{maxAttempts} محاولات). افحص journalctl -u cerastream.service.",
+		streamStartTimeoutFailed:
+			"فشل بدء البث: انتهت مهلة المحرك ({attempt}/{maxAttempts} محاولات). افحص journalctl -u cerastream.service.",
+		streamStartInvalidFailed:
+			"فشل بدء البث: الإعداد أو الجهاز غير صالح. افحص journalctl -u cerastream.service.",
+		streamStartProtocolFailed:
+			"فشل بدء البث: بروتوكول المحرك غير متوافق. افحص journalctl -u cerastream.service.",
+		streamStartInternalFailed:
+			"فشل بدء البث: خطأ داخلي في المحرك. افحص journalctl -u cerastream.service.",
 		ceraliveUpdateAvailable:
 			"يتوفر تحديث CERALIVE. افتح الإعدادات ← تحديثات البرامج لتثبيته.",
 		ceraliveUpdateFailed:

--- a/packages/i18n/src/de/index.ts
+++ b/packages/i18n/src/de/index.ts
@@ -766,6 +766,26 @@ const de = {
 		bitrateRange: "Die Bitrate muss zwischen 2000 und 12000 Kbps liegen",
 	},
 	notifications: {
+		streamAutostartNoLinksFailed:
+			"Automatischer Streamstart fehlgeschlagen: nach {attempt}/{maxAttempts} Prüfungen waren keine Netzwerkverbindungen verfügbar. Prüfe journalctl -u ceralive.service.",
+		streamStartEngineUnavailableRetrying:
+			"Streaming-Engine nicht verfügbar – neuer Versuch ({nextAttempt}/{maxAttempts})…",
+		streamStartEngineRestartingRetrying:
+			"Streaming-Engine wird neu gestartet – neuer Versuch ({nextAttempt}/{maxAttempts})…",
+		streamStartTimeoutRetrying:
+			"Streaming-Engine antwortete nicht rechtzeitig – neuer Versuch ({nextAttempt}/{maxAttempts})…",
+		streamStartEngineUnavailableFailed:
+			"Streamstart fehlgeschlagen: Engine nicht verfügbar ({attempt}/{maxAttempts} Versuche). Prüfe journalctl -u cerastream.service.",
+		streamStartEngineRestartingFailed:
+			"Streamstart fehlgeschlagen: Engine startete wiederholt neu ({attempt}/{maxAttempts} Versuche). Prüfe journalctl -u cerastream.service.",
+		streamStartTimeoutFailed:
+			"Streamstart fehlgeschlagen: Zeitüberschreitung ({attempt}/{maxAttempts} Versuche). Prüfe journalctl -u cerastream.service.",
+		streamStartInvalidFailed:
+			"Streamstart fehlgeschlagen: Konfiguration oder Gerät ungültig. Prüfe journalctl -u cerastream.service.",
+		streamStartProtocolFailed:
+			"Streamstart fehlgeschlagen: Engine-Protokoll inkompatibel. Prüfe journalctl -u cerastream.service.",
+		streamStartInternalFailed:
+			"Streamstart fehlgeschlagen: interner Engine-Fehler. Prüfe journalctl -u cerastream.service.",
 		ceraliveUpdateAvailable:
 			"Ein CERALIVE-Update ist verfügbar. Öffnen Sie Einstellungen → Softwareupdates, um es zu installieren.",
 		ceraliveUpdateFailed:

--- a/packages/i18n/src/en/index.ts
+++ b/packages/i18n/src/en/index.ts
@@ -748,6 +748,26 @@ const en = {
 		bitrateRange: "Bitrate must be between 2000 and 12000 Kbps",
 	},
 	notifications: {
+		streamAutostartNoLinksFailed:
+			"Automatic stream start failed: no network links became available after {attempt:number}/{maxAttempts:number} checks. Check journalctl -u ceralive.service.",
+		streamStartEngineUnavailableRetrying:
+			"Streaming engine unavailable — retrying ({nextAttempt:number}/{maxAttempts:number})…",
+		streamStartEngineRestartingRetrying:
+			"Streaming engine is restarting — retrying ({nextAttempt:number}/{maxAttempts:number})…",
+		streamStartTimeoutRetrying:
+			"Streaming engine did not answer in time — retrying ({nextAttempt:number}/{maxAttempts:number})…",
+		streamStartEngineUnavailableFailed:
+			"Stream failed to start: streaming engine unavailable ({attempt:number}/{maxAttempts:number} attempts). Check journalctl -u cerastream.service.",
+		streamStartEngineRestartingFailed:
+			"Stream failed to start: streaming engine kept restarting ({attempt:number}/{maxAttempts:number} attempts). Check journalctl -u cerastream.service.",
+		streamStartTimeoutFailed:
+			"Stream failed to start: streaming engine timed out ({attempt:number}/{maxAttempts:number} attempts). Check journalctl -u cerastream.service.",
+		streamStartInvalidFailed:
+			"Stream failed to start: configuration or device is invalid. Check journalctl -u cerastream.service.",
+		streamStartProtocolFailed:
+			"Stream failed to start: streaming engine protocol is incompatible. Check journalctl -u cerastream.service.",
+		streamStartInternalFailed:
+			"Stream failed to start: streaming engine internal error. Check journalctl -u cerastream.service.",
 		ceraliveUpdateAvailable:
 			"A CERALIVE update is available. Open Settings → Software Updates to install it.",
 		ceraliveUpdateFailed:

--- a/packages/i18n/src/es/index.ts
+++ b/packages/i18n/src/es/index.ts
@@ -769,6 +769,26 @@ const es = {
 		bitrateRange: "El bitrate debe estar entre 2000 y 12000 Kbps",
 	},
 	notifications: {
+		streamAutostartNoLinksFailed:
+			"El inicio automático falló: no hubo enlaces de red tras {attempt}/{maxAttempts} comprobaciones. Revisa journalctl -u ceralive.service.",
+		streamStartEngineUnavailableRetrying:
+			"Motor de streaming no disponible; reintentando ({nextAttempt}/{maxAttempts})…",
+		streamStartEngineRestartingRetrying:
+			"El motor de streaming se está reiniciando; reintentando ({nextAttempt}/{maxAttempts})…",
+		streamStartTimeoutRetrying:
+			"El motor de streaming no respondió a tiempo; reintentando ({nextAttempt}/{maxAttempts})…",
+		streamStartEngineUnavailableFailed:
+			"No se pudo iniciar el stream: motor no disponible ({attempt}/{maxAttempts} intentos). Revisa journalctl -u cerastream.service.",
+		streamStartEngineRestartingFailed:
+			"No se pudo iniciar el stream: el motor siguió reiniciándose ({attempt}/{maxAttempts} intentos). Revisa journalctl -u cerastream.service.",
+		streamStartTimeoutFailed:
+			"No se pudo iniciar el stream: tiempo de espera agotado ({attempt}/{maxAttempts} intentos). Revisa journalctl -u cerastream.service.",
+		streamStartInvalidFailed:
+			"No se pudo iniciar el stream: la configuración o el dispositivo no son válidos. Revisa journalctl -u cerastream.service.",
+		streamStartProtocolFailed:
+			"No se pudo iniciar el stream: el protocolo del motor es incompatible. Revisa journalctl -u cerastream.service.",
+		streamStartInternalFailed:
+			"No se pudo iniciar el stream: error interno del motor. Revisa journalctl -u cerastream.service.",
 		ceraliveUpdateAvailable:
 			"Hay una actualización de CERALIVE disponible. Abre Ajustes → Actualizaciones de software para instalarla.",
 		ceraliveUpdateFailed:

--- a/packages/i18n/src/fr/index.ts
+++ b/packages/i18n/src/fr/index.ts
@@ -1532,6 +1532,26 @@ const fr = {
 		bitrateRange: "Le débit doit être compris entre 2000 et 12000 Kbps",
 	},
 	notifications: {
+		streamAutostartNoLinksFailed:
+			"Échec du démarrage automatique : aucun lien réseau après {attempt}/{maxAttempts} vérifications. Consultez journalctl -u ceralive.service.",
+		streamStartEngineUnavailableRetrying:
+			"Moteur de streaming indisponible — nouvelle tentative ({nextAttempt}/{maxAttempts})…",
+		streamStartEngineRestartingRetrying:
+			"Le moteur de streaming redémarre — nouvelle tentative ({nextAttempt}/{maxAttempts})…",
+		streamStartTimeoutRetrying:
+			"Le moteur de streaming n’a pas répondu à temps — nouvelle tentative ({nextAttempt}/{maxAttempts})…",
+		streamStartEngineUnavailableFailed:
+			"Échec du démarrage : moteur indisponible ({attempt}/{maxAttempts} tentatives). Consultez journalctl -u cerastream.service.",
+		streamStartEngineRestartingFailed:
+			"Échec du démarrage : redémarrages répétés du moteur ({attempt}/{maxAttempts} tentatives). Consultez journalctl -u cerastream.service.",
+		streamStartTimeoutFailed:
+			"Échec du démarrage : délai du moteur dépassé ({attempt}/{maxAttempts} tentatives). Consultez journalctl -u cerastream.service.",
+		streamStartInvalidFailed:
+			"Échec du démarrage : configuration ou appareil non valide. Consultez journalctl -u cerastream.service.",
+		streamStartProtocolFailed:
+			"Échec du démarrage : protocole du moteur incompatible. Consultez journalctl -u cerastream.service.",
+		streamStartInternalFailed:
+			"Échec du démarrage : erreur interne du moteur. Consultez journalctl -u cerastream.service.",
 		ceraliveUpdateAvailable:
 			"Une mise à jour CERALIVE est disponible. Ouvrez Paramètres → Mises à jour logicielles pour l'installer.",
 		ceraliveUpdateFailed:

--- a/packages/i18n/src/hi/index.ts
+++ b/packages/i18n/src/hi/index.ts
@@ -1331,6 +1331,26 @@ const hi = {
 		bitrateRange: "बिटरेट 2000 और 12000 Kbps के बीच होना चाहिए",
 	},
 	notifications: {
+		streamAutostartNoLinksFailed:
+			"स्वचालित स्ट्रीम शुरू नहीं हुई: {attempt}/{maxAttempts} जाँचों के बाद कोई नेटवर्क लिंक उपलब्ध नहीं था। journalctl -u ceralive.service देखें।",
+		streamStartEngineUnavailableRetrying:
+			"स्ट्रीमिंग इंजन उपलब्ध नहीं है — पुनः प्रयास ({nextAttempt}/{maxAttempts})…",
+		streamStartEngineRestartingRetrying:
+			"स्ट्रीमिंग इंजन पुनः आरंभ हो रहा है — पुनः प्रयास ({nextAttempt}/{maxAttempts})…",
+		streamStartTimeoutRetrying:
+			"स्ट्रीमिंग इंजन ने समय पर उत्तर नहीं दिया — पुनः प्रयास ({nextAttempt}/{maxAttempts})…",
+		streamStartEngineUnavailableFailed:
+			"स्ट्रीम शुरू नहीं हुई: इंजन उपलब्ध नहीं है ({attempt}/{maxAttempts} प्रयास)। journalctl -u cerastream.service देखें।",
+		streamStartEngineRestartingFailed:
+			"स्ट्रीम शुरू नहीं हुई: इंजन बार-बार पुनः आरंभ हुआ ({attempt}/{maxAttempts} प्रयास)। journalctl -u cerastream.service देखें।",
+		streamStartTimeoutFailed:
+			"स्ट्रीम शुरू नहीं हुई: इंजन का समय समाप्त हुआ ({attempt}/{maxAttempts} प्रयास)। journalctl -u cerastream.service देखें।",
+		streamStartInvalidFailed:
+			"स्ट्रीम शुरू नहीं हुई: कॉन्फ़िगरेशन या डिवाइस अमान्य है। journalctl -u cerastream.service देखें।",
+		streamStartProtocolFailed:
+			"स्ट्रीम शुरू नहीं हुई: इंजन प्रोटोकॉल असंगत है। journalctl -u cerastream.service देखें।",
+		streamStartInternalFailed:
+			"स्ट्रीम शुरू नहीं हुई: इंजन की आंतरिक त्रुटि। journalctl -u cerastream.service देखें।",
 		ceraliveUpdateAvailable:
 			"एक CERALIVE अपडेट उपलब्ध है। इसे इंस्टॉल करने के लिए सेटिंग्स → सॉफ़्टवेयर अपडेट खोलें।",
 		ceraliveUpdateFailed:

--- a/packages/i18n/src/ja/index.ts
+++ b/packages/i18n/src/ja/index.ts
@@ -1374,6 +1374,26 @@ const ja = {
 		bitrateRange: "ビットレートは2000から12000 Kbpsの間でなければなりません",
 	},
 	notifications: {
+		streamAutostartNoLinksFailed:
+			"自動配信を開始できませんでした：{attempt}/{maxAttempts} 回確認してもネットワークリンクを利用できません。journalctl -u ceralive.service を確認してください。",
+		streamStartEngineUnavailableRetrying:
+			"ストリーミングエンジンを利用できません — 再試行中（{nextAttempt}/{maxAttempts}）…",
+		streamStartEngineRestartingRetrying:
+			"ストリーミングエンジンを再起動中です — 再試行中（{nextAttempt}/{maxAttempts}）…",
+		streamStartTimeoutRetrying:
+			"ストリーミングエンジンが時間内に応答しませんでした — 再試行中（{nextAttempt}/{maxAttempts}）…",
+		streamStartEngineUnavailableFailed:
+			"配信を開始できませんでした：エンジンを利用できません（{attempt}/{maxAttempts} 回）。journalctl -u cerastream.service を確認してください。",
+		streamStartEngineRestartingFailed:
+			"配信を開始できませんでした：エンジンが再起動を繰り返しました（{attempt}/{maxAttempts} 回）。journalctl -u cerastream.service を確認してください。",
+		streamStartTimeoutFailed:
+			"配信を開始できませんでした：エンジンがタイムアウトしました（{attempt}/{maxAttempts} 回）。journalctl -u cerastream.service を確認してください。",
+		streamStartInvalidFailed:
+			"配信を開始できませんでした：設定またはデバイスが無効です。journalctl -u cerastream.service を確認してください。",
+		streamStartProtocolFailed:
+			"配信を開始できませんでした：エンジンプロトコルに互換性がありません。journalctl -u cerastream.service を確認してください。",
+		streamStartInternalFailed:
+			"配信を開始できませんでした：エンジン内部エラー。journalctl -u cerastream.service を確認してください。",
 		ceraliveUpdateAvailable:
 			"CERALIVE のアップデートがあります。設定 → ソフトウェア更新 を開いてインストールしてください。",
 		ceraliveUpdateFailed:

--- a/packages/i18n/src/ko/index.ts
+++ b/packages/i18n/src/ko/index.ts
@@ -1348,6 +1348,26 @@ const ko = {
 		bitrateRange: "비트레이트는 2000에서 12000 Kbps 사이여야 합니다",
 	},
 	notifications: {
+		streamAutostartNoLinksFailed:
+			"자동 스트림 시작에 실패했습니다: {attempt}/{maxAttempts}회 확인 후에도 네트워크 링크가 없습니다. journalctl -u ceralive.service를 확인하세요.",
+		streamStartEngineUnavailableRetrying:
+			"스트리밍 엔진을 사용할 수 없습니다 — 재시도 중 ({nextAttempt}/{maxAttempts})…",
+		streamStartEngineRestartingRetrying:
+			"스트리밍 엔진이 다시 시작 중입니다 — 재시도 중 ({nextAttempt}/{maxAttempts})…",
+		streamStartTimeoutRetrying:
+			"스트리밍 엔진이 제시간에 응답하지 않았습니다 — 재시도 중 ({nextAttempt}/{maxAttempts})…",
+		streamStartEngineUnavailableFailed:
+			"스트림을 시작하지 못했습니다: 엔진을 사용할 수 없습니다 ({attempt}/{maxAttempts}회). journalctl -u cerastream.service를 확인하세요.",
+		streamStartEngineRestartingFailed:
+			"스트림을 시작하지 못했습니다: 엔진이 계속 다시 시작되었습니다 ({attempt}/{maxAttempts}회). journalctl -u cerastream.service를 확인하세요.",
+		streamStartTimeoutFailed:
+			"스트림을 시작하지 못했습니다: 엔진 시간 초과 ({attempt}/{maxAttempts}회). journalctl -u cerastream.service를 확인하세요.",
+		streamStartInvalidFailed:
+			"스트림을 시작하지 못했습니다: 구성 또는 장치가 올바르지 않습니다. journalctl -u cerastream.service를 확인하세요.",
+		streamStartProtocolFailed:
+			"스트림을 시작하지 못했습니다: 엔진 프로토콜이 호환되지 않습니다. journalctl -u cerastream.service를 확인하세요.",
+		streamStartInternalFailed:
+			"스트림을 시작하지 못했습니다: 엔진 내부 오류. journalctl -u cerastream.service를 확인하세요.",
 		ceraliveUpdateAvailable:
 			"CERALIVE 업데이트가 있습니다. 설정 → 소프트웨어 업데이트를 열어 설치하세요.",
 		ceraliveUpdateFailed:

--- a/packages/i18n/src/pt-BR/index.ts
+++ b/packages/i18n/src/pt-BR/index.ts
@@ -1507,6 +1507,26 @@ const ptBR = {
 		bitrateRange: "A taxa de bits deve estar entre 2000 e 12000 Kbps",
 	},
 	notifications: {
+		streamAutostartNoLinksFailed:
+			"Falha no início automático: nenhum link de rede após {attempt}/{maxAttempts} verificações. Verifique journalctl -u ceralive.service.",
+		streamStartEngineUnavailableRetrying:
+			"Mecanismo de streaming indisponível — tentando novamente ({nextAttempt}/{maxAttempts})…",
+		streamStartEngineRestartingRetrying:
+			"O mecanismo de streaming está reiniciando — tentando novamente ({nextAttempt}/{maxAttempts})…",
+		streamStartTimeoutRetrying:
+			"O mecanismo de streaming não respondeu a tempo — tentando novamente ({nextAttempt}/{maxAttempts})…",
+		streamStartEngineUnavailableFailed:
+			"Falha ao iniciar: mecanismo indisponível ({attempt}/{maxAttempts} tentativas). Verifique journalctl -u cerastream.service.",
+		streamStartEngineRestartingFailed:
+			"Falha ao iniciar: o mecanismo continuou reiniciando ({attempt}/{maxAttempts} tentativas). Verifique journalctl -u cerastream.service.",
+		streamStartTimeoutFailed:
+			"Falha ao iniciar: tempo limite do mecanismo ({attempt}/{maxAttempts} tentativas). Verifique journalctl -u cerastream.service.",
+		streamStartInvalidFailed:
+			"Falha ao iniciar: configuração ou dispositivo inválido. Verifique journalctl -u cerastream.service.",
+		streamStartProtocolFailed:
+			"Falha ao iniciar: protocolo do mecanismo incompatível. Verifique journalctl -u cerastream.service.",
+		streamStartInternalFailed:
+			"Falha ao iniciar: erro interno do mecanismo. Verifique journalctl -u cerastream.service.",
 		ceraliveUpdateAvailable:
 			"Há uma atualização do CERALIVE disponível. Abra Configurações → Atualizações de software para instalá-la.",
 		ceraliveUpdateFailed:

--- a/packages/i18n/src/zh/index.ts
+++ b/packages/i18n/src/zh/index.ts
@@ -1283,6 +1283,26 @@ const zh = {
 		bitrateRange: "比特率必须在 2000 到 12000 Kbps 之间",
 	},
 	notifications: {
+		streamAutostartNoLinksFailed:
+			"自动流启动失败：检查 {attempt}/{maxAttempts} 次后仍无可用网络链路。请检查 journalctl -u ceralive.service。",
+		streamStartEngineUnavailableRetrying:
+			"流媒体引擎不可用 — 正在重试（{nextAttempt}/{maxAttempts}）…",
+		streamStartEngineRestartingRetrying:
+			"流媒体引擎正在重启 — 正在重试（{nextAttempt}/{maxAttempts}）…",
+		streamStartTimeoutRetrying:
+			"流媒体引擎未及时响应 — 正在重试（{nextAttempt}/{maxAttempts}）…",
+		streamStartEngineUnavailableFailed:
+			"流启动失败：引擎不可用（已尝试 {attempt}/{maxAttempts} 次）。请检查 journalctl -u cerastream.service。",
+		streamStartEngineRestartingFailed:
+			"流启动失败：引擎持续重启（已尝试 {attempt}/{maxAttempts} 次）。请检查 journalctl -u cerastream.service。",
+		streamStartTimeoutFailed:
+			"流启动失败：引擎超时（已尝试 {attempt}/{maxAttempts} 次）。请检查 journalctl -u cerastream.service。",
+		streamStartInvalidFailed:
+			"流启动失败：配置或设备无效。请检查 journalctl -u cerastream.service。",
+		streamStartProtocolFailed:
+			"流启动失败：引擎协议不兼容。请检查 journalctl -u cerastream.service。",
+		streamStartInternalFailed:
+			"流启动失败：引擎内部错误。请检查 journalctl -u cerastream.service。",
 		ceraliveUpdateAvailable:
 			"有可用的 CERALIVE 更新。打开 设置 → 软件更新 进行安装。",
 		ceraliveUpdateFailed: "软件更新失败。打开 设置 → 软件更新 查看原因并重试。",


### PR DESCRIPTION
## What
- Add bounded exponential retry for retriable connect-phase stream-start failures, with one attempt identity across retries and cancellation on Stop.
- Suppress transient operator errors during update, boot, and known engine-restart windows; emit one keyed terminal notification after exhaustion.
- Bound autostart link waiting and replace retry claims with copy that names the component that actually retries.
- Add all notification keys to the ten supported locales and document the lifecycle contract.

## Why
A cerastream restart could make a valid Start fail immediately, while existing notifications promised retries that were not always scheduled. The device needs a finite recovery window and a truthful terminal result.

## How to verify
- bun test apps/backend/src/tests/stream-session-orchestrator.test.ts apps/backend/src/tests/stream-start-retry-reporting.test.ts apps/backend/src/tests/edge-cases/streamloop-autostart.test.ts
- bun run --filter frontend test
- bun run --filter backend check
- bun run --filter frontend check
- BUILD_ARCH=arm64 bun run build
- bun run --filter frontend test:e2e -- tests/e2e/stream-start-failure.spec.ts tests/e2e/relay-notifications.spec.ts

Full backend test comparison: this branch and the untouched base have the same four privilege-only failures under /run and /var/run; the branch adds nine passing tests.

## Risks
The retry window can delay a terminal response for a genuinely unavailable engine. It is bounded by both attempt count and elapsed time, retries only typed transient connect failures, and Stop cancels the pending wait.
