### PR TITLE
fix(audio): stop the meter drawing another card's audio when the pick is dead

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -270,9 +270,39 @@ Do NOT add a CeraUI-side "force this device" path that tries to override that.
 A failed push NEVER breaks the meter: `pushPreference` swallows and logs, the previous
 preference stands, and the next config change or reconnect re-pushes.
 
+**Because it is only a preference, the bridge must also REFUSE another card's audio.**
+The engine reorders candidates but still meters whatever it CAN open, so an unopenable
+selection leaves real, moving bars on screen that belong to a different device — the
+meter lies rather than goes quiet. Found live on a Rock 5B+ with nothing plugged into
+the HDMI-RX port: the operator selected `HDMI Input`, and the meter reported the RØDE
+(`card:usbaudio`, rms ≈ −30 dBFS ⇒ ~49% fill on BOTH channels), which reads as healthy
+embedded HDMI audio. `projectLevel()` therefore drops a level whose reported
+`source.identity` names a different ALSA card than `meterPreference()` and broadcasts
+the ADR's existing `unavailable` + `no_device` gap instead. `alsaCardKey()` reduces both
+sides to the bare card id (mirroring cerastream's own `alsa_card_key`), so
+`hw:CARD=x` / `plughw:CARD=x,DEV=0` / `card:x` all compare equal.
+
+**It can only ever suppress a reading PROVEN foreign.** `isForeignCardLevel` returns
+false unless BOTH sides name a card: an `Auto` pick (`null`) hands selection to the
+engine by design, and an engine that reports no identity cannot be shown to mismatch.
+An engine-sent `unavailable` passes through with its OWN reason. Do NOT "simplify" this
+by gating on the video-side `signal` field — audio and video are separate device lists
+with no shared identifier (see "THREE capture-row states"), and the audio card's own
+absence is the direct, device-agnostic evidence.
+
+**Why an absent HDMI signal is genuinely NO audio, not silence.** Verified on the board:
+without a signal the RK3588 `rockchiphdmiin` card still lists in `/proc/asound/cards` but
+exposes NO capture PCM substream (no `card3/pcm0c`), `alsasrc device=hw:CARD=rockchiphdmiin`
+fails `No such file or directory`, and the card never appears in the engine's
+`list-devices` at all — so the preference is inert rather than merely losing. HDMI
+embedded audio is therefore unavailable, never noise-that-reads-as-signal; a device that
+DOES deliver audio without video still enumerates, still matches, and still meters.
+
 Coverage: `tests/audio-meter-bridge.test.ts` (push on connect, `null` for Auto, re-push
 on change, nothing sent to a pre-0.9.0 engine, a refused reload leaves levels flowing,
-no-op while down, plus the schema gate) and `tests/audio-sources.test.ts`
+no-op while down, the schema gate, plus the foreign-card gate: suppressed mismatch,
+untouched match, never-gated Auto/identity-less, passthrough `unavailable`, and the
+`alsaCardKey`/`isForeignCardLevel` unit table) and `tests/audio-sources.test.ts`
 (`resolveMeterPreference` — alias, no-alias, every `null` case, selector passthrough).
 
 ## SOFTWARE-UPDATE START CONTRACT [EXISTS]

