### PR TITLE
fix(sources): re-check a capture input's signal instead of latching the first answer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1828,6 +1828,21 @@ snapshots) and never at a render site. Display-only — `input_id`/`device_path`
 `stable_id` and the kind heuristic are untouched. Full contract:
 `apps/backend/AGENTS.md` → ONBOARD VIDEO DISPLAY NAMES.
 
+**And that port's signal is re-checked, not read once.** The `signal` verdict
+(`present`/`absent`/`unknown`, PR #216) was only ever recomputed when the device
+SET changed — but an HDMI receiver that reports "no link" while its link
+retrains and locks seconds later never changes the set, so the retraining answer
+latched. Confirmed live on a Rock 5B+: `dmesg` logged `signal lock ok` +
+`New format: 1920x1080p59.94` at 04:29 and the engine's `list-devices` reported
+that mode correctly, while the UI still read "No signal" 45 minutes later —
+nothing had asked the engine again. The device registry now fires a
+`VIDEO_SIGNAL_RECHECK_INTERVAL_MS` (5 s) `onSignalRecheck` tick into
+`recheckSourceSignals()`, which re-probes and broadcasts ONLY on change. It is
+device-agnostic by construction — no driver or controller string anywhere in the
+path, just the caps the engine's own `VIDIOC_QUERY_DV_TIMINGS` result projected.
+Full contract: `apps/backend/AGENTS.md` → "A SIGNAL change is invisible to every
+hotplug detector".
+
 **The idle level meter follows the picker.** Selecting an audio source used to change
 nothing about the meter: cerastream chose its own idle card, so an operator who picked
 the RØDE could watch the meter report the DJI Mic Mini — or "Meter unavailable" — with

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -764,6 +764,47 @@ namespace, not the engine's, and `buildSources` overlays video only. The
 `engineAudioDeviceCache` is still refreshed from the probe on this path — it is
 the one cache the local scan cannot populate.
 
+**A SIGNAL change is invisible to every hotplug detector, so it gets its own
+tick.** All three triggers above — `fs.watch` on `/dev`, the 2 s poll's
+device-SET comparison, and the boot/reconnect seeds — key on a device
+APPEARING or DISAPPEARING. A capture device that stops or starts carrying a
+usable picture does neither: same node, same `input_id`, same place in the set.
+Confirmed live on a Rock 5B+ whose HDMI-RX answered `VIDIOC_QUERY_DV_TIMINGS`
+with `ENOLINK` for the ~6 s its link spent retraining (`dmesg`:
+`hdmirx_query_dv_timings port has no link!` ×3 → `hdmirx_phy_register_write
+wait cr write done failed!` ×15 → `signal lock ok` → `New format:
+1920x1080p59.94`). cerastream drops a signal-less receiver's degenerate range
+caps entirely, so `fromEngineDevice` stamped `signal: 'absent'` from that
+retraining answer — and 45 minutes later the engine's `list-devices` reported
+`1920x1080 @ 60000/1001` while the UI still read "No signal", because nothing
+had asked it again. While IDLE nothing can: `listDevicesIfActive()` returns
+`null` with no live control session, so the registry's own poll is the local
+v4l2 scan, whose output is byte-identical every tick forever.
+
+`recheckSourceSignals(observed)` (`sources.ts`), fired by the registry's
+`onSignalRecheck` on a `VIDEO_SIGNAL_RECHECK_INTERVAL_MS` (5 s) interval, is the
+re-poke that closes it. It is device-agnostic BY CONSTRUCTION — no driver name,
+no controller string, no HDMI special case anywhere in the path; it re-reads
+whatever the engine's `VIDIOC_QUERY_DV_TIMINGS` result projected into `caps[]`,
+so any device whose engine-reported caps change is picked up identically. It
+reuses `refreshSourcesForHotplug`'s membership rule, metadata rule and
+generation fence verbatim, with TWO deliberate divergences:
+
+- **A probe that says nothing changes nothing.** A hotplug tick MUST fall back
+  to `observed` (it holds a detected removal the retained cache would mask);
+  this tick holds no detected transition at all, so falling back would
+  republish the scan's coarse guess over the engine's last real answer for no
+  reason. An unreachable engine simply leaves the last-known view standing.
+- **It broadcasts only on change** (`broadcastSourcesIfChanged`), so `sources`
+  keeps its documented on-change cadence instead of pushing an identical
+  snapshot to every client every 5 s.
+
+While STREAMING this tick is redundant-but-harmless: a live control session
+makes `getEngineDevices()` engine-backed, so a signal change DOES alter the
+device-SET serialization and the ordinary hotplug trigger already fires. Both
+paths commit the same engine-authored rows, so they cannot disagree.
+Coverage: `tests/hdmi-signal-recheck.test.ts`.
+
 **Overlapping hotplug refreshes are ordered by a generation fence.** Each
 `onDevicesChanged` starts its own probe, so an unplug and a replug moments apart
 run two round-trips concurrently and the OLDER one can answer LAST — republishing

--- a/apps/backend/src/modules/streaming/constants.ts
+++ b/apps/backend/src/modules/streaming/constants.ts
@@ -51,6 +51,11 @@ export const VIDEO_HOTPLUG_DEBOUNCE_MS = 200;
  *  hotplug is reflected in the picker within the 3s product budget (T34). */
 export const VIDEO_HOTPLUG_POLL_INTERVAL_MS = 2_000;
 
+/** Signal-only re-probe (ms). A receiver that reports "no link" while its HDMI
+ *  link retrains, then locks, changes NEITHER the `/dev` node nor the device SET,
+ *  so both detectors above stay silent and the signal-less answer latches. */
+export const VIDEO_SIGNAL_RECHECK_INTERVAL_MS = 5_000;
+
 // ─── timing / jitter (shared across periodic loops) ──────────────────────────
 // Per-tick jitter de-correlates fleet-wide fixed-period timers so devices stop
 // hitting a relay/hub on the same wall-clock boundary (thundering herd). Shared

--- a/apps/backend/src/modules/streaming/devices.ts
+++ b/apps/backend/src/modules/streaming/devices.ts
@@ -48,6 +48,7 @@ import { getAudioDevices } from "./audio.ts";
 import {
 	VIDEO_HOTPLUG_DEBOUNCE_MS,
 	VIDEO_HOTPLUG_POLL_INTERVAL_MS,
+	VIDEO_SIGNAL_RECHECK_INTERVAL_MS,
 } from "./constants.ts";
 import { reportActiveVideoSource } from "./lifecycle-indicators.ts";
 import { applyOnboardVideoDisplayRule } from "./onboard-display-names.ts";
@@ -93,11 +94,18 @@ export interface DeviceRegistryDeps {
 	// the observed list when that probe fails — a retained-because-unreachable
 	// cache would otherwise keep an unplugged device on screen.
 	onDevicesChanged: (observed: readonly CaptureDevice[]) => void;
+	// Fired on a fixed interval REGARDLESS of whether anything changed, because
+	// the change it exists to catch is invisible to every detector above: a
+	// device whose signal appears or disappears keeps its node and its place in
+	// the set. Only the engine can answer it, so this hands the observed list to
+	// a fresh `list-devices` probe.
+	onSignalRecheck: (observed: readonly CaptureDevice[]) => void;
 	reportActiveVideoSource: typeof reportActiveVideoSource;
 	watch: typeof fs.watch;
 	now: () => number;
 	debounceMs: number;
 	pollMs: number;
+	signalRecheckMs: number;
 	logger: Pick<typeof defaultLogger, "debug" | "warn" | "error">;
 }
 
@@ -318,11 +326,17 @@ function defaultDeps(): DeviceRegistryDeps {
 				refreshSourcesForHotplug(observed),
 			);
 		},
