### PR TITLE
fix(sources): reconcile device re-enumeration, drop stale Lost rows

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -765,6 +765,19 @@ Every row is one of four `origin` variants (`capture`/`coarse`/`virtual`/
   producers/fields. Tracked as `TD-legacy-source-broadcasts` in
   `docs/TECHNICAL_DEBT.md`; do not delete the producers until that entry's
   exit condition is met.
+- **Hotplug re-enumeration reconciliation (Todo 34)**: a capture device that
+  re-enumerates under a new node path (video1→video2, e.g. a USB reset or
+  module unbind-rebind) is reconciled by STABLE IDENTITY, not node path. The
+  engine's `stable_id` (cerastream Todo 20, `usb:<vid>:<pid>[:serial|@port]`) is
+  threaded verbatim through `fromEngineDevice()` → the engine-device cache →
+  the persisted `last_seen_devices` snapshot (`stableId`). In `buildSources`,
+  a remembered snapshot absent from the live list by node path but PRESENT by
+  stable identity is dropped (the live successor owns the row) — so a rename
+  migrates the row instead of leaving a stuck `lost:true` row. A TRUE unplug
+  (no live device shares the snapshot's stable id) still yields a `lost` row,
+  and an engine that never emits `stable_id` degrades to the prior node-path
+  behavior. Coverage: `tests/sources.test.ts` ("hotplug re-enumeration
+  reconciliation (Todo 34)").
 - **`getLinkTelemetry` null-on-stop** is a backend-locked contract:
   `stopLinkTelemetry()` clears the source state so the NEXT heartbeat tick's
   `broadcastLinkTelemetryIfChanged()` emits `{linkTelemetry: null}` exactly

--- a/apps/backend/src/helpers/config-schemas.ts
+++ b/apps/backend/src/helpers/config-schemas.ts
@@ -165,6 +165,12 @@ export const lastSeenDeviceSchema = z.object({
 	kind: deviceKindSchema,
 	pipelineId: z.string(),
 	devicePath: z.string(),
+	// Reboot-stable hardware identity (cerastream Todo 20 `stable_id`) captured at
+	// observation time. Additive + optional: a snapshot persisted before Todo 34
+	// still parses, and the reconciler falls back to node-path identity when it is
+	// absent. Lets a re-enumerated device (video1→video2) migrate its row instead
+	// of leaving a stuck `lost` row (Todo 34).
+	stableId: z.string().optional(),
 });
 
 export type LastSeenDevice = z.infer<typeof lastSeenDeviceSchema>;

--- a/apps/backend/src/modules/streaming/devices.ts
+++ b/apps/backend/src/modules/streaming/devices.ts
@@ -157,6 +157,10 @@ export interface EngineCaptureDevice {
 	media_class: DeviceMediaClass;
 	kind?: string | undefined;
 	caps?: CaptureCap[] | undefined;
+	// Reboot-stable hardware identity (cerastream Todo 20 `stable_id`). Carried
+	// verbatim so sources reconciliation can migrate a re-enumerated device by
+	// stable identity rather than node path (Todo 34).
+	stable_id?: string | undefined;
 }
 
 /** Map one engine device onto a CeraUI {@link CaptureDevice}: ids are carried
@@ -170,6 +174,7 @@ export function fromEngineDevice(device: EngineCaptureDevice): CaptureDevice {
 		media_class: device.media_class,
 		kind: mapEngineDeviceKind(device.kind, device.display_name),
 		...(device.caps !== undefined ? { caps: device.caps } : {}),
+		...(device.stable_id !== undefined ? { stable_id: device.stable_id } : {}),
 	};
 }
 
@@ -237,6 +242,7 @@ async function defaultGetEngineDevices(): Promise<CaptureDevice[] | null> {
 				media_class: d.media_class,
 				kind: d.kind,
 				caps: d.caps,
+				stable_id: d.stable_id,
 			}),
 		);
 	} catch (err) {

--- a/apps/backend/src/modules/streaming/sources.ts
+++ b/apps/backend/src/modules/streaming/sources.ts
@@ -370,9 +370,19 @@ export function buildSources(input: BuildSourcesInput): StreamSource[] {
 
 	const capturesByPipeline = new Map<string, StreamSource[]>();
 	const liveVideoIds = new Set<string>();
+	// Stable hardware identities of the currently-live video devices. A remembered
+	// device absent from the live list by NODE PATH but present here by STABLE
+	// IDENTITY has re-enumerated (video1→video2 on a USB reset / unbind-rebind);
+	// its row migrates to the live successor instead of orphaning a `lost` row
+	// (Todo 34). An engine that never emits `stable_id` contributes nothing here,
+	// so the lost loop degrades to node-path identity.
+	const liveStableIds = new Set<string>();
 	for (const device of input.devices) {
 		if (device.media_class !== "video") continue;
 		liveVideoIds.add(device.input_id);
+		if (device.stable_id !== undefined && device.stable_id !== "") {
+			liveStableIds.add(device.stable_id);
+		}
 		const bridged = deviceKindToPipelineId(device.kind);
 		if (bridged === undefined) continue;
 		const coarse = coarseByPipeline.get(bridged);
@@ -390,6 +400,17 @@ export function buildSources(input: BuildSourcesInput): StreamSource[] {
 	const lostByPipeline = new Map<string, StreamSource[]>();
 	for (const snapshot of collectLostCandidates(input)) {
 		if (liveVideoIds.has(snapshot.id)) continue;
+		// Same physical device under a new node path (re-enumeration): the live
+		// successor already owns the row, so drop the stale `lost` candidate — this
+		// is the migrate-don't-orphan fix (Todo 34). A true unplug (no successor)
+		// has no matching live stable id, so its `lost` row is preserved.
+		if (
+			snapshot.stableId !== undefined &&
+			snapshot.stableId !== "" &&
+			liveStableIds.has(snapshot.stableId)
+		) {
+			continue;
+		}
 		const coarse = coarseByPipeline.get(snapshot.pipelineId);
 		if (coarse === undefined) continue;
 		const list = lostByPipeline.get(snapshot.pipelineId) ?? [];
@@ -545,6 +566,7 @@ function snapshotFromDevice(device: CaptureDevice): LastSeenDevice | undefined {
 		kind: device.kind,
 		pipelineId,
 		devicePath: device.device_path,
+		...(device.stable_id !== undefined ? { stableId: device.stable_id } : {}),
 	};
 }
 
@@ -651,6 +673,7 @@ export async function refreshEngineDeviceCache(
 				media_class: d.media_class,
 				kind: d.kind,
 				caps: d.caps,
+				stable_id: d.stable_id,
 			}),
 		);
 		// Parallel AUDIO cache (T4): an EXPLICIT field copy of the audio entries

--- a/apps/backend/src/tests/sources.test.ts
+++ b/apps/backend/src/tests/sources.test.ts
@@ -632,3 +632,148 @@ describe("source routing stays isolated from cerastream-backend.ts", () => {
 		expect(backend).not.toContain("buildSources");
 	});
 });
+
+describe("buildSources — hotplug re-enumeration reconciliation (Todo 34)", () => {
+	// A physical device carries a stable hardware identity that survives a node
+	// rename (video1→video2 on a USB reset / unbind-rebind). Reconciliation keys
+	// on this, not the node path, so a rename migrates the row.
+	const STABLE_A = "usb:19f7:0003:SN-A";
+	const STABLE_B = "usb:19f7:0003:SN-B";
+
+	function hotplugDevice(
+		input_id: string,
+		stableId: string | undefined,
+	): CaptureDevice {
+		return {
+			input_id,
+			device_path: `/dev/${input_id}`,
+			display_name: "RØDE HDMI to USB-C",
+			media_class: "video",
+			kind: "hdmi",
+			...(stableId !== undefined ? { stable_id: stableId } : {}),
+		};
+	}
+
+	function seenSnapshot(
+		id: string,
+		stableId: string | undefined,
+	): LastSeenDevice {
+		return {
+			id,
+			displayName: "RØDE HDMI to USB-C",
+			kind: "hdmi",
+			pipelineId: "hdmi",
+			devicePath: `/dev/${id}`,
+			...(stableId !== undefined ? { stableId } : {}),
+		};
+	}
+
+	function lostRows(sources: StreamSource[]): StreamSource[] {
+		return sources.filter((s) => s.lost === true);
+	}
+
+	function captureRows(sources: StreamSource[]): StreamSource[] {
+		return sources.filter((s) => s.origin === "capture" && s.lost !== true);
+	}
+
+	it("a video1→video2 rename migrates the row: ONE live capture, no stuck Lost row", () => {
+		// video1 was seen this session (and is the configured source); the engine
+		// now lists the SAME physical device re-enumerated at video2.
+		const video1 = seenSnapshot("video1", STABLE_A);
+		const sources = buildSources({
+			sources: [capSource("hdmi"), capSource("test")],
+			devices: [hotplugDevice("video2", STABLE_A)],
+			networkIngest: NO_INGEST,
+			configSource: "video1",
+			lastSeenDevices: [video1],
+			sessionSnapshots: new Map([[video1.id, video1]]),
+		});
+
+		expect(lostRows(sources)).toHaveLength(0);
+		const captures = captureRows(sources);
+		expect(captures).toHaveLength(1);
+		expect(captures[0]?.id).toBe("video2");
+	});
+
+	it("a TRUE unplug (no successor) still shows Lost — guards against over-deletion", () => {
+		// video1 was seen this session; the engine now lists NOTHING — a genuine
+		// unplug, not a rename. The Lost row MUST remain.
+		const video1 = seenSnapshot("video1", STABLE_A);
+		const sources = buildSources({
+			sources: [capSource("hdmi"), capSource("test")],
+			devices: [],
+			networkIngest: NO_INGEST,
+			configSource: "video1",
+			lastSeenDevices: [video1],
+			sessionSnapshots: new Map([[video1.id, video1]]),
+		});
+
+		const lost = lostRows(sources);
+		expect(lost).toHaveLength(1);
+		expect(lost[0]?.id).toBe("video1");
+		expect(captureRows(sources)).toHaveLength(0);
+	});
+
+	it("a rapid rename cycle (video1→video2→video3) collapses to ONE live row, no Lost rows", () => {
+		// Every intermediate node was session-seen; the engine now lists only the
+		// final node. All prior nodes share the ONE stable identity.
+		const video1 = seenSnapshot("video1", STABLE_A);
+		const video2 = seenSnapshot("video2", STABLE_A);
+		const sources = buildSources({
+			sources: [capSource("hdmi"), capSource("test")],
+			devices: [hotplugDevice("video3", STABLE_A)],
+			networkIngest: NO_INGEST,
+			configSource: "video1",
+			lastSeenDevices: [video1, video2],
+			sessionSnapshots: new Map([
+				[video1.id, video1],
+				[video2.id, video2],
+			]),
+		});
+
+		expect(lostRows(sources)).toHaveLength(0);
+		const captures = captureRows(sources);
+		expect(captures).toHaveLength(1);
+		expect(captures[0]?.id).toBe("video3");
+	});
+
+	it("a DIFFERENT physical device at a new node does NOT suppress the original's Lost row", () => {
+		// video1 (SN-A) vanished; the engine lists a genuinely different device
+		// (SN-B) at video2. SN-A has no successor, so its Lost row must remain and
+		// SN-B is its own live row.
+		const video1 = seenSnapshot("video1", STABLE_A);
+		const sources = buildSources({
+			sources: [capSource("hdmi"), capSource("test")],
+			devices: [hotplugDevice("video2", STABLE_B)],
+			networkIngest: NO_INGEST,
+			configSource: "video1",
+			lastSeenDevices: [video1],
+			sessionSnapshots: new Map([[video1.id, video1]]),
+		});
+
+		const lost = lostRows(sources);
+		expect(lost).toHaveLength(1);
+		expect(lost[0]?.id).toBe("video1");
+		const captures = captureRows(sources);
+		expect(captures).toHaveLength(1);
+		expect(captures[0]?.id).toBe("video2");
+	});
+
+	it("without a stable identity (old engine), a rename falls back to node-path behavior (unchanged)", () => {
+		// No stable_id on either side → the reconciler cannot prove a successor, so
+		// the pre-Todo-34 node-path behavior is preserved (a Lost row appears). This
+		// documents the safe degradation boundary, not a regression.
+		const video1 = seenSnapshot("video1", undefined);
+		const sources = buildSources({
+			sources: [capSource("hdmi"), capSource("test")],
+			devices: [hotplugDevice("video2", undefined)],
+			networkIngest: NO_INGEST,
+			configSource: "video1",
+			lastSeenDevices: [video1],
+			sessionSnapshots: new Map([[video1.id, video1]]),
+		});
+
+		expect(lostRows(sources)).toHaveLength(1);
+		expect(captureRows(sources)).toHaveLength(1);
+	});
+});

--- a/packages/rpc/src/schemas/streaming.schema.ts
+++ b/packages/rpc/src/schemas/streaming.schema.ts
@@ -887,6 +887,11 @@ export const captureDeviceSchema = z.object({
 	media_class: deviceMediaClassSchema,
 	kind: deviceKindSchema,
 	caps: z.array(captureCapSchema).optional(),
+	// Reboot-stable hardware identity (cerastream Todo 20 `stable_id`). Additive +
+	// optional. Sources reconciliation keys a re-enumerated device (node path
+	// changed, video1→video2) on this, not `input_id`, so a rename migrates the
+	// row instead of orphaning a stale `lost:true` one (Todo 34).
+	stable_id: z.string().optional(),
 	lost: z.boolean().optional(),
 });
 export type CaptureDevice = z.infer<typeof captureDeviceSchema>;


### PR DESCRIPTION
## What

A capture device that re-enumerates under a **new node path** (e.g. `/dev/video1` → `/dev/video2` on a USB reset or module unbind-rebind) previously left a permanent **"Lost"** row for the old node *alongside* a new row for the same physical device. Root cause: device identity in the source reconciler was keyed on the **node path** (`input_id`) instead of a stable hardware identity.

`buildSources()` now reconciles re-enumeration by **stable identity**. The engine's `stable_id` (cerastream Todo 20 — `usb:<vid>:<pid>[:serial|@port]`) is threaded verbatim through `fromEngineDevice()` → the engine-device cache → the persisted `last_seen_devices` snapshot. A remembered snapshot that is absent from the live list by node path but **present by stable identity** is dropped, so its row **migrates** to the live successor instead of orphaning a `lost:true` row.

## Why

Reported IDLE hotplug-staleness bug (repro documented in `device-stability-wrapup` task-12 §8): after a `video1→video2` shift, CeraUI kept a stuck "Lost" row for `/dev/video1` and offered no clean single row for the re-enumerated device. This blocks a downstream Wave-H hotplug drill.

## How it stays safe

- **True unplug preserved** — when no live device shares the snapshot's `stable_id`, the `lost` row is kept. A genuine unplug must still surface as Lost; a negative test asserts this.
- **Graceful degradation** — an engine that never emits `stable_id` contributes nothing to the live-identity set, so the lost loop falls back to the prior node-path behavior. No regression on old engines.
- **Additive-only** — `stable_id` on `captureDeviceSchema` and `stableId` on the persisted `lastSeenDeviceSchema` are both additive-optional; a legacy persisted snapshot still parses.
- This is a **CeraUI control-plane reconciliation fix only** — no engine-side enumeration changes.

## How to verify

Red→green characterization tests in `apps/backend/src/tests/sources.test.ts` under *"hotplug re-enumeration reconciliation (Todo 34)"*:

- `video1→video2 rename` migrates the row → ONE live capture, no stuck Lost row (RED before, GREEN after).
- `TRUE unplug (no successor)` → still shows Lost (passes before **and** after — guards over-deletion).
- `rapid rename cycle (video1→video2→video3)` → collapses to ONE live row, no Lost rows.
- `different physical device at a new node` → the original's Lost row is preserved and the new device is its own row.
- `no stable identity (old engine)` → documented node-path fallback (Lost row still appears).

```
bun test src/tests/sources.test.ts   # 34 pass / 0 fail
```

Full gate green locally: backend `tsc` clean, rpc `tsc` clean, Biome clean on changed files, full backend suite 2169 pass / 4 fail (all 4 are the pre-existing local-only EACCES baseline: 3× srtla ips-file writer + 1× bcrpt `/var/run/bcrpt` — unrelated to this change).

## Risks

Low. Additive schema/snapshot fields; the reconciliation only *suppresses* a lost row when a live device proves the same physical hardware is present. Over-deletion is guarded by the true-unplug negative test; old-engine behavior is unchanged.

## Board confirmation

Hardware re-enumeration confirmation (trigger `video1→video2` via `usbreset`/module unbind-rebind on the RK3588 board, verify ONE row / no stuck Lost) is **DEFERRED to Wave H1** — the board's universal lock is held by an unrelated in-flight todo. The code + test portion is complete and independently verifiable via the fake-hotplug characterization suite above.