### PR TITLE
fix(streaming): distinguish a connection's own lifecycle from the session's

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -30,6 +30,9 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 | Transactional launch cleanup + phase/stop deadlines | `modules/streaming/launch-transaction.ts`, `start-lifecycle-timing.ts`, `streamloop/start-stream.ts`; contract in `../../docs/START-LIFECYCLE.md` |
 | Bounded start retry + suppression + diagnostics | `modules/streaming/stream-start-retry.ts`, `stream-start-retry-reporting.ts` |
 | Pre-engine gate deadline deferral (`pendingGateRemainingMs` ← `asrcProbeRemainingMs`) | `modules/streaming/stream-start-retry.ts` + `modules/streaming/audio.ts`; contract in `../../AGENTS.md` → STREAMING BACKEND QUALITY |
+| Raw `active_encode` bridge (passthrough + frame-liveness the typed client strips) | `modules/streaming/active-passthrough.ts`; cache-lifetime contract below → RAW `active_encode` BRIDGE |
+| Engine restarted mid-session (session control connection dropped → retire the session so the next start works) | `modules/streaming/cerastream-backend.ts` (`noteConnectionLoss`, `withSessionClient`, `onSessionConnectionLost`); contract below → SESSION CONTROL CONNECTION |
+| Stream health rollup (`frames.advancing` freshness window, idle/dead/degraded/healthy) | `modules/streaming/health.ts` (`collectRealLiveness`, `deriveFramesAdvancing`, `FRAMES_FRESHNESS_MS`) |
 | WebSocket server wiring | `modules/ui/websocket-server.ts` + `rpc/server.ts` |
 | Auth token logic | `modules/ui/auth.ts` + `rpc/middleware/auth.middleware.ts` |
 | PASETO device-token verification (relay-config + device-control, ADR-0006) | `modules/pairing/device-token.ts` — `verifyDeviceControlToken`, `resolveControlChannelEndpoint` |
@@ -354,6 +357,46 @@ The gate itself is unchanged: a level whose `source.identity` names a different 
 than the preference is still dropped. Only the reason string and the retry behaviour
 moved. `AudioLevelMeter` needed no change — it already indexes
 `$LL.live.preview.audioUnavailableReason[reason]()`.