+		onSignalRecheck: (observed) => {
+			void import("./sources.ts").then(({ recheckSourceSignals }) =>
+				recheckSourceSignals(observed),
+			);
+		},
 		reportActiveVideoSource,
 		watch: fs.watch,
 		now: () => performance.now(),
 		debounceMs: VIDEO_HOTPLUG_DEBOUNCE_MS,
 		pollMs: VIDEO_HOTPLUG_POLL_INTERVAL_MS,
+		signalRecheckMs: VIDEO_SIGNAL_RECHECK_INTERVAL_MS,
 		logger: defaultLogger,
 	};
 }
@@ -338,6 +352,7 @@ export function createDeviceRegistry(
 	let lastDeviceSetSerialized = "";
 	let debounceHandle: ReturnType<typeof setTimeout> | undefined;
 	let pollHandle: ReturnType<typeof setInterval> | undefined;
+	let signalRecheckHandle: ReturnType<typeof setInterval> | undefined;
 	let devWatcher: fs.FSWatcher | undefined;
 	let stopped = false;
 	let engineWasReachable = false;
@@ -506,6 +521,9 @@ export function createDeviceRegistry(
 		pollHandle = setInterval(() => {
 			if (!stopped) void rescan();
 		}, deps.pollMs);
+		signalRecheckHandle = setInterval(() => {
+			if (!stopped) deps.onSignalRecheck(devices);
+		}, deps.signalRecheckMs);
 	}
 
 	function stop(): void {
@@ -517,6 +535,10 @@ export function createDeviceRegistry(
 		if (pollHandle) {
 			clearInterval(pollHandle);
 			pollHandle = undefined;
+		}
+		if (signalRecheckHandle) {
+			clearInterval(signalRecheckHandle);
+			signalRecheckHandle = undefined;
 		}
 		devWatcher?.close();
 		devWatcher = undefined;

--- a/apps/backend/src/modules/streaming/sources.ts
+++ b/apps/backend/src/modules/streaming/sources.ts
@@ -875,6 +875,7 @@ export function resetEngineDeviceCache(): void {
 	engineAudioDeviceCache = [];
 	sessionSeenDeviceSnapshots.clear();
 	lastEngineVideoDevices.clear();
+	lastBroadcastSources = undefined;
 }
 
 /**
@@ -974,15 +975,31 @@ export function reconcileConfiguredSourceIdentity(
 	return true;
 }
 
+// The last payload `broadcastSources` put on the wire, so a periodic re-probe
+// can honour the "on-change" cadence of the `sources` event instead of pushing
+// an identical snapshot to every client on every tick.
+let lastBroadcastSources: string | undefined;
+
 /** Push the current `sources` snapshot to all authenticated clients. */
 export function broadcastSources(): void {
 	const message = getSourcesMessage();
 	// `config.source` feeds `collectLostCandidates`, so a migration has to be
 	// rebuilt rather than published from the pre-migration snapshot.
 	if (reconcileConfiguredSourceIdentity(message.sources)) {
-		broadcastMsg("sources", getSourcesMessage());
+		const migrated = getSourcesMessage();
+		lastBroadcastSources = JSON.stringify(migrated);
+		broadcastMsg("sources", migrated);
 		return;
 	}
+	lastBroadcastSources = JSON.stringify(message);
+	broadcastMsg("sources", message);
+}
+
+function broadcastSourcesIfChanged(): void {
+	const message = getSourcesMessage();
+	const serialized = JSON.stringify(message);
+	if (serialized === lastBroadcastSources) return;
+	lastBroadcastSources = serialized;
 	broadcastMsg("sources", message);
 }
 
@@ -1087,4 +1104,40 @@ export async function refreshSourcesForHotplug(
 		probe.audio,
 	);
 	broadcastSources();
+}
+
+/**
+ * Re-probe the engine for devices whose SIGNAL may have changed while their
+ * identity did not.
+ *
+ * The engine re-runs `VIDIOC_QUERY_DV_TIMINGS` on EVERY `list-devices`, so an
+ * HDMI receiver that reports no modes while its link retrains and the one real
+ * mode once it locks is answered correctly on the very next call. But NOTHING
+ * calls: `refreshSourcesForHotplug` fires only on a device-SET change, and while
+ * idle CeraUI holds no engine connection, so the registry polls a local v4l2
+ * scan whose output never varies. `fromEngineDevice` reads zero caps as
+ * `signal: 'absent'`, so the retraining answer latches and the operator reads
+ * "No signal" for a device that locked minutes ago. Nothing here knows what an
+ * HDMI receiver is — any device whose engine-reported caps change is picked up
+ * identically.
+ *
+ * Membership, metadata and the generation fence follow `refreshSourcesForHotplug`
+ * verbatim. The ONE deliberate divergence: a probe that says nothing changes
+ * nothing. This tick carries no detected transition to publish, so falling back
+ * to `observed` the way a hotplug tick must would republish a coarse guess over
+ * the engine's last real answer for no reason at all.
+ */
+export async function recheckSourceSignals(
+	observed: readonly CaptureDevice[],
+	deps: EngineDeviceCacheDeps = defaultEngineDeviceCacheDeps,
+): Promise<void> {
+	const generation = ++hotplugRefreshGeneration;
+	const probe = await probeEngineDevices(deps);
+	if (generation !== hotplugRefreshGeneration) return;
+	if (probe === undefined) return;
+	commitEngineDevices(
+		mergeObservedWithProbe(observed, probe.devices),
+		probe.audio,
+	);
+	broadcastSourcesIfChanged();
 }

--- a/apps/backend/src/tests/hdmi-signal-recheck.test.ts
+++ b/apps/backend/src/tests/hdmi-signal-recheck.test.ts
@@ -1,0 +1,341 @@
+/*
+ * A capture device whose SIGNAL appears after CeraUI's first look at it.
+ *
+ * Reproduced on a Rock 5B+: the RK3588 HDMI-RX answers
+ * `VIDIOC_QUERY_DV_TIMINGS` with ENOLINK for the seconds its link spends
+ * retraining, so the engine truthfully reports the node with NO caps and
+ * `fromEngineDevice` stamps `signal: 'absent'`. Seconds later the kernel logs
+ * `signal lock ok` + `New format: 1920x1080p59.94` and the engine's very next
+ * `list-devices` carries the real mode — but nothing asked it again, so the UI
+ * kept rendering "No signal" for a locked 1080p59.94 source.
+ *
+ * The device never left the list, so neither hotplug detector could fire. These
+ * tests pin the periodic re-probe that closes the gap, and the three rules it
+ * must not break while doing so.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+	type GetCapabilitiesResult,
+	type ListDevicesResult,
+	SCHEMA_VERSION,
+} from "@ceralive/cerastream";
+import type { CaptureDevice, StreamSource } from "@ceraui/rpc/schemas";
+
+import { getConfig } from "../modules/config.ts";
+import {
+	clearCapabilitiesCache,
+	getCapabilities,
+} from "../modules/streaming/capabilities.ts";
+import {
+	createDeviceRegistry,
+	type DeviceRegistryDeps,
+} from "../modules/streaming/devices.ts";
+import {
+	applyObservedEngineDevices,
+	getEngineDeviceCache,
+	getSourcesMessage,
+	recheckSourceSignals,
+	resetEngineDeviceCache,
+} from "../modules/streaming/sources.ts";
+import { addClient, removeClient } from "../rpc/events.ts";
+import type { AppWebSocket } from "../rpc/types.ts";
+
+const HDMI_RX_ID = "/dev/video0";
+
+/** The engine's entry for the HDMI-RX node, verbatim from the board. `caps`
+ *  absent is the signal-less shape cerastream actually emits — it DROPS the
+ *  degenerate range bounds rather than reporting them as modes. */
+function hdmiRxEntry(
+	caps?: ListDevicesResult["devices"][number]["caps"],
+): ListDevicesResult["devices"][number] {
+	return {
+		input_id: HDMI_RX_ID,
+		device_path: HDMI_RX_ID,
+		display_name: "rk_hdmirx",
+		media_class: "video",
+		kind: "hdmi",
+		stable_id: "port:fdee0000.hdmirx-controller",
+		...(caps !== undefined ? { caps } : {}),
+	};
+}
+
+/** What `list-devices` returns once the link finishes retraining: the ONE mode
+ *  the cable is carrying, derived from the kernel's own pixel clock. */
+const LOCKED_1080P5994: ListDevicesResult["devices"][number]["caps"] = [
+	{ width: 1920, height: 1080, framerate: "60000/1001" },
+];
+
+/** What the registry's own local v4l2 scan sees: the node is present, and that
+ *  never changes while the link retrains — only the engine can see the signal. */
+function observedHdmiRx(): CaptureDevice[] {
+	return [
+		{
+			input_id: HDMI_RX_ID,
+			device_path: HDMI_RX_ID,
+			display_name: "HDMI Input",
+			media_class: "video",
+			kind: "hdmi",
+		},
+	];
+}
+
+function recordingClient(sink: string[]): AppWebSocket {
+	return {
+		data: { isAuthenticated: true, lastActive: Date.now() },
+		send: (message: string) => sink.push(message),
+	} as unknown as AppWebSocket;
+}
+
+async function seedHdmiCaps(): Promise<void> {
+	const caps: GetCapabilitiesResult = {
+		platform: {
+			supports_h265: true,
+			hardware_accelerated: true,
+			max_resolution: "1080p",
+		},
+		encoder: {
+			codecs: ["h264"],
+			bitrate_range: { min: 500, max: 20000, unit: "kbps" },
+		},
+		sources: [
+			{
+				id: "hdmi",
+				supports_audio: false,
+				supports_resolution_override: true,
+				supports_framerate_override: true,
+				default_resolution: "1080p",
+				default_framerate: 30,
+			},
+		],
+	};
+	await getCapabilities({
+		fetchEngineCapabilities: async () => ({
+			caps,
+			schemaVersion: SCHEMA_VERSION,
+		}),
+		fetchEngineDevices: async () => ({ devices: [] }),
+	});
+}
+
+function hdmiSource(): StreamSource | undefined {
+	return getSourcesMessage().sources.find((s) => s.id === HDMI_RX_ID);
+}
+
+function captureFrames(
+	run: () => Promise<void>,
+): Promise<Array<Record<string, unknown>>> {
+	const sink: string[] = [];
+	const client = recordingClient(sink);
+	addClient(client);
+	return run()
+		.finally(() => removeClient(client))
+		.then(() => sink.map((raw) => JSON.parse(raw) as Record<string, unknown>));
+}
+
+describe("recheckSourceSignals — a signal that arrives after the first probe", () => {
+	beforeEach(() => {
+		resetEngineDeviceCache();
+		clearCapabilitiesCache();
+		getConfig().last_seen_devices = [];
+		delete getConfig().source;
+	});
+
+	afterEach(() => {
+		resetEngineDeviceCache();
+		clearCapabilitiesCache();
+		getConfig().last_seen_devices = [];
+		delete getConfig().source;
+	});
+
+	test("a device that answered 'no signal' first and a locked mode second transitions to present — no replug, no device-set change", async () => {
+		await seedHdmiCaps();
+
+		// FIRST probe: mid-retraining. The engine lists the node and projects
+		// nothing, which is a real finding — this is the state that used to latch.
+		await recheckSourceSignals(observedHdmiRx(), {
+			fetchEngineDevices: async () => ({ devices: [hdmiRxEntry()] }),
+		});
+		expect(hdmiSource()?.signal).toBe("absent");
+
+		// SECOND probe: the same node, same id, same display name — the kernel has
+		// simply locked onto 1080p59.94 in between. Nothing about the device SET
+		// changed, so only this re-probe can carry the news.
+		await recheckSourceSignals(observedHdmiRx(), {
+			fetchEngineDevices: async () => ({
+				devices: [hdmiRxEntry(LOCKED_1080P5994)],
+			}),
+		});
+
+		const locked = hdmiSource();
+		expect(locked?.signal).toBe("present");
+		expect(locked?.available).toBe(true);
+		expect(locked?.modes).toEqual([
+			{ width: 1920, height: 1080, framerates: [59.94] },
+		]);
+	});
+
+	test("the transition is pushed to connected clients, so the row corrects itself with no page reload", async () => {
+		await seedHdmiCaps();
+		await recheckSourceSignals(observedHdmiRx(), {
+			fetchEngineDevices: async () => ({ devices: [hdmiRxEntry()] }),
+		});
+
+		const frames = await captureFrames(() =>
+			recheckSourceSignals(observedHdmiRx(), {
+				fetchEngineDevices: async () => ({
+					devices: [hdmiRxEntry(LOCKED_1080P5994)],
+				}),
+			}),
+		);
+
+		const sources = frames.find((f) => "sources" in f)?.sources as
+			| { sources: StreamSource[] }
+			| undefined;
+		expect(sources).toBeDefined();
+		expect(sources?.sources.find((s) => s.id === HDMI_RX_ID)?.signal).toBe(
+			"present",
+		);
+	});
+
+	test("a losing signal is reported just as promptly as a gained one", async () => {
+		await seedHdmiCaps();
+		await recheckSourceSignals(observedHdmiRx(), {
+			fetchEngineDevices: async () => ({
+				devices: [hdmiRxEntry(LOCKED_1080P5994)],
+			}),
+		});
+		expect(hdmiSource()?.signal).toBe("present");
+
+		await recheckSourceSignals(observedHdmiRx(), {
+			fetchEngineDevices: async () => ({ devices: [hdmiRxEntry()] }),
+		});
+		expect(hdmiSource()?.signal).toBe("absent");
+	});
+
+	test("an unchanged answer broadcasts NOTHING, so `sources` keeps its on-change cadence", async () => {
+		await seedHdmiCaps();
+		const answer = async () => ({
+			devices: [hdmiRxEntry(LOCKED_1080P5994)],
+		});
+		await recheckSourceSignals(observedHdmiRx(), {
+			fetchEngineDevices: answer,
+		});
+
+		const frames = await captureFrames(() =>
+			recheckSourceSignals(observedHdmiRx(), { fetchEngineDevices: answer }),
+		);
+		expect(frames.find((f) => "sources" in f)).toBeUndefined();
+	});
+
+	test("a probe that says nothing leaves the last-known view standing — it never republishes the coarse observation", async () => {
+		await seedHdmiCaps();
+		await recheckSourceSignals(observedHdmiRx(), {
+			fetchEngineDevices: async () => ({
+				devices: [hdmiRxEntry(LOCKED_1080P5994)],
+			}),
+		});
+
+		// Unlike a hotplug tick, this one detected no transition: with the engine
+		// unreachable there is nothing here worth publishing over its last answer.
+		const frames = await captureFrames(() =>
+			recheckSourceSignals(observedHdmiRx(), {
+				fetchEngineDevices: async () => {
+					throw new Error("engine unavailable");
+				},
+			}),
+		);
+
+		expect(frames.find((f) => "sources" in f)).toBeUndefined();
+		expect(hdmiSource()?.signal).toBe("present");
+		expect(getEngineDeviceCache()).toHaveLength(1);
+	});
+
+	test("membership still comes from the caller's observation, so a stale answer cannot resurrect an unplugged device", async () => {
+		await seedHdmiCaps();
+		getConfig().source = HDMI_RX_ID;
+		applyObservedEngineDevices([
+			{
+				input_id: HDMI_RX_ID,
+				device_path: HDMI_RX_ID,
+				display_name: "rk_hdmirx",
+				media_class: "video",
+				kind: "hdmi",
+			},
+		]);
+
+		// The registry no longer sees the node; the probe answers about a moment
+		// before it went away. The observation wins, exactly as on the hotplug path.
+		await recheckSourceSignals([], {
+			fetchEngineDevices: async () => ({
+				devices: [hdmiRxEntry(LOCKED_1080P5994)],
+			}),
+		});
+
+		expect(getEngineDeviceCache()).toHaveLength(0);
+		expect(hdmiSource()?.lost).toBe(true);
+	});
+});
+
+describe("device registry — signal recheck tick", () => {
+	function makeDeps(
+		overrides: Partial<DeviceRegistryDeps> = {},
+	): Partial<DeviceRegistryDeps> {
+		return {
+			listVideoCards: async () => ["video0"],
+			readCardName: async () => "rk_hdmirx",
+			getAudioSources: () => ({}),
+			getEngine: () => "cerastream",
+			isStreaming: () => false,
+			engineSwitch: async () => undefined,
+			// Idle: CeraUI holds no engine connection, so the registry's own poll is
+			// the local v4l2 scan — byte-identical on every tick forever.
+			getEngineDevices: async () => null,
+			getSelectedVideoInput: () => undefined,
+			clearSelectedVideoInput: () => undefined,
+			notify: () => undefined,
+			broadcast: () => undefined,
+			onDevicesChanged: () => undefined,
+			onSignalRecheck: () => undefined,
+			watch: (() => {
+				throw new Error("no /dev watch in tests");
+			}) as unknown as DeviceRegistryDeps["watch"],
+			now: () => 0,
+			pollMs: 10_000,
+			signalRecheckMs: 5,
+			logger: { debug() {}, warn() {}, error() {} },
+			...overrides,
+		};
+	}
+
+	test("fires on its interval even though the device set never changes, handing over the list it observed", async () => {
+		const onSignalRecheck = mock(() => undefined);
+		const onDevicesChanged = mock(() => undefined);
+		const registry = createDeviceRegistry(
+			makeDeps({ onSignalRecheck, onDevicesChanged }),
+		);
+
+		registry.start();
+		await Bun.sleep(40);
+		registry.stop();
+
+		expect(onSignalRecheck.mock.calls.length).toBeGreaterThan(0);
+		// The set was stable throughout, which is precisely why the hotplug trigger
+		// stayed silent and the recheck had to exist.
+		expect(onDevicesChanged).not.toHaveBeenCalled();
+		expect(onSignalRecheck.mock.calls[0]?.[0]).toEqual(registry.getDevices());
+	});
+
+	test("stop() clears the tick — a stopped registry never re-probes the engine", async () => {
+		const onSignalRecheck = mock(() => undefined);
+		const registry = createDeviceRegistry(makeDeps({ onSignalRecheck }));
+
+		registry.start();
+		await Bun.sleep(30);
+		registry.stop();
+		const afterStop = onSignalRecheck.mock.calls.length;
+
+		await Bun.sleep(30);
+		expect(onSignalRecheck.mock.calls.length).toBe(afterStop);
+	});
+});


### PR DESCRIPTION
## What

A capture input's `signal` verdict (`present`/`absent`/`unknown`, PR #216) is now
re-checked on a 5 s cadence instead of being computed once and latched.

- `constants.ts` — `VIDEO_SIGNAL_RECHECK_INTERVAL_MS = 5_000`.
- `devices.ts` — new `onSignalRecheck` registry dep plus a `signalRecheckMs`
  interval armed in `start()` and cleared in `stop()`. It fires unconditionally,
  because the change it exists to catch is invisible to every other detector.
- `sources.ts` — `recheckSourceSignals(observed)`: re-probe the engine, commit,
  and broadcast only on change (`broadcastSourcesIfChanged`).
- New suite `tests/hdmi-signal-recheck.test.ts` (8 tests).
- Contract written up in `apps/backend/AGENTS.md` and root `AGENTS.md`.

## Why

An operator reported an HDMI port stuck on "No signal" while it carried a locked
1080p59.94. The engine was right and was never at fault — the evidence chain,
captured live on a Rock 5B+:

1. **Kernel** — `v4l2-ctl --query-dv-timings` → `1920x1080`, `148356000 Hz (59.94 fps)`.
2. **dmesg** — `hdmirx_query_dv_timings port has no link!` ×3 spanning CeraUI's
   boot, then at 04:29:16 a phy retrain → `signal lock ok` →
   `New format: 1920x1080p59.94`.
3. **Engine** — `list-devices` at 05:05 already reported
   `caps: [{1920x1080, "60000/1001"}]`. `probe_dv_timings` runs per `list-devices`,
   so the ENOLINK → locked transition is answered on the very next call.
4. **UI** — still "No signal", ~45 minutes after the lock.

So: not a parsing bug, not a stale engine probe. **Nothing re-asked the engine.**
`fromEngineDevice` maps zero caps to `signal: 'absent'` (correct — cerastream
drops a signal-less receiver's degenerate range caps entirely), and that verdict
reaches the UI through the `sources` cache, which is rebuilt on exactly three
triggers: boot, engine reconnect, and a device-SET change. A signal lock is none
of them — same node, same `input_id`, same place in the set. And while idle
nothing else can help either: `listDevicesIfActive()` returns `null` with no live
control session, so the registry's 2 s poll is a local v4l2 scan whose output is
byte-identical every tick forever. The 04:22 retraining answer was latched
permanently.

**Device-agnostic by construction.** No driver name, controller string, node path
or HDMI special case appears anywhere in the new path — it re-reads whatever the
engine's own `VIDIOC_QUERY_DV_TIMINGS` result projected into `caps[]`, so any
device whose engine-reported caps change is picked up identically.

**Why here and not an engine-side event.** `Event::Device` exists on the wire but
has no emitter in `crates/cerastream/src` (the registry is wired to a `NullSink`),
and it keys on `GstDeviceMonitor` add/remove — which a signal lock does not
produce either. A new engine event would also need a binding republish, and
`@ceralive/cerastream` is pinned at 2026.7.3 against an engine already on schema
0.9.0.

`recheckSourceSignals` reuses `refreshSourcesForHotplug`'s membership rule,
metadata rule and generation fence verbatim, with two deliberate divergences:

- **A probe that says nothing changes nothing.** A hotplug tick must fall back to
  `observed` (it holds a detected removal a retained cache would mask); this tick
  holds no detected transition, so the same fallback would republish the scan's
  coarse guess over the engine's last real answer for no reason.
- **It broadcasts only on change**, so `sources` keeps its documented on-change
  cadence rather than pushing an identical snapshot every 5 s.

Please do not later "simplify" the two into one function — their probe-failure
branches must differ, and unifying them reintroduces the #214 class of bug.

## How to verify

- `bun run --filter backend test` → 2305 pass / 0 fail.
- `bun run --filter backend check` and `bunx tsc --noEmit` clean; `bunx biome check .` clean.
- Targeted: `bun test src/tests/hdmi-signal-recheck.test.ts` → 8/8, including the
  regression that matters — `absent` on the first probe, `present` on the second,
  with **no device-set change** in between. Negative control: removing the
  interval from `start()` makes the wiring test fail.
- **Live on hardware.** Deployed the rebuilt arm64 binary to a Rock 5B+ and forced
  a real HPD drop/restore with `v4l2-ctl --clear-edid` / `--set-edid` (EDID saved
  and restored; final state re-locked at 148352000 Hz). Kernel vs DOM on one clock:

  | UTC | kernel | UI badge |
  |---|---|---|
  | 05:20:48 | LOCKED | absent |
  | 05:20:51 | NO-SIGNAL | — |
  | 05:20:53 | — | **appears** (+2 s) |
  | 05:20:54 | LOCKED | — |
  | 05:20:58 | — | **clears** (+4 s) |

  Both directions inside one re-poll interval, no replug and no page reload — and
  critically the UI **recovered**, which was previously impossible.

## Risks

- **One extra engine round-trip per 5 s while a control session is live.** While
  idle there is no session, so `probeEngineDevices` short-circuits and the tick is
  nearly free. While streaming the tick is redundant-but-harmless: an engine-backed
  `getEngineDevices()` means a signal change already alters the device-SET
  serialization and the ordinary hotplug trigger fires too. Both paths commit the
  same engine-authored rows, so they cannot disagree.
- **No new `sources` traffic in the steady state.** `broadcastSourcesIfChanged`
  compares the serialized payload, so an unchanged snapshot is not sent. The
  new `lastBroadcastSources` module state is reset by `resetEngineDeviceCache()`
  alongside the other caches.
- Concurrency is covered by the existing generation fence, shared verbatim with
  the hotplug path — a slow probe answering after a newer one is discarded.
