### PR TITLE
fix(sources): keep a replugged capture device's own identity, not a coarse guess

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -664,17 +664,40 @@ from the cache write (`commitEngineDevices`): the fence has to be checked betwee
 them. `tryRefreshEngineDeviceCache` is the unchanged probe+commit composition for
 every caller that has no ordering concern.
 
-The fallback is id-safe and its cost is bounded: `buildDeviceList()` keys the
-fallback scan `/dev/<card>`, which is byte-identical to the engine's own
-`input_id` (verified on a real Rock 5B+: cerastream reports `/dev/video0` +
-`/dev/video1`, and de-dupes the RØDE's two nodes exactly as the scan does), so a
-fallback row can never split into a duplicate or orphan a persisted
-`config.source`. What DOES degrade is `kind`: the scan's `deriveKind()` heuristic
-labels the RØDE `usb` where the engine says `mjpeg`, so a device ADDED while
-cerastream is unreachable can bridge to a neighbouring coarse row until the next
-poll's probe answers. That is accepted — a present-but-coarsely-labelled row beats
-an absent one, and the specific USB-as-HDMI mislabel this seam was originally
-warned about cannot recur (`deriveKind` tests usb/uvc BEFORE hdmi).
+**Staying PRESENT is not the same as staying ITSELF — an observed row falls back
+to the engine's LAST ANSWER before it falls back to the scan's guess.** The
+fallback is id-safe: `buildDeviceList()` keys the fallback scan `/dev/<card>`,
+byte-identical to the engine's own `input_id` (verified on a real Rock 5B+:
+cerastream reports `/dev/video0` + `/dev/video1`, and de-dupes the RØDE's two
+nodes exactly as the scan does), so a fallback row can never split into a
+duplicate or orphan a persisted `config.source`. What the scan CANNOT supply is
+`kind`: `deriveKind()` guesses it from the card name, and for a UVC dongle named
+`RØDE HDMI to USB-C: RØDE HDMI` the guess is `usb` — which bridges to NO
+pipeline. This was previously written off as a bounded cosmetic degradation; it
+is not. An unbridged row is DROPPED by `buildSources` (no capture row) and is
+simultaneously live enough to suppress its own `lost` row, so its coarse slot
+renders as **"USB MJPEG · not connected"** — a device that is physically present,
+enumerated, and named, reported as absent under a generic label. And the same
+"nothing re-pokes a stable device set" fact that made the #215 bug permanent
+makes this one permanent too. Confirmed live and reproduced byte-for-byte from
+the board's own `list-devices` + `/sys/class/video4linux/*/name` payloads.
+
+`lastEngineVideoDevices` (`sources.ts`) is the fix: the last ENGINE-AUTHORED row
+per `input_id`, recorded in `probeEngineDevices` and monotonic (a device leaving
+the list must not erase what the engine said about it — the whole case is a
+device that left and came back). A video device the probe omits, on BOTH the
+merge path and the #214 probe-failure path, is restored from it — kind, caps,
+`stable_id` and display name together, exactly as a live probe entry would win.
+It is **guarded by display name, not `input_id` alone**: the kernel recycles node
+paths, and inheriting an identity is worse than showing a coarse one. Both lists
+read the name from the same kernel string (byte-identical on the bug hardware),
+so an equal name is real evidence of the same device and an unequal one leaves
+the observation untouched. `resetEngineDeviceCache()` clears the map.
+
+The specific USB-as-HDMI mislabel this seam was originally warned about still
+cannot recur (`deriveKind` tests usb/uvc BEFORE hdmi), and a device seen for the
+FIRST time while cerastream is unreachable still has no memory to draw on — it
+keeps the coarse fallback, which is the accepted degradation.
 Coverage: `tests/devices.test.ts` (`fires onDevicesChanged on a hotplug set
 change…` + `hands onDevicesChanged the list this scan observed…`) and
 `tests/lost-device-retention.test.ts` (`refreshSourcesForHotplug — a failing
@@ -1195,3 +1218,4 @@ FIRST, reason `live.education.reason.disabledInSettings`). See root `AGENTS.md`
 - Don't re-apply an onboard display-name rule at a render site (a Svelte label, a summary derivation) — it belongs at the device-construction seam (`fromEngineDevice`), which is why the row and the "Configured" label are both fixed by one call.
 - Don't re-derive `pipeline`/`selected_video_input` resolution inline in a new procedure — route through `resolveSourceRouting()`/`deriveEngineRouting()` in `modules/streaming/sources.ts`.
 - Don't let a `list-devices` probe decide device MEMBERSHIP on the hotplug path, and don't drop the generation fence — a probe that answers can still be stale or out of order, and both have already stranded a real device on a board. Membership comes from the registry's observation (`mergeObservedWithProbe`); the probe supplies metadata.
+- Don't let the v4l2 scan's `deriveKind()` guess overwrite a kind the engine has already reported for that device, and don't clear `lastEngineVideoDevices` when a device leaves the list — a `usb` guess bridges to no pipeline, so the row is dropped and its coarse slot renders "not connected" for a device that is physically present. Don't relax the display-name gate on the restore to an `input_id`-only lookup either: node paths are recycled, and a fabricated identity is worse than a coarse one.

--- a/apps/backend/src/modules/streaming/sources.ts
+++ b/apps/backend/src/modules/streaming/sources.ts
@@ -578,6 +578,18 @@ let engineDeviceCache: CaptureDevice[] = [];
 // copy — because those all drop the join key. `buildSources` never reads it.
 let engineAudioDeviceCache: EngineAudioDevice[] = [];
 
+// The last ENGINE-AUTHORED row for every video device this process has probed,
+// keyed by `input_id`. Monotonic like `sessionSeenDeviceSnapshots` — a device
+// leaving the list must NOT erase what the engine told us about it, because the
+// case this exists for is precisely a device that left and came back.
+//
+// The local v4l2 scan reads a truthful card NAME but can only GUESS a kind from
+// it (`deriveKind`), and for a UVC dongle that guess is `usb`, which bridges to
+// no pipeline at all — so a row the scan alone vouches for silently disappears
+// from `buildSources` and its coarse slot renders "not connected" instead. This
+// map is what turns that guess back into the engine's own answer.
+const lastEngineVideoDevices = new Map<string, CaptureDevice>();
+
 /** The persisted last-seen list cap (C7). The current `config.source` id is
  *  exempt from eviction, so the configured device's snapshot survives churn. */
 const LAST_SEEN_DEVICES_CAP = 12;
@@ -707,18 +719,20 @@ async function probeEngineDevices(
 ): Promise<EngineDeviceProbe | undefined> {
 	try {
 		const result = await deps.fetchEngineDevices();
+		const devices = result.devices.map((d) =>
+			fromEngineDevice({
+				input_id: d.input_id,
+				device_path: d.device_path,
+				display_name: d.display_name,
+				media_class: d.media_class,
+				kind: d.kind,
+				caps: d.caps,
+				stable_id: d.stable_id,
+			}),
+		);
+		rememberEngineVideoDevices(devices);
 		return {
-			devices: result.devices.map((d) =>
-				fromEngineDevice({
-					input_id: d.input_id,
-					device_path: d.device_path,
-					display_name: d.display_name,
-					media_class: d.media_class,
-					kind: d.kind,
-					caps: d.caps,
-					stable_id: d.stable_id,
-				}),
-			),
+			devices,
 			// Parallel AUDIO cache (T4): an EXPLICIT field copy of the audio entries
 			// that PRESERVES the `alsa_card_id` join key verbatim. It is read
 			// defensively (the pre-T18 binding schema strips it → `undefined`; the
@@ -758,6 +772,38 @@ async function probeEngineDevices(
 		);
 		return undefined;
 	}
+}
+
+function rememberEngineVideoDevices(devices: readonly CaptureDevice[]): void {
+	for (const device of devices) {
+		if (device.media_class !== "video") continue;
+		lastEngineVideoDevices.set(device.input_id, device);
+	}
+}
+
+/**
+ * Restore the last engine-authored row for an observed video device the current
+ * probe cannot speak for — the same rule as "a probe entry matching an observed
+ * `input_id` wins outright", applied to a REMEMBERED probe entry when there is
+ * no current one.
+ *
+ * GUARDED BY DISPLAY NAME, not by `input_id` alone: the kernel recycles node
+ * paths, so `/dev/video1` after an unplug may be a different device entirely,
+ * and inheriting an identity is worse than showing a coarse one. Both lists
+ * derive the name from the SAME kernel string — verified on the bug hardware,
+ * where `/sys/class/video4linux/video1/name` and the engine's `display_name` are
+ * byte-identical — so an equal name is real evidence of the same device, and an
+ * unequal one leaves the observation exactly as it was.
+ */
+function withKnownEngineMetadata(
+	observed: CaptureDevice,
+	known: ReadonlyMap<string, CaptureDevice>,
+): CaptureDevice {
+	if (observed.media_class !== "video") return observed;
+	const remembered = known.get(observed.input_id);
+	if (remembered === undefined) return observed;
+	if (remembered.display_name !== observed.display_name) return observed;
+	return { ...remembered };
 }
 
 /** Make a device list the current view, remembering every device it proves live. */
@@ -806,6 +852,7 @@ export function resetEngineDeviceCache(): void {
 	engineDeviceCache = [];
 	engineAudioDeviceCache = [];
 	sessionSeenDeviceSnapshots.clear();
+	lastEngineVideoDevices.clear();
 }
 
 /**
@@ -889,6 +936,13 @@ export async function refreshAndBroadcastSources(
  * its observed row rather than disappearing, and a device the probe still lists
  * but the scan no longer sees is dropped.
  *
+ * Staying PRESENT is not the same as staying ITSELF, though, and the scan's
+ * guess is not a harmless approximation: `deriveKind` calls a UVC dongle `usb`,
+ * which bridges to no pipeline, so `buildSources` drops the row and renders the
+ * coarse slot as "not connected". A device the probe omits therefore falls back
+ * to what the engine last said about it (`known`) before it falls back to the
+ * scan's guess.
+ *
  * The join key is `input_id` alone: `buildDeviceList()` keys the fallback scan
  * `/dev/<card>`, byte-identical to the engine's own path-preferred id (verified
  * on a real Rock 5B+), so the two lists share one id namespace.
@@ -900,6 +954,7 @@ export async function refreshAndBroadcastSources(
 export function mergeObservedWithProbe(
 	observed: readonly CaptureDevice[],
 	probed: readonly CaptureDevice[],
+	known: ReadonlyMap<string, CaptureDevice> = lastEngineVideoDevices,
 ): CaptureDevice[] {
 	const observedVideoIds = new Set(
 		observed.filter((d) => d.media_class === "video").map((d) => d.input_id),
@@ -910,9 +965,9 @@ export function mergeObservedWithProbe(
 	const confirmed = probed.filter(
 		(d) => d.media_class !== "video" || observedVideoIds.has(d.input_id),
 	);
-	const unprobed = observed.filter(
-		(d) => d.media_class === "video" && !probedVideoIds.has(d.input_id),
-	);
+	const unprobed = observed
+		.filter((d) => d.media_class === "video" && !probedVideoIds.has(d.input_id))
+		.map((d) => withKnownEngineMetadata(d, known));
 	return [...confirmed, ...unprobed];
 }
 
@@ -949,7 +1004,9 @@ export async function refreshSourcesForHotplug(
 	const probe = await probeEngineDevices(deps);
 	if (generation !== hotplugRefreshGeneration) return;
 	if (probe === undefined) {
-		applyObservedDevicesAndBroadcast(observed);
+		applyObservedDevicesAndBroadcast(
+			observed.map((d) => withKnownEngineMetadata(d, lastEngineVideoDevices)),
+		);
 		return;
 	}
 	commitEngineDevices(

--- a/apps/backend/src/tests/lost-device-retention.test.ts
+++ b/apps/backend/src/tests/lost-device-retention.test.ts
@@ -40,6 +40,7 @@ import {
 	getEngineDeviceCache,
 	getSessionSeenDeviceSnapshots,
 	getSourcesMessage,
+	mergeObservedWithProbe,
 	refreshAndBroadcastSources,
 	refreshEngineDeviceCache,
 	refreshSourcesForHotplug,
@@ -881,5 +882,223 @@ describe("refreshSourcesForHotplug — a stale successful probe never masks the 
 		// The PR #214 observed-fallback is still correct — it just belongs to the
 		// generation that owns the current view, not to a superseded one.
 		expect(getEngineDeviceCache().map((d) => d.input_id)).toEqual(["video0"]);
+	});
+});
+
+// ─── replug: a probe that cannot speak for the device must not DEGRADE it ─────
+//
+// The live RØDE reconnect regression. #214/#215 made the replugged device stay
+// PRESENT; this is about it staying ITSELF. The local scan can only guess a kind
+// from the card name (`deriveKind`), and for a UVC dongle the guess is `usb` —
+// which bridges to NO pipeline, so `buildSources` drops the row entirely and the
+// coarse `usb_mjpeg` slot renders "USB MJPEG / not connected" instead. It is
+// permanent for the same reason #215 was: nothing re-pokes a stable device set.
+
+describe("refreshSourcesForHotplug — a replug the probe has not caught up with keeps its engine identity", () => {
+	// Byte-exact strings from the bug hardware (Rock 5B+). The v4l2 card name
+	// (`/sys/class/video4linux/video1/name`) and the engine's `display_name` are
+	// the SAME kernel string — that is what makes the name a sound identity gate.
+	const RODE_NAME = "RØDE HDMI to USB-C: RØDE HDMI";
+	const RODE_STABLE_ID = "usb:19f7:0080:RØDE_RØDE_HDMI_to_USB-C_OC0001967";
+
+	beforeEach(() => {
+		resetEngineDeviceCache();
+		clearCapabilitiesCache();
+		getConfig().last_seen_devices = [];
+		delete getConfig().source;
+	});
+
+	afterEach(() => {
+		resetEngineDeviceCache();
+		clearCapabilitiesCache();
+		getConfig().last_seen_devices = [];
+		delete getConfig().source;
+	});
+
+	function engineHdmiRx(): ListDevicesResult["devices"][number] {
+		return {
+			input_id: "/dev/video0",
+			device_path: "/dev/video0",
+			display_name: "rk_hdmirx",
+			media_class: "video",
+			kind: "hdmi",
+		};
+	}
+
+	function engineRode(): ListDevicesResult["devices"][number] {
+		return {
+			input_id: "/dev/video1",
+			device_path: "/dev/video1",
+			display_name: RODE_NAME,
+			media_class: "video",
+			kind: "mjpeg",
+			stable_id: RODE_STABLE_ID,
+			caps: [
+				{
+					media_type: "video/x-raw",
+					width: 1920,
+					height: 1080,
+					framerate: "30/1",
+				},
+			],
+		};
+	}
+
+	// What the v4l2 fallback scan sees: real card names, GUESSED kinds.
+	function scannedHdmiRx(): CaptureDevice {
+		return captureDevice("/dev/video0", "hdmi", {
+			device_path: "/dev/video0",
+			display_name: "stream_hdmirx",
+		});
+	}
+	function scannedRode(): CaptureDevice {
+		return captureDevice("/dev/video1", "usb", {
+			device_path: "/dev/video1",
+			display_name: RODE_NAME,
+		});
+	}
+
+	async function seedHdmiAndMjpegCaps(): Promise<void> {
+		await getCapabilities({
+			fetchEngineCapabilities: async () => ({
+				caps: {
+					platform: {
+						supports_h265: true,
+						hardware_accelerated: true,
+						max_resolution: "1080p",
+					},
+					encoder: {
+						codecs: ["h264"],
+						bitrate_range: { min: 500, max: 20000, unit: "kbps" },
+					},
+					sources: [capSource("hdmi"), capSource("usb_mjpeg")],
+				},
+				schemaVersion: SCHEMA_VERSION,
+			}),
+			fetchEngineDevices: async () => ({ devices: [] }),
+		});
+	}
+
+	async function seedThenUnplugRode(): Promise<void> {
+		await seedHdmiAndMjpegCaps();
+		getConfig().source = "/dev/video1";
+		await refreshEngineDeviceCache({
+			fetchEngineDevices: async () => ({
+				devices: [engineHdmiRx(), engineRode()],
+			}),
+		});
+		await refreshSourcesForHotplug([scannedHdmiRx()], {
+			fetchEngineDevices: async () => ({ devices: [engineHdmiRx()] }),
+		});
+		expect(
+			getSourcesMessage().sources.find((s) => s.id === "/dev/video1")?.lost,
+		).toBe(true);
+	}
+
+	it("a replugged device the probe still omits keeps its engine kind, name and stable id — never a coarse 'not connected' row", async () => {
+		await seedThenUnplugRode();
+
+		// The node is back and the scan proves it, but the engine's list-devices
+		// has not caught up with the re-enumeration yet.
+		await refreshSourcesForHotplug([scannedHdmiRx(), scannedRode()], {
+			fetchEngineDevices: async () => ({ devices: [engineHdmiRx()] }),
+		});
+
+		const sources = getSourcesMessage().sources;
+		const rode = sources.find((s) => s.id === "/dev/video1");
+		expect(rode?.origin).toBe("capture");
+		expect(rode?.available).toBe(true);
+		expect(rode?.lost).toBeUndefined();
+		if (rode?.origin === "capture") {
+			expect(rode.displayName).toBe(RODE_NAME);
+			expect(rode.kind).toBe("mjpeg");
+			expect(rode.stableId).toBe(RODE_STABLE_ID);
+		}
+		// the coarse slot it bridges to is REPLACED, not left rendering
+		// "USB MJPEG · not connected" beside a vanished device.
+		expect(
+			sources.some((s) => s.origin === "coarse" && s.id === "usb_mjpeg"),
+		).toBe(false);
+	});
+
+	it("the same restoration applies when the probe FAILS outright (the #214 observed-fallback branch)", async () => {
+		await seedThenUnplugRode();
+
+		await refreshSourcesForHotplug([scannedHdmiRx(), scannedRode()], {
+			fetchEngineDevices: async () => {
+				throw new Error("engine unavailable");
+			},
+		});
+
+		const rode = getSourcesMessage().sources.find(
+			(s) => s.id === "/dev/video1",
+		);
+		expect(rode?.origin).toBe("capture");
+		expect(rode?.available).toBe(true);
+		if (rode?.origin === "capture") expect(rode.kind).toBe("mjpeg");
+	});
+
+	it("a DIFFERENT device recycling the same node path is never given the old identity", async () => {
+		await seedThenUnplugRode();
+
+		// The kernel handed /dev/video1 to something else entirely.
+		await refreshSourcesForHotplug(
+			[
+				scannedHdmiRx(),
+				captureDevice("/dev/video1", "usb", {
+					device_path: "/dev/video1",
+					display_name: "Generic USB Camera",
+				}),
+			],
+			{ fetchEngineDevices: async () => ({ devices: [engineHdmiRx()] }) },
+		);
+
+		const cached = getEngineDeviceCache().find(
+			(d) => d.input_id === "/dev/video1",
+		);
+		expect(cached?.display_name).toBe("Generic USB Camera");
+		expect(cached?.kind).toBe("usb");
+		expect(cached?.stable_id).toBeUndefined();
+	});
+
+	it("a live probe entry still wins outright over the remembered one", async () => {
+		await seedThenUnplugRode();
+
+		await refreshSourcesForHotplug([scannedHdmiRx(), scannedRode()], {
+			fetchEngineDevices: async () => ({
+				devices: [
+					engineHdmiRx(),
+					{ ...engineRode(), display_name: "RØDE (renamed by the engine)" },
+				],
+			}),
+		});
+
+		const cached = getEngineDeviceCache().find(
+			(d) => d.input_id === "/dev/video1",
+		);
+		expect(cached?.display_name).toBe("RØDE (renamed by the engine)");
+	});
+
+	it("mergeObservedWithProbe restores only from the map it is handed (pure)", () => {
+		const remembered = new Map<string, CaptureDevice>([
+			[
+				"/dev/video1",
+				captureDevice("/dev/video1", "mjpeg", {
+					device_path: "/dev/video1",
+					display_name: RODE_NAME,
+				}),
+			],
+		]);
+		const merged = mergeObservedWithProbe(
+			[scannedRode()],
+			[],
+			remembered,
+		) as CaptureDevice[];
+		expect(merged.map((d) => d.kind)).toEqual(["mjpeg"]);
+
+		// with no memory to draw on, the observation passes through untouched.
+		expect(
+			mergeObservedWithProbe([scannedRode()], [], new Map()).map((d) => d.kind),
+		).toEqual(["usb"]);
 	});
 });


### PR DESCRIPTION
**Affected repo & language:** CeraUI — TypeScript (backend)

## What

`apps/backend/src/modules/streaming/sources.ts` now remembers the last
engine-authored `CaptureDevice` per `input_id` (`lastEngineVideoDevices`) and
restores a video device the engine probe omits from that memory — kind, caps,
`stable_id` and display name together — instead of committing the local v4l2
scan's guess. The restore is guarded by display name, so a recycled node path
can never inherit another device's identity.

## Why

Found live on a Rock 5B+: a RØDE HDMI-to-USB-C dongle that came back after an
unplug rendered as the generic **"USB MJPEG · not connected"** row — physically
present, enumerated, named, and listed by cerastream, yet reported as absent
under a label that is not its own.

This is a third distinct bug in the seam #214 and #215 touched, not a duplicate:
#214 fixed a probe FAILURE masking a removal, #215 fixed a stale probe SUCCESS
masking a return. Both keep the device PRESENT. This one keeps it ITSELF.

`refreshSourcesForHotplug` runs while CeraUI is idle, so the observed list is the
local v4l2 scan. That scan reads a truthful card name but can only guess the
kind, and `deriveKind()` on `RØDE HDMI to USB-C: RØDE HDMI` returns `usb` —
which is not in `DEVICE_KIND_TO_PIPELINE_ID` at all. An unbridged row gets no
capture entry from `buildSources`, while `liveVideoIds` still suppresses its
`lost` candidate, so neither row renders and only the coarse `usb_mjpeg` base
entry survives. And because `applyAndBroadcast` fires `onDevicesChanged` only on
a device-SET change, nothing ever re-probes once the replug settles — the
degraded row is permanent until a reboot or an engine-reconnect heal.

Board evidence pinned the branch: `/opt/ceralive/debug.log` shows paired
`devices`→`sources` broadcasts ~15 ms apart at every unplug/replug and **zero**
`engine device fetch failed` lines, so the probe answered fast and simply did not
list the just-replugged node. That is the #215 "probe omits it" branch, now shown
to degrade metadata rather than membership; the #214 probe-failure branch has the
identical defect and is fixed too.

Two deliberate narrowings are worth calling out for review:

- The map is **monotonic** — a device leaving the list must not erase what the
  engine said about it, because the entire case is a device that left and came
  back. It is cleared only by `resetEngineDeviceCache()`.
- The restore joins on **display name**, not `input_id` alone. The kernel
  recycles node paths, so `/dev/video1` after an unplug may be a different
  device, and inheriting an identity is strictly worse than showing a coarse one.
  Both lists derive the name from the same kernel string (byte-identical on the
  bug hardware), so an equal name is real evidence and an unequal one leaves the
  observation exactly as it is today. Membership still joins on `input_id` alone.

## How to verify

```bash
cd apps/backend
bun test              # 2267 pass / 0 fail, 232 files
bunx tsc --noEmit     # clean
cd ../.. && bunx biome check apps/backend/src/modules/streaming/sources.ts \
  apps/backend/src/tests/lost-device-retention.test.ts   # clean
```

Red-first is confirmed: the three behavioural new tests fail on unmodified
`sources.ts` with `expect(rode?.origin).toBe("capture") / Received: undefined` —
the board symptom as a unit test. The other two new tests (a different device on
a recycled node path; a live probe entry still winning) pass before and after and
exist to pin what the fix must NOT do. All existing hotplug tests
(`sources.test.ts`, `devices.test.ts`, `devices-engine-kinds.test.ts`,
`lost-device-retention.test.ts`, `source-lost-rejection.test.ts`,
`onboard-video-display-name.test.ts`) pass unchanged — none weakened or skipped.

The board could not prove the fix by physical replug (the deployed binary is a
pre-fix build and an operator was actively cycling the cable), so both real
payloads were captured over `/run/cerastream/control.sock` (`hello` +
`list-devices` + `get-capabilities`, engine `2026.7.2`) together with the three
`/sys/class/video4linux/*/name` strings and replayed through the real
`buildDeviceList` → `refreshSourcesForHotplug` → `buildSources` path:

```
unplugged            /dev/video1 [capture kind=mjpeg name="RØDE HDMI to USB-C: RØDE HDMI" available=false lost=true]
REPLUGGED  pre-fix   usb_mjpeg   [coarse available=true]          <- /dev/video1 GONE = the reported symptom
REPLUGGED  fixed     /dev/video1 [capture kind=mjpeg name="RØDE HDMI to USB-C: RØDE HDMI" available=true lost=false modes=13]
```

Caps come back too (`modes=13`), so the Encoder dialog keeps its Tier-2 axes.
Remaining manual step for the reviewer: deploy and do a physical replug on the
fixed build.

## Risks

Low, and bounded to the hotplug metadata path.

- A device seen for the FIRST time while cerastream is unreachable has no memory
  to draw on and keeps the coarse fallback — unchanged behaviour.
- The display-name guard means an unequal name leaves the observation exactly as
  it is today, so the worst case is the current behaviour, not a new one.
- `mergeObservedWithProbe` gained an optional third `known` parameter defaulting
  to the module map, so it stays pure when a caller hands one in.
- No wire/schema change, no frontend change, no i18n.

Rollback is a straight revert of this commit.

---

**Checklist**

- [x] Docs updated if behavior or structure changed (Rule A: `apps/backend/AGENTS.md` — SIGUSR2-hotplug section + one ANTI-PATTERNS bullet)
- [x] Started from updated main; branch rebased on latest canonical branch (Rule B)
- [x] Rule D local-scratch reference check passes for tracked files
- [x] Tests pass; QA evidence above