--- a/apps/backend/src/modules/streaming/audio-meter-bridge.ts
+++ b/apps/backend/src/modules/streaming/audio-meter-bridge.ts
@@ -84,6 +84,53 @@ export interface AudioMeterBridgeDeps {
 }
 
 /**
+ * The ALSA card identity inside a device/identity string, so the operator's
+ * preference (`hw:CARD=rockchiphdmiin`, `plughw:CARD=usbaudio,DEV=0`) and the
+ * engine's reported source identity (`card:usbaudio`) both reduce to the bare
+ * card id they name. Mirrors cerastream's own `alsa_card_key` so the two sides
+ * cannot drift on spelling. `undefined` when nothing is named.
+ */
+export function alsaCardKey(value: string | undefined): string | undefined {
+	if (value === undefined) return undefined;
+	const head = value.trim().split(",")[0] ?? "";
+	const colon = head.lastIndexOf(":");
+	const tail = colon === -1 ? head : head.slice(colon + 1);
+	const card = tail.startsWith("CARD=") ? tail.slice("CARD=".length) : tail;
+	return card === "" ? undefined : card;
+}
+
+/**
+ * Is this level a reading of a DIFFERENT card than the one the operator picked?
+ *
+ * The engine's `meter_device` is a PREFERENCE, not a pin (ADR-0007 §10-11): it
+ * only reorders the candidate list, so a selected card the engine cannot open —
+ * or does not enumerate at all — silently leaves the meter on some other card.
+ * Found live on a Rock 5B+: with nothing plugged into the HDMI-RX port, the
+ * RK3588 `rockchiphdmiin` card exposes NO capture PCM substream (`alsasrc
+ * device=hw:CARD=rockchiphdmiin` fails "No such file or directory") and never
+ * reaches the engine's device list at all, so selecting "HDMI Input" left the
+ * meter reporting a USB microphone. The operator saw real, moving bars and read
+ * them as live HDMI embedded audio.
+ *
+ * A level that names a different card is simply not the selected source's level,
+ * so it must be reported as a gap rather than rendered. Deliberately requires
+ * BOTH sides to be known: an "Auto" pick (`null` preference) hands selection to
+ * the engine by design, and an engine that reports no identity cannot be PROVEN
+ * to mismatch — neither is gated, so this can only ever suppress a reading we
+ * know belongs to another device.
+ */
+export function isForeignCardLevel(
+	preference: string | null,
+	identity: string | undefined,
+): boolean {
+	if (preference === null) return false;
+	const wanted = alsaCardKey(preference);
+	const reported = alsaCardKey(identity);
+	if (wanted === undefined || reported === undefined) return false;
+	return wanted !== reported;
+}
+
+/**
  * Project a cerastream `audio-level` event onto the wire message: drop the
  * envelope `type`/`seq` (the broadcast layer stamps its own `seq`) and keep every
  * level/unavailable field. Exported for the bridge test.
@@ -155,11 +202,27 @@ function errMessage(err: unknown): string {
 	return err instanceof Error ? err.message : String(err);
 }
 
+// A foreign-card level reuses the ADR's existing `no_device` reason ("No audio
+// device") rather than a new one: from the operator's seat the SELECTED device
+// is precisely the one not being metered, and the reason set is already wired
+// through 10 locales.
+function projectLevel(
+	event: Extract<EventParams, { type: "audio-level" }>,
+	deps: AudioMeterBridgeDeps,
+): AudioLevelMessage {
+	const message = toAudioLevelMessage(event);
+	if (message.unavailable === true) return message;
+	if (!isForeignCardLevel(deps.meterPreference(), message.source?.identity)) {
+		return message;
+	}
+	return { unavailable: true, reason: "no_device" };
+}
+
 function handleEvent(event: EventParams): void {
 	if (!state || state.stopped) return;
 	if (event.type !== "audio-level") return;
 	try {
-		state.deps.broadcast(toAudioLevelMessage(event));
+		state.deps.broadcast(projectLevel(event, state.deps));
 	} catch (err) {
 		state.deps.logger.debug(
 			`audio-meter bridge: broadcast threw: ${errMessage(err)}`,

--- a/apps/backend/src/tests/audio-meter-bridge.test.ts
+++ b/apps/backend/src/tests/audio-meter-bridge.test.ts
@@ -9,7 +9,9 @@ import type { AudioLevelMessage } from "@ceraui/rpc/schemas";
 import {
 	type AudioMeterBridgeDeps,
 	type AudioMeterBridgeLogger,
+	alsaCardKey,
 	initAudioMeterBridge,
+	isForeignCardLevel,
 	settleAudioMeterBridge,
 	stopAudioMeterBridge,
 	syncAudioMeterPreference,
@@ -283,6 +285,84 @@ describe("audio-meter bridge — the operator's audio pick reaches the idle mete
 	test("syncing while the bridge is down is a silent no-op", () => {
 		stopAudioMeterBridge();
 		expect(() => syncAudioMeterPreference()).not.toThrow();
+	});
+});
+
+// The board bug (live QA, 2026-07-25): with NOTHING plugged into the RK3588
+// HDMI-RX port, selecting "HDMI Input" as the audio source showed moving bars on
+// both channels. Verified on a Rock 5B+: the `rockchiphdmiin` card exposes no
+// capture PCM substream without a signal (`alsasrc device=hw:CARD=rockchiphdmiin`
+// → "No such file or directory") and never enters the engine's device list, so
+// the meter_device preference was inert and the meter stayed on a USB mic. Those
+// bars were real audio — from the wrong device.
+describe("audio-meter bridge — a level from an unselected card is never rendered", () => {
+	test("reports the selected device as unavailable instead of another card's audio", async () => {
+		const h = harness([true]);
+		h.setPreference("hw:CARD=rockchiphdmiin");
+		initAudioMeterBridge(h.deps);
+		await settleAudioMeterBridge();
+
+		h.emit(levelEvent);
+
+		expect(h.broadcasts).toEqual([{ unavailable: true, reason: "no_device" }]);
+	});
+
+	test("forwards the level untouched once the selected card IS the metered one", async () => {
+		const h = harness([true]);
+		h.setPreference("hw:CARD=usbaudio");
+		initAudioMeterBridge(h.deps);
+		await settleAudioMeterBridge();
+
+		h.emit(levelEvent);
+
+		expect(h.broadcasts).toEqual([toAudioLevelMessage(levelEvent)]);
+	});
+
+	test("never suppresses a level it cannot prove foreign (Auto, or no identity)", async () => {
+		const h = harness([true]);
+		h.setPreference(null);
+		initAudioMeterBridge(h.deps);
+		await settleAudioMeterBridge();
+		h.emit(levelEvent);
+
+		h.setPreference("hw:CARD=rockchiphdmiin");
+		h.emit({ ...levelEvent, source: { owner: "sidecar" } });
+
+		expect(h.broadcasts).toHaveLength(2);
+		expect(h.broadcasts.every((b) => b.unavailable === undefined)).toBe(true);
+	});
+
+	test("passes an engine-sent unavailable marker through with its own reason", async () => {
+		const h = harness([true]);
+		h.setPreference("hw:CARD=rockchiphdmiin");
+		initAudioMeterBridge(h.deps);
+		await settleAudioMeterBridge();
+
+		h.emit(unavailableEvent);
+
+		expect(h.broadcasts).toEqual([{ unavailable: true, reason: "mode_none" }]);
+	});
+});
+
+describe("alsaCardKey / isForeignCardLevel — card identity, not literal spelling", () => {
+	test("every ALSA spelling of one card reduces to the same key", () => {
+		for (const spelling of [
+			"usbaudio",
+			"hw:CARD=usbaudio",
+			"plughw:CARD=usbaudio,DEV=0",
+			"card:usbaudio",
+		]) {
+			expect(alsaCardKey(spelling)).toBe("usbaudio");
+		}
+		expect(alsaCardKey(undefined)).toBeUndefined();
+		expect(alsaCardKey("   ")).toBeUndefined();
+	});
+
+	test("a mismatch is only claimed when BOTH sides name a card", () => {
+		expect(isForeignCardLevel("hw:CARD=rockchiphdmiin", "card:Rx")).toBe(true);
+		expect(isForeignCardLevel("hw:CARD=usbaudio", "card:usbaudio")).toBe(false);
+		expect(isForeignCardLevel(null, "card:Rx")).toBe(false);
+		expect(isForeignCardLevel("hw:CARD=rockchiphdmiin", undefined)).toBe(false);
 	});
 });
 


### PR DESCRIPTION
**Affected repo & language:** CeraUI — TypeScript (backend)

## What

`audio-meter-bridge.ts` `projectLevel()` now drops an `audio-level` whose reported
`source.identity` names a different ALSA card than `meterPreference()`, and
broadcasts the ADR's EXISTING `unavailable` + `no_device` ("No audio device") gap
instead of forwarding the foreign reading. `alsaCardKey()` reduces both sides to
the bare card id so every ALSA spelling compares equal.

## Why

**Symptom (live).** With NOTHING plugged into the HDMI-RX port, selecting
**"HDMI Input"** as the Audio source showed an ACTIVE meter — moving yellow bars,
both channels well above zero.

**The bars were real audio. From the wrong device.** Reproduced on the board with
the video side confirmed dead (`v4l2-ctl --query-dv-timings` → `Link has been
severed`) and `config.asrc: "HDMI"`: the engine's live `audio-level` event carried
`source.identity: "card:usbaudio"` (the RØDE) at rms ≈ −30 dBFS. Replayed through
`AudioLevelMeter`'s own −60 dBFS floor that is 49%/50% fill on both channels —
exactly the reported picture.

**Root cause — a preference nothing enforced.** `resolveMeterPreference("HDMI")`
→ `hw:CARD=rockchiphdmiin` is pushed as `audio.meter_device`, but cerastream's
`set_preferred_device` only REORDERS its candidate list (ADR-0007 §10-11, by
design — a preference must not pin the meter to a dead card). The bridge then
forwarded whatever the engine metered VERBATIM, and `LiveAudioMeter` never reads
`source.identity` at all. So the picker said one thing and the meter drew another,
with nothing in the path comparing the two.

**Is HDMI embedded audio even valid without video? No — it is absent, not noise.**
The alternative hypothesis (HDMI-RX emitting silence/noise that reads as signal)
was tested and DISPROVED on hardware: without a signal `rockchiphdmiin` still
lists in `/proc/asound/cards` but exposes NO capture PCM substream (no
`card3/pcm0c`), `alsasrc device=hw:CARD=rockchiphdmiin` fails `No such file or
directory`, and the card is absent from the engine's `list-devices` entirely (only
`card:Rx`, `card:Loopback`, `card:usbaudio` are listed). The preference was
therefore INERT, not merely outranked. A device that genuinely delivers audio
without video still enumerates, still matches, and still meters — so the honest
rule distinguishes both cases without special-casing HDMI.

Two properties worth reviewing:

- **It can only ever suppress a reading PROVEN foreign.** `isForeignCardLevel`
  returns false unless BOTH sides name a card, so an `Auto` pick (`null`) hands
  selection to the engine by design and an engine that reports no identity cannot
  be shown to mismatch. An engine-sent `unavailable` passes through with its OWN
  reason.
- **Rejected: gating on the video-side `signal` field from #216.** Audio sources
  and video capture rows are separate lists with NO shared identifier
  (`buildSources` ignores audio; the shared "HDMI Input" name is a display
  coincidence from two independent onboard-name rules, not a join key).
  Correlating on a label would be wrong, and the audio card's own absence is
  direct evidence that needs no correlation.

**cerastream is UNTOUCHED.** The engine behaves as designed — a preference that
only reorders is correct, and it cannot know CeraUI's picker is lying to the
operator. No engine change is required; CeraUI now fails honestly on its own. (A
future engine-side "preferred device not among candidates" report is noted as an
option, not a handoff.)

## How to verify

```bash
cd apps/backend
bun test                # 2268 pass / 0 fail, 232 files (adds 6)
bunx tsc --noEmit       # clean
cd ../.. && bunx biome check apps/backend/src/modules/streaming/audio-meter-bridge.ts \
  apps/backend/src/tests/audio-meter-bridge.test.ts   # clean
```

The 6 new tests cover the foreign-card gate end to end: suppressed mismatch,
untouched match, never-gated Auto and identity-less engine, passthrough of an
engine `unavailable`, and the `alsaCardKey`/`isForeignCardLevel` unit table. All
pre-existing `audio-meter-bridge.test.ts` cases (push on connect, `null` for Auto,
re-push on change, nothing sent to a pre-0.9.0 engine, a refused reload leaves
levels flowing, no-op while down, the schema gate) pass unchanged.

On-device check for the reviewer: with nothing in the HDMI-RX port and "HDMI
Input" selected, the meter should show the "No audio device" unavailable state,
not moving bars. Selecting the RØDE (or Auto) should meter normally.

## Risks

Low, and strictly narrowing.

- The gate needs BOTH sides to name a card, so the only behaviour that changes is
  a level whose identity provably names a different card than the operator picked.
  Auto and identity-less engines are byte-unchanged.
- No schema change, no new i18n key (it reuses the existing `unavailable` +
  `no_device` gap), no frontend change. One seam covers both mount sites — the
  idle `SourceSection` meter and the live strip.
- Worst case if the identity comparison were ever too strict, the meter shows the
  existing "No audio device" copy rather than a wrong reading — a fail-honest, not
  fail-loud, degradation.

Rollback is a straight revert of this commit.

---

**Checklist**

- [x] Docs updated if behavior or structure changed (Rule A: `apps/backend/AGENTS.md` — IDLE AUDIO-METER DEVICE PREFERENCE section + coverage note)
- [x] Started from updated main; branch rebased on latest canonical branch (Rule B)
- [x] Rule D local-scratch reference check passes for tracked files
- [x] Tests pass; QA evidence above