+
+**"No audio" is NOT "Auto", and only the picker value can tell them apart.**
+`resolveMeterPreference` answers `null` for both, and `null` on the wire means
+"engine, choose for yourself" — so the one pick that means *meter nothing* made the
+engine auto-pick a card AND left `isForeignCardLevel` unarmed (it returns `false` for
+a `null` preference by design). The meter therefore rendered another card's real,
+moving audio under an "Audio source: No audio" label. Found live in Wave H QA; it read
+as a transient "few seconds of green bars" only because PR #232's frozen-content
+watchdog happened to age the bars out once that card's content stopped changing.
+`isMeterSilencedByPick(asrc)` (`audio.ts`, true for `NO_AUDIO_ID` alone) is the
+distinction, and `projectLevel` applies it BEFORE every other branch — including the
+engine's own `unavailable` reason, because the operator's explicit silence outranks
+whatever gap the engine is reporting. It reuses the existing `mode_none` reason
+(`resolveAudioMode("No audio")` is literally `{mode:"none"}`), so no schema or locale
+change was needed. `DEFAULT_AUDIO_ID` and `AUDIO_SOURCE_AUTO` are deliberately NOT
+silenced — both hand sourcing to the engine, so whatever it picks IS the operator's
+meter.
+
+**A pick change retires the level already on screen, without waiting for a frame.**
+Every gate above acts on the NEXT event the engine sends, and the engine needs a
+moment to re-point its sidecar — so between the config write and that event the meter
+keeps drawing the PREVIOUS device's bars. `noteMeterSelection()` broadcasts the gap
+immediately on a changed pick: `mode_none` when the new pick is silenced, `handoff`
+otherwise. Three properties are load-bearing:
+
+- **The change key is the PAIR** `(silenced, preference)` — "Auto" and "No audio" both
+  resolve to a `null` preference, so a preference-only diff cannot see that switch.
+- **It fires even while the bridge is disconnected.** `syncAudioMeterPreference()`
+  calls it BEFORE the client check: the stale level was already broadcast, so it must
+  be retired whether or not the engine can be told about the change yet.
+- **It never fires on the first connect** (no prior selection recorded ⇒ nothing has
+  been shown) nor on a re-enumeration that re-syncs an UNCHANGED pick — otherwise
+  `updateAudioDevices` would blink the meter on every hotplug.
+
+This is a re-evaluation, never a pin: the very next real level replaces the gap.
+
+Coverage for both: `tests/audio-meter-bridge.test.ts` (the silenced pick vs. Auto at
+the same `null` preference, the engine-reason override, no re-assert while silenced,
+the switching gap before any frame, the Auto→No-audio pair key, the unchanged-pick and
+first-connect silences, the disconnected path, and the hand-back to the new device).
 
 Coverage: `tests/audio-meter-bridge.test.ts` (push on connect, `null` for Auto, re-push
 on change, nothing sent to a pre-0.9.0 engine, a refused reload leaves levels flowing,
@@ -1515,6 +1558,122 @@ for stream telemetry: the HUD's stream-gated `throughputKbps` is unchanged, and
 
 Coverage: `tests/netif-throughput-rate.test.ts`.
 
+## RAW `active_encode` BRIDGE — SESSION vs CONNECTION LIFETIME [EXISTS]
+
+`modules/streaming/active-passthrough.ts` holds its OWN persistent control-socket
+connection, separate from the streaming session's, purely to read the raw
+`active_encode` fields the published `@ceralive/cerastream` client Zod-strips
+(`passthrough`, `frames_emitted`, `pipeline_playing`). Both caches it keeps
+describe the SESSION — what the engine is encoding — not that socket.
+
+**Those are different lifetimes, and conflating them made health lie.** The
+bridge's `close`/`error` fire on any transient reconnect (engine restart, socket
+hiccup, a read that outlived its window) — none of which says anything about
+whether video is flowing. Clearing `cachedLiveness` there erased a REAL,
+correctly-stalled frame counter, and `collectRealLiveness()` (`health.ts`) read
+the resulting `undefined` as the genuine COLD-START case and fell back to
+`processAlive` — which only reports that the supervised OS process has not
+crashed. Confirmed live during a Wave H HDMI mid-stream unplug drill: health
+reported the frozen counter as `degraded` for several seconds, then flipped to
+`state: "healthy"`, `frames: {advancing: true, count: null}` the instant the
+bridge reconnected — while a local SRT receiver had already errored out
+(`Error during demuxing: Input/output error`) and the kernel reported
+`power_present: 0`. The wipe also BYPASSED `FRAMES_FRESHNESS_MS`, the mechanism
+that exists precisely to age a stale reading into `advancing: false`.
+
+The caches are therefore cleared at SESSION boundaries only, and there are
+exactly three:
+
+| Seam | Why it is a boundary |
+|------|----------------------|
+| `readStreamingFalse(msg)` in `onLine` | an engine-AUTHORED status event saying the session ended — ground truth, clears immediately |
+| `startStream()` (beside `clearStreamProcessExit()`) | a new session must not inherit the previous one's counter; the bridge holds its connection across a stop/start, so nothing else retires it |
+| `stopActivePassthroughBridge()` | process teardown — nothing left to describe |
+
+A dropped socket is NOT one of them. The retained reading ages out on its own:
+`lastStatusAtMs` stops advancing and `health.ts`'s freshness window turns it into
+`advancing: false` (degraded) — the honest verdict, and the one the wipe was
+preventing from ever running. `cachedPassthrough` follows the same rule for the
+same reason (a blip used to drop the "Passthrough active" state mid-session);
+it is overlaid onto `active_encode` only when the engine telemetry already
+carries one, so a retained value can never outlive a stopped session on the wire.
+
+The cold-start fallback itself is CORRECT and must not be "fixed": on a stream's
+very first heartbeat window no frame telemetry exists to judge advancement, so
+raw process liveness is the only honest signal available.
+
+Coverage: `tests/liveness-bridge-reconnect.test.ts` (the blip drives the real
+`close`/`error` handlers over an injected socket; the engine-authored stop, the
+fresh-start reset, and both cold-start cases are the controls).
+
+## SESSION CONTROL CONNECTION — A DROP *IS* A SESSION BOUNDARY [EXISTS]
+
+The exact inverse of the rule above, for a different connection. Read both
+together: the same event (a socket closing) carries opposite authority depending
+on what the socket is FOR.
+
+`cerastream-backend.ts`'s `this.client` is opened once in `start()` and held for
+the session's whole lifetime. It is dialled with the published client's
+`autoReconnect` at its default (**false**), and that client — inspected in the
+shipped `dist/client.js`, v2026.7.3 — exposes **no** close/error event, **no**
+`isConnected()`, and **no** `reconnect()`. Once its Unix socket drops, the
+instance is permanently unusable: `rawRequest` short-circuits on `if (!socket)`
+and every later call rejects `CerastreamConnectionError("control connection is
+not open", code "closed")`. Only a fresh `connect()` produces a usable client.
+
+**Nothing was watching, and three things compounded.** Confirmed live in Wave H:
+`cerastream.service` restarted mid-session and CeraUI never noticed for 11+
+minutes.
+
+1. `switchInput` (and `switchAudio` / `setBitrate` / `reloadConfig` /
+   `reloadAudioDelay` / `listDevicesIfActive`) kept dispatching onto the dead
+   client, rejecting identically forever, changing no state.
+2. `reconcileRuntimeState()` short-circuits on
+   `telemetry !== null && this.client !== undefined` — it treated a **dead client
+   as proof of a live session** and re-affirmed `"streaming"` from the last stale
+   heartbeat, so even the `engine-reconnect.ts` heal path's
+   `reconcileStreamSession()` could not correct it.
+3. `is_streaming` therefore stayed true and the lifecycle stayed `streaming`, so
+   a fresh `streaming.start` was inadmissible; forced through, an engine with no
+   memory of the session answered an RPC error classified `engine_internal`.
+
+`engine-reconnect.ts` does NOT cover this: it SETTLES (`state.stopped = true`)
+once the engine is reachable at boot and never re-arms, and it heals the
+capability probe — a short-lived connection — not a session's dedicated one.
+
+**The rule.** cerastream is systemd-owned (ADR-0005), so a dropped control
+connection means the process CeraUI was driving went away; a restarted engine has
+no memory of the session, and the client cannot re-establish one. The socket is
+the ONLY handle on the engine-side pipeline, so losing it retires the session.
+
+`noteConnectionLoss(client, error, site)` is the single seam. It acts only on
+PROOF — a `CerastreamConnectionError` from the client we are STILL holding, for a
+session we still believe is `active`. An engine RPC error, a request timeout, a
+rejection from an already-superseded client, and our own `stop()`'s close (which
+clears `active` first) are all deliberately NOT proof.
+
+| Concern | Rule |
+|---------|------|
+| Detection (proactive) | `listDevicesIfActive()` — the device registry re-polls it every couple of seconds for the whole session, so it is the first call to touch a dead socket. **No watchdog timer**, so nothing can mis-fire on a missed heartbeat. |
+| Detection (on demand) | `withSessionClient(site, op)` wraps every session-scoped RPC; the caller still receives its ORIGINAL error, this only adds the missing state change. `handleOpFailure` covers the queued ops. |
+| Order | The dead client is dropped FIRST (see cause 2 above), with the subscription and telemetry, then `bridge.broadcastStatus()`. |
+| `active` | Deliberately LEFT SET, so `stop()` still recognises the session it must tear down — clearing it makes `stop()` return `false` and trips `reportSessionInvariant`. |
+| Reaction | `deps.onSessionConnectionLost(site)`. Production wiring raises the EXISTING `engine-crashed` lifecycle indicator (before the stop, since the reporter is gated on `isStreaming`), then retires the session via `stopStreamSession()` — its single owner. Fire-and-forget: it runs inside a rejected RPC's catch and must never replace the caller's error. |
+
+Net effect: the board lands in a real `idle` and the next `streaming.start` dials
+a fresh connection and succeeds — no `ceralive.service` restart.
+
+**Scoped OUT, deliberately:** there is no transparent mid-session reconnect that
+resumes the running stream. It is not achievable against this engine — a
+restarted cerastream has no session to resume — and would need engine-side
+session recovery first. The stream ends; the operator restarts it.
+
+Coverage: `tests/engine-session-connection-loss.test.ts` (dead-connection
+`switchInput` retires once and only once, the registry poll detects it with no
+operator action, a fresh start dials a NEW client and works, reconciliation stops
+re-affirming the phantom session, and the orchestrator re-admits a start; the RPC
+error and operator-stop negatives are the controls, green on both trees).
+
 ## ANTI-PATTERNS
 
 - Don't import from `@ceralive/srtla` — that package is retired from CeraUI. Use `@ceralive/srtla-send` (the `srtla-send-rs` binding, registry dep). Check `../../../srtla-send-rs/AGENTS.md` before touching call sites.
@@ -1534,7 +1693,11 @@ Coverage: `tests/netif-throughput-rate.test.ts`.
 - Don't send the idle-meter preference through the typed `reloadConfig()` — the published client Zod-strips `audio.meter_device`; it goes over `rawRequest` behind `supportsMeterDevicePreference`. And don't send `undefined` for "Auto": absent means *unchanged*, `null` means Auto.
 - Don't report a suppressed foreign-card level as `no_device` when CeraUI still lists the selected card AND that card owns a capture PCM (`isMeterPreferenceDevicePresent()`) — that makes a mis-bound meter indistinguishable from an unplugged cable — and don't try to fix a sustained mismatch by re-pushing the same preference value: `set_preferred_device` early-returns on an unchanged value, so the re-assert must pass through `null`.
 - Don't equate "the card is in `audioDevices`" with "the card can deliver audio" — a permanently-enumerated input with no capture PCM (idle HDMI-RX) is genuinely `no_device`, not `not_selected_device`. Gate presence on `audioCaptureCardIds`/`hasCapturePcmNode`, and don't "simplify" that by filtering the card out of the picker instead.
+- Don't infer "the operator wants no meter" from a `null` meter preference — `null` is ALSO "Auto", which legitimately meters whatever the engine picks. Ask `isMeterSilencedByPick()`, key the selection-change detection on the `(silenced, preference)` PAIR, and don't let an engine-sent `unavailable` reason outrank an explicit "No audio".
+- Don't leave a pick change to be corrected by the next engine frame — the level already broadcast belongs to the previous pick, so `noteMeterSelection()` must retire it immediately (and must stay silent on an unchanged pick, or every re-enumeration blinks the meter).
 - Don't fold `active_encode` into telemetry preserve-on-omission past the end of a session, and don't let `stop()` rely on a final engine status frame to clear it — a crashed engine sends none, and the stale encode then renders the stopped session under a "Live" badge.
