### PR TITLE
fix(audio): stop the meter calling a present card a missing one, and let it recover

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -300,12 +300,46 @@ fails `No such file or directory`, and the card never appears in the engine's
 embedded audio is therefore unavailable, never noise-that-reads-as-signal; a device that
 DOES deliver audio without video still enumerates, still matches, and still meters.
 
+**A suppressed reading must name the RIGHT gap, and must not be permanent.** The gate
+above is correct to refuse another card's audio; two things about how it did so were
+not. It reported every suppression as `no_device` ("No audio device") — a claim CeraUI
+can prove false, because the selected card was still in its own `/sys/class/sound` list.
+A mis-bound preference was therefore indistinguishable from an unplugged cable, and a
+live investigation went looking for a missing config write that never existed. And it
+never re-tried: the engine's `set_preferred_device` early-returns on an unchanged value,
+so a plain re-push is inert, a card demoted for not delivering during its probe window
+stays demoted while any other candidate keeps delivering, and a preference pushed while
+the card was absent from the engine's registry stays inert. The meter was dead
+indefinitely for a present device, with no recovery short of the operator re-picking.
+
+- `foreignCardReason()` answers `not_selected_device` (additive
+  `AUDIO_LEVEL_UNAVAILABLE_REASONS` member, copy in all 10 locales) when
+  `isMeterPreferenceDevicePresent()` — an `audio.ts` predicate keyed on the PICKER
+  VALUE, not the resolved ALSA string — says CeraUI still lists the pick. A selection
+  CeraUI can no longer see keeps `no_device`, unchanged. Keying on the picker value is
+  deliberate: a pick that is not a device-map key resolves through the alias fallback to
+  a card CeraUI cannot vouch for, and must not claim presence.
+- `noteForeignCardLevel()` re-asserts the preference **through `null`** — the only way
+  to make the value change, so the engine clears its demotions and re-probes — after
+  `AUDIO_METER_MISMATCH_GRACE_MS` (5 s) of uninterrupted foreign readings, at most once
+  per `AUDIO_METER_REASSERT_INTERVAL_MS` (30 s). Bounded on both sides so a mismatch
+  that is simply permanent (a selected card with no capture PCM) costs one cheap reload
+  pair per interval and never a loop. One `warn` per episode names the selected card;
+  the live investigation had zero signal because nothing was logged at all.
+
+The gate itself is unchanged: a level whose `source.identity` names a different card
+than the preference is still dropped. Only the reason string and the retry behaviour
+moved. `AudioLevelMeter` needed no change — it already indexes
+`$LL.live.preview.audioUnavailableReason[reason]()`.
+
 Coverage: `tests/audio-meter-bridge.test.ts` (push on connect, `null` for Auto, re-push
 on change, nothing sent to a pre-0.9.0 engine, a refused reload leaves levels flowing,
 no-op while down, the schema gate, plus the foreign-card gate: suppressed mismatch,
-untouched match, never-gated Auto/identity-less, passthrough `unavailable`, and the
-`alsaCardKey`/`isForeignCardLevel` unit table) and `tests/audio-sources.test.ts`
-(`resolveMeterPreference` — alias, no-alias, every `null` case, selector passthrough).
+untouched match, never-gated Auto/identity-less, passthrough `unavailable`, the
+`alsaCardKey`/`isForeignCardLevel` unit table, and the reason/re-assert behaviour:
+`not_selected_device` vs `no_device`, the grace window, the interval floor, and the
+run reset) and `tests/audio-sources.test.ts` (`resolveMeterPreference` — alias,
+no-alias, every `null` case, selector passthrough).
 
 ## SOFTWARE-UPDATE START CONTRACT [EXISTS]
 
@@ -1314,6 +1348,7 @@ Coverage: `tests/netif-throughput-rate.test.ts`.
   update guards at a call site — `startSoftwareUpdate()` owns every refusal and
   always names it (see SOFTWARE-UPDATE START CONTRACT).
 - Don't send the idle-meter preference through the typed `reloadConfig()` — the published client Zod-strips `audio.meter_device`; it goes over `rawRequest` behind `supportsMeterDevicePreference`. And don't send `undefined` for "Auto": absent means *unchanged*, `null` means Auto.
