### PR TITLE
fix(sources): stop a stale engine probe hiding a device that came back

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -535,6 +535,40 @@ unweakened — retain-on-failure is still its contract for every caller that has
 independent observation (`main.ts` boot seed, `engine-reconnect.ts` heal). Do NOT
 "simplify" the hotplug path back to a bare `refreshAndBroadcastSources()`.
 
+**On the hotplug path the OBSERVED set is authoritative for MEMBERSHIP; the probe
+supplies METADATA only.** A probe that answers is not the same as a probe that is
+right. Its `list-devices` reflects whatever the engine could enumerate at the
+moment it was asked, and a just-replugged USB device the kernel has not finished
+re-enumerating is truthfully ABSENT from a successful answer. Overwriting the
+cache with that reply hid a device the registry's own scan had already proved
+present — confirmed live: a RØDE HDMI-to-USB-C came back at the kernel level but
+its row stayed `lost:true`, and because `lost` is never explicitly cleared (a live
+row simply wins) and the registry only re-pokes on a device-SET *change*, the row
+stayed stuck rather than self-correcting. This is the mirror of the probe-FAILURE
+case above and needed its own fix: `mergeObservedWithProbe(observed, probed)`
+(`sources.ts`) now takes video membership from `observed` and metadata from
+`probed` — a probe entry matching an observed `input_id` wins outright (typed
+kind, caps, `stable_id` all survive), a video device the probe never mentions
+keeps its observed row instead of vanishing, and a video device the probe still
+lists but the scan no longer sees is dropped. NON-video entries follow the probe
+verbatim: the observed list's audio rows are in CeraUI's own `audio:<id>`
+namespace, not the engine's, and `buildSources` overlays video only. The
+`engineAudioDeviceCache` is still refreshed from the probe on this path — it is
+the one cache the local scan cannot populate.
+
+**Overlapping hotplug refreshes are ordered by a generation fence.** Each
+`onDevicesChanged` starts its own probe, so an unplug and a replug moments apart
+run two round-trips concurrently and the OLDER one can answer LAST — republishing
+the world it asked about over the newer, correct view. `refreshSourcesForHotplug`
+therefore takes a monotonic `hotplugRefreshGeneration` ticket before probing and
+drops its result (no cache write, no broadcast, on BOTH the success and the
+observed-fallback branch) if a newer refresh has since started. The counter is
+deliberately NOT reset by `resetEngineDeviceCache()` — a superseded probe must
+stay superseded. This is why the probe round-trip (`probeEngineDevices`) is split
+from the cache write (`commitEngineDevices`): the fence has to be checked between
+them. `tryRefreshEngineDeviceCache` is the unchanged probe+commit composition for
+every caller that has no ordering concern.
+
 The fallback is id-safe and its cost is bounded: `buildDeviceList()` keys the
 fallback scan `/dev/<card>`, which is byte-identical to the engine's own
 `input_id` (verified on a real Rock 5B+: cerastream reports `/dev/video0` +
@@ -549,7 +583,10 @@ warned about cannot recur (`deriveKind` tests usb/uvc BEFORE hdmi).
 Coverage: `tests/devices.test.ts` (`fires onDevicesChanged on a hotplug set
 change…` + `hands onDevicesChanged the list this scan observed…`) and
 `tests/lost-device-retention.test.ts` (`refreshSourcesForHotplug — a failing
-engine probe never masks a removal`).
+engine probe never masks a removal` + `refreshSourcesForHotplug — a stale
+successful probe never masks the observed set`, which covers the replug-vs-empty-
+probe case, the removal-vs-pre-removal-probe case, metadata preference, the audio
+cache, and both out-of-order fences).
 
 ## BROADCAST EVENTS
 
@@ -1025,3 +1062,4 @@ FIRST, reason `live.education.reason.disabledInSettings`). See root `AGENTS.md`
 - Don't re-add an operator audio-device rename/alias surface (RPC, contract entry, or config field) — device naming is code-level only (`ONBOARD_AUDIO_DISPLAY_RULES` + `cleanAudioDeviceName`); the #206 alias layer was removed in #207 by product decision. The same holds for VIDEO (`ONBOARD_VIDEO_DISPLAY_RULES`) — no rename affordance for any device, of any media type.
 - Don't re-apply an onboard display-name rule at a render site (a Svelte label, a summary derivation) — it belongs at the device-construction seam (`fromEngineDevice`), which is why the row and the "Configured" label are both fixed by one call.
 - Don't re-derive `pipeline`/`selected_video_input` resolution inline in a new procedure — route through `resolveSourceRouting()`/`deriveEngineRouting()` in `modules/streaming/sources.ts`.
+- Don't let a `list-devices` probe decide device MEMBERSHIP on the hotplug path, and don't drop the generation fence — a probe that answers can still be stale or out of order, and both have already stranded a real device on a board. Membership comes from the registry's observation (`mergeObservedWithProbe`); the probe supplies metadata.

--- a/apps/backend/src/modules/streaming/sources.ts
+++ b/apps/backend/src/modules/streaming/sources.ts
@@ -686,6 +686,87 @@ export function getEngineAudioDevices(): EngineAudioDevice[] {
 	return engineAudioDeviceCache;
 }
 
+/** One answered `list-devices` probe, mapped but NOT yet applied to the caches. */
+interface EngineDeviceProbe {
+	devices: CaptureDevice[];
+	audio: EngineAudioDevice[];
+}
+
+/**
+ * Run one `list-devices` probe and map its result, WITHOUT touching the caches.
+ * Separating the round-trip from the commit lets a caller decide — after the
+ * await, with fresher knowledge than it had before — whether this answer still
+ * deserves to become the current view (see `refreshSourcesForHotplug`).
+ * `undefined` means the engine said nothing at all.
+ */
+async function probeEngineDevices(
+	deps: EngineDeviceCacheDeps,
+): Promise<EngineDeviceProbe | undefined> {
+	try {
+		const result = await deps.fetchEngineDevices();
+		return {
+			devices: result.devices.map((d) =>
+				fromEngineDevice({
+					input_id: d.input_id,
+					device_path: d.device_path,
+					display_name: d.display_name,
+					media_class: d.media_class,
+					kind: d.kind,
+					caps: d.caps,
+					stable_id: d.stable_id,
+				}),
+			),
+			// Parallel AUDIO cache (T4): an EXPLICIT field copy of the audio entries
+			// that PRESERVES the `alsa_card_id` join key verbatim. It is read
+			// defensively (the pre-T18 binding schema strips it → `undefined`; the
+			// bumped schema retains it), and it is NOT routed through the video
+			// whitelist copy above or `fromEngineDevice()`, both of which drop it.
+			audio: result.devices
+				.filter((d) => d.media_class === "audio")
+				.map((d) => {
+					const extra = d as {
+						alsa_card_id?: string;
+						product_name?: string;
+						transport?: EngineAudioDevice["transport"];
+						stable_id?: string;
+					};
+					return {
+						input_id: d.input_id,
+						display_name: d.display_name,
+						...(extra.alsa_card_id !== undefined
+							? { alsa_card_id: extra.alsa_card_id }
+							: {}),
+						...(extra.product_name !== undefined
+							? { product_name: extra.product_name }
+							: {}),
+						...(extra.transport !== undefined
+							? { transport: extra.transport }
+							: {}),
+						...(extra.stable_id !== undefined
+							? { stable_id: extra.stable_id }
+							: {}),
+					};
+				}),
+		};
+	} catch (err) {
+		logger.debug(
+			"sources: engine device fetch failed; retaining last-known device cache",
+			{ err },
+		);
+		return undefined;
+	}
+}
+
+/** Make a device list the current view, remembering every device it proves live. */
+function commitEngineDevices(
+	devices: readonly CaptureDevice[],
+	audio?: readonly EngineAudioDevice[],
+): void {
+	engineDeviceCache = [...devices];
+	if (audio !== undefined) engineAudioDeviceCache = [...audio];
+	recordObservedDevices(engineDeviceCache);
+}
+
 /**
  * Refresh the engine-device cache from a fresh `list-devices` probe, reporting
  * whether the probe actually answered. A throwing fetch (engine unavailable)
@@ -697,59 +778,10 @@ export function getEngineAudioDevices(): EngineAudioDevice[] {
 export async function tryRefreshEngineDeviceCache(
 	deps: EngineDeviceCacheDeps = defaultEngineDeviceCacheDeps,
 ): Promise<boolean> {
-	try {
-		const result = await deps.fetchEngineDevices();
-		engineDeviceCache = result.devices.map((d) =>
-			fromEngineDevice({
-				input_id: d.input_id,
-				device_path: d.device_path,
-				display_name: d.display_name,
-				media_class: d.media_class,
-				kind: d.kind,
-				caps: d.caps,
-				stable_id: d.stable_id,
-			}),
-		);
-		// Parallel AUDIO cache (T4): an EXPLICIT field copy of the audio entries
-		// that PRESERVES the `alsa_card_id` join key verbatim. It is read
-		// defensively (the pre-T18 binding schema strips it → `undefined`; the
-		// bumped schema retains it), and it is NOT routed through the video
-		// whitelist copy above or `fromEngineDevice()`, both of which drop it.
-		engineAudioDeviceCache = result.devices
-			.filter((d) => d.media_class === "audio")
-			.map((d) => {
-				const extra = d as {
-					alsa_card_id?: string;
-					product_name?: string;
-					transport?: EngineAudioDevice["transport"];
-					stable_id?: string;
-				};
-				return {
-					input_id: d.input_id,
-					display_name: d.display_name,
-					...(extra.alsa_card_id !== undefined
-						? { alsa_card_id: extra.alsa_card_id }
-						: {}),
-					...(extra.product_name !== undefined
-						? { product_name: extra.product_name }
-						: {}),
-					...(extra.transport !== undefined
-						? { transport: extra.transport }
-						: {}),
-					...(extra.stable_id !== undefined
-						? { stable_id: extra.stable_id }
-						: {}),
-				};
-			});
-		recordObservedDevices(engineDeviceCache);
-		return true;
-	} catch (err) {
-		logger.debug(
-			"sources: engine device fetch failed; retaining last-known device cache",
-			{ err },
-		);
-		return false;
-	}
+	const probe = await probeEngineDevices(deps);
+	if (probe === undefined) return false;
+	commitEngineDevices(probe.devices, probe.audio);
+	return true;
 }
 
 /**
@@ -785,8 +817,7 @@ export function resetEngineDeviceCache(): void {
 export function applyObservedEngineDevices(
 	devices: readonly CaptureDevice[],
 ): void {
-	engineDeviceCache = [...devices];
-	recordObservedDevices(engineDeviceCache);
+	commitEngineDevices(devices);
 }
 
 /**
@@ -845,24 +876,82 @@ export async function refreshAndBroadcastSources(
 }
 
 /**
+ * Fold an answered probe into the observation that triggered the rebuild.
+ *
+ * MEMBERSHIP comes from `observed` — the scan that just detected the transition
+ * is, for the video set, the only list here known to be current. METADATA comes
+ * from `probed`: an engine entry matching an observed `input_id` wins outright,
+ * so typed kinds, capabilities and stable ids survive (the local scan only ever
+ * guesses a kind from the display name). A device the probe never mentions keeps
+ * its observed row rather than disappearing, and a device the probe still lists
+ * but the scan no longer sees is dropped.
+ *
+ * The join key is `input_id` alone: `buildDeviceList()` keys the fallback scan
+ * `/dev/<card>`, byte-identical to the engine's own path-preferred id (verified
+ * on a real Rock 5B+), so the two lists share one id namespace.
+ *
+ * NON-VIDEO entries follow the probe verbatim. The observed list's audio rows
+ * live in CeraUI's own `audio:<id>` namespace, not the engine's, so they are not
+ * comparable — and `buildSources` overlays video only.
+ */
+export function mergeObservedWithProbe(
+	observed: readonly CaptureDevice[],
+	probed: readonly CaptureDevice[],
+): CaptureDevice[] {
+	const observedVideoIds = new Set(
+		observed.filter((d) => d.media_class === "video").map((d) => d.input_id),
+	);
+	const probedVideoIds = new Set(
+		probed.filter((d) => d.media_class === "video").map((d) => d.input_id),
+	);
+	const confirmed = probed.filter(
+		(d) => d.media_class !== "video" || observedVideoIds.has(d.input_id),
+	);
+	const unprobed = observed.filter(
+		(d) => d.media_class === "video" && !probedVideoIds.has(d.input_id),
+	);
+	return [...confirmed, ...unprobed];
+}
+
+// Monotonic, never reset: a superseded probe answering late must stay superseded
+// even across a `resetEngineDeviceCache()`.
+let hotplugRefreshGeneration = 0;
+
+/**
  * Rebuild + broadcast `sources` for a hotplug transition the device registry
  * detected with its OWN scan.
  *
  * A fresh authoritative engine `list-devices` probe is still preferred — its
  * typed kinds beat the local scan's display-name heuristic — but it is a SECOND,
- * separately-fallible round-trip, and on failure the cache is deliberately
- * RETAINED. For a removal that means rebroadcasting the device the operator just
- * unplugged as still available, until some later poll's probe happens to answer.
- * So a failing probe hands over to the observation the registry already paid for,
- * which is the one thing here that is known to be current.
+ * separately-fallible round-trip that answers about a moment of its own choosing.
+ * Two ways it can be wrong, and neither may overrule the observation:
+ *
+ * 1. It FAILS, and the cache is deliberately RETAINED — rebroadcasting the device
+ *    the operator just unplugged as still available. So a failing probe hands over
+ *    to the observation the registry already paid for.
+ * 2. It SUCCEEDS but answers stale — a just-replugged USB device the OS has not
+ *    finished re-enumerating is simply absent from a truthful engine answer. So
+ *    membership is taken from the observation and only metadata from the probe.
+ *
+ * And because each transition starts its own round-trip, an OLDER refresh can
+ * answer after a NEWER one has already published: a generation fence drops any
+ * result that is no longer the current view rather than reviving the world it
+ * asked about.
  */
 export async function refreshSourcesForHotplug(
 	observed: readonly CaptureDevice[],
 	deps: EngineDeviceCacheDeps = defaultEngineDeviceCacheDeps,
 ): Promise<void> {
-	if (await tryRefreshEngineDeviceCache(deps)) {
-		broadcastSources();
+	const generation = ++hotplugRefreshGeneration;
+	const probe = await probeEngineDevices(deps);
+	if (generation !== hotplugRefreshGeneration) return;
+	if (probe === undefined) {
+		applyObservedDevicesAndBroadcast(observed);
 		return;
 	}
-	applyObservedDevicesAndBroadcast(observed);
+	commitEngineDevices(
+		mergeObservedWithProbe(observed, probe.devices),
+		probe.audio,
+	);
+	broadcastSources();
 }

--- a/apps/backend/src/tests/lost-device-retention.test.ts
+++ b/apps/backend/src/tests/lost-device-retention.test.ts
@@ -36,6 +36,7 @@ import {
 	applyObservedDevicesAndBroadcast,
 	applyObservedEngineDevices,
 	buildSources,
+	getEngineAudioDevices,
 	getEngineDeviceCache,
 	getSessionSeenDeviceSnapshots,
 	getSourcesMessage,
@@ -648,5 +649,237 @@ describe("refreshSourcesForHotplug — a failing engine probe never masks a remo
 		// last-known list is better than an empty one. That is precisely why the
 		// hotplug path must feed its own observation in instead of re-fetching.
 		expect(getEngineDeviceCache()).toHaveLength(1);
+	});
+});
+
+// ─── hotplug rebuild: a SUCCEEDING but stale probe never masks the observation ─
+
+describe("refreshSourcesForHotplug — a stale successful probe never masks the observed set", () => {
+	beforeEach(() => {
+		resetEngineDeviceCache();
+		clearCapabilitiesCache();
+		getConfig().last_seen_devices = [];
+		delete getConfig().source;
+	});
+
+	afterEach(() => {
+		resetEngineDeviceCache();
+		clearCapabilitiesCache();
+		getConfig().last_seen_devices = [];
+		delete getConfig().source;
+	});
+
+	function captureBroadcast(
+		run: () => void | Promise<void>,
+	): Promise<Array<Record<string, unknown>>> {
+		const sink: string[] = [];
+		const client = recordingClient(sink);
+		addClient(client);
+		return Promise.resolve(run())
+			.finally(() => removeClient(client))
+			.then(() =>
+				sink.map((raw) => JSON.parse(raw) as Record<string, unknown>),
+			);
+	}
+
+	function sourceRow(
+		frames: Array<Record<string, unknown>>,
+		id: string,
+	): Record<string, unknown> | undefined {
+		const frame = frames.find((f) => "sources" in f);
+		expect(frame).toBeDefined();
+		return (
+			frame?.sources as { sources: Array<Record<string, unknown>> }
+		).sources.find((s) => s.id === id);
+	}
+
+	/** The device was seen, then unplugged — so it currently renders `lost`. */
+	async function seedLostDevice(): Promise<void> {
+		await seedHdmiCaps();
+		getConfig().source = "video0";
+		applyObservedEngineDevices([
+			captureDevice("video0", "hdmi", { display_name: "Studio HDMI" }),
+		]);
+		applyObservedEngineDevices([]);
+		expect(
+			getSourcesMessage().sources.find((s) => s.id === "video0")?.lost,
+		).toBe(true);
+	}
+
+	it("a replug the local scan observed is NOT hidden by a probe that answers with a stale empty list", async () => {
+		await seedLostDevice();
+
+		const frames = await captureBroadcast(() =>
+			// The RØDE replug: the registry's own scan already proved the node is
+			// back, but the engine probe answers BEFORE the OS finished re-
+			// enumerating the USB device, so it truthfully reports "no devices".
+			refreshSourcesForHotplug(
+				[captureDevice("video0", "hdmi", { display_name: "Studio HDMI" })],
+				{ fetchEngineDevices: async () => ({ devices: [] }) },
+			),
+		);
+
+		const video0 = sourceRow(frames, "video0");
+		expect(video0?.lost).toBeUndefined();
+		expect(video0?.available).toBe(true);
+		expect(getEngineDeviceCache().map((d) => d.input_id)).toEqual(["video0"]);
+	});
+
+	it("a removal the local scan observed is NOT resurrected by a probe still answering with the pre-removal list", async () => {
+		await seedHdmiCaps();
+		getConfig().source = "video0";
+		applyObservedEngineDevices([
+			captureDevice("video0", "hdmi", { display_name: "Studio HDMI" }),
+		]);
+
+		const frames = await captureBroadcast(() =>
+			refreshSourcesForHotplug([], {
+				fetchEngineDevices: async () => ({
+					devices: [engineDevice("video0", "Studio HDMI")],
+				}),
+			}),
+		);
+
+		const video0 = sourceRow(frames, "video0");
+		expect(video0?.lost).toBe(true);
+		expect(video0?.available).toBe(false);
+		expect(getEngineDeviceCache()).toHaveLength(0);
+	});
+
+	it("the probe still supplies the richer metadata for every device the observation confirms", async () => {
+		await seedHdmiCaps();
+
+		await refreshSourcesForHotplug(
+			[
+				captureDevice("video0", "usb", { display_name: "Local Scan Name" }),
+				captureDevice("video1", "usb", {
+					display_name: "Only The Scan Saw It",
+				}),
+			],
+			{
+				fetchEngineDevices: async () => ({
+					devices: [engineDevice("video0", "Engine HDMI")],
+				}),
+			},
+		);
+
+		const cached = getEngineDeviceCache();
+		expect(cached.map((d) => d.input_id)).toEqual(["video0", "video1"]);
+		expect(cached[0]?.display_name).toBe("Engine HDMI");
+		expect(cached[0]?.kind).toBe("hdmi");
+		expect(cached[1]?.display_name).toBe("Only The Scan Saw It");
+		expect(cached[1]?.kind).toBe("usb");
+	});
+
+	it("keeps refreshing the audio-naming cache, which only the engine can populate", async () => {
+		await seedHdmiCaps();
+
+		await refreshSourcesForHotplug(
+			[
+				captureDevice("video0", "hdmi", { display_name: "Studio HDMI" }),
+				// The local scan names audio in CeraUI's own namespace, which shares
+				// no ids with the engine's — so it is not comparable, and merging it
+				// in would duplicate the card under a second identity.
+				captureDevice("audio:usbaudio", "audio", {
+					device_path: "alsa:usbaudio",
+					media_class: "audio",
+				}),
+			],
+			{
+				fetchEngineDevices: async () => ({
+					devices: [
+						engineDevice("video0", "Studio HDMI"),
+						{
+							input_id: "audio:card0",
+							device_path: "alsa:card0",
+							display_name: "RØDE HDMI to USB-C",
+							media_class: "audio",
+							kind: "audio",
+							alsa_card_id: "Device",
+						} as ListDevicesResult["devices"][number],
+					],
+				}),
+			},
+		);
+
+		const audio = getEngineAudioDevices();
+		expect(audio).toHaveLength(1);
+		expect(audio[0]?.alsa_card_id).toBe("Device");
+		// The observation carries no engine audio rows, so it must not evict them.
+		expect(getEngineDeviceCache().map((d) => d.input_id)).toEqual([
+			"video0",
+			"audio:card0",
+		]);
+	});
+
+	it("an OLDER hotplug refresh answering late never clobbers a NEWER one's result", async () => {
+		await seedHdmiCaps();
+		getConfig().source = "video0";
+		applyObservedEngineDevices([
+			captureDevice("video0", "hdmi", { display_name: "Studio HDMI" }),
+		]);
+
+		// The unplug fires first, but its engine probe hangs.
+		let releaseStaleProbe: (result: ListDevicesResult) => void = () => {};
+		const staleProbe = new Promise<ListDevicesResult>((resolve) => {
+			releaseStaleProbe = resolve;
+		});
+		const older = refreshSourcesForHotplug([], {
+			fetchEngineDevices: () => staleProbe,
+		});
+
+		await refreshSourcesForHotplug(
+			[captureDevice("video0", "hdmi", { display_name: "Studio HDMI" })],
+			{
+				fetchEngineDevices: async () => ({
+					devices: [engineDevice("video0", "Studio HDMI")],
+				}),
+			},
+		);
+		expect(getEngineDeviceCache()).toHaveLength(1);
+
+		// Only NOW does the removal's probe answer — with the world as it was.
+		const frames = await captureBroadcast(() => {
+			releaseStaleProbe({ devices: [] });
+			return older;
+		});
+
+		expect(frames.some((f) => "sources" in f)).toBe(false);
+		expect(getEngineDeviceCache().map((d) => d.input_id)).toEqual(["video0"]);
+		expect(
+			getSourcesMessage().sources.find((s) => s.id === "video0")?.lost,
+		).toBeUndefined();
+	});
+
+	it("an OLDER refresh whose probe FAILS late does not fall back over a NEWER result", async () => {
+		await seedHdmiCaps();
+		getConfig().source = "video0";
+		applyObservedEngineDevices([
+			captureDevice("video0", "hdmi", { display_name: "Studio HDMI" }),
+		]);
+
+		let failStaleProbe: (err: Error) => void = () => {};
+		const staleProbe = new Promise<ListDevicesResult>((_resolve, reject) => {
+			failStaleProbe = reject;
+		});
+		const older = refreshSourcesForHotplug([], {
+			fetchEngineDevices: () => staleProbe,
+		});
+
+		await refreshSourcesForHotplug(
+			[captureDevice("video0", "hdmi", { display_name: "Studio HDMI" })],
+			{
+				fetchEngineDevices: async () => ({
+					devices: [engineDevice("video0", "Studio HDMI")],
+				}),
+			},
+		);
+
+		failStaleProbe(new Error("engine unavailable"));
+		await older;
+
+		// The PR #214 observed-fallback is still correct — it just belongs to the
+		// generation that owns the current view, not to a superseded one.
+		expect(getEngineDeviceCache().map((d) => d.input_id)).toEqual(["video0"]);
 	});
 });


### PR DESCRIPTION
## What

A USB capture device (RØDE HDMI-to-USB-C) was unplugged and replugged. The kernel had it back and cerastream could see it, but its row in the Live source list stayed **Lost** and unselectable — and because it was also the configured source, the operator's active input was stuck unusable with no way back short of a service restart.

Two independent gaps in the hotplug reconciliation path, both in `refreshSourcesForHotplug`:

1. **A successful-but-stale probe could hide a device the scan proved present.** Membership is now taken from the registry's own observation; the engine probe supplies metadata only.
2. **Overlapping refreshes had no ordering.** A monotonic generation fence now drops any result that is no longer the current view.

## Why

`refreshSourcesForHotplug` re-fetches the engine `list-devices` and, on a successful answer, replaced the device cache with it wholesale. But a probe that *answers* is not a probe that is *right*: a just-replugged USB device the kernel has not finished re-enumerating is genuinely absent from a truthful engine reply. That reply then overwrote a device the registry's `/dev` scan had already proved present.

Nothing clears `lost` explicitly — a live row simply wins — and the registry only re-pokes `onDevicesChanged` on a device-set *change*. With the set now stable, the row never recovered on its own. On the board it took a `ceralive` restart to clear.

The second gap is the classic late-response race: an unplug and a replug moments apart each start their own round-trip, and the older one can answer last, republishing the world it asked about over the newer, correct view.

This is the mirror of PR #214, which fixed probe **failure** masking a **removal**. That fallback is untouched — this is probe **success-with-stale-data** masking a **return**.

### The merge rule

`mergeObservedWithProbe(observed, probed)` keeps the engine authoritative where it is actually better:

- a probe entry matching an observed `input_id` wins outright, so typed kinds (`mjpeg`, not the scan's `usb` guess), caps and `stable_id` all survive;
- a video device the probe omits keeps its observed row instead of vanishing;
- a video device the probe still lists but the scan no longer sees is dropped;
- non-video entries follow the probe verbatim — the scan's audio rows are in CeraUI's own `audio:<id>` namespace, not the engine's, so they are not comparable, and `buildSources` overlays video only. The audio-naming cache is still refreshed from the probe; it is the one cache the local scan cannot populate.

The join key is `input_id` alone, which holds because `buildDeviceList()` keys the fallback scan `/dev/<card>` — byte-identical to the engine's path-preferred id. Re-verified on the board below.

The generation fence is why the probe round-trip (`probeEngineDevices`) is now split from the cache write (`commitEngineDevices`): the check has to happen between them. `tryRefreshEngineDeviceCache` is the unchanged probe+commit composition for every caller with no ordering concern, so the boot seed and the engine-reconnect heal keep retain-on-failure exactly as before.

## How to verify

Red-first: all five new tests fail against unmodified `sources.ts` (the replug case fails with `available: false` / `lost: true` — the board symptom reproduced as a unit test).

`apps/backend/src/tests/lost-device-retention.test.ts`, new describe block `refreshSourcesForHotplug — a stale successful probe never masks the observed set`:

- a replug the scan observed is not hidden by a probe answering with a stale empty list;
- a removal the scan observed is not resurrected by a probe still answering with the pre-removal list;
- the probe still supplies richer metadata for every device the observation confirms;
- the audio-naming cache is still refreshed, and the scan's own-namespace audio rows are not injected;
- an older refresh answering late never clobbers a newer one's result — on both the success and the failure branch.

```
bun run lint          # exit 0 (35 pre-existing warnings)
cd apps/backend && bun test    # 2235 pass / 0 fail  (2229 + 6 new)
cd packages/rpc   && bun test  # 238 pass / 0 fail
bun run --filter frontend test # 1818 pass / 0 fail
```

No existing assertion was weakened or removed. PR #214's `a failing engine probe never masks a removal` suite passes unchanged.

### Board (Rock 5B+, read-only, nothing unplugged)

The stuck row had already cleared — `ceralive` restarted 24 min before the check, which re-seeds the cache at boot. That restart *is* the confirmation: the row did not recover through the hotplug path, it took a process restart, exactly as the root cause predicts.

What the board did confirm:

- kernel: `video0` (`stream_hdmirx`), `video1` + `video2` (RØDE, identical names → the scan dedupes to `video1`);
- engine `list-devices` over `control.sock`: `/dev/video0` (`hdmi`) and `/dev/video1` (`mjpeg`, `stable_id: usb:…`);
- CeraUI live `sources`: `/dev/video1`, `available: true`, kind `mjpeg`, and `config.source = "/dev/video1"`.

So the `input_id` namespace parity the merge joins on holds on the exact hardware from the report.

## Risks

- **Membership authority moves to the local scan on the hotplug path only.** Every other caller is untouched. The risk is a device the engine sees but the v4l2 scan does not being dropped from the cache until the next successful reconcile. This is the same trust PR #214 already places in the observed list on the failure branch, and it rests on the id-parity verified above.
- **The generation counter is deliberately never reset**, including by `resetEngineDeviceCache()` — a superseded probe must stay superseded. Resetting it could let a stale in-flight probe match a fresh ticket.
- Local e2e shards could not run (`playwright install-deps` is apt-only on this Arch host, failing in 4.5 s before any test); every other local gate — lint, typecheck, backend, frontend, rpc, build/arm64, build/amd64 — passed. Cloud CI is the authoritative signal.