### PR TITLE
fix(sources): self-heal config.source routing across a device renumber

### DIFF
--- a/apps/backend/src/modules/streaming/sources.ts
+++ b/apps/backend/src/modules/streaming/sources.ts
@@ -265,6 +265,9 @@ function buildCaptureEntry(
 		kind: device.kind,
 		displayName: device.display_name,
 		devicePath: device.device_path,
+		...(device.stable_id !== undefined && device.stable_id !== ""
+			? { stableId: device.stable_id }
+			: {}),
 	};
 }
 
@@ -497,11 +500,38 @@ export type ResolveSourceRoutingResult =
 // the picker but must STILL route (a hidden-but-selected source is not broken); a
 // capture row's only false path is `lost`, handled above. Absent →
 // `unknown_source` (semantics unchanged). Never mutates config.
+// Self-heal a persisted `config.source` whose literal id went stale after a
+// device re-enumerated under a new node path (video1→video2). When the id is no
+// longer a live source, look it up in `last_seen_devices` to recover its stable
+// hardware identity, then return the LIVE capture source sharing that identity —
+// so the operator's chosen device keeps routing across a replug instead of
+// failing closed. A direct id hit, a missing stable id, or no live successor all
+// return the id unchanged (no over-matching: a genuinely different device is
+// never silently adopted). Mirrors the audio `resolveAudioSelection` stable-id
+// join, adapted to the id→stableId indirection video persists.
+export function resolveSourceIdentity(
+	sourceId: string,
+	sources: readonly StreamSource[],
+	lastSeenDevices?: readonly LastSeenDevice[],
+): string {
+	if (sources.some((s) => s.id === sourceId)) return sourceId;
+	const stableId = (lastSeenDevices ?? []).find(
+		(d) => d.id === sourceId,
+	)?.stableId;
+	if (stableId === undefined || stableId === "") return sourceId;
+	const successor = sources.find(
+		(s) => s.origin === "capture" && s.stableId === stableId,
+	);
+	return successor?.id ?? sourceId;
+}
+
 export function resolveSourceRouting(
 	sourceId: string,
 	sources: readonly StreamSource[],
+	lastSeenDevices?: readonly LastSeenDevice[],
 ): ResolveSourceRoutingResult {
-	const source = sources.find((s) => s.id === sourceId);
+	const effectiveId = resolveSourceIdentity(sourceId, sources, lastSeenDevices);
+	const source = sources.find((s) => s.id === effectiveId);
 	if (source === undefined) {
 		return { ok: false, error: UNKNOWN_SOURCE_ERROR };
 	}
@@ -511,7 +541,7 @@ export function resolveSourceRouting(
 	if (source.origin === "network" && source.available === false) {
 		return { ok: false, error: SOURCE_UNAVAILABLE_ERROR };
 	}
-	const routing = deriveEngineRouting(sourceId, sources);
+	const routing = deriveEngineRouting(effectiveId, sources);
 	if (routing === undefined) {
 		return { ok: false, error: UNKNOWN_SOURCE_ERROR };
 	}

--- a/apps/backend/src/rpc/procedures/streaming.procedure.ts
+++ b/apps/backend/src/rpc/procedures/streaming.procedure.ts
@@ -206,6 +206,7 @@ export const streamingStartProcedure = authedProcedure
 					const routed = resolveSourceRouting(
 						effectiveSource,
 						getSourcesMessage().sources,
+						getConfig().last_seen_devices,
 					);
 					if (!routed.ok) {
 						legacyError = routed.error;
@@ -471,6 +472,7 @@ export const setConfigProcedure = authedProcedure
 			const routed = resolveSourceRouting(
 				input.source,
 				getSourcesMessage().sources,
+				getConfig().last_seen_devices,
 			);
 			if (!routed.ok) {
 				return { success: false, error: routed.error, applied: {} };

--- a/apps/backend/src/tests/sources.test.ts
+++ b/apps/backend/src/tests/sources.test.ts
@@ -17,6 +17,7 @@ import {
 	getEngineDeviceCache,
 	refreshEngineDeviceCache,
 	resetEngineDeviceCache,
+	resolveSourceIdentity,
 	resolveSourceRouting,
 	SOURCE_LOST_ERROR,
 	SOURCE_UNAVAILABLE_ERROR,
@@ -69,6 +70,9 @@ function captureDevice(
 		media_class: overrides.media_class ?? "video",
 		kind,
 		...(overrides.caps !== undefined ? { caps: overrides.caps } : {}),
+		...(overrides.stable_id !== undefined
+			? { stable_id: overrides.stable_id }
+			: {}),
 	};
 }
 
@@ -775,5 +779,82 @@ describe("buildSources — hotplug re-enumeration reconciliation (Todo 34)", () 
 
 		expect(lostRows(sources)).toHaveLength(1);
 		expect(captureRows(sources)).toHaveLength(1);
+	});
+});
+
+describe("resolveSourceRouting — renumbered-replug self-heal (Todo 36)", () => {
+	const STABLE_A = "usb:19f7:0080:SN-A";
+	const STABLE_B = "usb:19f7:0080:SN-B";
+
+	function seen(id: string, stableId: string | undefined): LastSeenDevice {
+		return {
+			id,
+			displayName: "RØDE HDMI to USB-C",
+			kind: "hdmi",
+			pipelineId: "hdmi",
+			devicePath: `/dev/${id}`,
+			...(stableId !== undefined ? { stableId } : {}),
+		};
+	}
+
+	it("a renumbered replug (video1→video2, same stable id) self-heals the persisted config.source routing", () => {
+		const video1 = seen("video1", STABLE_A);
+		const sources = buildSources({
+			sources: [capSource("hdmi"), capSource("test")],
+			devices: [captureDevice("video2", "hdmi", { stable_id: STABLE_A })],
+			networkIngest: NO_INGEST,
+			configSource: "video1",
+			lastSeenDevices: [video1],
+			sessionSnapshots: new Map([[video1.id, video1]]),
+		});
+		// Todo 34 already suppressed the stale video1 Lost row; the persisted
+		// config.source "video1" is now absent from the live list.
+		expect(sources.find((s) => s.id === "video1")).toBeUndefined();
+
+		const routed = resolveSourceRouting("video1", sources, [video1]);
+		expect(routed).toEqual({
+			ok: true,
+			pipeline: "hdmi",
+			selected_video_input: "video2",
+		});
+	});
+
+	it("a persisted id whose stable identity matches NO live device is NOT silently adopted (over-matching guard)", () => {
+		const video1 = seen("video1", STABLE_A);
+		const sources = buildSources({
+			sources: [capSource("hdmi"), capSource("test")],
+			// A genuinely DIFFERENT device (SN-B) at the new node — not video1's.
+			devices: [captureDevice("video2", "hdmi", { stable_id: STABLE_B })],
+			networkIngest: NO_INGEST,
+		});
+
+		expect(resolveSourceIdentity("video1", sources, [video1])).toBe("video1");
+		const routed = resolveSourceRouting("video1", sources, [video1]);
+		expect(routed).toEqual({ ok: false, error: UNKNOWN_SOURCE_ERROR });
+	});
+
+	it("no remembered stable identity → the stale id keeps failing closed (no self-heal, unchanged)", () => {
+		const sources = buildSources({
+			sources: [capSource("hdmi"), capSource("test")],
+			devices: [captureDevice("video2", "hdmi", { stable_id: STABLE_A })],
+			networkIngest: NO_INGEST,
+		});
+		// No last_seen record for video1 → its identity cannot be recovered.
+		expect(resolveSourceRouting("video1", sources, [])).toEqual({
+			ok: false,
+			error: UNKNOWN_SOURCE_ERROR,
+		});
+	});
+
+	it("a live capture source exposes its stable identity on the wire", () => {
+		const sources = buildSources({
+			sources: [capSource("hdmi"), capSource("test")],
+			devices: [captureDevice("video2", "hdmi", { stable_id: STABLE_A })],
+			networkIngest: NO_INGEST,
+		});
+		const live = sources.find((s) => s.id === "video2");
+		expect(live?.origin === "capture" ? live.stableId : undefined).toBe(
+			STABLE_A,
+		);
 	});
 });

--- a/packages/rpc/src/schemas/sources.schema.ts
+++ b/packages/rpc/src/schemas/sources.schema.ts
@@ -77,6 +77,9 @@ export const captureSourceSchema = streamSourceBase.extend({
 	kind: deviceKindSchema,
 	displayName: z.string(),
 	devicePath: z.string(),
+	// Reboot-stable hardware identity (cerastream `stable_id`). Lets routing
+	// self-heal a persisted selection whose node id went stale after a replug.
+	stableId: z.string().optional(),
 });
 export type CaptureStreamSource = z.infer<typeof captureSourceSchema>;
 


### PR DESCRIPTION
## What

Makes the persisted operator source selection (`config.source`) self-heal when its chosen capture device re-enumerates under a new node path after a replug (e.g. `video1`→`video2`, same hardware).

- Threads the engine `stable_id` through the capture `StreamSource` (additive-optional, mirroring the `CaptureDevice`/`LastSeenDevice` threading Todo 34 landed).
- Adds a `resolveSourceIdentity()` step to `resolveSourceRouting()`: when the persisted id is no longer a live source, recover its stable identity from `last_seen_devices` and route to the live capture source sharing that identity.

## Why

Todo 34 already migrates the source-list *row* by stable identity, but the routing seam still resolved `config.source` only by literal id. So a renumbered replug of the operator's chosen device failed closed as `unknown_source` (visible failure, not misroute) and stayed broken until the operator manually re-picked the source. This closes that self-healing gap end to end.

## How to verify

- `cd apps/backend && bun test src/tests/sources.test.ts` — 38 pass.
- New tests (red→green): a renumbered replug (`video1`→`video2`, same `stable_id`) self-heals the persisted `config.source` routing; a genuinely different device (no `stable_id` match) is **not** silently adopted; a missing remembered identity still fails closed; a live capture source exposes its `stableId` on the wire.
- `bun tsc --noEmit` clean; `biome check` clean on the changed files; `bun test packages/rpc` 238 pass.
- Full backend suite: 2173 pass / 4 fail — the 4 are the pre-existing local EACCES baseline (3× srtla ips-file writer + 1× bcrpt `/var/run/bcrpt`), in files this PR does not touch (matches the Todo 34 baseline).

## Risks

- Additive and backward-compatible: consumes the already-published `stable_id` (no cerastream/binding change). `resolveSourceRouting`'s new `lastSeenDevices` argument is optional; call sites without it keep the exact prior behavior, and existing Todo 34 tests are unchanged.
- Over-matching guard is explicit and tested: only a live `capture` source with an exact `stableId` match is adopted; different hardware and missing-identity cases never resolve to a new device.
- Hardware confirmation deferred to the Wave H HDMI/RØDE drills (same pattern Todo 34 used).