+- Don't report a suppressed foreign-card level as `no_device` when CeraUI still lists the selected card (`isMeterPreferenceDevicePresent()`) — that makes a mis-bound meter indistinguishable from an unplugged cable — and don't try to fix a sustained mismatch by re-pushing the same preference value: `set_preferred_device` early-returns on an unchanged value, so the re-assert must pass through `null`.
 - Don't re-add stderr regex on the cerastream path — engine errors are structured
   codes mapped via `cerastream-error-mapping.ts`.
 - Don't wire `@ceralive/cerastream` as a sibling `link:` or vendored `.tgz` — it

--- a/apps/backend/src/modules/streaming/audio-meter-bridge.ts
+++ b/apps/backend/src/modules/streaming/audio-meter-bridge.ts
@@ -50,12 +50,20 @@ import { logger as defaultLogger } from "../../helpers/logger.ts";
 import { getConfig } from "../config.ts";
 import { setup } from "../setup.ts";
 import { broadcastMsg } from "../ui/websocket-server.ts";
-import { resolveMeterPreference } from "./audio.ts";
+import {
+	isMeterPreferenceDevicePresent,
+	resolveMeterPreference,
+} from "./audio.ts";
 import { supportsMeterDevicePreference } from "./cerastream-backend.ts";
 
 /** Backoff bounds for the initial-connect retry. Mirrors `engine-reconnect.ts`. */
 export const AUDIO_METER_CONNECT_BASE_MS = 2_000;
 export const AUDIO_METER_CONNECT_MAX_MS = 30_000;
+
+/** How long a foreign-card reading must persist before it is re-asserted. */
+export const AUDIO_METER_MISMATCH_GRACE_MS = 5_000;
+/** Floor between two re-assertions, so a permanent mismatch stays cheap. */
+export const AUDIO_METER_REASSERT_INTERVAL_MS = 30_000;
 
 type TimerHandle = ReturnType<typeof setTimeout>;
 
