### PR TITLE
fix(streaming): preserve cerastream start diagnostics

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -1499,3 +1499,12 @@ Coverage: `tests/netif-throughput-rate.test.ts`.
 - Don't leave a re-enumerated `config.source`/`config.asrc` unrepaired, and don't repair either by name, slot, or "whichever id resolves" — migration is by STABLE IDENTITY only (`reconcileConfiguredSourceIdentity` / `reconcileConfiguredAudioIdentity`), and the retired id must be published as `previousIds` so consumers can tell MOVED from GONE.
 - Don't let the v4l2 scan's `deriveKind()` guess overwrite a kind the engine has already reported for that device, and don't clear `lastEngineVideoDevices` when a device leaves the list — a `usb` guess bridges to no pipeline, so the row is dropped and its coarse slot renders "not connected" for a device that is physically present. Don't relax the display-name gate on the restore to an `input_id`-only lookup either: node paths are recycled, and a fabricated identity is worse than a coarse one.
 - Don't assert a GLOBAL call count on a process-wide seam like `helpers/run.ts` — `bun test` loads every file into ONE process, and background work started by an earlier file keeps issuing OS commands. `wifiUpdateDevices()` is the known offender: while any Wi-Fi adapter reads unavailable it re-arms itself every 3 s for a five-minute budget (`modules/wifi/wifi-interfaces.ts`), firing several `run("nmcli", …)` calls per pass. Filter the spy's calls to the binary under test instead (`logs-injection.test.ts`), which asserts the same property and cannot be flipped by a foreign command.
+## START-FAILURE DIAGNOSTICS [EXISTS]
+
+The typed `StartFailure` contract preserves the optional original diagnostic
+`message` alongside its stable `class` and `code`. `classifyStartFailure()` keeps
+cerastream JSON-RPC messages (including invalid-params `-32602` and internal
+`-32603` responses) generic and engine-authored; retry/terminal diagnostics and
+notification params carry the field to logs, and the frontend appends it to the
+localized start-failure toast. Do not replace this with an engine-code-specific
+or HDMI-specific mapping — the message is the generic diagnostic surface.

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -155,3 +155,9 @@ See [`docs/RPC_COMMUNICATION.md`](../../docs/RPC_COMMUNICATION.md) for the full 
 ## License
 
 GPL-3.0. See the [LICENSE](LICENSE) file for details.
+## Start-failure diagnostics
+
+Terminal start failures retain the engine's original diagnostic `message` beside
+the typed class/code. It is logged and carried in notification params, and the
+frontend includes it in the operator-facing failure toast, so JSON-RPC reasons
+such as an unavailable ALSA capture device are not reduced to `-32602` alone.

--- a/apps/backend/src/modules/streaming/start-failure-taxonomy.ts
+++ b/apps/backend/src/modules/streaming/start-failure-taxonomy.ts
@@ -89,6 +89,20 @@ function isZodLikeError(err: unknown): boolean {
 	);
 }
 
+function diagnosticMessage(error: unknown): string | undefined {
+	if (error instanceof Error && error.message.length > 0) return error.message;
+	if (typeof error !== "object" || error === null) return undefined;
+	const message = Reflect.get(error, "message");
+	return typeof message === "string" && message.length > 0
+		? message
+		: undefined;
+}
+
+function diagnosticMessageField(error: unknown): { message?: string } {
+	const message = diagnosticMessage(error);
+	return message === undefined ? {} : { message };
+}
+
 export interface ClassifyDeps {
 	warn: (message: string, meta?: Record<string, unknown>) => void;
 }
@@ -110,12 +124,13 @@ export function classifyStartFailure(
 	attemptId: string,
 	deps: ClassifyDeps = defaultClassifyDeps,
 ): StartFailure {
-	const { cls, code } = classifyClass(phase, error, deps);
+	const { cls, code, message } = classifyClass(phase, error, deps);
 	return {
 		attemptId,
 		phase,
 		class: cls,
 		...(code !== undefined ? { code } : {}),
+		...(message !== undefined ? { message } : {}),
 		retriable: isRetriableStartFailure(cls, phase),
 	};
 }
