### PR TITLE
fix(packaging): stage addon-reconciler unit from deployment/ + package-contract test

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -108,6 +108,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-store-
 
+      - name: Cache Ruby gems (fpm)
+        uses: actions/cache@v6
+        with:
+          path: /var/lib/gems
+          key: ${{ runner.os }}-ruby-gems-fpm-v1
+          restore-keys: |
+            ${{ runner.os }}-ruby-gems-fpm-
+
+      - name: Install Ruby and FPM
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ruby-dev gcc g++
+          sudo gem install --no-document fpm
+
       - name: Install dependencies
         working-directory: CeraUI
         run: bun install --frozen-lockfile

--- a/scripts/build/build-debian-package.sh
+++ b/scripts/build/build-debian-package.sh
@@ -83,7 +83,9 @@ log_step "Copying files to package structure"
 cp dist/ceralive "$TEMP_DIR/usr/local/bin/ceralive"
 cp dist/ceralive.service "$TEMP_DIR/etc/systemd/system/"
 # Post-boot add-on reconciler oneshot (T29). Non-blocking; never gates rollback.
-cp dist/ceralive-addon-reconciler.service "$TEMP_DIR/etc/systemd/system/"
+# Sourced from deployment/ (the repo source of truth), not dist/, so the unit lands
+# in the .deb even if smart_build's deployment/*→dist/ mirror is reordered or skipped.
+cp deployment/ceralive-addon-reconciler.service "$TEMP_DIR/etc/systemd/system/"
 cp dist/98-ceralive-audio.rules "$TEMP_DIR/etc/udev/rules.d/"
 cp dist/99-ceralive-check-usb-devices.rules "$TEMP_DIR/etc/udev/rules.d/"
 cp -r dist/public/* "$TEMP_DIR/var/www/ceralive/"

--- a/scripts/build/deb-reconciler-staging.test.sh
+++ b/scripts/build/deb-reconciler-staging.test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Package-contract test: the post-boot add-on reconciler oneshot
+# (ceralive-addon-reconciler.service) MUST be staged into the ceralive-device .deb
+# and enabled by the maintainer postinst. Regression guard for the T29 reconciler
+# (a dropped unit means add-on state is never reconciled after an OTA).
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+build_script="scripts/build/build-debian-package.sh"
+unit="deployment/ceralive-addon-reconciler.service"
+unit_basename="ceralive-addon-reconciler.service"
+
+fail() { printf 'FAIL: %s\n' "$1" >&2; exit 1; }
+
+# --- Part A: static contract on the source artifact + build script --------------
+
+[[ -f "$unit" ]] || fail "reconciler unit missing from source of truth: $unit"
+
+grep -Fq 'systemctl enable ceralive-addon-reconciler.service' "$build_script" \
+  || fail "postinst does not enable ceralive-addon-reconciler.service"
+
+# The unit must be staged into the packaged systemd system dir from deployment/
+# (not dist/) so packaging never depends on smart_build's deployment/*->dist/ mirror.
+staging_line="$(grep -E "cp[[:space:]]+deployment/${unit_basename}[[:space:]]+\"\\\$TEMP_DIR/etc/systemd/system/\"" "$build_script" || true)"
+[[ -n "$staging_line" ]] \
+  || fail "build script does not stage $unit_basename from deployment/ into etc/systemd/system/"
+
+# --- Part B: real fpm round-trip — the unit survives into a scratch .deb ---------
+# Builds a minimal package from a tree staged EXACTLY as build-debian-package.sh
+# stages the reconciler, then lists the .deb payload (ar + tar; no dpkg-deb needed).
+
+command -v fpm >/dev/null 2>&1 || fail "fpm not on PATH (required build dependency)"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+stage="$work/temp"
+mkdir -p "$stage/etc/systemd/system" "$stage/usr/local/bin"
+cp "$unit" "$stage/etc/systemd/system/$unit_basename"
+printf '#!/bin/sh\ntrue\n' > "$stage/usr/local/bin/ceralive"
+chmod +x "$stage/usr/local/bin/ceralive"
+
+(
+  cd "$work"
+  fpm -s dir -t deb \
+    -n ceralive-device-recontract \
+    -v 0.0.0 \
+    -a all \
+    --iteration test \
+    --maintainer 'contract@ceralive.tv' \
+    --description 'reconciler staging contract' \
+    --deb-no-default-config-files \
+    -C temp \
+    . >/dev/null
+)
+
+shopt -s nullglob
+deb_candidates=("$work"/*.deb)
+[[ ${#deb_candidates[@]} -gt 0 ]] || fail "fpm did not emit a .deb"
+deb="${deb_candidates[0]}"
+
+listing_dir="$work/listing"
+mkdir -p "$listing_dir"
+( cd "$listing_dir" && ar x "$deb" )
+data_candidates=("$listing_dir"/data.tar.*)
+[[ ${#data_candidates[@]} -gt 0 ]] || fail "no data.tar.* member in the built .deb"
+data_tar="${data_candidates[0]}"
+
+# GNU tar auto-detects the compression on read.
+if ! tar tf "$data_tar" | grep -Eq "(^|\\./)etc/systemd/system/${unit_basename}\$"; then
+  fail "reconciler unit is NOT present in the scratch .deb payload"
+fi
+
+printf 'PASS: ceralive-addon-reconciler.service is staged from deployment/, enabled in postinst, and lands in the .deb\n'

--- a/scripts/build/release-package-contracts.sh
+++ b/scripts/build/release-package-contracts.sh
@@ -6,6 +6,7 @@ cd "$repo_root"
 
 bash scripts/build/build-provenance.test.sh
 bash scripts/build/shared-build-functions.test.sh
+bash scripts/build/deb-reconciler-staging.test.sh
 bash scripts/build/documentation-contract.test.sh
 bash scripts/build/publish-federation-immutable.test.sh
 bash scripts/ci/service-contract-wiring.test.sh


### PR DESCRIPTION
## What
Stage the T29 post-boot add-on reconciler unit (`ceralive-addon-reconciler.service`) into the `ceralive-device` `.deb` directly from `deployment/` (the repo source of truth) instead of from `dist/`, and add a package-contract test that proves the unit is staged, enabled in the maintainer postinst, and present in a scratch `.deb` payload.

## Why
The reconciler unit only reached `dist/` because `build_backend_only` mirrors `deployment/*` into `dist/` as a side effect. Sourcing it straight from `deployment/` makes packaging independent of that mirror step's presence/ordering, so a future refactor of the dist copy can't silently drop the unit from the image (which would mean add-on state is never reconciled after an OTA). The `.deb` bytes are unchanged today — this is a robustness + regression-guard change.

## How to verify
- `bash scripts/build/deb-reconciler-staging.test.sh` → `PASS` (builds a real scratch `.deb` via `fpm`, lists it with `ar`+`tar`, asserts `etc/systemd/system/ceralive-addon-reconciler.service` present).
- Red-first: delete the `cp deployment/ceralive-addon-reconciler.service …` line → the test fails with a precise message; restore → green.
- The test is wired into `scripts/build/release-package-contracts.sh` (`bun run test:release-package-contracts`).

## Risks
Low. No behavior/byte change to the produced `.deb`; only the copy source path moved and a new contract test was added. shellcheck clean (only pre-existing SC1091 source-follow info).