@@ -75,8 +83,11 @@ export interface AudioMeterBridgeDeps {
 	 * "Auto" (hand selection back to the engine's own delivery-based pick).
 	 */
 	meterPreference: () => string | null;
+	/** Whether that pick is a card CeraUI's own device scan currently lists. */
+	meterPreferencePresent: () => boolean;
 	logger: AudioMeterBridgeLogger;
 	random: () => number;
+	now: () => number;
 	setTimer: (fn: () => void, ms: number) => TimerHandle;
 	clearTimer: (timer: TimerHandle) => void;
 	baseDelayMs: number;
@@ -165,8 +176,10 @@ function defaultDeps(): AudioMeterBridgeDeps {
 		},
 		broadcast: (payload) => broadcastMsg("audio-level", payload),
 		meterPreference: () => resolveMeterPreference(getConfig().asrc),
+		meterPreferencePresent: () => isMeterPreferenceDevicePresent(),
 		logger: defaultLogger,
 		random: Math.random,
+		now: Date.now,
 		setTimer: (fn, ms) => setTimeout(fn, ms),
 		clearTimer: (timer) => clearTimeout(timer),
 		baseDelayMs: AUDIO_METER_CONNECT_BASE_MS,
@@ -183,6 +196,10 @@ interface BridgeState {
 	subscription: Subscription | undefined;
 	/** Tail of the in-flight connect attempt (test seam via settleAudioMeterBridge). */
 	inflight: Promise<void>;
+	/** Start of the current uninterrupted run of foreign-card readings. */
+	mismatchSince: number | undefined;
+	mismatchLogged: boolean;
+	lastReassertAt: number | undefined;
 }
 
 let state: BridgeState | undefined;
@@ -202,20 +219,76 @@ function errMessage(err: unknown): string {
 	return err instanceof Error ? err.message : String(err);
 }
 
-// A foreign-card level reuses the ADR's existing `no_device` reason ("No audio
-// device") rather than a new one: from the operator's seat the SELECTED device
-// is precisely the one not being metered, and the reason set is already wired
-// through 10 locales.
+/**
+ * The gap reason a suppressed foreign-card level is reported as.
+ *
+ * `no_device` is only honest when the selected card is genuinely absent. When
+ * CeraUI's OWN device scan still lists it, the operator's device IS plugged in —
+ * the meter is simply on a different card — and saying "No audio device" sent a
+ * live investigation looking for an unplugged cable that was never unplugged.
+ */
+function foreignCardReason(
+	deps: AudioMeterBridgeDeps,
+): "no_device" | "not_selected_device" {
+	return deps.meterPreferencePresent() ? "not_selected_device" : "no_device";
+}
+
+/**
+ * A sustained foreign-card run means the engine is NOT honouring the preference,
+ * and the engine will not correct itself: `set_preferred_device` early-returns on
+ * an unchanged value, so a card demoted for not delivering during its probe
+ * window stays demoted while any other candidate keeps delivering, and a
+ * preference pushed while the card was missing from the engine's registry stays
+ * inert. Either way the meter is dead for a device that is present, with no
+ * recovery short of the operator re-picking. Re-asserting through `null` is what
+ * makes the value change, so the engine clears its demotions and re-probes.
+ *
+ * Bounded on both sides (a grace window, then an interval floor) so a mismatch
+ * that is simply permanent — a selected card with no capture PCM — costs one
+ * cheap pair of reloads per interval and never a loop.
+ */
+function noteForeignCardLevel(deps: AudioMeterBridgeDeps): void {
+	if (!state || state.stopped) return;
+	const now = deps.now();
+	if (state.mismatchSince === undefined) state.mismatchSince = now;
+	if (!state.mismatchLogged) {
+		state.mismatchLogged = true;
+		deps.logger.warn(
+			`audio-meter bridge: the engine is metering a different card than the selected ${deps.meterPreference() ?? "auto"} — suppressing its levels`,
+		);
+	}
+	if (now - state.mismatchSince < AUDIO_METER_MISMATCH_GRACE_MS) return;
+	if (
+		state.lastReassertAt !== undefined &&
+		now - state.lastReassertAt < AUDIO_METER_REASSERT_INTERVAL_MS
+	) {
+		return;
+	}
+	state.lastReassertAt = now;
+	void reassertPreference();
+}
+
+function clearForeignCardRun(): void {
+	if (!state) return;
+	state.mismatchSince = undefined;
+	state.mismatchLogged = false;
+}
+
 function projectLevel(
 	event: Extract<EventParams, { type: "audio-level" }>,
 	deps: AudioMeterBridgeDeps,
 ): AudioLevelMessage {
 	const message = toAudioLevelMessage(event);
-	if (message.unavailable === true) return message;
-	if (!isForeignCardLevel(deps.meterPreference(), message.source?.identity)) {
+	if (message.unavailable === true) {
+		clearForeignCardRun();
 		return message;
 	}
-	return { unavailable: true, reason: "no_device" };
+	if (!isForeignCardLevel(deps.meterPreference(), message.source?.identity)) {
+		clearForeignCardRun();
+		return message;
+	}
+	noteForeignCardLevel(deps);
+	return { unavailable: true, reason: foreignCardReason(deps) };
 }
 
 function handleEvent(event: EventParams): void {
@@ -253,17 +326,49 @@ async function pushPreference(client: CerastreamClient): Promise<void> {
 		return;
 	}
 	const meter_device = deps.meterPreference();
-	const raw = client as unknown as {
-		rawRequest(method: string, params?: unknown): Promise<unknown>;
-	};
 	try {
-		await raw.rawRequest("reload-config", { audio: { meter_device } });
+		await sendMeterDevice(client, meter_device);
 		deps.logger.debug(
 			`audio-meter bridge: idle-meter preference set to ${meter_device ?? "auto"}`,
 		);
 	} catch (err) {
 		deps.logger.warn(
 			`audio-meter bridge: could not set the idle-meter preference: ${errMessage(err)}`,
+		);
+	}
+}
+
+function sendMeterDevice(
+	client: CerastreamClient,
+	meter_device: string | null,
+): Promise<unknown> {
+	const raw = client as unknown as {
+		rawRequest(method: string, params?: unknown): Promise<unknown>;
+	};
+	return raw.rawRequest("reload-config", { audio: { meter_device } });
+}
+
+/**
+ * Clear the engine's preference, then re-apply it — see `noteForeignCardLevel`
+ * for why the intermediate `null` is the whole point. Never throws, and a failed
+ * half leaves the meter exactly where it already was.
+ */
+async function reassertPreference(): Promise<void> {
+	const client = state?.stopped === false ? state.client : undefined;
+	if (client === undefined || !state) return;
+	const { deps } = state;
+	if (!supportsMeterDevicePreference(client.hello.schema_version)) return;
+	const meter_device = deps.meterPreference();
+	if (meter_device === null) return;
+	try {
+		await sendMeterDevice(client, null);
+		await sendMeterDevice(client, meter_device);
+		deps.logger.info(
+			`audio-meter bridge: re-asserted the idle-meter preference ${meter_device} after a sustained foreign-card reading`,
+		);
+	} catch (err) {
+		deps.logger.warn(
+			`audio-meter bridge: could not re-assert the idle-meter preference: ${errMessage(err)}`,
 		);
 	}
 }
@@ -359,6 +464,9 @@ export function initAudioMeterBridge(
 		client: undefined,
 		subscription: undefined,
 		inflight: Promise.resolve(),
+		mismatchSince: undefined,
+		mismatchLogged: false,
+		lastReassertAt: undefined,
 	};
 	state.inflight = tick();
 }

--- a/apps/backend/src/modules/streaming/audio.ts
+++ b/apps/backend/src/modules/streaming/audio.ts
@@ -118,6 +118,26 @@ export function resolveMeterPreference(
 	return toAlsaCaptureDevice(cardId);
 }
 
+/**
+ * Is the card the operator's pick resolves to one CeraUI itself enumerated?
+ *
+ * The `/sys/class/sound` scan and the engine's own meter-candidate list are
+ * INDEPENDENT: a card the kernel exposes can be absent from the engine (it owns
+ * no capture PCM, or the engine never re-probed after a hotplug). That gap is
+ * what turns a mis-bound meter preference into a level from another card, so it
+ * is also what separates "the pick is genuinely gone" from "the pick is here and
+ * the meter is elsewhere". Deliberately keyed on the picker value, not the
+ * resolved ALSA string — a pick that is not a device-map key resolves through the
+ * alias fallback to a card CeraUI cannot vouch for, and must not claim presence.
+ */
+export function isMeterPreferenceDevicePresent(
+	asrc: string | undefined = getConfig().asrc,
+): boolean {
+	if (asrc === undefined) return false;
+	if (resolveMeterPreference(asrc) === null) return false;
+	return asrc in audioDevices;
+}
+
 // The engine passes `audio.device` straight to `alsasrc device=`, which needs a
 // real ALSA device string, not a bare card id: `alsasrc device="usbaudio"` never
 // opens and the engine rejects the start with `-32602 audio-device-unavailable`.

--- a/apps/backend/src/tests/audio-meter-bridge.test.ts
+++ b/apps/backend/src/tests/audio-meter-bridge.test.ts
@@ -7,6 +7,8 @@ import type {
 } from "@ceralive/cerastream";
 import type { AudioLevelMessage } from "@ceraui/rpc/schemas";
 import {
+	AUDIO_METER_MISMATCH_GRACE_MS,
+	AUDIO_METER_REASSERT_INTERVAL_MS,
 	type AudioMeterBridgeDeps,
 	type AudioMeterBridgeLogger,
 	alsaCardKey,
@@ -27,6 +29,10 @@ const silent: AudioMeterBridgeLogger = {
 
 type TimerHandle = ReturnType<typeof setTimeout>;
 
+// The re-assert is fired-and-forgotten from a synchronous broadcast path, so its
+// two awaited reloads settle over several microtask turns.
+const drainMicrotasks = () => new Promise<void>((r) => setTimeout(r, 0));
+
 // A fake engine: `connect` either throws (engine down) or resolves a client whose
 // `subscribeEvents` captures the handler so the test can push events by hand. The
 // manual timer queue drives the boot-retry loop with no real time.
@@ -41,6 +47,8 @@ function harness(connectOutcomes: boolean[], schemaVersion = "0.9.0") {
 
 	const reloads: unknown[] = [];
 	let preference: string | null = "hw:CARD=usbaudio";
+	let preferencePresent = false;
+	let clock = 1_000;
 	let reloadRejects = false;
 
 	const subscription: Subscription = {
@@ -78,8 +86,10 @@ function harness(connectOutcomes: boolean[], schemaVersion = "0.9.0") {
 		connectOptions: {},
 		broadcast: (payload) => broadcasts.push(payload),
 		meterPreference: () => preference,
+		meterPreferencePresent: () => preferencePresent,
 		logger: silent,
 		random: () => 0.5,
+		now: () => clock,
 		setTimer: (fn: () => void, _ms: number): TimerHandle => {
 			timers.push({ fn });
 			return timers.length as unknown as TimerHandle;
@@ -102,6 +112,13 @@ function harness(connectOutcomes: boolean[], schemaVersion = "0.9.0") {
 		reloads,
 		setPreference: (next: string | null) => {
 			preference = next;
+		},
+		setPreferencePresent: (next: boolean) => {
+			preferencePresent = next;
+		},
+		advance: async (ms: number) => {
+			clock += ms;
+			await drainMicrotasks();
 		},
 		failReloads: () => {
 			reloadRejects = true;
@@ -341,6 +358,143 @@ describe("audio-meter bridge — a level from an unselected card is never render
 		h.emit(unavailableEvent);
 
 		expect(h.broadcasts).toEqual([{ unavailable: true, reason: "mode_none" }]);
+	});
+});
+
+// The follow-up board bug (live QA, 2026-07-25): explicitly picking a CONNECTED,
+// audio-delivering device left the idle meter on "Meter unavailable · No audio
+// device" indefinitely, while "Auto" — resolving to that same device — showed
+// bars at once. The gate was right to refuse the other card's audio; what was
+// wrong is that it said the device was gone, and that nothing ever re-tried.
+describe("audio-meter bridge — a suppressed foreign level names the real cause", () => {
+	test("reports the selection as not-metered while CeraUI still lists it", async () => {
+		const h = harness([true]);
+		h.setPreference("hw:CARD=usbaudio");
+		h.setPreferencePresent(true);
+		initAudioMeterBridge(h.deps);
+		await settleAudioMeterBridge();
+
+		h.emit({
+			...levelEvent,
+			source: { identity: "card:Rx", owner: "sidecar" },
+		});
+
+		expect(h.broadcasts).toEqual([
+			{ unavailable: true, reason: "not_selected_device" },
+		]);
+	});
+
+	test("keeps `no_device` for a selection CeraUI can no longer see", async () => {
+		const h = harness([true]);
+		h.setPreference("hw:CARD=usbaudio");
+		h.setPreferencePresent(false);
+		initAudioMeterBridge(h.deps);
+		await settleAudioMeterBridge();
+
+		h.emit({
+			...levelEvent,
+			source: { identity: "card:Rx", owner: "sidecar" },
+		});
+
+		expect(h.broadcasts).toEqual([{ unavailable: true, reason: "no_device" }]);
+	});
+});
+
+describe("audio-meter bridge — a stuck preference is re-asserted, bounded", () => {
+	const foreign = {
+		...levelEvent,
+		source: { identity: "card:Rx", owner: "sidecar" as const },
+	};
+
+	async function connectedWithForeignLevels() {
+		const h = harness([true]);
+		h.setPreference("hw:CARD=usbaudio");
+		h.setPreferencePresent(true);
+		initAudioMeterBridge(h.deps);
+		await settleAudioMeterBridge();
+		h.reloads.length = 0;
+		return h;
+	}
+
+	test("re-asserts through null only after the grace window, exactly once", async () => {
+		const h = await connectedWithForeignLevels();
+
+		h.emit(foreign);
+		await h.advance(AUDIO_METER_MISMATCH_GRACE_MS - 1);
+		h.emit(foreign);
+		expect(h.reloads).toEqual([]);
+
+		await h.advance(2);
+		h.emit(foreign);
+		await h.advance(0);
+
+		expect(h.reloads).toEqual([
+			{ audio: { meter_device: null } },
+			{ audio: { meter_device: "hw:CARD=usbaudio" } },
+		]);
+	});
+
+	test("holds the interval floor rather than re-asserting on every level", async () => {
+		const h = await connectedWithForeignLevels();
+
+		h.emit(foreign);
+		await h.advance(AUDIO_METER_MISMATCH_GRACE_MS);
+		h.emit(foreign);
+		await h.advance(0);
+		expect(h.reloads).toHaveLength(2);
+
+		await h.advance(AUDIO_METER_REASSERT_INTERVAL_MS - 1);
+		h.emit(foreign);
+		await h.advance(0);
+		expect(h.reloads).toHaveLength(2);
+
+		await h.advance(2);
+		h.emit(foreign);
+		await h.advance(0);
+		expect(h.reloads).toHaveLength(4);
+	});
+
+	test("a level from the selected card ends the run and re-arms the grace", async () => {
+		const h = await connectedWithForeignLevels();
+
+		h.emit(foreign);
+		await h.advance(AUDIO_METER_MISMATCH_GRACE_MS);
+		h.emit(levelEvent);
+		await h.advance(AUDIO_METER_MISMATCH_GRACE_MS);
+		h.emit(foreign);
+		await h.advance(0);
+
+		expect(h.reloads).toEqual([]);
+	});
+
+	test("never re-asserts for Auto — the engine owns that selection", async () => {
+		const h = harness([true]);
+		h.setPreference(null);
+		initAudioMeterBridge(h.deps);
+		await settleAudioMeterBridge();
+		h.reloads.length = 0;
+
+		h.emit(foreign);
+		await h.advance(AUDIO_METER_MISMATCH_GRACE_MS * 4);
+		h.emit(foreign);
+		await h.advance(0);
+
+		expect(h.reloads).toEqual([]);
+		expect(h.broadcasts.every((b) => b.unavailable === undefined)).toBe(true);
+	});
+
+	test("a refused re-assert leaves levels flowing, never a thrown bridge", async () => {
+		const h = await connectedWithForeignLevels();
+		h.failReloads();
+
+		h.emit(foreign);
+		await h.advance(AUDIO_METER_MISMATCH_GRACE_MS);
+		h.emit(foreign);
+		await h.advance(0);
+
+		h.setPreference("hw:CARD=Rx");
+		h.emit(foreign);
+		expect(h.broadcasts.at(-1)).toEqual(toAudioLevelMessage(foreign));
 	});
 });
 

--- a/apps/frontend/src/lib/components/preview/AudioLevelMeter.test.ts
+++ b/apps/frontend/src/lib/components/preview/AudioLevelMeter.test.ts
@@ -84,6 +84,17 @@ describe("AudioLevelMeter — unavailable state (device-quality-wave2 Todo 22)",
 		expect(marker?.textContent).toContain("No audio device");
 	});
 
+	it("distinguishes a present-but-unmetered device from a missing one", () => {
+		const { container } = render(AudioLevelMeter, {
+			props: { unavailable: true, reason: "not_selected_device" },
+		});
+		const marker = meterOf(container).querySelector(
+			'[data-testid="audio-unavailable"]',
+		);
+		expect(marker?.textContent).toContain("Not the selected device");
+		expect(marker?.textContent).not.toContain("No audio device");
+	});
+
 	it("prefers unavailable over any stale rms/peak arrays (never fake silence)", () => {
 		const { container } = render(AudioLevelMeter, {
 			props: { unavailable: true, rmsDb: [-12], peakDb: [-6] },

--- a/packages/i18n/src/ar/index.ts
+++ b/packages/i18n/src/ar/index.ts
@@ -1250,6 +1250,7 @@ const ar = {
 			audioUnavailableReason: {
 				device_busy: "جهاز الصوت مشغول",
 				no_device: "لا يوجد جهاز صوت",
+				not_selected_device: "ليس الجهاز المحدَّد",
 				mode_none: "الصوت معطّل",
 				handoff: "جارٍ التبديل\u2026",
 			},

--- a/packages/i18n/src/de/index.ts
+++ b/packages/i18n/src/de/index.ts
@@ -543,6 +543,7 @@ const de = {
 			audioUnavailableReason: {
 				device_busy: "Audiogerät belegt",
 				no_device: "Kein Audiogerät",
+				not_selected_device: "Nicht das gewählte Gerät",
 				mode_none: "Audio deaktiviert",
 				handoff: "Wird umgeschaltet\u2026",
 			},

--- a/packages/i18n/src/en/index.ts
+++ b/packages/i18n/src/en/index.ts
@@ -526,6 +526,7 @@ const en = {
 			audioUnavailableReason: {
 				device_busy: "Audio device busy",
 				no_device: "No audio device",
+				not_selected_device: "Not the selected device",
 				mode_none: "Audio disabled",
 				handoff: "Switching\u2026",
 			},

--- a/packages/i18n/src/es/index.ts
+++ b/packages/i18n/src/es/index.ts
@@ -545,6 +545,7 @@ const es = {
 			audioUnavailableReason: {
 				device_busy: "Dispositivo de audio ocupado",
 				no_device: "Sin dispositivo de audio",
+				not_selected_device: "No es el dispositivo seleccionado",
 				mode_none: "Audio desactivado",
 				handoff: "Cambiando\u2026",
 			},

--- a/packages/i18n/src/fr/index.ts
+++ b/packages/i18n/src/fr/index.ts
@@ -1313,6 +1313,7 @@ const fr = {
 			audioUnavailableReason: {
 				device_busy: "Périphérique audio occupé",
 				no_device: "Aucun périphérique audio",
+				not_selected_device: "Pas le périphérique sélectionné",
 				mode_none: "Audio désactivé",
 				handoff: "Changement\u2026",
 			},

--- a/packages/i18n/src/hi/index.ts
+++ b/packages/i18n/src/hi/index.ts
@@ -1113,6 +1113,7 @@ const hi = {
 			audioUnavailableReason: {
 				device_busy: "ऑडियो डिवाइस व्यस्त",
 				no_device: "कोई ऑडियो डिवाइस नहीं",
+				not_selected_device: "चयनित डिवाइस नहीं",
 				mode_none: "ऑडियो अक्षम",
 				handoff: "बदल रहा है\u2026",
 			},

--- a/packages/i18n/src/ja/index.ts
+++ b/packages/i18n/src/ja/index.ts
@@ -1152,6 +1152,7 @@ const ja = {
 			audioUnavailableReason: {
 				device_busy: "オーディオデバイス使用中",
 				no_device: "オーディオデバイスなし",
+				not_selected_device: "選択したデバイスではありません",
 				mode_none: "オーディオ無効",
 				handoff: "切り替え中\u2026",
 			},

--- a/packages/i18n/src/ko/index.ts
+++ b/packages/i18n/src/ko/index.ts
@@ -1129,6 +1129,7 @@ const ko = {
 			audioUnavailableReason: {
 				device_busy: "오디오 장치 사용 중",
 				no_device: "오디오 장치 없음",
+				not_selected_device: "선택한 장치가 아님",
 				mode_none: "오디오 비활성화",
 				handoff: "전환 중\u2026",
 			},

--- a/packages/i18n/src/pt-BR/index.ts
+++ b/packages/i18n/src/pt-BR/index.ts
@@ -1290,6 +1290,7 @@ const ptBR = {
 			audioUnavailableReason: {
 				device_busy: "Dispositivo de áudio ocupado",
 				no_device: "Nenhum dispositivo de áudio",
+				not_selected_device: "Não é o dispositivo selecionado",
 				mode_none: "Áudio desativado",
 				handoff: "Alternando\u2026",
 			},

--- a/packages/i18n/src/zh/index.ts
+++ b/packages/i18n/src/zh/index.ts
@@ -1063,6 +1063,7 @@ const zh = {
 			audioUnavailableReason: {
 				device_busy: "音频设备忙",
 				no_device: "无音频设备",
+				not_selected_device: "不是所选设备",
 				mode_none: "音频已禁用",
 				handoff: "切换中\u2026",
 			},

--- a/packages/rpc/src/schemas/audio-level.schema.ts
+++ b/packages/rpc/src/schemas/audio-level.schema.ts
@@ -17,9 +17,14 @@ export const AUDIO_LEVEL_OWNERS = ['sidecar', 'streaming'] as const;
 export const audioLevelOwnerSchema = z.enum(AUDIO_LEVEL_OWNERS);
 export type AudioLevelOwner = z.infer<typeof audioLevelOwnerSchema>;
 
+// `not_selected_device` is CeraUI's own reason, never emitted by the engine: the
+// backend gate raises it for a level belonging to a different ALSA card than the
+// operator picked, while that pick IS present. `no_device` there claimed the
+// device was gone when it was plugged in and delivering.
 export const AUDIO_LEVEL_UNAVAILABLE_REASONS = [
 	'device_busy',
 	'no_device',
+	'not_selected_device',
 	'mode_none',
 	'handoff',
 ] as const;


### PR DESCRIPTION
## What

The idle audio meter stopped blaming a missing device for the wrong card, and now recovers on its own.

- `packages/rpc/src/schemas/audio-level.schema.ts` — additive `not_selected_device` member of `AUDIO_LEVEL_UNAVAILABLE_REASONS`; `packages/i18n` carries the copy in all 10 locales.
- `apps/backend/src/modules/streaming/audio.ts` — new `isMeterPreferenceDevicePresent()` predicate.
- `apps/backend/src/modules/streaming/audio-meter-bridge.ts` — `foreignCardReason()` picks the honest reason; `noteForeignCardLevel()` re-asserts the preference through `null` after a bounded grace window, with an interval floor and one `warn` per mismatch episode.

`AudioLevelMeter.svelte` needed no change — it already indexes `$LL.live.preview.audioUnavailableReason[reason]()`.

## Why

PR #221's foreign-card gate is right to refuse another card's audio: the engine reorders candidates but still meters whatever it *can* open, so an unopenable selection otherwise leaves real, moving bars on screen belonging to a different device. Two things about **how** it refused were wrong.

**1. It lied about the cause.** A suppressed foreign level was reported as `no_device` ("No audio device") — a claim CeraUI can prove false, since the selected card was still in its own `/sys/class/sound` list. A mis-bound preference was therefore indistinguishable from an unplugged cable. That is exactly why a live session read this as *"the explicit audio picker does not work"* and went looking for a missing `audio.meter_device` config write. There is no such write to find: `audio.meter_device` is never a config key, it is a runtime `reload-config` push derived from `config.asrc` (`resolveMeterPreference` → `pushPreference`), and the whole `SourceSection → setConfig({asrc}) → syncAudioMeterPreference()` chain was traced and is intact.

`isMeterPreferenceDevicePresent()` keys on the **picker value**, not the resolved ALSA string, deliberately: a pick that is not a device-map key resolves through the alias fallback to a card CeraUI cannot vouch for, and must not claim presence. A selection CeraUI can no longer see keeps `no_device`, unchanged.

**2. It never re-tried.** The engine's `set_preferred_device` early-returns on an unchanged value, so a plain re-push is inert. A card demoted for not delivering during its probe window stays demoted while any *other* candidate keeps delivering (`rearm_when_no_candidate_can_deliver` only fires when **all** candidates are demoted), and a preference pushed while the card was missing from the engine's registry stays inert. Either way the meter was dead indefinitely for a device that is present, with no recovery short of the operator re-picking. Re-asserting **through `null`** is the only way to make the value change so the engine clears its demotions and re-probes. It is bounded on both sides — `AUDIO_METER_MISMATCH_GRACE_MS` (5 s) of uninterrupted foreign readings, then at most once per `AUDIO_METER_REASSERT_INTERVAL_MS` (30 s) — so a mismatch that is simply permanent costs one cheap reload pair per interval and never a loop.

One `warn` per episode names the selected card. The live investigation had zero signal because nothing was logged at all.

Note for context: the *engine-side* half of the original report was cerastream PR #73 (ALSA capture cards appearing after engine startup were invisible to the registry forever, because `alsadeviceprovider` implements only the `probe` vfunc and posts no `DeviceAdded`). That is already fixed upstream and the reported bug does not reproduce on the fixed engine. This PR is the residual CeraUI-side defect only.

## How to verify

```bash
bun install --frozen-lockfile
cd apps/backend && bun test && bun tsc --noEmit
cd ../frontend && bunx svelte-check --tsconfig ./tsconfig.app.json
NODE_OPTIONS=--localstorage-file=/tmp/ls.db \
  bunx vitest run src/lib/components/preview/AudioLevelMeter.test.ts
```

Measured on this branch in an isolated worktree: backend **2304 pass / 0 fail** (234 files), `tsc --noEmit` clean for `apps/backend`, `packages/rpc` and `packages/i18n`, `svelte-check` **0 errors**, `biome check` clean on all 15 touched code files, `AudioLevelMeter.test.ts` **8 pass**. No existing audio test was deleted, skipped, or weakened.

Board reconfirmation (Rock 5B+, arm64 backend installed to `/usr/local/bin/ceralive`):
- explicit **"HDMI"** (listed by CeraUI, no capture PCM ⇒ genuinely unmeterable) → `{"unavailable":true,"reason":"not_selected_device"}` — truthful — instead of the false `no_device`. `debug.log` shows the mismatch warn **once** and the re-assert **once** for the whole episode, so the grace window and interval floor hold on real hardware.
- explicit **"USB audio"** (RØDE physically connected) → 20/20 real frames, `card:usbaudio`, sustained past 10 s, no unavailable interim state.

## Risks

- `not_selected_device` is an additive enum member with copy in all 10 locales, so no consumer loses a case. A frontend that predates it would fall through its default branch rather than crash — and `AudioLevelMeter` already indexes the reason map generically.
- The re-assert writes to the engine (`reload-config` with `null`, then the real value). It is gated on `supportsMeterDevicePreference`, skipped entirely for an "Auto" (`null`) preference, never throws, and a failed half leaves the meter exactly where it already was. Worst case for a permanently unmeterable pick is two reload calls per 30 s.
- Momentary meter interruption during a re-assert is possible by construction — that is the cost of clearing the engine's demotions, and it only happens after 5 s of readings that were being discarded anyway.
- Surfaced, not fixed: CeraUI's audio device list does not react to an ALSA card appearing or disappearing (the `/sys/class/sound` watcher missed both edges during an `snd-aloop` test). Separate subsystem.
