### PR TITLE
fix(sources): include UVC in coarse USB camera label

### DIFF
--- a/apps/frontend/src/lib/helpers/PipelineHelper.test.ts
+++ b/apps/frontend/src/lib/helpers/PipelineHelper.test.ts
@@ -46,9 +46,7 @@ describe("getSourceLabel", () => {
 	});
 
 	it("still resolves a known video source to its friendly label", () => {
-		expect(getSourceLabel("libuvch264")).toBe(
-			"USB camera with hardware H.264 (UVC)",
-		);
+		expect(getSourceLabel("libuvch264")).toBe("USB camera (UVC)");
 	});
 
 	it("preserves the translated-key branch when a resolver hits", () => {
@@ -58,16 +56,14 @@ describe("getSourceLabel", () => {
 	});
 
 	it("falls back to bindings label when the resolver misses the key", () => {
-		expect(getSourceLabel("libuvch264", passthroughT)).toBe(
-			"USB camera with hardware H.264 (UVC)",
-		);
+		expect(getSourceLabel("libuvch264", passthroughT)).toBe("USB camera (UVC)");
 	});
 });
 
 describe("getPipelineDisplayName", () => {
 	it("resolves a known source id to its friendly label", () => {
 		expect(getPipelineDisplayName("libuvch264", pipelines)).toBe(
-			"USB camera with hardware H.264 (UVC)",
+			"USB camera (UVC)",
 		);
 	});
 
@@ -83,9 +79,7 @@ describe("getPipelineDisplayName", () => {
 	});
 
 	it("is pure and tolerates missing pipelines", () => {
-		expect(getPipelineDisplayName("libuvch264")).toBe(
-			"USB camera with hardware H.264 (UVC)",
-		);
+		expect(getPipelineDisplayName("libuvch264")).toBe("USB camera (UVC)");
 		expect(getPipelineDisplayName(HASH_ID)).toBe("Unknown source");
 	});
 });

