### PR TITLE
fix(live): give the Test Pattern source a colour-bars icon

### DIFF
--- a/apps/frontend/src/lib/components/custom/SourceSection.svelte
+++ b/apps/frontend/src/lib/components/custom/SourceSection.svelte
@@ -45,11 +45,11 @@ import {
 	Cable,
 	Check,
 	ChevronRight,
+	Columns3,
 	Copy,
 	Pencil,
 	QrCode,
 	Radio,
-	SquareDashed,
 	TriangleAlert,
 	Unplug,
 	Usb,
@@ -317,7 +317,11 @@ function captureBadgeClass(source: CaptureStreamSource): string {
 }
 function rowIcon(source: StreamSource) {
 	if (source.origin === 'capture') return KIND_ICON[kindFamily(source.kind)];
-	if (source.origin === 'virtual') return SquareDashed;
+	// The virtual row is the generated test pattern: `Columns3` is a framed screen
+	// split into three vertical bars, which reads as broadcast colour bars. The
+	// previous `SquareDashed` rendered as a plain empty square and carried no
+	// meaning — an operator scanning the list could not tell what the row was.
+	if (source.origin === 'virtual') return Columns3;
 	if (source.origin === 'network') return Radio;
 	return Video;
 }

--- a/apps/frontend/src/main/dialogs/EncoderDialog.svelte
+++ b/apps/frontend/src/main/dialogs/EncoderDialog.svelte
@@ -59,7 +59,7 @@ export interface EncoderConfig {
 
 <script lang="ts">
 import { LL } from '@ceraui/i18n/svelte';
-import { Binary, Cable, Cpu, Radio, SquareDashed, Usb, Video } from '@lucide/svelte';
+import { Binary, Cable, Columns3, Cpu, Radio, Usb, Video } from '@lucide/svelte';
 import { BITRATE_DEFAULT_MIN, type DeviceKind, type StreamSource } from '@ceraui/rpc/schemas';
 
 import AppliesNextStart from '$lib/components/custom/AppliesNextStart.svelte';
@@ -339,7 +339,9 @@ function sourceKindLabel(source: StreamSource): string {
 }
 function sourceIcon(source: StreamSource) {
 	if (source.origin === 'capture') return SOURCE_KIND_ICON[kindFamily(source.kind)];
-	if (source.origin === 'virtual') return SquareDashed;
+	// Colour-bars glyph for the generated test pattern — kept identical to
+	// SourceSection's row icon so the same source reads the same on both surfaces.
+	if (source.origin === 'virtual') return Columns3;
 	if (source.origin === 'network') return Radio;
 	return Video;
 }


### PR DESCRIPTION
**Affected repo & language:** CeraUI — Svelte 5 / TypeScript (frontend only)

## What

The "Test Pattern" row in the Live page Source list used the `SquareDashed` icon, which draws as an empty dashed square. It communicated nothing — an operator scanning the source list could not tell what the row was without stopping to read the label, and it looked like a placeholder or a broken/missing glyph next to the concrete HDMI, USB, and network icons.

It now uses `Columns3`: a framed screen split into three vertical bars, which reads as broadcast colour bars — what a test pattern actually looks like on a monitor.

The same swap is applied at both places that render this source: the Live source list (`SourceSection.svelte`) and the Encoder dialog's source picker (`EncoderDialog.svelte`). They render the same underlying `origin === 'virtual'` row, so leaving one behind would make the same source look like two different things depending on where you opened it.

## Why

Reported directly by a user during a hardware QA session while live-testing the board UI — a real, noticed defect, not a speculative polish item.

`SquareDashed` carries no meaning here. In Lucide it reads as "empty placeholder / drop target", which is actively misleading for a source that is always available and always produces a picture. Every sibling row already has a glyph that names its transport at a glance (cable for HDMI, USB connector, radio waves for RTMP/SRT); the test pattern was the one row breaking that pattern.

## How to verify

The Test Pattern row is operator-hidden by default, so it has to be switched on first:

1. `bun install && bun run dev`, then open http://localhost:6173 (default `multi-modem-wifi` mock scenario).
2. Settings → **Sources** → toggle **Show test pattern** on.
3. Go to **Live**. The Test Pattern row at the bottom of the source list now shows a three-bar colour-bars glyph instead of an empty dashed square.
4. Confirm it matches its siblings: same size and stroke weight as the HDMI/USB/RTMP/SRT icons (all render `size-4 shrink-0 text-muted-foreground`).
5. Open the **Encoder** dialog and check the source picker shows the same glyph for the same row.

Programmatic check on the rendered DOM:

```js
document.querySelector('[data-testid="source-row-test"] svg').getAttribute('class')
// before: "lucide-icon lucide lucide-square-dashed size-4 shrink-0 text-muted-foreground"
// after:  "lucide-icon lucide lucide-columns-3  size-4 shrink-0 text-muted-foreground"
```

Verified in a real browser (Playwright against a local dev instance), before and after, with screenshots of the full source list captured for both states. Only the Test Pattern row's glyph changes; every other row is byte-identical.

Gates run locally:

- Frontend unit — 174 files / 1816 tests pass
- Backend unit — 2220 tests pass
- `biome check` clean on both changed files; `svelte-check` 0 errors
- `.deb` build passes for arm64 and amd64

Playwright e2e was not run locally — it needs the real `srtla_send` binary and sudo-installed browser deps that the CI lane provisions. CI covers it.

## Risks

None meaningful. This is an icon-identity swap: two `return` values and their imports. No layout, spacing, sizing, or colour changes; no other source row touched; no new dependency (`Columns3` ships in the `@lucide/svelte` package already in use). No test asserts on the icon component identity, so nothing is pinned to the old glyph. Rollback is reverting the commit.

---

**Checklist**

- [x] Docs updated if behavior or structure changed (Rule A) — n/a, no behavior or structure change; no documented contract references this glyph
- [x] Started from updated main; branch rebased on latest canonical branch (Rule B) — branched off `origin/main` @ `e1212c85`
- [x] Rule D local-scratch reference check passes for tracked files — no paths outside the repo in any tracked file; QA screenshots kept in gitignored `test-results/`
- [x] Tests pass; QA evidence attached or linked — see **How to verify**
