### PR TITLE
fix(sources): keep an unplugged device from surviving a failed engine probe

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -509,18 +509,47 @@ RØDE is not even covered by the Elgato-scoped `99-ceralive-check-usb-devices.ru
 The live video-hotplug → `sources` reactivity is owned by `modules/streaming/
 devices.ts`: its `/dev` `fs.watch` + 2 s `VIDEO_HOTPLUG_POLL_INTERVAL_MS` poll
 already detected the device-set change but previously only rebroadcast the legacy
-`devices` event. It now also fires the injected `onDevicesChanged` (default →
-`sources.ts` `refreshAndBroadcastSources()`) on a genuine device-SET change —
-keyed on the device array alone, so a live `active_input` switch (same set) never
-re-probes and the boot seed (already covered by `main.ts`) is skipped. The rebuild
-re-fetches the AUTHORITATIVE engine `list-devices` (idle-safe short-lived probe),
-NOT the local v4l2 scan, so the correct engine kind labels (e.g. `mjpeg`) are
-preserved. This is why unplug/replug now updates the Live Sources list with no
-page refresh. cerastream's own `GstDeviceMonitor` DOES watch add/remove but the
-production engine wires it to a `NullSink`, so the engine emits no device-change
-IPC push today — CeraUI's `/dev` watch is the live trigger. Coverage:
-`tests/devices.test.ts` (`fires onDevicesChanged on a hotplug set change, not on
-the boot seed, an unchanged rescan, or an input switch`).
+`devices` event. It now also fires the injected `onDevicesChanged(observed)`
+(default → `sources.ts` `refreshSourcesForHotplug()`) on a genuine device-SET
+change — keyed on the device array alone, so a live `active_input` switch (same
+set) never re-probes and the boot seed (already covered by `main.ts`) is skipped.
+This is why unplug/replug updates the Live Sources list with no page refresh.
+cerastream's own `GstDeviceMonitor` DOES watch add/remove but the production
+engine wires it to a `NullSink`, so the engine emits no device-change IPC push
+today — CeraUI's `/dev` watch is the live trigger.
+
+**The rebuild prefers the engine probe but never LOSES a removal to it.**
+`refreshSourcesForHotplug(observed)` first re-fetches the AUTHORITATIVE engine
+`list-devices` (idle-safe short-lived probe) so the correct engine kind labels
+(e.g. `mjpeg`) are preserved — the local v4l2 scan's display-name heuristic is
+still not what feeds `sources` on the happy path. But that probe is a SECOND,
+separately-fallible round-trip, and `tryRefreshEngineDeviceCache` deliberately
+RETAINS the last-known cache when it throws (a transient outage must not erase
+the device list). For a REMOVAL that retention is exactly wrong: it rebroadcasts
+the device the operator just unplugged as still available until some later poll's
+probe happens to answer — observed live on a board as a stale, still-selectable
+source row that self-corrected only after ~a minute. So a FAILING probe now hands
+over to `applyObservedDevicesAndBroadcast(observed)`, applying the list the
+registry's own scan already proved current. The engine-fetch path itself is
+unweakened — retain-on-failure is still its contract for every caller that has no
+independent observation (`main.ts` boot seed, `engine-reconnect.ts` heal). Do NOT
+"simplify" the hotplug path back to a bare `refreshAndBroadcastSources()`.
+
+The fallback is id-safe and its cost is bounded: `buildDeviceList()` keys the
+fallback scan `/dev/<card>`, which is byte-identical to the engine's own
+`input_id` (verified on a real Rock 5B+: cerastream reports `/dev/video0` +
+`/dev/video1`, and de-dupes the RØDE's two nodes exactly as the scan does), so a
+fallback row can never split into a duplicate or orphan a persisted
+`config.source`. What DOES degrade is `kind`: the scan's `deriveKind()` heuristic
+labels the RØDE `usb` where the engine says `mjpeg`, so a device ADDED while
+cerastream is unreachable can bridge to a neighbouring coarse row until the next
+poll's probe answers. That is accepted — a present-but-coarsely-labelled row beats
+an absent one, and the specific USB-as-HDMI mislabel this seam was originally
+warned about cannot recur (`deriveKind` tests usb/uvc BEFORE hdmi).
+Coverage: `tests/devices.test.ts` (`fires onDevicesChanged on a hotplug set
+change…` + `hands onDevicesChanged the list this scan observed…`) and
+`tests/lost-device-retention.test.ts` (`refreshSourcesForHotplug — a failing
+engine probe never masks a removal`).
 
 ## BROADCAST EVENTS
 

--- a/apps/backend/src/modules/streaming/devices.ts
+++ b/apps/backend/src/modules/streaming/devices.ts
@@ -85,11 +85,13 @@ export interface DeviceRegistryDeps {
 		isDismissable: boolean,
 	) => void;
 	broadcast: (type: string, data: unknown) => void;
-	// Fired on a video-device SET change so the unified `sources` snapshot is
-	// rebuilt from a fresh authoritative engine `list-devices` probe. The default
-	// must NOT feed the local v4l2 scan into sources — its kind heuristic would
-	// re-introduce the USB-as-HDMI mislabel the sources model removed.
-	onDevicesChanged: () => void;
+	// Fired on a video-device SET change, carrying the list this scan actually
+	// observed, so the unified `sources` snapshot can be rebuilt. The default
+	// still prefers a fresh authoritative engine `list-devices` probe (its typed
+	// kinds beat the v4l2 scan's display-name heuristic) and only falls back to
+	// the observed list when that probe fails — a retained-because-unreachable
+	// cache would otherwise keep an unplugged device on screen.
+	onDevicesChanged: (observed: readonly CaptureDevice[]) => void;
 	reportActiveVideoSource: typeof reportActiveVideoSource;
 	watch: typeof fs.watch;
 	now: () => number;
@@ -291,9 +293,9 @@ function defaultDeps(): DeviceRegistryDeps {
 				broadcastMsg(type, data),
 			);
 		},
-		onDevicesChanged: () => {
-			void import("./sources.ts").then(({ refreshAndBroadcastSources }) =>
-				refreshAndBroadcastSources(),
+		onDevicesChanged: (observed) => {
+			void import("./sources.ts").then(({ refreshSourcesForHotplug }) =>
+				refreshSourcesForHotplug(observed),
 			);
 		},
 		reportActiveVideoSource,
@@ -393,7 +395,7 @@ export function createDeviceRegistry(
 		if (deviceSetSerialized !== lastDeviceSetSerialized) {
 			const isInitialScan = lastDeviceSetSerialized === "";
 			lastDeviceSetSerialized = deviceSetSerialized;
-			if (!isInitialScan) deps.onDevicesChanged();
+			if (!isInitialScan) deps.onDevicesChanged(devices);
 		}
 		// Lifecycle indicator: the applied video source vanishing from the device
 		// set WHILE streaming raises a persistent notification (the idle

--- a/apps/backend/src/modules/streaming/sources.ts
+++ b/apps/backend/src/modules/streaming/sources.ts
@@ -687,15 +687,16 @@ export function getEngineAudioDevices(): EngineAudioDevice[] {
 }
 
 /**
- * Refresh the engine-device cache from a fresh `list-devices` probe. A throwing
- * fetch (engine unavailable) RETAINS the prior cache — the last-known device list
- * is never lost to a transient outage. A successful fetch replaces the cache
- * wholesale (an empty live list legitimately clears it — that is a reachable
- * engine reporting no devices, NOT an outage).
+ * Refresh the engine-device cache from a fresh `list-devices` probe, reporting
+ * whether the probe actually answered. A throwing fetch (engine unavailable)
+ * RETAINS the prior cache — the last-known device list is never lost to a
+ * transient outage — and returns `false`, so a caller holding its OWN truthful
+ * observation can tell "the engine confirmed this" from "the engine said nothing
+ * and you are looking at the previous answer".
  */
-export async function refreshEngineDeviceCache(
+export async function tryRefreshEngineDeviceCache(
 	deps: EngineDeviceCacheDeps = defaultEngineDeviceCacheDeps,
-): Promise<CaptureDevice[]> {
+): Promise<boolean> {
 	try {
 		const result = await deps.fetchEngineDevices();
 		engineDeviceCache = result.devices.map((d) =>
@@ -741,12 +742,26 @@ export async function refreshEngineDeviceCache(
 				};
 			});
 		recordObservedDevices(engineDeviceCache);
+		return true;
 	} catch (err) {
 		logger.debug(
 			"sources: engine device fetch failed; retaining last-known device cache",
 			{ err },
 		);
+		return false;
 	}
+}
+
+/**
+ * Refresh the engine-device cache from a fresh `list-devices` probe. A successful
+ * fetch replaces the cache wholesale (an empty live list legitimately clears it —
+ * that is a reachable engine reporting no devices, NOT an outage); a failing one
+ * retains the prior cache.
+ */
+export async function refreshEngineDeviceCache(
+	deps: EngineDeviceCacheDeps = defaultEngineDeviceCacheDeps,
+): Promise<CaptureDevice[]> {
+	await tryRefreshEngineDeviceCache(deps);
 	return engineDeviceCache;
 }
 
@@ -827,4 +842,27 @@ export async function refreshAndBroadcastSources(
 ): Promise<void> {
 	await refreshEngineDeviceCache(deps);
 	broadcastSources();
+}
+
+/**
+ * Rebuild + broadcast `sources` for a hotplug transition the device registry
+ * detected with its OWN scan.
+ *
+ * A fresh authoritative engine `list-devices` probe is still preferred — its
+ * typed kinds beat the local scan's display-name heuristic — but it is a SECOND,
+ * separately-fallible round-trip, and on failure the cache is deliberately
+ * RETAINED. For a removal that means rebroadcasting the device the operator just
+ * unplugged as still available, until some later poll's probe happens to answer.
+ * So a failing probe hands over to the observation the registry already paid for,
+ * which is the one thing here that is known to be current.
+ */
+export async function refreshSourcesForHotplug(
+	observed: readonly CaptureDevice[],
+	deps: EngineDeviceCacheDeps = defaultEngineDeviceCacheDeps,
+): Promise<void> {
+	if (await tryRefreshEngineDeviceCache(deps)) {
+		broadcastSources();
+		return;
+	}
+	applyObservedDevicesAndBroadcast(observed);
 }

--- a/apps/backend/src/tests/devices.test.ts
+++ b/apps/backend/src/tests/devices.test.ts
@@ -139,6 +139,26 @@ describe("device registry", () => {
 		expect(onDevicesChanged).toHaveBeenCalledTimes(2);
 	});
 
+	test("hands onDevicesChanged the list this scan observed, so a removal never depends on a second engine round-trip", async () => {
+		const observed: string[][] = [];
+		let cards = ["video63", "video64"];
+		const registry = createDeviceRegistry(
+			makeDeps({
+				onDevicesChanged: (devices) =>
+					observed.push(devices.map((d) => d.input_id)),
+				getAudioSources: () => ({}),
+				listVideoCards: async () => cards,
+				readCardName: async (card) =>
+					card === "video64" ? "Second-Cam" : "QA-Cam",
+			}),
+		);
+		await registry.rescan(); // boot seed
+		cards = ["video63"];
+		await registry.rescan(); // video64 unplugged
+
+		expect(observed).toEqual([["/dev/video63"]]);
+	});
+
 	test("switchInput returns a sub-frame gap_ms and sets the active input", async () => {
 		let clock = 0;
 		const registry = createDeviceRegistry(

--- a/apps/backend/src/tests/lost-device-retention.test.ts
+++ b/apps/backend/src/tests/lost-device-retention.test.ts
@@ -39,7 +39,9 @@ import {
 	getEngineDeviceCache,
 	getSessionSeenDeviceSnapshots,
 	getSourcesMessage,
+	refreshAndBroadcastSources,
 	refreshEngineDeviceCache,
+	refreshSourcesForHotplug,
 	resetEngineDeviceCache,
 } from "../modules/streaming/sources.ts";
 import { addClient, removeClient } from "../rpc/events.ts";
@@ -546,5 +548,105 @@ describe("applyObservedDevicesAndBroadcast — combined hotplug transition (C7)"
 		// getSourcesMessage rebuilt from module state agrees (single source of truth).
 		const rebuilt = getSourcesMessage().sources.find((s) => s.id === "video0");
 		expect(rebuilt?.lost).toBe(true);
+	});
+});
+
+// ─── hotplug rebuild: the engine probe never gets to mask an observed removal ──
+
+describe("refreshSourcesForHotplug — a failing engine probe never masks a removal", () => {
+	beforeEach(() => {
+		resetEngineDeviceCache();
+		clearCapabilitiesCache();
+		getConfig().last_seen_devices = [];
+		delete getConfig().source;
+	});
+
+	afterEach(() => {
+		resetEngineDeviceCache();
+		clearCapabilitiesCache();
+		getConfig().last_seen_devices = [];
+		delete getConfig().source;
+	});
+
+	async function seedPresentDevice(): Promise<void> {
+		await seedHdmiCaps();
+		getConfig().source = "video0";
+		applyObservedEngineDevices([
+			captureDevice("video0", "hdmi", { display_name: "Studio HDMI" }),
+		]);
+		expect(getEngineDeviceCache()).toHaveLength(1);
+	}
+
+	function captureBroadcast(
+		run: () => void | Promise<void>,
+	): Promise<Array<Record<string, unknown>>> {
+		const sink: string[] = [];
+		const client = recordingClient(sink);
+		addClient(client);
+		return Promise.resolve(run())
+			.finally(() => removeClient(client))
+			.then(() =>
+				sink.map((raw) => JSON.parse(raw) as Record<string, unknown>),
+			);
+	}
+
+	it("a removal seen by the local scan still reaches the sources broadcast when the engine list-devices probe throws", async () => {
+		await seedPresentDevice();
+
+		const frames = await captureBroadcast(() =>
+			// The registry observed the device gone; the second engine round-trip is
+			// down (mid-restart / socket refused) — exactly the live-board case where
+			// the unplugged device kept rendering as available.
+			refreshSourcesForHotplug([], {
+				fetchEngineDevices: async () => {
+					throw new Error("engine unavailable");
+				},
+			}),
+		);
+
+		const sourcesFrame = frames.find((f) => "sources" in f);
+		expect(sourcesFrame).toBeDefined();
+		const video0 = (
+			sourcesFrame?.sources as { sources: Array<Record<string, unknown>> }
+		).sources.find((s) => s.id === "video0");
+		expect(video0?.lost).toBe(true);
+		expect(video0?.available).toBe(false);
+
+		// the cache followed the observation, not the retained pre-removal list.
+		expect(getEngineDeviceCache()).toHaveLength(0);
+	});
+
+	it("a reachable engine still wins: its typed device list replaces the local observation", async () => {
+		await seedPresentDevice();
+
+		await refreshSourcesForHotplug(
+			[captureDevice("video0", "usb", { display_name: "Local Scan Name" })],
+			{
+				fetchEngineDevices: async () => ({
+					devices: [engineDevice("video0", "Engine HDMI")],
+				}),
+			},
+		);
+
+		const cached = getEngineDeviceCache();
+		expect(cached).toHaveLength(1);
+		expect(cached[0]?.display_name).toBe("Engine HDMI");
+		// the engine's typed kind survives — the local scan's heuristic never lands.
+		expect(cached[0]?.kind).toBe("hdmi");
+	});
+
+	it("the plain refresh keeps its retain-on-failure contract (a transient outage must not erase the last-known list)", async () => {
+		await seedPresentDevice();
+
+		await refreshAndBroadcastSources({
+			fetchEngineDevices: async () => {
+				throw new Error("engine unavailable");
+			},
+		});
+
+		// Deliberate and unchanged: with no independent observation to trust, the
+		// last-known list is better than an empty one. That is precisely why the
+		// hotplug path must feed its own observation in instead of re-fetching.
+		expect(getEngineDeviceCache()).toHaveLength(1);
 	});
 });

--- a/docs/LIFECYCLE-INDICATORS.md
+++ b/docs/LIFECYCLE-INDICATORS.md
@@ -42,7 +42,7 @@ Each row below carries exactly one `Status: <tag>` line.
 
 ### `usb-source-connect-idle`
 **Current indicator:** `apps/backend/src/modules/streaming/devices.ts:363-380` detects
-a changed device set and calls `onDevicesChanged()`, rebroadcasting the unified
+a changed device set and calls `onDevicesChanged(observed)`, rebroadcasting the unified
 `sources` list; `apps/frontend/src/lib/components/custom/SourceSection.svelte:192-200`
 re-renders the newly-appeared row. There is no dedicated "device connected" toast —
 the row simply appears, which is the correct calm behavior while idle (nothing was
@@ -56,7 +56,11 @@ place. No dedicated idle-disconnect banner or toast exists — while idle (no ac
 stream), the passive row-graying is sufficient: nothing is actively broken, so a
 persistent alert would be noise. Contrast with `usb-source-disconnect-streaming`
 below, where the same disappearance IS alert-worthy because a stream is actually
-consuming the source.
+consuming the source. The passive graying is only calm if it is also PROMPT: the
+rebuild hands the observed device list to `sources.ts` `refreshSourcesForHotplug()`,
+which falls back to that observation when the engine `list-devices` re-probe fails,
+so a removal can no longer sit behind a retained (stale) engine cache until a later
+poll succeeds — see `apps/backend/AGENTS.md` → SIGUSR2 UDEV HOTPLUG HOOK.
 **Status: EXISTS**
 
 ### `usb-source-disconnect-streaming`


### PR DESCRIPTION
**Affected repo & language:** CeraUI — TypeScript (backend)

## What

The video-hotplug rebuild no longer depends on a second engine round-trip to notice
that a device is gone.

`devices.ts`'s `/dev` watch + 2 s poll detects a device-set change and fires
`onDevicesChanged`, which used to call `sources.ts` `refreshAndBroadcastSources()` —
a *fresh* `list-devices` probe against cerastream. That probe deliberately RETAINS
the previous cache when it throws, so on a removal it rebroadcast the device the
operator had just unplugged as still present and selectable.

`onDevicesChanged` now carries the device list the triggering scan actually observed,
and the default handler is `refreshSourcesForHotplug(observed)`. It still prefers the
engine probe — its typed kinds beat the local scan's display-name heuristic — but when
that probe fails it applies the observation the registry already paid for, via the
existing `applyObservedDevicesAndBroadcast()`.

`refreshEngineDeviceCache()` is unchanged in behaviour; it now delegates to a new
`tryRefreshEngineDeviceCache()` that reports whether the probe actually answered.
Retain-on-failure is still the contract for every caller with no independent
observation (`main.ts` boot seed, `engine-reconnect.ts` heal).

## Why

Found live during a board QA drill: after physically unplugging a capture device the
Live source list kept showing it as an available source, self-correcting only after
roughly a minute — i.e. whenever a later poll's probe happened to succeed. "The device
you just unplugged is still offered" is not an acceptable idle state, and the delay
made it look like the UI had simply stopped updating.

The local `/sys/class/video4linux` scan that fired the rebuild had *already* proved the
device was gone. Trusting a second, separately-fallible call over that observation is
what created the window.

## How to verify

Unit (red-first — the first test fails on `main`):

```
cd apps/backend
bun test src/tests/lost-device-retention.test.ts src/tests/devices.test.ts
```

- `refreshSourcesForHotplug — a failing engine probe never masks a removal` drives the
  exact failure mode: seed a present device, then rebuild with a throwing
  `fetchEngineDevices` and a removal in the observed list. Against unmodified code the
  broadcast row comes back with `lost: undefined` (still available) — the board symptom.
- A sibling test pins that a *reachable* engine still wins (its `mjpeg`/`hdmi` kinds are
  not replaced by the local heuristic), and a third pins that the plain refresh keeps
  its retain-on-failure contract, so this did not weaken the fetch path.
- `devices.test.ts` gains a check that the registry hands the observed list through.

Full backend suite: `bun test` in `apps/backend` — 2229 pass, 0 fail. Root `bun run lint`
clean (35 pre-existing warnings).

Board (Rock 5B+, read-only, idle, nothing unplugged): probed cerastream's real
`list-devices` over its control socket to confirm the assumption the fallback rests on —
the engine reports `input_id: "/dev/video0"` and `"/dev/video1"` and de-dupes the RØDE's
two nodes, which is byte-identical to what `buildDeviceList()` produces. So a fallback
row cannot split into a duplicate or orphan a persisted `config.source`. Board left as
found; no config, service, or state touched.

## Risks

Low, and confined to the engine-unreachable path — the happy path is unchanged
(probe succeeds → same broadcast as before).

When the probe fails and the fallback runs, capture rows carry the scan's heuristic
`kind` rather than the engine's typed one: the RØDE reads `usb` where cerastream says
`mjpeg`, so a device *added* while cerastream is down can bridge to a neighbouring
coarse row until the next poll's probe answers. Accepted: a present-but-coarsely-labelled
row beats an absent one, and the specific USB-as-HDMI mislabel this seam was originally
warned about cannot recur — `deriveKind` tests usb/uvc before hdmi.

Rollback is a revert; there is no migration, no schema change, and no wire-format change.

---

**Checklist**

- [x] Docs updated if behavior or structure changed (Rule A: AGENTS.md, README, docs/, ARCHITECTURE.md, versions.yaml)
- [x] Started from updated main; branch rebased on latest canonical branch (Rule B)
- [x] Rule D local-scratch reference check passes for tracked files
- [x] Tests pass; QA evidence attached or linked