@@ -145,16 +160,16 @@ function classifyClass(
 	phase: StartFailurePhase,
 	error: unknown,
 	deps: ClassifyDeps,
-): { cls: StartFailureClass; code?: number | string } {
+): { cls: StartFailureClass; code?: number | string; message?: string } {
 	// A timeout is always a timeout, whatever the phase — retriability is derived
 	// per-phase downstream (connect-only) so we don't decide it here.
 	if (error instanceof CerastreamTimeoutError) {
-		return { cls: "start_timeout" };
+		return { cls: "start_timeout", ...diagnosticMessageField(error) };
 	}
 
 	// A lost/unreachable control connection means the engine isn't answering.
 	if (error instanceof CerastreamConnectionError) {
-		return { cls: "engine_unavailable" };
+		return { cls: "engine_unavailable", ...diagnosticMessageField(error) };
 	}
 
 	// A structured engine error response — map by its numeric JSON-RPC code. The
@@ -164,10 +179,10 @@ function classifyClass(
 	if (error instanceof CerastreamRpcError) {
 		const mapped = RPC_CODE_TO_CLASS[error.code];
 		if (mapped !== undefined) {
-			return { cls: mapped, code: error.code };
+			return { cls: mapped, code: error.code, message: error.message };
 		}
 		// A real engine error with an unknown code is an engine-side fault.
-		return { cls: "engine_internal", code: error.code };
+		return { cls: "engine_internal", code: error.code, message: error.message };
 	}
 
 	// A Zod validation failure: params-phase → invalid config; hello-phase →
@@ -175,6 +190,7 @@ function classifyClass(
 	if (isZodLikeError(error)) {
 		return {
 			cls: phase === "hello" ? "protocol_incompatible" : "start_invalid",
+			...diagnosticMessageField(error),
 		};
 	}
 
@@ -183,7 +199,7 @@ function classifyClass(
 		error instanceof Error &&
 		(phase === "params" || phase === "spawn-sender")
 	) {
-		return { cls: "start_invalid" };
+		return { cls: "start_invalid", ...diagnosticMessageField(error) };
 	}
 
 	// Unmapped/opaque — never throw. Bucket as engine_internal + a warning so the
@@ -191,8 +207,11 @@ function classifyClass(
 	deps.warn("start-failure-taxonomy: unmapped error shape → engine_internal", {
 		phase,
 		errorName: error instanceof Error ? error.name : typeof error,
+		...(diagnosticMessage(error) !== undefined
+			? { message: diagnosticMessage(error) }
+			: {}),
 	});
-	return { cls: "engine_internal" };
+	return { cls: "engine_internal", ...diagnosticMessageField(error) };
 }
 
 // ─── (d) Retry policy — bounded exponential backoff, retriable classes only ──

--- a/apps/backend/src/modules/streaming/stream-start-retry-reporting.ts
+++ b/apps/backend/src/modules/streaming/stream-start-retry-reporting.ts
@@ -63,6 +63,9 @@ function notificationParams(
 		phase: diagnostic.phase,
 		class: diagnostic.class,
 		...(diagnostic.code !== undefined ? { code: diagnostic.code } : {}),
+		...(diagnostic.message !== undefined
+			? { message: diagnostic.message }
+			: {}),
 		retryState: diagnostic.retry.state,
 		attempt: diagnostic.retry.attempt,
 		maxAttempts: diagnostic.retry.maxAttempts,

--- a/apps/backend/src/modules/streaming/stream-start-retry.ts
+++ b/apps/backend/src/modules/streaming/stream-start-retry.ts
@@ -21,6 +21,7 @@ export type StartRetryDiagnostic = {
 	readonly phase: StartFailurePhase;
 	readonly class: StartFailureClass;
 	readonly code?: number | string;
+	readonly message?: string;
 	readonly retry:
 		| {
 				readonly state: "scheduled";
@@ -186,6 +187,7 @@ function diagnostic(
 		phase: failure.phase,
 		class: failure.class,
 		...(failure.code !== undefined ? { code: failure.code } : {}),
+		...(failure.message !== undefined ? { message: failure.message } : {}),
 		retry,
 	};
 }

--- a/apps/backend/src/tests/start-failure-taxonomy.test.ts
+++ b/apps/backend/src/tests/start-failure-taxonomy.test.ts
@@ -210,6 +210,22 @@ describe("classifyStartFailure — table over every known failure site", () => {
 		});
 	}
 
+	test("preserves the descriptive JSON-RPC message alongside code and class", () => {
+		const message =
+			"invalid params: audio-device-unavailable: ALSA capture device 'hw:CARD=rockchiphdmiin' is busy or unavailable";
+		const failure = classifyStartFailure(
+			"start-rpc",
+			new CerastreamRpcError(-32602, message, "cerastream.params.invalid"),
+			"att_diagnostic",
+		);
+
+		expect(failure).toMatchObject({
+			class: "start_invalid",
+			code: -32602,
+			message,
+		});
+	});
+
 	test("an unmapped/opaque error falls to engine_internal + a logged warning, never throws", () => {
 		const warnings: string[] = [];
 		const failure = classifyStartFailure(

--- a/apps/frontend/src/main/LiveView.svelte
+++ b/apps/frontend/src/main/LiveView.svelte
@@ -233,6 +233,7 @@ function startFailedMessage(code: string): string {
 function startFailureMessage(failure: {
 	class: string;
 	retriable: boolean;
+	message?: string;
 }): string {
 	const cls = $LL.live.startFailure.class[
 		failure.class as keyof (typeof $LL.live.startFailure)['class']
@@ -241,7 +242,7 @@ function startFailureMessage(failure: {
 	const retryState = failure.retriable
 		? $LL.live.startFailure.retriedThenFailed()
 		: $LL.live.startFailure.notRetriable();
-	return `${reason} ${retryState}`;
+	return `${reason} ${retryState}${failure.message ? `: ${failure.message}` : ""}`;
 }
 
 // Show error toast if start failed. Prefer the typed failure (class + retry

--- a/apps/frontend/src/tests/live-start-failed-reason.test.ts
+++ b/apps/frontend/src/tests/live-start-failed-reason.test.ts
@@ -8,7 +8,13 @@ import en from "../../../../packages/i18n/src/en/index";
 const state = vi.hoisted(() => ({
 	stopReason: undefined as string | undefined,
 	failure: undefined as
-		| { class: string; phase: string; retriable: boolean; attemptId: string }
+		| {
+				class: string;
+				phase: string;
+				retriable: boolean;
+				attemptId: string;
+				message?: string;
+		  }
 		| undefined,
 }));
 const toastError = vi.hoisted(() => vi.fn());
@@ -161,6 +167,24 @@ describe("LiveView typed start-failure rendering (Todo 29)", () => {
 		expect(toastError).toHaveBeenCalledTimes(1);
 		expect(toastError).toHaveBeenCalledWith(
 			`${startFailure.class.engine_internal} ${startFailure.notRetriable}`,
+		);
+	});
+
+	it("includes the descriptive engine message in the typed failure toast", async () => {
+		state.failure = {
+			class: "start_invalid",
+			phase: "start-rpc",
+			retriable: false,
+			attemptId: "att_d",
+			message:
+				"invalid params: audio-device-unavailable: ALSA capture device is busy",
+		};
+
+		render(LiveView);
+		await tick();
+
+		expect(toastError).toHaveBeenCalledWith(
+			`${startFailure.class.start_invalid} ${startFailure.notRetriable}: invalid params: audio-device-unavailable: ALSA capture device is busy`,
 		);
 	});
 });

--- a/packages/rpc/src/schemas/streaming-lifecycle.schema.ts
+++ b/packages/rpc/src/schemas/streaming-lifecycle.schema.ts
@@ -80,6 +80,7 @@ export const startFailureSchema = z.object({
 	phase: startFailurePhaseSchema,
 	class: startFailureClassSchema,
 	code: z.union([z.number(), z.string()]).optional(),
+	message: z.string().optional(),
 	retriable: z.boolean(),
 });
 export type StartFailure = z.infer<typeof startFailureSchema>;


### PR DESCRIPTION
## What
Preserve cerastream JSON-RPC start-failure messages through CeraUI's typed failure taxonomy, retry diagnostics, notifications, logs, and operator toast.

## Why
CeraUI previously reduced descriptive engine refusals such as `-32602 invalid params: audio-device-unavailable...` to only `start_invalid`/`-32602`, hiding the actionable diagnosis.

## How to verify
- `bun test` in `apps/backend`
- `bun test packages/rpc`
- `NODE_OPTIONS=--localstorage-file=... bun run --filter frontend test`
- `bun tsc --noEmit` in `apps/backend`
- `bunx biome check .`
- ARM64 build and real-board RPC start failure confirmed the full HDMI/ALSA message in the response and `debug.log`.
- GitHub Actions required checks must pass before merge.

## Risks
Additive optional `StartFailure.message` field; class/code taxonomy and legacy error behavior remain unchanged. No engine-specific or HDMI-specific branching.