+- Don't clear the raw bridge's `cachedLiveness`/`cachedPassthrough` from its own socket `close`/`error` — that is a CONNECTION blip, not a session boundary, and wiping there hands `collectRealLiveness()` an `undefined` it can only read as a cold start, so a dead stream reports `healthy` off raw process liveness. Let `FRAMES_FRESHNESS_MS` age the retained reading out instead.
+- Don't apply that same rule to the SESSION-scoped control client — it is the inverse case. Losing `cerastream-backend.ts`'s `this.client` retires the session (the published client cannot reconnect and a restarted engine has no session to resume), so route every session RPC through `withSessionClient` and never swallow a `CerastreamConnectionError` without calling `noteConnectionLoss`. And don't treat `this.client !== undefined` as evidence the engine is reachable — that is exactly how `reconcileRuntimeState()` re-affirmed a phantom "streaming" state off stale telemetry until the backend was restarted.
 - Don't re-add stderr regex on the cerastream path — engine errors are structured
   codes mapped via `cerastream-error-mapping.ts`.
 - Don't wire `@ceralive/cerastream` as a sibling `link:` or vendored `.tgz` — it

--- a/apps/backend/src/modules/streaming/active-passthrough.ts
+++ b/apps/backend/src/modules/streaming/active-passthrough.ts
@@ -36,6 +36,36 @@
  *     rollup consumes (a monotonic counter increasing across two consecutive status
  *     heartbeats = advancing; a flat counter = a stalled encode). Idle/legacy → the
  *     cache is cleared/absent so the fields simply stay undefined.
+ *
+ * WHAT CLEARS THE CACHES — a SESSION boundary, never a CONNECTION blip.
+ *
+ * Both caches describe the SESSION (what the engine is encoding), not this
+ * module's socket (how we happen to be reading it). Those are different
+ * lifetimes, and conflating them made the health rollup lie: this bridge holds
+ * its OWN persistent connection, so its `close`/`error` fire on any transient
+ * reconnect — an engine restart, a socket hiccup, a slow read — none of which
+ * says anything about whether video is still flowing. Wiping `cachedLiveness`
+ * there erased a REAL, correctly-stalled frame counter, and `collectRealLiveness`
+ * read the resulting `undefined` as the genuine cold-start case and fell back to
+ * raw process liveness. Confirmed live during a Wave H HDMI mid-stream unplug:
+ * health reported the frozen counter as `degraded` for several seconds, then
+ * flipped to `state: "healthy"`, `frames: {advancing: true, count: null}` the
+ * instant the bridge reconnected — while the receiver had already errored out
+ * and the kernel reported no HDMI signal at all.
+ *
+ * So the ONLY clearing paths are:
+ *
+ *   - `readStreamingFalse(msg)` in `onLine` — an engine-AUTHORED status event
+ *     saying the session ended. That is ground truth and clears immediately.
+ *   - a fresh stream start (`streamloop/start-stream.ts`, beside
+ *     `clearStreamProcessExit()`) — so a new session never inherits the previous
+ *     one's counter.
+ *   - `stopActivePassthroughBridge()` — process teardown, nothing left to describe.
+ *
+ * A dropped socket is NOT one of them. The retained reading ages out on its own:
+ * `lastStatusAtMs` stops advancing, and `health.ts`'s `FRAMES_FRESHNESS_MS`
+ * window turns it into `advancing: false` (degraded) — the honest verdict, and
+ * the mechanism the cache wipe was bypassing.
  */
 
 import { join } from "node:path";
@@ -98,7 +128,7 @@ export function getActivePassthrough(): boolean | undefined {
 	return cachedPassthrough;
 }
 
-/** Test/teardown seam: drop the cached value. */
+/** Session-boundary/teardown seam: drop the cached value. */
 export function resetActivePassthrough(): void {
 	cachedPassthrough = undefined;
 }
@@ -169,7 +199,11 @@ export function getActiveEncodeLiveness(): ActiveEncodeLiveness | undefined {
 	return cachedLiveness;
 }
 
-/** Test/teardown seam: drop the cached liveness telemetry. */
+/**
+ * Session-boundary/teardown seam: drop the cached liveness telemetry. Called by
+ * a fresh stream start so a new session cannot inherit the previous session's
+ * frame counter. NOT a reconnect hook — see the module header.
+ */
 export function resetActiveEncodeLiveness(): void {
 	cachedLiveness = undefined;
 }
@@ -263,6 +297,9 @@ export function startActivePassthroughBridge(
 			} catch {
 				return;
 			}
+			// A genuine session boundary, authored by the engine itself: the stream
+			// is over, so the cached session state describes nothing and is dropped
+			// at once. This is the ONLY mid-run clearing path (see the module header).
 			if (readStreamingFalse(msg)) {
 				cachedPassthrough = undefined;
 				cachedLiveness = undefined;
@@ -286,16 +323,15 @@ export function startActivePassthroughBridge(
 							nl = buffer.indexOf("\n");
 						}
 					},
+					// Losing THIS socket says nothing about the session behind it, so
+					// neither cache is touched — the retained reading ages out through
+					// `health.ts`'s freshness window instead (see the module header).
 					close: () => {
-						cachedPassthrough = undefined;
-						cachedLiveness = undefined;
 						activeSocket = undefined;
 						if (!stopRequested) deps.onEngineReachable(false);
 						scheduleReconnect();
 					},
 					error: () => {
-						cachedPassthrough = undefined;
-						cachedLiveness = undefined;
 						activeSocket = undefined;
 						if (!stopRequested) deps.onEngineReachable(false);
 					},

--- a/apps/backend/src/modules/streaming/cerastream-backend.ts
+++ b/apps/backend/src/modules/streaming/cerastream-backend.ts
@@ -31,6 +31,38 @@
 // never spawns it, so `start`/`stop` drive the pipeline over IPC rather than an OS
 // process. Every effectful collaborator is injected (`CerastreamBackendDeps`) so
 // the contract suite drives a real backend against an in-memory fake client.