--- a/packages/i18n/src/ar/index.ts
+++ b/packages/i18n/src/ar/index.ts
@@ -453,7 +453,7 @@ const ar = {
 		},
 		sources: {
 			camlink: "Cam Link 4K",
-			libuvch264: "كاميرا USB",
+			libuvch264: "كاميرا USB (UVC)",
 			hdmi: "التقاط HDMI",
 			usb_mjpeg: "USB MJPEG",
 			v4l_mjpeg: "V4L2 MJPEG",

--- a/packages/i18n/src/de/index.ts
+++ b/packages/i18n/src/de/index.ts
@@ -1098,7 +1098,7 @@ const de = {
 		},
 		sources: {
 			camlink: "Cam Link 4K",
-			libuvch264: "USB-Kamera",
+			libuvch264: "USB-Kamera (UVC)",
 			hdmi: "HDMI Capture",
 			usb_mjpeg: "USB MJPEG",
 			v4l_mjpeg: "V4L2 MJPEG",

--- a/packages/i18n/src/en/index.ts
+++ b/packages/i18n/src/en/index.ts
@@ -1088,7 +1088,7 @@ const en = {
 		// Video sources
 		sources: {
 			camlink: "Cam Link 4K",
-			libuvch264: "USB camera",
+			libuvch264: "USB camera (UVC)",
 			hdmi: "HDMI Capture",
 			usb_mjpeg: "USB MJPEG",
 			v4l_mjpeg: "V4L2 MJPEG",

--- a/packages/i18n/src/es/index.ts
+++ b/packages/i18n/src/es/index.ts
@@ -1115,7 +1115,7 @@ const es = {
 		// Video sources
 		sources: {
 			camlink: "Cam Link 4K",
-			libuvch264: "Cámara USB",
+			libuvch264: "Cámara USB (UVC)",
 			hdmi: "Captura HDMI",
 			usb_mjpeg: "USB MJPEG",
 			v4l_mjpeg: "V4L2 MJPEG",

--- a/packages/i18n/src/fr/index.ts
+++ b/packages/i18n/src/fr/index.ts
@@ -486,7 +486,7 @@ const fr = {
 		},
 		sources: {
 			camlink: "Cam Link 4K",
-			libuvch264: "Caméra USB",
+			libuvch264: "Caméra USB (UVC)",
 			hdmi: "Capture HDMI",
 			usb_mjpeg: "USB MJPEG",
 			v4l_mjpeg: "V4L2 MJPEG",

--- a/packages/i18n/src/hi/index.ts
+++ b/packages/i18n/src/hi/index.ts
@@ -315,7 +315,7 @@ const hi = {
 		},
 		sources: {
 			camlink: "Cam Link 4K",
-			libuvch264: "USB कैमरा",
+			libuvch264: "USB कैमरा (UVC)",
 			hdmi: "HDMI कैप्चर",
 			usb_mjpeg: "USB MJPEG",
 			v4l_mjpeg: "V4L2 MJPEG",

--- a/packages/i18n/src/ja/index.ts
+++ b/packages/i18n/src/ja/index.ts
@@ -330,7 +330,7 @@ const ja = {
 		},
 		sources: {
 			camlink: "Cam Link 4K",
-			libuvch264: "USB カメラ",
+			libuvch264: "USB カメラ (UVC)",
 			hdmi: "HDMI キャプチャ",
 			usb_mjpeg: "USB MJPEG",
 			v4l_mjpeg: "V4L2 MJPEG",

--- a/packages/i18n/src/ko/index.ts
+++ b/packages/i18n/src/ko/index.ts
@@ -320,7 +320,7 @@ const ko = {
 		},
 		sources: {
 			camlink: "Cam Link 4K",
-			libuvch264: "USB 카메라",
+			libuvch264: "USB 카메라 (UVC)",
 			hdmi: "HDMI 캡처",
 			usb_mjpeg: "USB MJPEG",
 			v4l_mjpeg: "V4L2 MJPEG",

--- a/packages/i18n/src/pt-BR/index.ts
+++ b/packages/i18n/src/pt-BR/index.ts
@@ -483,7 +483,7 @@ const ptBR = {
 		},
 		sources: {
 			camlink: "Cam Link 4K",
-			libuvch264: "Câmera USB",
+			libuvch264: "Câmera USB (UVC)",
 			hdmi: "Captura HDMI",
 			usb_mjpeg: "USB MJPEG",
 			v4l_mjpeg: "V4L2 MJPEG",

--- a/packages/i18n/src/zh/index.ts
+++ b/packages/i18n/src/zh/index.ts
@@ -307,7 +307,7 @@ const zh = {
 		},
 		sources: {
 			camlink: "Cam Link 4K",
-			libuvch264: "USB 摄像头",
+			libuvch264: "USB 摄像头 (UVC)",
 			hdmi: "HDMI 采集",
 			usb_mjpeg: "USB MJPEG",
 			v4l_mjpeg: "V4L2 MJPEG",

--- a/packages/rpc/src/schemas/streaming.schema.ts
+++ b/packages/rpc/src/schemas/streaming.schema.ts
@@ -307,7 +307,7 @@ export const HARDWARE_COLORS: Record<HardwareType, { text: string; bg: string; b
 // Video source labels (browser-safe)
 export const VIDEO_SOURCE_LABELS: Record<string, string> = {
 	camlink: 'Cam Link 4K',
-	libuvch264: 'USB camera with hardware H.264 (UVC)',
+	libuvch264: 'USB camera (UVC)',
 	uvc_h264: 'UVC H.264 Camera',
 	uvc_h265: 'UVC H.265 Camera',
 	hdmi: 'HDMI Capture',


### PR DESCRIPTION
## What
Update the coarse `settings.sources.libuvch264` label in all 10 locales to a short codec-free UVC-tagged USB camera label.

## Why
Operators need the UVC device-family hint without reintroducing the removed H.264 claim.

## How to verify
- `PipelineHelper.test.ts` exact-label assertions pass.
- `bun run build` passes.
- Playwright measured the same constrained source-row badge at 1280, 768, and 375px; `USB camera (UVC)` had no row overflow at any width.
- CI runs the full CeraUI gate.

## Risks
None beyond the intentional coarse fallback copy change; concrete dynamic codec badges are untouched.