### PR TITLE
fix(sources): show both codecs for a dual-codec UVC camera

### DIFF
--- a/apps/frontend/src/lib/components/custom/SourceSection.svelte
+++ b/apps/frontend/src/lib/components/custom/SourceSection.svelte
@@ -68,6 +68,7 @@ import {
 } from '$lib/rpc/field-sync-state.svelte';
 import { AUDIO_SOURCE_AUTO } from '@ceraui/rpc/schemas';
 import { hasEffectiveSource } from '$lib/streaming/effective-source';
+import { captureModeCodecs } from '$lib/streaming/passthrough';
 import {
 	audioSourceLabel,
 	deriveActiveSummary,
@@ -287,12 +288,22 @@ const KIND_ICON = { hdmi: Cable, usb: Usb, network: Radio, other: Video } as con
 function kindLabel(kind: DeviceKind): string {
 	return t(`live.inputPicker.groups.${kind}`);
 }
+// A capture device that advertises BOTH hardware codecs is collapsed by the engine
+// to a single H.265-priority `kind`, so the scalar-kind label alone ("UVC H.265")
+// hides the H.264 capability. When the device's modes reveal both, name both.
+function captureBadgeLabel(source: CaptureStreamSource): string {
+	return captureModeCodecs(source.modes).length >= 2
+		? t('live.inputPicker.groups.uvc_dual')
+		: kindLabel(source.kind);
+}
 // Hardware-encoding UVC kinds run onboard H.264/H.265 — surface that with the
 // phosphor-lime "live" accent so the hardware-encode path reads distinctly from
 // raw/other capture (which stay neutral). The text differs per kind regardless,
-// so colour is reinforcement, never the sole signal.
-function kindBadgeClass(kind: DeviceKind): string {
-	return kind === 'uvc_h264' || kind === 'uvc_h265'
+// so colour is reinforcement, never the sole signal. A dual-codec device is
+// hardware-encoding on both, so it earns the same accent.
+function captureBadgeClass(source: CaptureStreamSource): string {
+	if (captureModeCodecs(source.modes).length >= 2) return 'bg-primary/10 text-primary';
+	return source.kind === 'uvc_h264' || source.kind === 'uvc_h265'
 		? 'bg-primary/10 text-primary'
 		: 'bg-muted text-muted-foreground';
 }
@@ -563,11 +574,11 @@ const showEmbedded = $derived(audioEmbeddedActive || resolvedAudio.embedded);
 									<span class="flex shrink-0 items-center gap-1.5">
 										{#if source.origin === 'capture'}
 											<span
-												class="{kindBadgeClass(source.kind)} rounded px-1.5 py-0.5 text-xs font-medium"
+												class="{captureBadgeClass(source)} rounded px-1.5 py-0.5 text-xs font-medium"
 												data-source-kind={source.kind}
 												data-testid={`source-kind-${source.id}`}
 											>
-												{kindLabel(source.kind)}
+												{captureBadgeLabel(source)}
 											</span>
 											{#if source.lost}
 												<span

--- a/apps/frontend/src/lib/components/custom/SourceSection.test.ts
+++ b/apps/frontend/src/lib/components/custom/SourceSection.test.ts
@@ -62,6 +62,26 @@ const RODE: CaptureStreamSource = {
 	audioKind: "selectable",
 	available: true,
 };
+// A dual-codec UVC camera: the engine collapsed its scalar `kind` to the
+// H.265-priority value, but its modes advertise BOTH hardware codecs — the badge
+// must name both instead of hiding the H.264 capability behind "UVC H.265".
+const DUAL_CODEC: CaptureStreamSource = {
+	origin: "capture",
+	id: "usb-dual",
+	pipelineId: "libuvch265",
+	kind: "uvc_h265",
+	displayName: "Elgato Dual Codec Cam",
+	devicePath: "/dev/video2",
+	modes: [
+		{ width: 1920, height: 1080, framerates: [30], media_type: "video/x-h265" },
+		{ width: 1920, height: 1080, framerates: [30], media_type: "video/x-h264" },
+	],
+	supportsAudio: true,
+	supportsResolutionOverride: true,
+	supportsFramerateOverride: true,
+	audioKind: "selectable",
+	available: true,
+};
 const HDMI_CAPTURE: CaptureStreamSource = {
 	origin: "capture",
 	id: "hdmi-rx",
@@ -224,6 +244,39 @@ describe("SourceSection — unified device-first source list (Task 13)", () => {
 		expect(kindBadge?.textContent?.trim()).toBe("UVC H.264");
 		// …never the coarse "HDMI Capture" mislabel.
 		expect(row?.textContent).not.toContain("HDMI Capture");
+	});
+
+	it("names BOTH codecs on a dual-codec device whose modes advertise h264+h265, not just the collapsed kind", () => {
+		const { container } = mount({ sources: sourcesMsg([DUAL_CODEC]) });
+		const kindBadge = container.querySelector<HTMLElement>(
+			'[data-testid="source-kind-usb-dual"]',
+		);
+		expect(kindBadge).not.toBeNull();
+		expect(kindBadge?.textContent?.trim()).toBe("UVC H.264/H.265");
+		// The raw collapsed kind stays on the data attribute as the stable hook.
+		expect(kindBadge?.getAttribute("data-source-kind")).toBe("uvc_h265");
+		// Never the single-codec label that hides the H.264 capability.
+		expect(kindBadge?.textContent?.trim()).not.toBe("UVC H.265");
+	});
+
+	it("leaves a single-codec device's badge unchanged (one accurate codec)", () => {
+		const singleH265: CaptureStreamSource = {
+			...DUAL_CODEC,
+			id: "usb-h265",
+			modes: [
+				{
+					width: 1920,
+					height: 1080,
+					framerates: [30],
+					media_type: "video/x-h265",
+				},
+			],
+		};
+		const { container } = mount({ sources: sourcesMsg([singleH265]) });
+		const kindBadge = container.querySelector<HTMLElement>(
+			'[data-testid="source-kind-usb-h265"]',
+		);
+		expect(kindBadge?.textContent?.trim()).toBe("UVC H.265");
 	});
 
 	it("renders a coarse capability source as a SELECTABLE row with its labelKey label", () => {

--- a/apps/frontend/src/lib/streaming/passthrough.test.ts
+++ b/apps/frontend/src/lib/streaming/passthrough.test.ts
@@ -1,9 +1,18 @@
+import type { DeviceMode } from "@ceraui/rpc/schemas";
 import { describe, expect, it } from "vitest";
 import {
+	captureModeCodecs,
 	type PassthroughInputs,
 	resolvePassthroughMode,
 	sourceOffersCodec,
 } from "./passthrough.ts";
+
+const mode = (media_type: string): DeviceMode => ({
+	width: 1920,
+	height: 1080,
+	framerates: [30],
+	media_type,
+});
 
 const base: PassthroughInputs = {
 	setting: "auto",
@@ -87,5 +96,39 @@ describe("sourceOffersCodec", () => {
 			expect(sourceOffersCodec(kind, "h264")).toBe(false);
 			expect(sourceOffersCodec(kind, "h265")).toBe(false);
 		}
+	});
+
+	it("modes-derived offeredCodecs win over the collapsed kind: a dual device passes through BOTH", () => {
+		const dual = ["h264", "h265"] as const;
+		// The engine collapsed this device's kind to uvc_h265, but its modes
+		// advertise both — so h264 passthrough must be eligible, not rejected.
+		expect(sourceOffersCodec("uvc_h265", "h264", dual)).toBe(true);
+		expect(sourceOffersCodec("uvc_h265", "h265", dual)).toBe(true);
+	});
+
+	it("an empty offeredCodecs falls back to the scalar-kind branch (old engine)", () => {
+		expect(sourceOffersCodec("uvc_h264", "h264", [])).toBe(true);
+		expect(sourceOffersCodec("uvc_h264", "h265", [])).toBe(false);
+	});
+});
+
+describe("captureModeCodecs", () => {
+	it("returns both codecs h264→h265 for a dual-capable device's modes", () => {
+		expect(
+			captureModeCodecs([mode("video/x-h265"), mode("video/x-h264")]),
+		).toEqual(["h264", "h265"]);
+	});
+
+	it("returns the single codec for a single-codec device", () => {
+		expect(captureModeCodecs([mode("video/x-h264")])).toEqual(["h264"]);
+		expect(captureModeCodecs([mode("video/x-h265")])).toEqual(["h265"]);
+	});
+
+	it("returns [] for raw/MJPEG/empty/undefined modes", () => {
+		expect(
+			captureModeCodecs([mode("image/jpeg"), mode("video/x-raw")]),
+		).toEqual([]);
+		expect(captureModeCodecs([])).toEqual([]);
+		expect(captureModeCodecs(undefined)).toEqual([]);
 	});
 });

--- a/apps/frontend/src/lib/streaming/passthrough.ts
+++ b/apps/frontend/src/lib/streaming/passthrough.ts
@@ -9,9 +9,31 @@
 // warning — the engine would reject that start typed, and the pre-start disclosure
 // is what makes `force` safe.
 
-import type { VideoCodec, VideoPassthrough } from "@ceraui/rpc/schemas";
+import type {
+	DeviceMode,
+	VideoCodec,
+	VideoPassthrough,
+} from "@ceraui/rpc/schemas";
 
 export type PassthroughMode = "passthrough" | "transcode" | "forceUnavailable";
+
+export const MEDIA_TYPE_H264 = "video/x-h264";
+export const MEDIA_TYPE_H265 = "video/x-h265";
+
+// The hardware codecs a capture device's probed modes reveal, h264→h265 order.
+// The engine collapses a dual-capable UVC camera's scalar `kind` to a single
+// H.265-priority value (`devices.rs`), but emits one mode per media type — so a
+// dual device returns `["h264","h265"]` here even though `kind` names only one.
+// Raw/MJPEG modes contribute nothing (`[]` → caller keeps its scalar-kind label).
+export function captureModeCodecs(
+	modes: readonly DeviceMode[] | undefined,
+): VideoCodec[] {
+	if (modes === undefined) return [];
+	const codecs: VideoCodec[] = [];
+	if (modes.some((m) => m.media_type === MEDIA_TYPE_H264)) codecs.push("h264");
+	if (modes.some((m) => m.media_type === MEDIA_TYPE_H265)) codecs.push("h265");
+	return codecs;
+}
 
 export interface PassthroughInputs {
 	setting: VideoPassthrough;
@@ -40,7 +62,14 @@ export function resolvePassthroughMode(i: PassthroughInputs): PassthroughMode {
 export function sourceOffersCodec(
 	kind: string | undefined,
 	outputCodec: VideoCodec,
+	offeredCodecs?: readonly VideoCodec[],
 ): boolean {
+	// The modes-derived codec set is authoritative when present: it is the ONLY
+	// input that stays correct for a dual-codec device (whose `kind` collapsed to
+	// one value). Scalar-kind matching is the coarse/old-engine fallback.
+	if (offeredCodecs !== undefined && offeredCodecs.length > 0) {
+		return offeredCodecs.includes(outputCodec);
+	}
 	if (kind === "uvc_h264" || kind === "libuvch264")
 		return outputCodec === "h264";
 	if (kind === "uvc_h265") return outputCodec === "h265";

--- a/apps/frontend/src/main/dialogs/EncoderDialog.svelte
+++ b/apps/frontend/src/main/dialogs/EncoderDialog.svelte
@@ -100,7 +100,11 @@ import {
 	getSources,
 } from '$lib/rpc/subscriptions.svelte';
 import { appliesOnNextStart } from '$lib/streaming/appliesNextStart';
-import { resolvePassthroughMode, sourceOffersCodec } from '$lib/streaming/passthrough';
+import {
+	captureModeCodecs,
+	resolvePassthroughMode,
+	sourceOffersCodec,
+} from '$lib/streaming/passthrough';
 
 interface Props {
 	open?: boolean;
@@ -275,8 +279,14 @@ const passthroughOutputCodec = $derived<VideoCodec>(localCodec ?? resolvedAutoCo
 const activeSourceKind = $derived(
 	activeSource?.origin === 'capture' ? activeSource.kind : undefined,
 );
+// A dual-codec device's `kind` collapses to one value, so pass the truthful
+// modes-derived codec set: it keeps passthrough eligibility correct when the
+// operator picks the codec the collapsed `kind` doesn't name.
+const activeSourceCodecs = $derived(
+	activeSource?.origin === 'capture' ? captureModeCodecs(activeSource.modes) : undefined,
+);
 const passthroughSourceEligible = $derived(
-	sourceOffersCodec(activeSourceKind, passthroughOutputCodec),
+	sourceOffersCodec(activeSourceKind, passthroughOutputCodec, activeSourceCodecs),
 );
 const resolvedPassthroughMode = $derived(
 	resolvePassthroughMode({

--- a/apps/frontend/tests/e2e/truthfulness.spec.ts
+++ b/apps/frontend/tests/e2e/truthfulness.spec.ts
@@ -310,6 +310,19 @@ function captureSource(
 const SRC_RODE = captureSource("video-usb", "uvc_h264", "libuvch264", RODE_DISPLAY_NAME);
 const SRC_HDMI_CAP = captureSource("video-hdmi", "hdmi", "hdmi", "Rockchip HDMI-RX");
 
+// A dual-codec UVC camera: the engine collapsed its `kind` to the H.265-priority
+// value, but its modes advertise BOTH hardware codecs — the badge must name both.
+const SRC_DUAL = captureSource(
+	"video-dual",
+	"uvc_h265",
+	"libuvch265",
+	"Elgato Dual Codec Cam",
+	[
+		{ width: 1920, height: 1080, framerates: [30], media_type: "video/x-h265" },
+		{ width: 1920, height: 1080, framerates: [30], media_type: "video/x-h264" },
+	] as Mode[],
+);
+
 const SRC_TEST: Record<string, unknown> = {
 	origin: "virtual",
 	id: "test",
@@ -567,6 +580,21 @@ test.describe("Capability truthfulness (functional)", () => {
 		await expect(kindBadge).toHaveText("UVC H.264");
 		// …and the coarse "HDMI Capture" pipeline label never appears on the row.
 		await expect(row).not.toContainText("HDMI Capture");
+	});
+
+	test("a dual-codec capture source names BOTH codecs, not just its collapsed kind", async ({
+		page,
+	}) => {
+		serverConfig();
+		sendFullCaps();
+		sendSources([SRC_DUAL]);
+
+		const kindBadge = page.getByTestId("source-kind-video-dual");
+		await expect(kindBadge).toBeVisible({ timeout: 15_000 });
+		// The engine collapsed the kind to uvc_h265 (stable data hook), but the
+		// visible badge must name both codecs the device's modes advertise.
+		await expect(kindBadge).toHaveAttribute("data-source-kind", "uvc_h265");
+		await expect(kindBadge).toHaveText("UVC H.264/H.265");
 	});
 
 	// ── (c) Network-ingest rows: disabled-with-reason ⇄ selectable via gateway ──

--- a/packages/i18n/src/ar/index.ts
+++ b/packages/i18n/src/ar/index.ts
@@ -453,7 +453,7 @@ const ar = {
 		},
 		sources: {
 			camlink: "Cam Link 4K",
-			libuvch264: "كاميرا USB مع H.264 عتادي (UVC)",
+			libuvch264: "كاميرا USB",
 			hdmi: "التقاط HDMI",
 			usb_mjpeg: "USB MJPEG",
 			v4l_mjpeg: "V4L2 MJPEG",
@@ -1310,6 +1310,7 @@ const ar = {
 				other: "أخرى",
 				uvc_h264: "UVC H.264",
 				uvc_h265: "UVC H.265",
+				uvc_dual: "UVC H.264/H.265",
 				mjpeg: "UVC · MJPEG",
 				camlink: "Cam Link",
 			},

--- a/packages/i18n/src/de/index.ts
+++ b/packages/i18n/src/de/index.ts
@@ -605,6 +605,7 @@ const de = {
 				other: "Sonstiges",
 				uvc_h264: "UVC H.264",
 				uvc_h265: "UVC H.265",
+				uvc_dual: "UVC H.264/H.265",
 				mjpeg: "UVC · MJPEG",
 				camlink: "Cam Link",
 			},
@@ -1097,7 +1098,7 @@ const de = {
 		},
 		sources: {
 			camlink: "Cam Link 4K",
-			libuvch264: "USB-Kamera mit Hardware-H.264 (UVC)",
+			libuvch264: "USB-Kamera",
 			hdmi: "HDMI Capture",
 			usb_mjpeg: "USB MJPEG",
 			v4l_mjpeg: "V4L2 MJPEG",

--- a/packages/i18n/src/en/index.ts
+++ b/packages/i18n/src/en/index.ts
@@ -589,6 +589,7 @@ const en = {
 				other: "Other",
 				uvc_h264: "UVC H.264",
 				uvc_h265: "UVC H.265",
+				uvc_dual: "UVC H.264/H.265",
 				mjpeg: "UVC · MJPEG",
 				camlink: "Cam Link",
 			},
@@ -1087,7 +1088,7 @@ const en = {
 		// Video sources
 		sources: {
 			camlink: "Cam Link 4K",
-			libuvch264: "USB camera with hardware H.264 (UVC)",
+			libuvch264: "USB camera",
 			hdmi: "HDMI Capture",
 			usb_mjpeg: "USB MJPEG",
 			v4l_mjpeg: "V4L2 MJPEG",

--- a/packages/i18n/src/es/index.ts
+++ b/packages/i18n/src/es/index.ts
@@ -607,6 +607,7 @@ const es = {
 				other: "Otro",
 				uvc_h264: "UVC H.264",
 				uvc_h265: "UVC H.265",
+				uvc_dual: "UVC H.264/H.265",
 				mjpeg: "UVC · MJPEG",
 				camlink: "Cam Link",
 			},
@@ -1114,7 +1115,7 @@ const es = {
 		// Video sources
 		sources: {
 			camlink: "Cam Link 4K",
-			libuvch264: "Cámara USB con H.264 por hardware (UVC)",
+			libuvch264: "Cámara USB",
 			hdmi: "Captura HDMI",
 			usb_mjpeg: "USB MJPEG",
 			v4l_mjpeg: "V4L2 MJPEG",

--- a/packages/i18n/src/fr/index.ts
+++ b/packages/i18n/src/fr/index.ts
@@ -486,7 +486,7 @@ const fr = {
 		},
 		sources: {
 			camlink: "Cam Link 4K",
-			libuvch264: "Caméra USB avec H.264 matériel (UVC)",
+			libuvch264: "Caméra USB",
 			hdmi: "Capture HDMI",
 			usb_mjpeg: "USB MJPEG",
 			v4l_mjpeg: "V4L2 MJPEG",
@@ -1371,6 +1371,7 @@ const fr = {
 				other: "Autre",
 				uvc_h264: "UVC H.264",
 				uvc_h265: "UVC H.265",
+				uvc_dual: "UVC H.264/H.265",
 				mjpeg: "UVC · MJPEG",
 				camlink: "Cam Link",
 			},

--- a/packages/i18n/src/hi/index.ts
+++ b/packages/i18n/src/hi/index.ts
@@ -315,7 +315,7 @@ const hi = {
 		},
 		sources: {
 			camlink: "Cam Link 4K",
-			libuvch264: "हार्डवेयर H.264 वाला USB कैमरा (UVC)",
+			libuvch264: "USB कैमरा",
 			hdmi: "HDMI कैप्चर",
 			usb_mjpeg: "USB MJPEG",
 			v4l_mjpeg: "V4L2 MJPEG",
@@ -1173,6 +1173,7 @@ const hi = {
 				other: "अन्य",
 				uvc_h264: "UVC H.264",
 				uvc_h265: "UVC H.265",
+				uvc_dual: "UVC H.264/H.265",
 				mjpeg: "UVC · MJPEG",
 				camlink: "Cam Link",
 			},

--- a/packages/i18n/src/ja/index.ts
+++ b/packages/i18n/src/ja/index.ts
@@ -330,7 +330,7 @@ const ja = {
 		},
 		sources: {
 			camlink: "Cam Link 4K",
-			libuvch264: "ハードウェア H.264 対応 USB カメラ (UVC)",
+			libuvch264: "USB カメラ",
 			hdmi: "HDMI キャプチャ",
 			usb_mjpeg: "USB MJPEG",
 			v4l_mjpeg: "V4L2 MJPEG",
@@ -1212,6 +1212,7 @@ const ja = {
 				other: "その他",
 				uvc_h264: "UVC H.264",
 				uvc_h265: "UVC H.265",
+				uvc_dual: "UVC H.264/H.265",
 				mjpeg: "UVC · MJPEG",
 				camlink: "Cam Link",
 			},

--- a/packages/i18n/src/ko/index.ts
+++ b/packages/i18n/src/ko/index.ts
@@ -320,7 +320,7 @@ const ko = {
 		},
 		sources: {
 			camlink: "Cam Link 4K",
-			libuvch264: "하드웨어 H.264 지원 USB 카메라 (UVC)",
+			libuvch264: "USB 카메라",
 			hdmi: "HDMI 캡처",
 			usb_mjpeg: "USB MJPEG",
 			v4l_mjpeg: "V4L2 MJPEG",
@@ -1188,6 +1188,7 @@ const ko = {
 				other: "기타",
 				uvc_h264: "UVC H.264",
 				uvc_h265: "UVC H.265",
+				uvc_dual: "UVC H.264/H.265",
 				mjpeg: "UVC · MJPEG",
 				camlink: "Cam Link",
 			},

--- a/packages/i18n/src/pt-BR/index.ts
+++ b/packages/i18n/src/pt-BR/index.ts
@@ -483,7 +483,7 @@ const ptBR = {
 		},
 		sources: {
 			camlink: "Cam Link 4K",
-			libuvch264: "Câmera USB com H.264 por hardware (UVC)",
+			libuvch264: "Câmera USB",
 			hdmi: "Captura HDMI",
 			usb_mjpeg: "USB MJPEG",
 			v4l_mjpeg: "V4L2 MJPEG",
@@ -1346,6 +1346,7 @@ const ptBR = {
 				other: "Outro",
 				uvc_h264: "UVC H.264",
 				uvc_h265: "UVC H.265",
+				uvc_dual: "UVC H.264/H.265",
 				mjpeg: "UVC · MJPEG",
 				camlink: "Cam Link",
 			},

--- a/packages/i18n/src/zh/index.ts
+++ b/packages/i18n/src/zh/index.ts
@@ -307,7 +307,7 @@ const zh = {
 		},
 		sources: {
 			camlink: "Cam Link 4K",
-			libuvch264: "带硬件 H.264 的 USB 摄像头 (UVC)",
+			libuvch264: "USB 摄像头",
 			hdmi: "HDMI 采集",
 			usb_mjpeg: "USB MJPEG",
 			v4l_mjpeg: "V4L2 MJPEG",
@@ -1124,6 +1124,7 @@ const zh = {
 				other: "其他",
 				uvc_h264: "UVC H.264",
 				uvc_h265: "UVC H.265",
+				uvc_dual: "UVC H.264/H.265",
 				mjpeg: "UVC · MJPEG",
 				camlink: "Cam Link",
 			},


### PR DESCRIPTION
## What

A USB camera that advertises **both** H.264 and H.265 over UVC was mislabelled in the Live source list: it showed only a single codec badge (e.g. "UVC H.265"), and the coarse fallback string hardcoded "USB camera with hardware H.264 (UVC)".

- The Source-list badge now reads **"UVC H.264/H.265"** for a dual-capable capture device, and stays exactly as before for a single-codec device.
- The coarse `libuvch264` fallback string is shortened to a neutral **"USB camera"** across all 10 locales (that coarse row shows a "Not connected" pill, not a codec badge, so the hardcoded codec claim is simply dropped — codec detail lives on the adjacent badge for concrete devices).
- The Encoder passthrough disclosure is now correct for a dual device too.

## Why

cerastream collapses a dual-codec device to a **single** `kind` (`devices.rs`, H.265-priority), so any UI reading the scalar `kind` alone can only name one codec. But the engine still emits one capture mode per media type, and CeraUI preserves that — `CaptureStreamSource.modes[].media_type` already carries **both** `video/x-h264` and `video/x-h265`. The truthful codec set was therefore already reachable in the frontend; the badge just wasn't using it. **No cerastream / engine change is needed.**

The same collapse made `sourceOffersCodec()` wrongly reject H.264 passthrough on a dual device whose `kind` had collapsed to `uvc_h265`; that is fixed by threading the modes-derived codec set through.

## How to verify

- `bun run --filter frontend test` (Node 24) — `passthrough.test.ts` and `SourceSection.test.ts` cover the dual/single badge and the passthrough codec set.
- The capability-truthfulness e2e gate (`truthfulness.spec.ts`) is **extended** (not weakened) with a dual-codec badge assertion: a device whose modes advertise both codecs renders "UVC H.264/H.265" while `data-source-kind` keeps the raw engine kind as the stable hook.
- Verified in a real headless-Chromium browser: the combined badge renders at 1280/768/375px with no overflow — at 375px the device name truncates (`truncate min-w-0`) while the badge stays fully visible in the `shrink-0` group.

## Risks

- Low. Frontend + i18n only; `sourceOffersCodec()` gained an optional trailing arg (additive, back-compatible). Single-codec devices are byte-unchanged. `data-source-kind` is untouched, so existing telemetry/e2e hooks keep working.
- The new `uvc_dual` i18n key is a universal codec string, identical across all 10 locales (like `uvc_h264`); `typesafe-i18n` codegen produced no `i18n-types.ts` churn.