+//
+// THE SESSION-SCOPED CONTROL CONNECTION *IS* THE SESSION.
+//
+// `this.client` is opened once, in `start()`, and held for the session's whole
+// lifetime. The published `@ceralive/cerastream` client is dialled with
+// `autoReconnect` at its default (false) and exposes NO close/error event, no
+// `isConnected()`, and no `reconnect()` — so once its Unix socket drops, that
+// instance is permanently unusable and every later call rejects with
+// `CerastreamConnectionError("control connection is not open")`. Only a fresh
+// `connect()` produces a usable client.
+//
+// That is the OPPOSITE of the rule the raw `active_encode` bridge follows
+// (`active-passthrough.ts`): there the socket is a READER, so losing it says
+// nothing about the session and its caches must age out instead of being wiped.
+// Here the socket is the ONLY handle CeraUI has on the engine-side pipeline, and
+// cerastream is systemd-owned — a dropped control connection means the process we
+// were driving went away, and a restarted engine has no memory of the session.
+// So a proven-dead control connection IS a session boundary and must retire the
+// session. Confirmed live during Wave H: cerastream restarted mid-session, three
+// `switchInput` calls rejected with `control connection is not open`, and nothing
+// ever noticed — `is_streaming` stayed true, `reconcileRuntimeState()` kept
+// re-affirming "streaming" from stale telemetry (it trusts `this.client !==
+// undefined` as proof of a live session), and every later action failed until the
+// whole backend process was restarted.
+//
+// `noteConnectionLoss()` is the one seam that acts on it: it drops the dead
+// client + subscription + telemetry and hands off to `onSessionConnectionLost`,
+// whose production wiring raises the existing `engine-crashed` indicator and
+// retires the session through the orchestrator — so the device lands in a real
+// `idle` and the NEXT `streaming.start` dials a fresh connection and succeeds.
+// It is proven ONLY by a `CerastreamConnectionError` from the CURRENT session's
+// client (never a guess, never an engine RPC error, never a timeout).
 
 import { existsSync } from "node:fs";
 import {
@@ -146,6 +178,9 @@ export interface CerastreamBackendDeps {
 		delayMs: number,
 	) => ReturnType<typeof setTimeout>;
 	cancelTimeout: (timer: ReturnType<typeof setTimeout>) => void;
+	// Called at most ONCE per session, when the session's control connection is
+	// PROVEN dead (see the module header). `site` names the call that found it.
+	onSessionConnectionLost: (site: string) => void;
 }
 
 function defaultBridge(): CerastreamBridge {
@@ -354,6 +389,44 @@ export type StartParamsWithAudioMode = z.infer<
 	typeof startParamsWithAudioModeSchema
 >;
 
+/**
+ * Production reaction to a proven-dead session control connection: raise the
+ * existing `engine-crashed` indicator, then retire the session through its single
+ * owner (the orchestrator) so the device lands in a real `idle`.
+ *
+ * Order is load-bearing — `reportEngineState` is gated on `isStreaming` inside
+ * the reporter, so it has to run BEFORE the stop clears that flag or the operator
+ * is never told why their stream ended.
+ *
+ * Fire-and-forget by design: this runs from inside a rejected RPC's catch, and a
+ * teardown failure must never replace the error the caller is already handling.
+ * Imports are dynamic to keep the session/lifecycle graph off this module's load
+ * path (same posture as `defaultBridge`).
+ */
+function defaultOnSessionConnectionLost(site: string): void {
+	void (async () => {
+		try {
+			const [{ stopStreamSession }, { reportEngineState }, { getIsStreaming }] =
+				await Promise.all([
+					import("./stream-session-orchestrator.ts"),
+					import("./lifecycle-indicators.ts"),
+					import("./streaming.ts"),
+				]);
+			reportEngineState({ isStreaming: getIsStreaming(), reachable: false });
+			const stopped = await stopStreamSession();
+			defaultLogger.warn(
+				"cerastream: engine session retired after a control-connection loss",
+				{ site, stop: stopped.result },
+			);
+		} catch (err) {
+			defaultLogger.error(
+				"cerastream: could not retire the session after a control-connection loss",
+				{ site, err },
+			);
+		}
+	})();
+}
+
 function defaultCerastreamBackendDeps(): CerastreamBackendDeps {
 	return {
 		connect,
@@ -370,6 +443,7 @@ function defaultCerastreamBackendDeps(): CerastreamBackendDeps {
 		isEmbeddedAudioActive: isEmbeddedAudioPipeline,
 		scheduleTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
 		cancelTimeout: (timer) => clearTimeout(timer),
+		onSessionConnectionLost: defaultOnSessionConnectionLost,
 	};
 }
 
@@ -778,11 +852,15 @@ export class CerastreamBackend implements StreamingBackend {
 	// ---- additive cerastream-only RPC passthroughs (NOT on the frozen seam) ----
 
 	async switchInput(params: SwitchInputParams): Promise<SwitchInputResult> {
-		return this.requireClient().switchInput(params);
+		return this.withSessionClient("switch-input", (client) =>
+			client.switchInput(params),
+		);
 	}
 
 	async listDevices(params?: ListDevicesParams): Promise<ListDevicesResult> {
-		return this.requireClient().listDevices(params);
+		return this.withSessionClient("list-devices", (client) =>
+			client.listDevices(params),
+		);
 	}
 
 	/**
@@ -801,6 +879,10 @@ export class CerastreamBackend implements StreamingBackend {
 			this.deps.logger.debug("cerastream: registry listDevices failed", {
 				err,
 			});
+			// `devices.ts` re-polls this every couple of seconds for the whole
+			// session, so it is the first call to touch a dead control connection —
+			// which makes detection proactive with no watchdog timer to mis-fire.
+			this.noteConnectionLoss(client, err, "list-devices-poll");
 			return null;
 		}
 	}
@@ -811,28 +893,32 @@ export class CerastreamBackend implements StreamingBackend {
 	// ends with the bindings' exported schemas so the call stays contract-safe.
 	async switchAudio(params: SwitchAudioParams): Promise<SwitchAudioResult> {
 		const parsed = switchAudioParamsSchema.parse(params);
-		const client = this.requireClient() as unknown as {
-			rawRequest(method: string, params?: unknown): Promise<unknown>;
-		};
-		const raw = await client.rawRequest("switch-audio", parsed);
+		const raw = await this.withSessionClient("switch-audio", (client) =>
+			(
+				client as unknown as {
+					rawRequest(method: string, params?: unknown): Promise<unknown>;
+				}
+			).rawRequest("switch-audio", parsed),
+		);
 		return switchAudioResultSchema.parse(raw);
 	}
 
 	async reloadAudioDelay(delayMs: number): Promise<ReloadConfigResult> {
-		const client = this.requireClient();
-		if (supportsSignedReloadDelay(client.hello.schema_version)) {
-			return client.reloadConfig({ audio: { delay_ms_signed: delayMs } });
-		}
-		const applied = Math.max(0, delayMs);
-		this.deps.logger.info(
-			"cerastream: engine schema_version < 0.4.0 — sending legacy unsigned audio.delay_ms (clamped to >= 0)",
-			{
-				schemaVersion: client.hello.schema_version,
-				requested: delayMs,
-				applied,
-			},
-		);
-		return client.reloadConfig({ audio: { delay_ms: applied } });
+		return this.withSessionClient("reload-audio-delay", (client) => {
+			if (supportsSignedReloadDelay(client.hello.schema_version)) {
+				return client.reloadConfig({ audio: { delay_ms_signed: delayMs } });
+			}
+			const applied = Math.max(0, delayMs);
+			this.deps.logger.info(
+				"cerastream: engine schema_version < 0.4.0 — sending legacy unsigned audio.delay_ms (clamped to >= 0)",
+				{
+					schemaVersion: client.hello.schema_version,
+					requested: delayMs,
+					applied,
+				},
+			);
+			return client.reloadConfig({ audio: { delay_ms: applied } });
+		});
 	}
 
 	/** Test seam: resolve once every queued IPC op has settled. */
@@ -941,7 +1027,70 @@ export class CerastreamBackend implements StreamingBackend {
 			this.active = false;
 			this.client = undefined;
 			this.subscription = undefined;
+			return;
 		}
+		this.noteConnectionLoss(this.client, err, label);
+	}
+
+	/**
+	 * Run one session-scoped RPC and, when it fails because the control
+	 * connection is gone, retire the session before re-throwing. The caller still
+	 * sees its original error — this only adds the state change that was missing.
+	 */
+	private async withSessionClient<Result>(
+		site: string,
+		op: (client: CerastreamClient) => Promise<Result>,
+	): Promise<Result> {
+		const client = this.requireClient();
+		try {
+			return await op(client);
+		} catch (error) {
+			this.noteConnectionLoss(client, error, site);
+			throw error;
+		}
+	}
+
+	/**
+	 * Act on PROOF that the session's control connection is dead — a
+	 * `CerastreamConnectionError` raised by the client we are still holding for a
+	 * session we still believe is active. Anything else (an engine RPC error, a
+	 * request timeout, a rejection from an already-superseded client, a rejection
+	 * during our own `stop()`) is deliberately NOT proof and is ignored.
+	 *
+	 * The dead client is dropped FIRST: `this.client !== undefined` is what
+	 * `reconcileRuntimeState()` trusts as evidence of a live session, so leaving
+	 * it in place is exactly how a phantom "streaming" state kept re-affirming
+	 * itself from stale telemetry. Dropping it also makes the next reconcile do a
+	 * real probe, and makes every later session call fail fast and loudly instead
+	 * of re-dispatching onto a socket that will never answer.
+	 *
+	 * `active` is deliberately LEFT SET so `stop()` still recognises the session
+	 * it has to tear down (srtla_send is still running and still sending nothing).
+	 */
+	private noteConnectionLoss(
+		client: CerastreamClient | undefined,
+		error: unknown,
+		site: string,
+	): void {
+		if (!(error instanceof CerastreamConnectionError)) return;
+		if (client === undefined || client !== this.client) return;
+		if (!this.active) return;
+
+		this.deps.logger.error(
+			"cerastream: session control connection lost; retiring the engine session",
+			{ site, code: error.code, message: error.message },
+		);
+
+		try {
+			this.subscription?.close();
+		} catch {
+			// The subscription rides the same dead socket; closing it is best-effort.
+		}
+		this.subscription = undefined;
+		this.client = undefined;
+		this.telemetry = null;
+		this.deps.bridge.broadcastStatus();
+		this.deps.onSessionConnectionLost(site);
 	}
 
 	/**

--- a/apps/backend/src/modules/streaming/streamloop/start-stream.ts
+++ b/apps/backend/src/modules/streaming/streamloop/start-stream.ts
@@ -30,6 +30,10 @@ import { logger } from "../../../helpers/logger.ts";
 import { getConfig } from "../../config.ts";
 import { setup } from "../../setup.ts";
 import { notificationBroadcast } from "../../ui/notifications.ts";
+import {
+	resetActiveEncodeLiveness,
+	resetActivePassthrough,
+} from "../active-passthrough.ts";
 import { asrcProbe, isPseudoAudioSource } from "../audio.ts";
 import {
 	buildAutoLaunchConfig,
@@ -123,8 +127,14 @@ export async function startStream(
 	getStreamingBackend().setBitrate(launchConfig);
 
 	// A fresh stream start clears any prior unexpected-exit health flag so the
-	// health rollup tracks this new session (ADR-0005 observe-and-notify).
+	// health rollup tracks this new session (ADR-0005 observe-and-notify). The
+	// raw-bridge caches are dropped for the same reason: they describe the
+	// PREVIOUS session, and the bridge holds its connection across a stop/start,
+	// so nothing else would retire them. A new session must read as a genuine
+	// cold start until its own first heartbeat lands.
 	clearStreamProcessExit();
+	resetActiveEncodeLiveness();
+	resetActivePassthrough();
 
 	if (!(await maybeProbeAudioSource(pipeline, launchConfig, audioDeps))) {
 		logger.warn("startStream: audio source probe failed; aborting start", {

--- a/apps/backend/src/tests/engine-session-connection-loss.test.ts
+++ b/apps/backend/src/tests/engine-session-connection-loss.test.ts
@@ -1,0 +1,387 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+	CerastreamClient,
+	EventParams,
+	SwitchInputResult,
+} from "@ceralive/cerastream";
+import {
+	CerastreamConnectionError,
+	CerastreamRpcError,
+} from "@ceralive/cerastream";
+import type { RuntimeConfig } from "../helpers/config-schemas.ts";
+import {
+	CerastreamBackend,
+	type CerastreamBackendDeps,
+} from "../modules/streaming/cerastream-backend.ts";
+import { createStreamSessionOrchestrator } from "../modules/streaming/stream-session-orchestrator.ts";
+import type { StreamRunOptions } from "../modules/streaming/streaming-backend.ts";
+
+// Wave H, live device: `cerastream.service` restarted WHILE CeraUI believed a
+// session was active. The published client is dialled with autoReconnect off and
+// exposes no close event, so `this.client` stayed in place, permanently dead —
+// three consecutive `switchInput` calls rejected with "control connection is not
+// open", `reconcileRuntimeState()` kept re-affirming "streaming" off stale
+// telemetry (it trusts `client !== undefined`), and only a full
+// `systemctl restart ceralive.service` recovered the board.
+//
+// These cases pin the seam that fixes it: a CerastreamConnectionError from the
+// CURRENT session's client retires the session exactly once, and the NEXT start
+// dials a brand-new connection and succeeds.
+
+const RUN_OPTS: StreamRunOptions = {
+	pipeline: "hdmi",
+	host: "127.0.0.1",
+	port: 9000,
+	streamid: "stream-1",
+};
+
+const STREAM_CONFIG: RuntimeConfig = {
+	max_br: 8000,
+	srt_latency: 2000,
+	balancer: "adaptive",
+	pipeline: "h264_hdmi_1080p",
+};
+
+const silentLogger: CerastreamBackendDeps["logger"] = {
+	debug() {},
+	info() {},
+	warn() {},
+	error() {},
+};
+
+const DEAD_CONNECTION = (): CerastreamConnectionError =>
+	new CerastreamConnectionError(
+		"control connection is not open",
+		undefined,
+		"closed",
+	);
+
+interface FakeClient {
+	client: CerastreamClient;
+	calls: string[];
+	emit(event: EventParams): void;
+	/** Every later RPC on this instance rejects, as a dropped socket really does. */
+	killConnection(): void;
+	subscriptionClosed(): boolean;
+}
+
+function makeFakeClient(): FakeClient {
+	const calls: string[] = [];
+	let listener: ((event: EventParams) => void) | undefined;
+	let dead = false;
+	let subClosed = false;
+
+	const guard = <Result>(op: string, result: Result): Promise<Result> => {
+		calls.push(op);
+		if (dead) return Promise.reject(DEAD_CONNECTION());
+		return Promise.resolve(result);
+	};
+
+	const client: CerastreamClient = {
+		hello: {
+			protocol: "cerastream-ipc/1",
+			schema_version: "0.9.0",
+			engine_version: "test",
+		},
+		start: async () => guard("start", { session_id: "s1", state: "streaming" }),
+		stop: async () => guard("stop", { state: "idle" }),
+		reloadConfig: async (params) => guard("reload-config", { applied: params }),
+		setBitrate: async (params) =>
+			guard("set-bitrate", { applied: { max_bitrate: params.max_bitrate } }),
+		switchInput: async (params) =>
+			guard<SwitchInputResult>("switch-input", {
+				active_input: params.input_id,
+				mode: params.mode,
+			}),
+		listDevices: async () => guard("list-devices", { devices: [] }),
+		getCapabilities: async () =>
+			guard("get-capabilities", {
+				platform: {
+					supports_h265: true,
+					hardware_accelerated: true,
+					max_resolution: "1920x1080",
+				},
+				encoder: {
+					codecs: ["h264"],
+					bitrate_range: { min: 500, max: 50_000, unit: "kbps" as const },
+				},
+				sources: [],
+			}),
+		subscribeEvents: async (_params, eventListener) => {
+			calls.push("subscribe-events");
+			listener = eventListener;
+			return {
+				result: { subscribed: ["status"] },
+				close: () => {
+					subClosed = true;
+				},
+			};
+		},
+		previewSession: async () =>
+			guard("preview-session", {
+				session_id: "p1",
+				tier: "webcodecs" as const,
+				transport: {
+					kind: "uds-binary" as const,
+					socket: "/run/cerastream/preview.sock",
+				},
+			}),
+		close: async () => {
+			calls.push("close");
+		},
+	};
+	// The backend dispatches `start` (and `switch-audio`) over the raw JSON-RPC
+	// primitive whenever the engine advertises the additive fields, so the fake
+	// has to answer a real start result here too.
+	(client as unknown as Record<string, unknown>).rawRequest = async (
+		method: string,
+	) =>
+		guard(
+			method,
+			method === "start" ? { session_id: "s1", state: "streaming" } : {},
+		);
+
+	return {
+		client,
+		calls,
+		emit: (event) => listener?.(event),
+		killConnection: () => {
+			dead = true;
+		},
+		subscriptionClosed: () => subClosed,
+	};
+}
+
+interface Harness {
+	backend: CerastreamBackend;
+	clients: FakeClient[];
+	connectCount: () => number;
+	lostSites: string[];
+	broadcasts: () => number;
+}
+
+function makeHarness(): Harness {
+	const clients: FakeClient[] = [];
+	const lostSites: string[] = [];
+	let connects = 0;
+	let broadcasts = 0;
+	const backend = new CerastreamBackend({
+		connect: async () => {
+			connects += 1;
+			const next = makeFakeClient();
+			clients.push(next);
+			return next.client;
+		},
+		connectOptions: {},
+		getConfig: () => STREAM_CONFIG,
+		saveConfig: () => undefined,
+		bridge: {
+			notify: () => undefined,
+			notificationExists: () => false,
+			broadcastStatus: () => {
+				broadcasts += 1;
+			},
+			broadcastBuffering: () => undefined,
+		},
+		execPath: "cerastream",
+		configPath: "/tmp/cerastream-connection-loss.json",
+		logger: silentLogger,
+		onSessionConnectionLost: (site) => {
+			lostSites.push(site);
+		},
+	});
+	return {
+		backend,
+		clients,
+		connectCount: () => connects,
+		lostSites,
+		broadcasts: () => broadcasts,
+	};
+}
+
+function liveSession(h: Harness): FakeClient {
+	const session = h.clients[0];
+	if (session === undefined) throw new Error("no session client was connected");
+	return session;
+}
+
+describe("engine restart mid-session — the session control connection is the session", () => {
+	test("a switchInput onto a dead connection retires the session exactly once", async () => {
+		const h = makeHarness();
+		await h.backend.start(STREAM_CONFIG, RUN_OPTS);
+		await h.backend.settle();
+		const session = liveSession(h);
+
+		session.killConnection();
+
+		await expect(
+			h.backend.switchInput({ input_id: "cam2", mode: "manual" }),
+		).rejects.toThrow("control connection is not open");
+
+		expect(h.lostSites).toEqual(["switch-input"]);
+		expect(session.subscriptionClosed()).toBe(true);
+		expect(h.backend.getTelemetry()).toBeNull();
+
+		// The dead client is gone, so the next call fails fast at the seam instead
+		// of re-dispatching onto a socket that will never answer — and the session
+		// is NOT retired a second time.
+		await expect(
+			h.backend.switchInput({ input_id: "cam3", mode: "manual" }),
+		).rejects.toThrow("no active control connection");
+		expect(h.lostSites).toEqual(["switch-input"]);
+	});
+
+	test("the device-registry poll detects the loss without any operator action", async () => {
+		const h = makeHarness();
+		await h.backend.start(STREAM_CONFIG, RUN_OPTS);
+		await h.backend.settle();
+		liveSession(h).killConnection();
+
+		// listDevicesIfActive is the registry's every-few-seconds poll; it degrades
+		// to null by contract, but it must still report the loss.
+		await expect(h.backend.listDevicesIfActive()).resolves.toBeNull();
+		expect(h.lostSites).toEqual(["list-devices-poll"]);
+	});
+
+	test("a fresh start after the loss dials a NEW connection and succeeds", async () => {
+		const h = makeHarness();
+		await h.backend.start(STREAM_CONFIG, RUN_OPTS);
+		await h.backend.settle();
+		liveSession(h).killConnection();
+		await expect(h.backend.listDevicesIfActive()).resolves.toBeNull();
+
+		// The operator's recovery path: stop, then start. Both must work against an
+		// engine CeraUI can no longer reach through the retired client.
+		await new Promise<void>((resolve) => {
+			h.backend.stop(resolve);
+		});
+		await h.backend.settle();
+
+		await h.backend.start(STREAM_CONFIG, RUN_OPTS);
+		await h.backend.settle();
+
+		expect(h.connectCount()).toBe(2);
+		const revived = h.clients[1];
+		expect(revived?.calls).toContain("start");
+		await expect(
+			h.backend.switchInput({ input_id: "cam2", mode: "manual" }),
+		).resolves.toMatchObject({ active_input: "cam2" });
+	});
+
+	test("reconciliation stops re-affirming a phantom session from stale telemetry", async () => {
+		const h = makeHarness();
+		await h.backend.start(STREAM_CONFIG, RUN_OPTS);
+		await h.backend.settle();
+		const session = liveSession(h);
+
+		// A real streaming heartbeat lands, so telemetry says "streaming"…
+		session.emit({
+			type: "status",
+			seq: 1,
+			state: "streaming",
+			streaming: true,
+		} as EventParams);
+		expect(await h.backend.reconcileRuntimeState()).toBe("streaming");
+
+		// …then the engine goes away. The stale snapshot must no longer be able to
+		// re-affirm itself: reconciliation has to go back to the engine.
+		session.killConnection();
+		await expect(h.backend.listDevicesIfActive()).resolves.toBeNull();
+
+		const reconciled = await h.backend.reconcileRuntimeState();
+		expect(reconciled).not.toBe("streaming");
+		expect(h.connectCount()).toBe(2);
+	});
+
+	test("the retired session leaves the orchestrator able to admit a new start", async () => {
+		const h = makeHarness();
+		let streaming = false;
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: () => "att_reconnect",
+			setStreamingStatus: (next) => {
+				streaming = next;
+			},
+			getStreamingStatus: () => streaming,
+			stopRuntime: async () => {
+				await new Promise<void>((resolve) => {
+					h.backend.stop(resolve);
+				});
+			},
+			queryRuntime: () => h.backend.reconcileRuntimeState(),
+		});
+
+		const first = await orchestrator.start({
+			origin: "ui",
+			launch: async () => {
+				await h.backend.start(STREAM_CONFIG, RUN_OPTS);
+				await h.backend.settle();
+			},
+		});
+		expect(first.result).toBe("started");
+		expect(streaming).toBe(true);
+
+		liveSession(h).killConnection();
+		await expect(h.backend.listDevicesIfActive()).resolves.toBeNull();
+		expect(h.lostSites).toHaveLength(1);
+
+		// The production hook routes into exactly this stop; drive it here so the
+		// assertion is on the orchestrator's own recovery, not on the wiring.
+		await orchestrator.stop();
+		expect(streaming).toBe(false);
+		expect(orchestrator.snapshot().state).toBe("idle");
+
+		const second = await orchestrator.start({
+			origin: "ui",
+			launch: async () => {
+				await h.backend.start(STREAM_CONFIG, RUN_OPTS);
+				await h.backend.settle();
+			},
+		});
+		expect(second.result).toBe("started");
+	});
+});
+
+describe("what is NOT proof that the connection died", () => {
+	test("an engine RPC error leaves the session and its client intact", async () => {
+		const h = makeHarness();
+		await h.backend.start(STREAM_CONFIG, RUN_OPTS);
+		await h.backend.settle();
+		const session = liveSession(h);
+		const original = session.client.switchInput;
+		session.client.switchInput = async () => {
+			throw new CerastreamRpcError(
+				-32003,
+				"device not found",
+				"cerastream.device.not_found",
+				1,
+			);
+		};
+
+		await expect(
+			h.backend.switchInput({ input_id: "gone", mode: "manual" }),
+		).rejects.toThrow("device not found");
+		expect(h.lostSites).toEqual([]);
+		expect(session.subscriptionClosed()).toBe(false);
+
+		session.client.switchInput = original;
+		await expect(
+			h.backend.switchInput({ input_id: "cam2", mode: "manual" }),
+		).resolves.toMatchObject({ active_input: "cam2" });
+	});
+
+	test("an operator stop is never reported as an unexpected connection loss", async () => {
+		const h = makeHarness();
+		await h.backend.start(STREAM_CONFIG, RUN_OPTS);
+		await h.backend.settle();
+		// A real client rejects every pending request with a connection error when
+		// it is closed on purpose; that must stay invisible to this seam.
+		liveSession(h).killConnection();
+
+		await new Promise<void>((resolve) => {
+			h.backend.stop(resolve);
+		});
+		await h.backend.settle();
+		expect(h.lostSites).toEqual([]);
+	});
+});

