### PR TITLE
fix(test): stop a leftover wifi interface faking a DEVICE_BUSY pass

### DIFF
--- a/apps/backend/src/rpc/procedures/wifi.procedure.test.ts
+++ b/apps/backend/src/rpc/procedures/wifi.procedure.test.ts
@@ -1,13 +1,17 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { call } from "@orpc/server";
 
 import { withDeviceLock } from "../../modules/network/state/device-lock.ts";
 import {
 	addWifiInterface,
-	removeWifiInterface,
+	getWifiInterfacesByMacAddress,
 } from "../../modules/wifi/wifi-connections.ts";
 import type { WifiInterface } from "../../modules/wifi/wifi-interfaces.ts";
+import {
+	isolateWifiRegistry,
+	restoreWifiRegistry,
+} from "../../tests/helpers/wifi-registry.ts";
 import type { AppWebSocket, RPCContext } from "../types.ts";
 import { hotspotConfigureProcedure } from "./wifi.procedure.ts";
 
@@ -49,17 +53,23 @@ const validConfig = {
 };
 
 describe("wifi.hotspotConfigure — device lock (S5)", () => {
-	let seededMac: string | undefined;
+	// An id-0 interface left in the shared registry by an earlier test file makes
+	// `device: "0"` resolve to a MAC this test never locked, so the lock below
+	// would guard a free device and the call would read as success.
+	let inherited: ReturnType<typeof isolateWifiRegistry> = [];
+
+	beforeEach(() => {
+		inherited = isolateWifiRegistry();
+	});
 
 	afterEach(() => {
-		if (seededMac) removeWifiInterface(seededMac);
-		seededMac = undefined;
+		restoreWifiRegistry(inherited);
 	});
 
 	test("returns DEVICE_BUSY while the interface lock is held by another op", async () => {
 		const mac = "dc:a6:32:de:ad:01";
-		seededMac = mac;
 		seedInterface(mac);
+		expect(Object.keys(getWifiInterfacesByMacAddress())).toEqual([mac]);
 
 		// A concurrent op holds the per-interface lock until we release the gate.
 		let release!: () => void;
@@ -82,8 +92,8 @@ describe("wifi.hotspotConfigure — device lock (S5)", () => {
 
 	test("acquires the lock and succeeds once the prior op releases it", async () => {
 		const mac = "dc:a6:32:de:ad:02";
-		seededMac = mac;
 		seedInterface(mac);
+		expect(Object.keys(getWifiInterfacesByMacAddress())).toEqual([mac]);
 
 		const result = await call(hotspotConfigureProcedure, validConfig, {
 			context: makeContext(),

--- a/apps/backend/src/tests/helpers/wifi-registry.ts
+++ b/apps/backend/src/tests/helpers/wifi-registry.ts
@@ -1,0 +1,56 @@
+/*
+    CeraUI - WiFi interface registry isolation for bun:test
+
+    `wifiInterfacesByMacAddress` (modules/wifi/wifi-connections.ts) is a
+    module-level singleton, and `bun test` loads every test file into ONE
+    process — so an interface a test seeds is visible to every file that runs
+    after it.
+
+    That matters because the RPC layer resolves an operator-facing device id
+    ("0", "1", ...) by scanning the registry for the FIRST entry with that
+    numeric `id` (`macForDeviceId`, rpc/procedures/wifi.procedure.ts). Two
+    entries carrying the same id are indistinguishable to that scan, so a
+    leftover id-0 interface from an earlier file makes `device: "0"` resolve to
+    a MAC the current test never seeded — silently steering a per-device lock
+    onto the wrong interface.
+
+    Any test that seeds an interface and then asserts on device-id resolution
+    must therefore own the whole registry for the duration of the test.
+*/
+
+import type { MacAddress } from "../../modules/network/network-manager.ts";
+import {
+	addWifiInterface,
+	getWifiInterfacesByMacAddress,
+	removeWifiInterface,
+} from "../../modules/wifi/wifi-connections.ts";
+import type { WifiInterface } from "../../modules/wifi/wifi-interfaces.ts";
+
+type RegistrySnapshot = ReadonlyArray<readonly [MacAddress, WifiInterface]>;
+
+function clearRegistry(): void {
+	for (const mac of Object.keys(getWifiInterfacesByMacAddress())) {
+		removeWifiInterface(mac);
+	}
+}
+
+/**
+ * Empty the WiFi interface registry and return a snapshot of what was in it.
+ * Pass the snapshot back to {@link restoreWifiRegistry} so the next file sees
+ * exactly the registry this one inherited.
+ */
+export function isolateWifiRegistry(): RegistrySnapshot {
+	const snapshot = Object.entries(getWifiInterfacesByMacAddress()) as Array<
+		readonly [MacAddress, WifiInterface]
+	>;
+	clearRegistry();
+	return snapshot;
+}
+
+/** Drop whatever the test seeded and put the inherited registry back. */
+export function restoreWifiRegistry(snapshot: RegistrySnapshot): void {
+	clearRegistry();
+	for (const [mac, wifiInterface] of snapshot) {
+		addWifiInterface(mac, wifiInterface);
+	}
+}

--- a/apps/backend/src/tests/rpc-network.procedure.test.ts
+++ b/apps/backend/src/tests/rpc-network.procedure.test.ts
@@ -1,4 +1,12 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from "bun:test";
 
 import { wifiMessageSchema } from "@ceraui/rpc/schemas";
 import { call } from "@orpc/server";
@@ -9,6 +17,7 @@ import { withDeviceLock } from "../modules/network/state/device-lock.ts";
 import {
 	addWifiInterface,
 	getWifiInterfaceByMacAddress,
+	getWifiInterfacesByMacAddress,
 	removeWifiInterface,
 } from "../modules/wifi/wifi-connections.ts";
 import type { WifiInterface } from "../modules/wifi/wifi-interfaces.ts";
@@ -20,6 +29,10 @@ import {
 	wifiConnectProcedure,
 } from "../rpc/procedures/wifi.procedure.ts";
 import type { AppWebSocket, RPCContext } from "../rpc/types.ts";
+import {
+	isolateWifiRegistry,
+	restoreWifiRegistry,
+} from "./helpers/wifi-registry.ts";
 
 function makeContext(): RPCContext {
 	const ws = {
@@ -162,6 +175,19 @@ describe("network.configure — mock immediate netif broadcast (Issue 2)", () =>
 });
 
 describe("wifi conflict — DEVICE_BUSY", () => {
+	// An id-0 interface left in the shared registry by an earlier test file makes
+	// `device: "0"` resolve to a MAC this test never locked, so the lock below
+	// would guard a free device and the call would read as success.
+	let inherited: ReturnType<typeof isolateWifiRegistry> = [];
+
+	beforeEach(() => {
+		inherited = isolateWifiRegistry();
+	});
+
+	afterEach(() => {
+		restoreWifiRegistry(inherited);
+	});
+
 	test("hotspotStart returns DEVICE_BUSY while the device lock is held", async () => {
 		const mac = "dc:a6:32:aa:bb:cc";
 		addWifiInterface(mac, {
@@ -173,6 +199,7 @@ describe("wifi conflict — DEVICE_BUSY", () => {
 			saved: {},
 			hotspot: { availableChannels: ["auto"], warnings: {} },
 		} as unknown as WifiInterface);
+		expect(Object.keys(getWifiInterfacesByMacAddress())).toEqual([mac]);
 
 		let release!: () => void;
 		const gate = new Promise<void>((resolve) => {
@@ -191,7 +218,6 @@ describe("wifi conflict — DEVICE_BUSY", () => {
 		} finally {
 			release();
 			await held;
-			removeWifiInterface(mac);
 		}
 	});
 });


### PR DESCRIPTION
## What

The two per-device-lock contention tests (`wifi.hotspotConfigure` and
`hotspotStart`) now own the WiFi interface registry for the duration of each
test instead of sharing whatever earlier test files left in it.

- New test-only helper `apps/backend/src/tests/helpers/wifi-registry.ts` —
  `isolateWifiRegistry()` empties the registry and hands back a snapshot,
  `restoreWifiRegistry(snapshot)` puts the inherited contents back.
- `wifi.procedure.test.ts` and `rpc-network.procedure.test.ts` isolate in
  `beforeEach`, restore in `afterEach`, and assert the registry holds exactly
  the MAC they seeded.

No production code changed.

## Why

`wifi.hotspotConfigure — device lock (S5) > returns DEVICE_BUSY while the
interface lock is held by another op` fails on GitHub Actions and never
locally. It is not a race and not scheduling — it is deterministic, and it
reproduces in under a second on any machine once the files are run in the
CI order.

`wifiInterfacesByMacAddress` (`modules/wifi/wifi-connections.ts`) is a
module-level singleton and `bun test` loads every test file into one process,
so an interface one file seeds stays visible to every file after it. The RPC
layer resolves the operator-facing device id to its lock key by scanning that
registry for the **first** entry with a matching numeric `id`:

```ts
for (const mac in interfaces) {
  if (interfaces[mac]?.id === id) return mac;
}
```

`for…in` walks string keys in insertion order, so with two `id: 0` entries the
older one always wins. The test seeds `dc:a6:32:de:ad:01` with `id: 0`, locks
that MAC, and calls `hotspotConfigure({ device: "0" })` — but the procedure
resolves `"0"` to the *stale* MAC, finds it free, acquires it, runs, and
answers `{ success: true }`. The assertion fails; the file's second test still
passes because it expects success either way, which is the exact 1-fail /
1-pass shape CI reported. `withDeviceLock`'s check-then-set is genuinely
synchronous and was never involved — the defect is upstream of it, in device-id
resolution.

The stale entry comes from a test helper on another branch that seeds an `id: 0`
interface and never removes it. Rather than chase one polluter, this makes both
contention tests immune to any of them: with a single interface in the registry
the device-id -> MAC resolution is unambiguous by construction, so the
`DEVICE_BUSY` assertion can no longer pass on a device it never locked. The
added registry assertion also turns a future mis-resolution into a named
failure instead of a confusing `success: true`.

`macForDeviceId` itself is left alone — it is correct on a device, where
`wifiIfId++` guarantees the interface ids it scans are unique.

## How to verify

```bash
cd apps/backend

# the two affected files, repeatedly
for i in $(seq 1 20); do bun test src/rpc/procedures/wifi.procedure.test.ts \
  src/tests/rpc-network.procedure.test.ts; done

# full backend suite
bun test
```

Both contention tests still prove the real property: a concurrent op on an
interface whose lock is held returns `DEVICE_BUSY`. No retries, no sleeps, no
timeout changes, no relaxed assertions.

Locally verified: 22 consecutive runs of the two files green; the full backend
suite green in natural order, in the exact CI file order (extracted from the
failing job log's per-file `::group::` markers), and again under
`taskset -c 0,1`. Replaying the failing branch in CI order goes from 2 failures
to 1 — the wifi one is gone and only an unrelated, separately-owned failure
remains. `bun run --filter backend check` and `bunx biome check .` are clean.

## Risks

Low. Test-only change; no production file is touched. The isolation helper
restores the registry it inherited, so a file that runs after these tests sees
exactly what it would have seen before.