--- a/apps/backend/src/tests/liveness-bridge-reconnect.test.ts
+++ b/apps/backend/src/tests/liveness-bridge-reconnect.test.ts
@@ -1,0 +1,338 @@
+/**
+ * A dropped BRIDGE socket is not a stopped STREAM.
+ *
+ * Found live during Wave H hardware QA (HDMI mid-stream unplug drill): with the
+ * cable pulled, health correctly reported `degraded` against a real, frozen
+ * frame counter (30415, unchanging) for several seconds — then flipped to
+ * `state: "healthy"`, `frames: {advancing: true, count: null}` while a local SRT
+ * receiver had already errored out ("Error during demuxing: Input/output error")
+ * and the kernel reported `power_present: 0`.
+ *
+ * The flip was the raw `active_encode` bridge reconnecting. Its `close`/`error`
+ * handlers wiped `cachedLiveness`, `collectRealLiveness()` read the resulting
+ * `undefined` as the genuine cold-start case, and fell back to `processAlive` —
+ * which only says the supervised OS process has not crashed, never that frames
+ * are flowing. The wipe also bypassed `FRAMES_FRESHNESS_MS`, the mechanism that
+ * exists precisely to age a stale reading into `advancing: false`.
+ *
+ * These tests pin the corrected boundary: a SESSION boundary (engine-authored
+ * stop, or a fresh start) clears the caches; a CONNECTION blip does not.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { getConfig } from "../modules/config.ts";
+import {
+	getActiveEncodeLiveness,
+	getActivePassthrough,
+	ingestLivenessForTest,
+	resetActiveEncodeLiveness,
+	resetActivePassthrough,
+	startActivePassthroughBridge,
+	stopActivePassthroughBridge,
+} from "../modules/streaming/active-passthrough.ts";
+import { AudioProbeTimeoutError } from "../modules/streaming/audio.ts";
+import {
+	clearStreamProcessExit,
+	collectLivenessSources,
+	deriveStreamHealth,
+	FRAMES_FRESHNESS_MS,
+	reportStreamProcessExit,
+	setHealthClockForTest,
+} from "../modules/streaming/health.ts";
+import {
+	type LinkTelemetryMessage,
+	setMockLinkTelemetryProvider,
+} from "../modules/streaming/link-telemetry.ts";
+import type { Pipeline } from "../modules/streaming/pipelines.ts";
+import { updateStatus } from "../modules/streaming/streaming.ts";
+import {
+	AUDIO_SOURCE_PROBE_FAILED,
+	startStream,
+} from "../modules/streaming/streamloop/start-stream.ts";
+
+type SocketHandlers = {
+	data: (socket: unknown, chunk: Buffer) => void;
+	close: () => void;
+	error: () => void;
+};
+
+type Bridge = {
+	/** Deliver one raw NDJSON frame exactly as the control socket would. */
+	deliver: (frame: unknown) => void;
+	/** The bridge's own socket closes (transient reconnect blip). */
+	drop: () => void;
+	/** The bridge's own socket errors (transient reconnect blip). */
+	fail: () => void;
+};
+
+/**
+ * Drive the REAL bridge over an injected socket, so the fix is exercised through
+ * the production `onLine`/`close`/`error` handlers rather than a reimplementation.
+ */
+async function startBridgeWithFakeSocket(): Promise<Bridge> {
+	let handlers: SocketHandlers | undefined;
+	const socket = { write: () => {}, flush: () => {}, end: () => {} };
+	const connect = ((options: { socket: SocketHandlers }) => {
+		handlers = options.socket;
+		return Promise.resolve(socket);
+	}) as unknown as typeof Bun.connect;
+
+	startActivePassthroughBridge({
+		socketPath: "/nonexistent/ceralive-test/control.sock",
+		connect,
+		warn: () => {},
+		onEngineReachable: () => {},
+	});
+	// connectOnce awaits the injected connect; let its microtasks settle.
+	await Promise.resolve();
+	await Promise.resolve();
+
+	if (handlers === undefined) throw new Error("bridge never connected");
+	const live = handlers;
+	return {
+		deliver: (frame) =>
+			live.data(socket, Buffer.from(`${JSON.stringify(frame)}\n`, "utf8")),
+		drop: () => live.close(),
+		fail: () => live.error(),
+	};
+}
+
+function statusFrame(activeEncode: unknown, streaming = true) {
+	return {
+		jsonrpc: "2.0",
+		method: "event",
+		params: {
+			type: "status",
+			seq: 1,
+			state: streaming ? "streaming" : "idle",
+			streaming,
+			active_encode: activeEncode,
+		},
+	};
+}
+
+/** One healthy bonded link, so the bond can never be what makes health degraded. */
+function healthyBond(): LinkTelemetryMessage {
+	return {
+		links: [
+			{
+				conn_id: "0",
+				iface: "eth0",
+				rtt_ms: 12,
+				nak_count: 0,
+				weight_percent: 100,
+				stale: false,
+			},
+		],
+		lastReadMs: Date.now(),
+	};
+}
+
+const audioPipeline = {
+	source: "hdmi",
+	name: "Test HDMI",
+	hardware: "rk3588",
+	description: "test pipeline",
+	supportsAudio: true,
+	supportsResolutionOverride: false,
+	supportsFramerateOverride: false,
+	audio_kind: "selectable",
+} as Pipeline;
+
+beforeEach(() => {
+	// A sibling test file may have booted the real bridge in this same process;
+	// stop it so the injected socket below is the one that connects.
+	stopActivePassthroughBridge();
+	setMockLinkTelemetryProvider(healthyBond);
+	clearStreamProcessExit();
+	updateStatus(true);
+});
+
+afterEach(() => {
+	stopActivePassthroughBridge();
+	setMockLinkTelemetryProvider(null);
+	setHealthClockForTest(null);
+	clearStreamProcessExit();
+	resetActiveEncodeLiveness();
+	resetActivePassthrough();
+	updateStatus(false);
+});
+
+describe("a transient bridge disconnect never erases the session's liveness", () => {
+	test("a mid-stream drop leaves the last real reading to age out into degraded", async () => {
+		const bridge = await startBridgeWithFakeSocket();
+
+		bridge.deliver(
+			statusFrame({
+				codec: "h265",
+				frames_emitted: 30_100,
+				pipeline_playing: true,
+			}),
+		);
+		bridge.deliver(
+			statusFrame({
+				codec: "h265",
+				frames_emitted: 30_415,
+				pipeline_playing: true,
+			}),
+		);
+		// The counter freezes — the cable is out, the encode has stopped moving.
+		bridge.deliver(
+			statusFrame({
+				codec: "h265",
+				frames_emitted: 30_415,
+				pipeline_playing: true,
+			}),
+		);
+		const lastHeartbeatAt = Date.now();
+		expect(collectLivenessSources().framesAdvancing).toBe(false);
+
+		bridge.drop();
+
+		// The bridge lost ITS socket. The session did not end, so the reading stands.
+		expect(getActiveEncodeLiveness()?.framesEmitted).toBe(30_415);
+
+		setHealthClockForTest(() => lastHeartbeatAt + FRAMES_FRESHNESS_MS + 1);
+		const sources = collectLivenessSources();
+		expect(sources.isStreaming).toBe(true);
+		expect(sources.processAlive).toBe(true);
+		expect(sources.framesAdvancing).toBe(false);
+		expect(sources.frameCount).toBe(30_415);
+
+		const health = deriveStreamHealth(sources);
+		expect(health.state).toBe("degraded");
+		expect(health.frames).toEqual({ advancing: false, count: 30_415 });
+		expect(health.reason).toEqual({
+			component: "frames",
+			detail: "No frames advancing",
+		});
+	});
+
+	test("a socket error is the same blip as a close", async () => {
+		const bridge = await startBridgeWithFakeSocket();
+
+		bridge.deliver(
+			statusFrame({
+				codec: "h265",
+				frames_emitted: 900,
+				pipeline_playing: true,
+				passthrough: true,
+			}),
+		);
+		bridge.fail();
+
+		expect(getActiveEncodeLiveness()?.framesEmitted).toBe(900);
+		expect(getActivePassthrough()).toBe(true);
+	});
+
+	test("telemetry still fresh at the moment of the drop keeps its own verdict", async () => {
+		const bridge = await startBridgeWithFakeSocket();
+
+		bridge.deliver(
+			statusFrame({
+				codec: "h265",
+				frames_emitted: 10,
+				pipeline_playing: true,
+			}),
+		);
+		bridge.deliver(
+			statusFrame({
+				codec: "h265",
+				frames_emitted: 70,
+				pipeline_playing: true,
+			}),
+		);
+		const lastHeartbeatAt = Date.now();
+		bridge.drop();
+
+		// Inside the freshness window a single dropped heartbeat must not flap the
+		// verdict — that is what the window is sized for.
+		setHealthClockForTest(() => lastHeartbeatAt + FRAMES_FRESHNESS_MS - 1);
+		const sources = collectLivenessSources();
+		expect(sources.framesAdvancing).toBe(true);
+		expect(sources.frameCount).toBe(70);
+		expect(deriveStreamHealth(sources).state).toBe("healthy");
+	});
+});
+
+describe("a genuine session boundary still clears the caches", () => {
+	test("an engine-authored streaming:false clears both caches immediately", async () => {
+		const bridge = await startBridgeWithFakeSocket();
+
+		bridge.deliver(
+			statusFrame({
+				codec: "h265",
+				frames_emitted: 500,
+				pipeline_playing: true,
+				passthrough: true,
+			}),
+		);
+		expect(getActiveEncodeLiveness()).toBeDefined();
+		expect(getActivePassthrough()).toBe(true);
+
+		bridge.deliver(statusFrame(undefined, false));
+
+		expect(getActiveEncodeLiveness()).toBeUndefined();
+		expect(getActivePassthrough()).toBeUndefined();
+	});
+
+	test("a fresh stream start drops the previous session's counter", async () => {
+		ingestLivenessForTest(
+			statusFrame({
+				codec: "h265",
+				frames_emitted: 30_415,
+				pipeline_playing: true,
+			}),
+			1000,
+		);
+		expect(getActiveEncodeLiveness()?.framesEmitted).toBe(30_415);
+
+		const config = getConfig();
+		const savedAsrc = config.asrc;
+		config.asrc = "HDMI";
+		try {
+			// The reset runs ahead of the audio probe, so even an aborted start
+			// proves the seam without spawning a sender or touching the engine.
+			const result = await startStream(
+				audioPipeline,
+				"192.0.2.10",
+				5000,
+				"sid",
+				{
+					probe: () => Promise.reject(new AudioProbeTimeoutError("HDMI")),
+				},
+			);
+			expect(result).toMatchObject({
+				success: false,
+				error: AUDIO_SOURCE_PROBE_FAILED,
+			});
+		} finally {
+			config.asrc = savedAsrc;
+		}
+
+		expect(getActiveEncodeLiveness()).toBeUndefined();
+		expect(getActivePassthrough()).toBeUndefined();
+	});
+});
+
+describe("a genuine cold start still falls back to process liveness", () => {
+	test("no telemetry ever received reports the process verdict, with no frame count", () => {
+		resetActiveEncodeLiveness();
+
+		const sources = collectLivenessSources();
+		expect(sources.framesAdvancing).toBe(true);
+		expect(sources.frameCount).toBeNull();
+		expect(deriveStreamHealth(sources).state).toBe("healthy");
+	});
+
+	test("a cold start whose process has exited reports dead, not advancing", () => {
+		resetActiveEncodeLiveness();
+		reportStreamProcessExit();
+
+		const sources = collectLivenessSources();
+		expect(sources.processAlive).toBe(false);
+		expect(sources.framesAdvancing).toBe(false);
+		expect(deriveStreamHealth(sources).state).toBe("dead");
+	});
+});


### PR DESCRIPTION
## What

Two related bugs found live during Wave H hardware QA (HDMI mid-stream unplug drill), both the same failure shape: cached state tracked a narrower connection's own lifecycle instead of the actual engine session's.

1. **False-healthy status after a bridge reconnect.** `active-passthrough.ts` holds its own persistent socket to cerastream purely to read raw frame-liveness telemetry. Its `close`/`error` handlers unconditionally wiped the cached liveness data — even on a transient reconnect unrelated to whether real video was flowing. That bypassed the existing `FRAMES_FRESHNESS_MS` staleness mechanism entirely: with no cached liveness, `health.ts` fell back to raw process-alive as a proxy for frame advancement, silently reporting a genuinely dead stream as `healthy`. Confirmed live: a local receiver had errored out and frozen, kernel confirmed no HDMI signal, yet health reported `state: healthy, frames: {advancing: true, count: null}` the instant the bridge reconnected.
2. **Stream permanently unusable after an engine restart mid-session.** The session-scoped control connection (`cerastream-backend.ts`) used for `start`/`switchInput`/`stop` has no built-in reconnect — confirmed by reading the published `@ceralive/cerastream` client: no close/error event, no `isConnected()`, no `reconnect()`. When cerastream restarted mid-session (confirmed via `systemctl status` uptime vs. the backend's own error timestamps), every subsequent session RPC failed forever with `control connection is not open`, and `reconcileRuntimeState()` even treated the dead client as proof of a live session, re-affirming `streaming` from stale telemetry. The only recovery we found live was restarting CeraUI's entire backend process.

## Why

Both bugs share the same root discipline gap: a connection dropping is not the same signal as a session ending, and neither direction was previously distinguished correctly (bug 1 treated a connection blip as if it were session-ending; bug 2 failed to treat a genuinely dead session connection as session-ending).

## How to verify

- New tests: `liveness-bridge-reconnect.test.ts` (bridge close/error mid-stream no longer wipes cached liveness; genuine `streaming:false` and a fresh start still correctly clear it) and `engine-session-connection-loss.test.ts` (7 cases — a proven-dead session connection retires the session cleanly; an engine RPC error, a timeout, or the operator's own stop are correctly NOT treated as connection loss).
- Both proven RED pre-fix via `git stash` of the respective source file alone.
- `bun test`: 2382/2382 pass. `lsp_diagnostics` clean.

## Risks

- A liveness reading up to 5s old can now survive a bridge reconnect instead of being wiped instantly — this is deliberate (the freshness window is sized exactly for this: a single dropped heartbeat must not flap the verdict), and has its own regression test.
- No transparent mid-session reconnect-and-resume for bug 2 — the session ends and the operator restarts the stream manually. A restarted cerastream has no memory of the prior session to resume, so full recovery would need engine-side session persistence first; that's a larger, separate effort.