### PR TITLE
fix(hotspot): one stable SSID per adapter, not a new one on every start

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,8 @@ CeraUI/
 | **Measured per-interface throughput (`tx_bps`/`rx_bps`, bits/s — `tp` is a byte delta, NOT a rate)** | `apps/backend/src/modules/network/network-interfaces.ts` (`computeInterfaceRate`) + `packages/rpc/src/schemas/network.schema.ts` |
 | **Consolidated bond bandwidth (per-link + `TOTAL BANDWIDTH` ↑/↓)** | `apps/frontend/src/lib/helpers/bond-bandwidth.ts` (`aggregateBondBandwidth`) → `apps/frontend/src/main/network/BondedLinksSection.svelte` |
 | **WiFi AP-vs-client classification (`isApMode` backend / `isApRadio` frontend)** | `apps/backend/src/modules/wifi/wifi-hotspot-types.ts` + `apps/frontend/src/lib/helpers/wifi-mode-outcome.ts` |
+| **WiFi adapter identity (permanent hardware address — NOT the scan-randomized operational one)** | `apps/backend/src/modules/wifi/wifi-permanent-mac.ts` (`resolveWifiPermanentMac`) |
+| **Durable per-adapter hotspot identity (SSID/password reused forever) + duplicate-profile consolidation** | `apps/backend/src/modules/wifi/hotspot-credentials.ts` + `wifi-hotspot-discovery.ts` (`findHotspotConnForAdapter`, `pruneDuplicateHotspotConns`) |
 | **Policy-route self-check for bonded wifi/modem interfaces** | `apps/backend/src/modules/network/policy-route-check.ts` |
 | **Subnet-collision + policy-route info/warning bands (frontend)** | `apps/frontend/src/main/network/CollisionBands.svelte` |
 | **Connection/subscriptions store (sole `rpcClient.onMessage` owner — `websocket-store` fully deleted)** | `apps/frontend/src/lib/rpc/subscriptions.svelte.ts` |
@@ -1950,3 +1952,5 @@ re-derived from bus-path string matching. Frontend label precedence is
 - Don't add a device rename affordance (text field, button, or dialog) for ANY device or media type — device naming is code-level only (`ONBOARD_AUDIO_DISPLAY_RULES` / `ONBOARD_VIDEO_DISPLAY_RULES`); a pluggable audio device gets the read-only `isExternalAudioSource` "External" badge instead.
 - Don't add a fifth fact to the compact HUD strip — the 4-fact scope (lifecycle badge, health dot, bitrate, one temp chip) is deliberate; anything else belongs in the expanded Sheet.
 - Don't add a second QR to `HotspotDialog`, and don't interpolate a raw SSID/password into a `WIFI:` payload — route the credentials through `escapeWifiQrField` in `generateWifiQr` (see HOTSPOT QR SURFACE).
+- Don't key a WiFi adapter (or pin a NetworkManager profile) on the MAC `ifconfig`/`GENERAL.HWADDR` reports — it is the scan-randomized OPERATIONAL address. Use `resolveWifiPermanentMac()`; see `apps/backend/AGENTS.md` → WIFI ADAPTER IDENTITY IS THE PERMANENT MAC.
+- Don't generate a hotspot SSID/password before `findHotspotConnForAdapter()` and the credential store have been consulted — that ordering is what stops a new `Hotspot-N` profile appearing on every start.

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -1573,6 +1573,104 @@ Frontend half: `apps/frontend/src/lib/helpers/wifi-mode-outcome.ts`
 
 Coverage: `tests/wifi-ap-mode-classification.test.ts`.
 
+## WIFI ADAPTER IDENTITY IS THE PERMANENT MAC [EXISTS]
+
+Every adapter-keyed WiFi structure — the `wifiInterfacesByMacAddress` registry,
+the `wifiState` cache, the numeric UI id map, the hotspot credential store, and
+the `802-11-wireless.mac-address` pinned into a NetworkManager profile — is keyed
+on the radio's **permanent hardware address**, resolved by
+`modules/wifi/wifi-permanent-mac.ts` (`resolveWifiPermanentMac`).
+
+**`ifconfig`/`GENERAL.HWADDR` report the OPERATIONAL address, and it moves.**
+NetworkManager randomizes a WiFi device's MAC while scanning
+(`wifi.scan-rand-mac-address`, on by default) and resets it when it activates a
+connection. Confirmed on a Rock 5B+, roughly every 7 minutes:
+`device (wlan0): set-hw-addr: set MAC address to 26:C3:93:B6:9C:A7 (scanning)`.
+Two things broke while the registry keyed on that value:
+
+- the registry re-keyed itself, so the adapter's adopted hotspot profile, saved
+  connection map and id were discarded and rebuilt empty; and
+- profiles were pinned to a randomized address. **NetworkManager matches
+  `802-11-wireless.mac-address` against the PERMANENT address**, so those
+  profiles could never activate again — the board's journal recorded
+  `audit: op="connection-activate" result="fail" reason="… device MAC address
+  does not match the profile"` on every hotspot start.
+
+**Resolution ladder** (`resolveWifiPermanentMac(ifname, currentMac)`):
+`/sys/class/net/<ifname>/phy80211/macaddress` (the cfg80211 `wiphy->perm_addr`,
+verified byte-equal to NetworkManager's D-Bus `PermHwAddress` on the reference
+board) → the last permanent address read for that interface → the current
+address. The cached tier is load-bearing: a transient sysfs failure must not
+re-key the registry onto a scan-time address for one poll. `busctl` is
+deliberately NOT used — it is not in the `helpers/run.ts` ALLOWED set, and a
+single sysfs read needs no spawn at all. `setPermanentMacReaderForTest` is the
+test seam.
+
+**A monitor event carries an ifname, never a MAC.** `getWifiInterfaceByIfname()`
+(`wifi-connections.ts`) is the bridge; do NOT route a device-state event through
+`wifiDeviceListGetMacAddress()` — that returns the operational address and will
+miss the registry.
+
+## DURABLE PER-ADAPTER HOTSPOT IDENTITY [EXISTS]
+
+A hotspot's SSID and password are generated **once per physical adapter and
+reused forever** — across station↔hotspot switches, backend restarts, and
+reboots. Before this, every start took the "no hotspot connection yet" branch
+and minted a new pair; a test device accumulated six NetworkManager profiles
+(`Hotspot`, `Hotspot-1` … `Hotspot-5`) with six different SSIDs and passwords,
+none of which the operator's phone had been told about consistently.
+
+**Discovery runs BEFORE generation.** `startHotspotLocked`
+(`wifi-hotspot-activation.ts`) resolves the profile to activate in this order:
+the in-memory `hotspot.conn` → `findHotspotConnForAdapter()` → generate. The
+lookup (`wifi-hotspot-discovery.ts`) is deterministic, never name-guessing: the
+persisted UUID first, then the profile whose `802-11-wireless.mac-address` binds
+it to this exact permanent address, and only as a last resort a profile matching
+the persisted SSID (for profiles written before the MAC binding was
+trustworthy).
+
+**The repair must land BEFORE the activation.** `hotspotProfileFields(permMac)`
+is re-asserted with `nmConnSetFields` and only then is the profile brought up —
+a profile carrying a randomized binding is one NetworkManager will refuse, so
+activating first and repairing after (the old order) fails every time. This also
+removes the misleading `result="fail"` audit line that used to accompany every
+otherwise-successful start.
+
+**`hotspot_credentials.json` is the BACKSTOP, not the source of truth.**
+NetworkManager's own `.nmconnection` files remain primary. The store
+(`modules/wifi/hotspot-credentials.ts`, atomic JSON per
+`docs/CONFIG_PERSISTENCE.md` — **not** SQLite) exists for the one case
+NetworkManager cannot cover: a profile deleted out from under CeraUI. The
+credentials are then reused to recreate an identical hotspot rather than mint a
+new identity. It is written on generation (**before** activation, so a start
+that dies mid-flight cannot strand credentials the UI already displayed), on
+adoption (`handleHotspotConn`), and on operator rename
+(`reconfigureHotspotLocked` — otherwise a later recreate would restore the stale
+generated pair). Writes are inert until `initHotspotCredentials()` runs, so a
+unit test that never opts in cannot litter the working directory.
+
+**Duplicate consolidation is deliberately narrow.**
+`pruneDuplicateHotspotConns()` runs best-effort after a successful start (never
+blocking or failing it) and only deletes a profile that is AP mode, carries the
+nmcli-generated id (`Hotspot`, `Hotspot-N`), is used by no adapter, is claimed by
+no other adapter's persisted identity, and is bound either to THIS adapter or to
+an address no present adapter has. A profile bound to another present radio is
+always kept, so a multi-radio device cannot lose its second hotspot to the
+first's cleanup.
+
+**Side effect worth knowing:** with the binding correct, `autoconnect=yes` +
+`autoconnect-priority=999` finally work, so a hotspot left on now survives a
+reboot. `wifiHotspotStop` still sets `autoconnect=no`, so a hotspot turned off
+stays off.
+
+Coverage: `tests/wifi-hotspot-identity.test.ts` (permanent-MAC ladder, first-ever
+generation from the permanent suffix, restart reuse with zero profile creation,
+recreate-after-external-delete, repair-before-activate ordering, multi-adapter
+isolation across a restart, store round-trip, deterministic lookup, and the four
+prune negatives). Rule E proof captured in both directions: neutering the
+discovery-before-generation step reddens 5 tests; swapping the repair/activate
+order reddens the ordering test alone.
+
 ## MEASURED INTERFACE THROUGHPUT [EXISTS]
 
 `netif` entries carry TWO different throughput quantities, and only one of them
@@ -1752,6 +1850,8 @@ error and operator-stop negatives are the controls, green on both trees).
 - Don't re-apply an onboard display-name rule at a render site (a Svelte label, a summary derivation) — it belongs at the device-construction seam (`fromEngineDevice`), which is why the row and the "Configured" label are both fixed by one call.
 - Don't re-derive `pipeline`/`selected_video_input` resolution inline in a new procedure — route through `resolveSourceRouting()`/`deriveEngineRouting()` in `modules/streaming/sources.ts`.
 - Don't classify a WiFi radio's AP-vs-client mode from `conn` (or from the presence of a `hotspot` block) — `conn` is IP-gated and lies during a poll skew. Use `isApMode()`; keep `isHotspot()` only where `hotspot.conn` is actually dereferenced.
+- Don't key an adapter on the MAC `ifconfig`/`GENERAL.HWADDR` reports — NetworkManager randomizes it while scanning, and pinning it into `802-11-wireless.mac-address` produces a profile no device can ever activate. Route through `resolveWifiPermanentMac()`, and bridge an ifname-carrying monitor event with `getWifiInterfaceByIfname()`.
+- Don't generate a hotspot SSID/password without asking `findHotspotConnForAdapter()` and the credential store first — that ordering IS the fix for the six orphaned `Hotspot-N` profiles. And don't move the `nmConnSetFields` repair after the `nmConnect`: NetworkManager rejects a profile whose pinned MAC does not match the adapter's permanent address, so the activation is what fails.
 - Don't render `netif.tp` as a rate — it is a byte delta over an unstated window. Use `tx_bps`/`rx_bps`.
 - Don't let a `list-devices` probe decide device MEMBERSHIP on the hotplug path, and don't drop the generation fence — a probe that answers can still be stale or out of order, and both have already stranded a real device on a board. Membership comes from the registry's observation (`mergeObservedWithProbe`); the probe supplies metadata.
 - Don't record a device's `stable_id` into `liveStableIds` before the bridge check in `buildSources` — an unbridged device renders no row, so letting it suppress the remembered `lost` row erases the device from the list entirely.

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -118,6 +118,7 @@ import {
 	ensureSshPasswordSynced,
 	getSshStatus,
 } from "./modules/system/ssh.ts";
+import { initHotspotCredentials } from "./modules/wifi/hotspot-credentials.ts";
 import { wifiStateInit } from "./modules/wifi/wifi-connections.ts";
 import { handleWifiMonitorEvent as handleHotspotMonitorEvent } from "./modules/wifi/wifi-hotspot-monitor.ts";
 import { onHeartbeatTick, startHeartbeat } from "./rpc/heartbeat.ts";
@@ -199,6 +200,8 @@ logger.info(bootTimer.phase("🚀", "server"));
 
 // Resolve device_id + paired state before anything that gates the control
 // channel (spec §9: it MUST NOT dial until identity is resolved).
+await guardNonCritical("hotspot-credentials", initHotspotCredentials);
+
 await guardNonCritical("identity", async () => {
 	await initIdentity();
 });

--- a/apps/backend/src/modules/wifi/hotspot-credentials.ts
+++ b/apps/backend/src/modules/wifi/hotspot-credentials.ts
@@ -1,0 +1,200 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+  Durable per-adapter hotspot identity.
+
+  NetworkManager's own `.nmconnection` files are the primary source of truth for
+  a hotspot profile and are already persistent — this store does NOT replace
+  them. It is the BACKSTOP for the one thing NetworkManager cannot provide: if
+  the profile is deleted out from under CeraUI (an operator `nmcli con del`, a
+  `/etc/NetworkManager/system-connections` wipe, an image re-flash that keeps
+  `/data`), the SSID and password the operator's phone already knows are gone
+  forever and the next hotspot start would mint a brand-new pair.
+
+  Keyed by the adapter's PERMANENT hardware address (see `wifi-permanent-mac.ts`)
+  so a device with several radios keeps one independent identity per radio, and
+  so the key survives NetworkManager's scan-time MAC randomization.
+
+  Follows the codebase's atomic-JSON convention (`docs/CONFIG_PERSISTENCE.md`):
+  whole-file replace through `writeFileAtomicSync` (temp → fsync → rename). No
+  database — that decision is recorded in the same document.
+*/
+
+import { z } from "zod";
+
+import {
+	loadCacheFile,
+	writeFileAtomicSync,
+} from "../../helpers/config-loader.ts";
+import { logger } from "../../helpers/logger.ts";
+import { isWifiChannelName, type WifiChannel } from "./wifi-channels.ts";
+import { normalizeMacAddress } from "./wifi-permanent-mac.ts";
+
+/** Default on-disk location, relative to the backend's working directory. */
+export const HOTSPOT_CREDENTIALS_FILE = "hotspot_credentials.json";
+
+/** The identity of one adapter's hotspot, reused for the life of the adapter. */
+export type HotspotCredentials = {
+	/** Broadcast SSID. Stable once generated. */
+	ssid: string;
+	/** WPA2 pre-shared key. Stable once generated. */
+	password: string;
+	/**
+	 * Last known NetworkManager connection UUID. A HINT only — it is re-verified
+	 * against NetworkManager before use, and a hotspot is recreated from `ssid` +
+	 * `password` when the profile behind it is gone.
+	 */
+	conn?: string;
+	/** Last configured channel selection. */
+	channel?: WifiChannel;
+};
+
+const entrySchema = z.object({
+	ssid: z.string().min(1),
+	password: z.string().min(1),
+	conn: z.string().min(1).optional(),
+	channel: z.string().min(1).optional(),
+	updatedAt: z.number().optional(),
+});
+
+const fileSchema = z.object({
+	version: z.literal(1).optional(),
+	adapters: z.record(z.string(), entrySchema).optional(),
+});
+
+type StoredEntry = z.infer<typeof entrySchema>;
+
+let filePath = HOTSPOT_CREDENTIALS_FILE;
+let entries: Record<string, StoredEntry> = {};
+/**
+ * Writes are inert until `initHotspotCredentials()` runs. Production calls it
+ * once at boot; a unit test that never opts in therefore gets a pure in-memory
+ * store and cannot litter the working directory.
+ */
+let initialized = false;
+
+function keyFor(macAddress: string): string | undefined {
+	return normalizeMacAddress(macAddress) ?? macAddress.trim().toLowerCase();
+}
+
+function toCredentials(entry: StoredEntry): HotspotCredentials {
+	return {
+		ssid: entry.ssid,
+		password: entry.password,
+		...(entry.conn !== undefined ? { conn: entry.conn } : {}),
+		...(entry.channel !== undefined && isWifiChannelName(entry.channel)
+			? { channel: entry.channel }
+			: {}),
+	};
+}
+
+function persist(): void {
+	if (!initialized) return;
+	try {
+		writeFileAtomicSync(
+			filePath,
+			JSON.stringify({ version: 1, adapters: entries }),
+		);
+	} catch (err) {
+		// A hotspot must never fail to start because its credential backstop could
+		// not be written — NetworkManager still holds the profile.
+		logger.warn(`Failed to persist hotspot credentials: ${err}`);
+	}
+}
+
+/**
+ * Load the store from disk and arm persistence. Never throws: a missing or
+ * corrupt file starts an empty store (the NetworkManager profile remains the
+ * primary source of truth, so nothing is lost that cannot be re-adopted).
+ */
+export async function initHotspotCredentials(
+	path: string = HOTSPOT_CREDENTIALS_FILE,
+): Promise<void> {
+	filePath = path;
+	const data = await loadCacheFile(path, fileSchema, {});
+	entries = { ...(data.adapters ?? {}) };
+	initialized = true;
+	const count = Object.keys(entries).length;
+	if (count > 0) {
+		logger.debug(`Loaded hotspot credentials for ${count} adapter(s)`);
+	}
+}
+
+/** The persisted hotspot identity for an adapter's permanent MAC, if any. */
+export function getHotspotCredentials(
+	macAddress: string,
+): HotspotCredentials | undefined {
+	const key = keyFor(macAddress);
+	if (!key) return undefined;
+	const entry = entries[key];
+	return entry ? toCredentials(entry) : undefined;
+}
+
+/**
+ * Record (or update) an adapter's hotspot identity. Writes only on a real
+ * change, so the routine re-assertions made on every hotspot start cost no I/O.
+ */
+export function rememberHotspotCredentials(
+	macAddress: string,
+	credentials: HotspotCredentials,
+): void {
+	const key = keyFor(macAddress);
+	if (!key || !credentials.ssid || !credentials.password) return;
+
+	const previous = entries[key];
+	const next: StoredEntry = {
+		ssid: credentials.ssid,
+		password: credentials.password,
+		...(credentials.conn !== undefined ? { conn: credentials.conn } : {}),
+		...(credentials.channel !== undefined
+			? { channel: credentials.channel }
+			: {}),
+		updatedAt: Date.now(),
+	};
+
+	if (
+		previous &&
+		previous.ssid === next.ssid &&
+		previous.password === next.password &&
+		previous.conn === next.conn &&
+		previous.channel === next.channel
+	) {
+		return;
+	}
+
+	entries[key] = next;
+	persist();
+}
+
+/** Injectable view of the store used by the hotspot activation flow. */
+export type HotspotCredentialsStore = {
+	get(macAddress: string): HotspotCredentials | undefined;
+	remember(macAddress: string, credentials: HotspotCredentials): void;
+};
+
+export const hotspotCredentialsStore: HotspotCredentialsStore = {
+	get: getHotspotCredentials,
+	remember: rememberHotspotCredentials,
+};
+
+/** Test seam: drop all in-memory state and disarm persistence. */
+export function resetHotspotCredentialsForTest(): void {
+	entries = {};
+	filePath = HOTSPOT_CREDENTIALS_FILE;
+	initialized = false;
+}

--- a/apps/backend/src/modules/wifi/wifi-connections.ts
+++ b/apps/backend/src/modules/wifi/wifi-connections.ts
@@ -35,7 +35,6 @@ import {
 	setWifiState,
 } from "./state/wifi-state.ts";
 import { broadcastWifiState, type WifiNetwork } from "./wifi.ts";
-import { wifiDeviceListGetMacAddress } from "./wifi-device-list.ts";
 import type { WifiInterface } from "./wifi-interfaces.ts";
 
 const wifiInterfacesByMacAddress: Record<MacAddress, WifiInterface> = {};
@@ -48,6 +47,21 @@ export function getWifiInterfacesByMacAddress(): Readonly<
 	Record<MacAddress, WifiInterface>
 > {
 	return wifiInterfacesByMacAddress;
+}
+
+/**
+ * Look an adapter up by interface name. Monitor events carry an ifname, and the
+ * registry key is the adapter's PERMANENT hardware address — which the ifconfig
+ * poll's operational address does not reliably equal (NetworkManager randomizes
+ * it while scanning), so it must not be used to bridge the two.
+ */
+export function getWifiInterfaceByIfname(
+	ifname: string,
+): WifiInterface | undefined {
+	for (const wifiInterface of Object.values(wifiInterfacesByMacAddress)) {
+		if (wifiInterface?.ifname === ifname) return wifiInterface;
+	}
+	return undefined;
 }
 
 export function removeWifiInterface(macAddress: MacAddress) {
@@ -206,10 +220,7 @@ function handleConnectionStateEvent(connection: string, state: string): void {
 }
 
 function handleDeviceStateEvent(device: string, state: string): void {
-	const macAddress = wifiDeviceListGetMacAddress(device);
-	if (!macAddress) return;
-
-	const wifiInterface = wifiInterfacesByMacAddress[macAddress];
+	const wifiInterface = getWifiInterfaceByIfname(device);
 	if (!wifiInterface) return;
 
 	if (state === "disconnected" || state === "unavailable") {

--- a/apps/backend/src/modules/wifi/wifi-hotspot-activation.ts
+++ b/apps/backend/src/modules/wifi/wifi-hotspot-activation.ts
@@ -16,6 +16,7 @@
 */
 
 import { randomBase64 } from "../../helpers/crypto.ts";
+import { logger } from "../../helpers/logger.ts";
 import { setNetifDupIpSuppression } from "../network/network-interfaces.ts";
 import {
 	nmConnect,
@@ -23,18 +24,25 @@ import {
 	nmHotspot,
 } from "../network/network-manager.ts";
 import { withDeviceLock } from "../network/state/device-lock.ts";
+import { hotspotCredentialsStore } from "./hotspot-credentials.ts";
 import { getWifiState, setWifiState } from "./state/wifi-state.ts";
 import { broadcastWifiState, wifiUpdateSavedConns } from "./wifi.ts";
 import { getWifiInterfaceByMacAddress } from "./wifi-connections.ts";
+import {
+	findHotspotConnForAdapter,
+	pruneDuplicateHotspotConns,
+} from "./wifi-hotspot-discovery.ts";
 import {
 	registerPendingConfirmation,
 	syncWifiStateCache,
 } from "./wifi-hotspot-monitor.ts";
 import {
 	canHotspot,
+	HOTSPOT_AUTOCONNECT_FIELDS,
 	HOTSPOT_UP_TO,
 	type HotspotActivationDeps,
 	type HotspotStartResult,
+	hotspotBindingFields,
 	isHotspot,
 	type WifiHotspotMessage,
 	type WifiInterfaceWithHotspot,
@@ -52,6 +60,11 @@ export const defaultHotspotDeps: HotspotActivationDeps = {
 	wifiUpdateSavedConns,
 	broadcastState: broadcastWifiState,
 	setDupIpSuppression: setNetifDupIpSuppression,
+	credentials: hotspotCredentialsStore,
+	findHotspotConn: findHotspotConnForAdapter,
+	pruneHotspotConns: async (macAddress, keepUuid) => {
+		await pruneDuplicateHotspotConns(macAddress, keepUuid);
+	},
 	pollHotspotActive: async (iface) => {
 		// Re-poll authoritative NM device state, then check whether the active
 		// connection now matches our hotspot connection.
@@ -131,47 +144,85 @@ async function startHotspotLocked(
 		return { success: false, error: "activation-failed" };
 	};
 
-	if (wifiInterface.hotspot.conn) {
-		// Existing hotspot connection: bring it up.
-		if (await deps.nmConnect(wifiInterface.hotspot.conn, HOTSPOT_UP_TO)) {
-			await deps.nmConnSetFields(wifiInterface.hotspot.conn, {
-				"connection.autoconnect": "yes",
-				"connection.autoconnect-priority": "999",
-			});
-		} else {
+	const stored = deps.credentials.get(macAddress);
+
+	const remember = (conn?: string) => {
+		const { name, password, channel } = wifiInterface.hotspot;
+		if (!name || !password) return;
+		deps.credentials.remember(macAddress, {
+			ssid: name,
+			password,
+			...(conn !== undefined ? { conn } : {}),
+			...(channel !== undefined ? { channel } : {}),
+		});
+	};
+
+	/*
+	  Discovery runs BEFORE generation, and it is what makes the SSID/password
+	  stable: an adapter that has ever hosted a hotspot already owns a profile, so
+	  a restart (which wipes `hotspot.conn`) must find it rather than mint a
+	  second identity the operator's phone has never been told about.
+	*/
+	let conn = wifiInterface.hotspot.conn;
+	if (!conn) {
+		const existing = await deps.findHotspotConn(macAddress, stored);
+		if (existing) {
+			conn = existing.uuid;
+			wifiInterface.hotspot.conn = existing.uuid;
+			wifiInterface.hotspot.name = existing.ssid;
+			wifiInterface.hotspot.password = existing.password;
+			wifiInterface.hotspot.channel = existing.channel;
+		}
+	}
+
+	// Cleanup is best-effort, runs off the critical path, and never fails a start.
+	const prune = (keepUuid: string) => {
+		void deps
+			.pruneHotspotConns(macAddress, keepUuid)
+			.catch((err) => logger.debug(`hotspot profile cleanup failed: ${err}`));
+	};
+
+	if (conn) {
+		await deps.nmConnSetFields(conn, hotspotBindingFields(macAddress));
+		prune(conn);
+		if (!(await deps.nmConnect(conn, HOTSPOT_UP_TO))) {
 			return rollback();
 		}
+		await deps.nmConnSetFields(conn, HOTSPOT_AUTOCONNECT_FIELDS);
+		remember(conn);
 	} else {
-		// No hotspot connection yet: create one with a generated name/password.
+		// First hotspot this adapter has ever hosted, or its profile was deleted
+		// outside CeraUI — reuse the persisted identity when there is one.
 		const ms = macAddress.split(":");
-		const name = `CERALIVE_${ms[4]}${ms[5]}`;
-		const password = randomBase64(9);
+		const name = stored?.ssid ?? `CERALIVE_${ms[4]}${ms[5]}`;
+		const password = stored?.password ?? randomBase64(9);
 
-		// Temporary hotspot config to send to the client during activation.
 		wifiInterface.hotspot.name = name;
 		wifiInterface.hotspot.password = password;
-		wifiInterface.hotspot.channel = "auto";
+		wifiInterface.hotspot.channel = stored?.channel ?? "auto";
+		// Persist before activating: a start that dies mid-flight must not strand
+		// credentials the UI has already shown the operator.
+		remember(stored?.conn);
 		deps.broadcastState();
 		syncWifiStateCache(macAddress, wifiInterface);
 
 		const uuid = await deps.nmHotspot(ifname, name, password, HOTSPOT_UP_TO);
-		if (uuid) {
-			await deps.nmConnSetFields(uuid, {
-				"connection.interface-name": "", // Empty string required; Bun runtime limitation with empty CLI args
-				"connection.autoconnect": "yes",
-				"connection.autoconnect-priority": "999",
-				"802-11-wireless.mac-address": macAddress,
-				"802-11-wireless-security.pmf": "disable",
-			});
-			// The updated settings let the connection be recognised as our hotspot.
-			await deps.wifiUpdateSavedConns();
-			// Restart the connection with the updated settings (needed to disable pmf).
-			if (!(await deps.nmConnect(uuid, HOTSPOT_UP_TO))) {
-				return rollback();
-			}
-		} else {
+		if (!uuid) {
 			return rollback();
 		}
+
+		await deps.nmConnSetFields(uuid, hotspotBindingFields(macAddress));
+		// The updated settings let the connection be recognised as our hotspot.
+		await deps.wifiUpdateSavedConns();
+		prune(uuid);
+		// Restart the connection with the updated settings (needed to disable pmf).
+		if (!(await deps.nmConnect(uuid, HOTSPOT_UP_TO))) {
+			return rollback();
+		}
+		await deps.nmConnSetFields(uuid, HOTSPOT_AUTOCONNECT_FIELDS);
+		conn = uuid;
+		wifiInterface.hotspot.conn ??= uuid;
+		remember(uuid);
 	}
 
 	// NM activation issued successfully. The mode flip waits for confirmation —

--- a/apps/backend/src/modules/wifi/wifi-hotspot-config.ts
+++ b/apps/backend/src/modules/wifi/wifi-hotspot-config.ts
@@ -25,6 +25,7 @@ import {
 } from "../network/network-manager.ts";
 import { withDeviceLock } from "../network/state/device-lock.ts";
 import { buildMsg, getSocketSenderId } from "../ui/websocket-server.ts";
+import { rememberHotspotCredentials } from "./hotspot-credentials.ts";
 import { broadcastWifiState, wifiUpdateSavedConns } from "./wifi.ts";
 import { isWifiChannelName, wifiChannels } from "./wifi-channels.ts";
 import {
@@ -289,6 +290,18 @@ async function reconfigureHotspotLocked(
 
 	// Successfully brought up the hotspot with the new settings, reload the conn.
 	delete wifiInterface.hotspot.transition;
+	// The operator's chosen credentials are now the adapter's durable identity —
+	// a later recreate must restore these, not the originally generated pair.
+	if (isWifiChannelName(channel)) {
+		rememberHotspotCredentials(macAddress, {
+			ssid: name,
+			password,
+			channel,
+			...(wifiInterface.hotspot.conn !== undefined
+				? { conn: wifiInterface.hotspot.conn }
+				: {}),
+		});
+	}
 	await wifiUpdateSavedConns();
 	broadcastWifiState();
 	syncWifiStateCache(macAddress, wifiInterface);

--- a/apps/backend/src/modules/wifi/wifi-hotspot-discovery.ts
+++ b/apps/backend/src/modules/wifi/wifi-hotspot-discovery.ts
@@ -17,24 +17,72 @@
 
 import { logger } from "../../helpers/logger.ts";
 import {
+	type ConnectionUUID,
+	type MacAddress,
+	nmConnDelete,
 	nmConnGetFields,
 	nmConnSetFields,
 	nmConnSetWifiMacAddress,
+	nmConnsGet,
+	nmcliParseSep,
 } from "../network/network-manager.ts";
+import {
+	getHotspotCredentials,
+	type HotspotCredentials,
+	rememberHotspotCredentials,
+} from "./hotspot-credentials.ts";
 import { channelFromNM } from "./wifi-channels.ts";
 import {
 	getWifiInterfaceByMacAddress,
 	getWifiInterfacesByMacAddress,
 } from "./wifi-connections.ts";
-import { canHotspot } from "./wifi-hotspot-types.ts";
+import { canHotspot, type ExistingHotspotConn } from "./wifi-hotspot-types.ts";
 
 // ─── NM connection discovery (hotspot bootstrap) ─────────────────────────────
+
+export type HotspotAdoptionOptions = {
+	/**
+	 * NetworkManager reports this profile as the radio's ACTIVE connection, so it
+	 * is what the adapter is actually broadcasting and outranks the persisted
+	 * identity. The saved-connection sweep sets this false: it walks every AP
+	 * profile in nmcli order, and without the persisted identity to arbitrate,
+	 * whichever duplicate happened to be enumerated first would become the
+	 * adapter's hotspot — which is how a restart changed the SSID out from under
+	 * an operator's phone.
+	 */
+	active?: boolean;
+};
+
+/**
+ * Whether an AP profile may claim an adapter. The persisted identity is the
+ * tie-breaker between duplicate profiles; only the connection NetworkManager is
+ * actually running overrides it.
+ */
+export function shouldAdoptHotspotConn(
+	uuid: ConnectionUUID,
+	stored: HotspotCredentials | undefined,
+	options: HotspotAdoptionOptions = {},
+): boolean {
+	if (options.active) return true;
+	return !stored?.conn || stored.conn === uuid;
+}
 
 export async function handleHotspotConn(
 	macAddress_: string | undefined,
 	uuid: string,
+	options: HotspotAdoptionOptions = {},
 ) {
-	const macAddress = macAddress_ || (await findMacAddressForConnection(uuid));
+	/*
+	  A profile's pinned `802-11-wireless.mac-address` is only a usable adapter key
+	  while it holds a PERMANENT address. Profiles written before that was enforced
+	  carry a scan-time randomized address that matches no present adapter, so fall
+	  back to the ifname/active-connection match rather than dropping the profile.
+	*/
+	const pinned =
+		macAddress_ && getWifiInterfaceByMacAddress(macAddress_)
+			? macAddress_
+			: undefined;
+	const macAddress = pinned || (await findMacAddressForConnection(uuid));
 	if (!macAddress) {
 		return;
 	}
@@ -60,6 +108,15 @@ export async function handleHotspotConn(
 		logger.warn(
 			"Can not update hotspot connection, interface already has an active connection",
 		);
+		return;
+	}
+
+	if (
+		!shouldAdoptHotspotConn(uuid, getHotspotCredentials(macAddress), options)
+	) {
+		// Another profile is this adapter's persisted identity — keep this
+		// duplicate from auto-starting and from claiming the adapter.
+		await nmConnSetFields(uuid, { "connection.autoconnect": "no" });
 		return;
 	}
 
@@ -94,6 +151,7 @@ export async function handleHotspotConn(
 	const fields = await nmConnGetFields(uuid, [
 		...settingsFields,
 		...checkFields,
+		"802-11-wireless.mac-address",
 	] as const);
 
 	if (fields === undefined) return;
@@ -106,10 +164,26 @@ export async function handleHotspotConn(
 		await nmConnSetFields(uuid, { "connection.autoconnect-priority": "999" });
 	}
 
+	/*
+	  Repair a profile bound to anything other than the adapter's permanent
+	  address. NetworkManager matches this property against the PERMANENT address,
+	  so a profile carrying a randomized one can never be activated again.
+	*/
+	if (fields[11].toLowerCase() !== macAddress) {
+		await nmConnSetWifiMacAddress(uuid, macAddress);
+	}
+
 	wifiInterface.hotspot.conn = uuid;
 	wifiInterface.hotspot.name = fields[1];
 	wifiInterface.hotspot.password = fields[2];
 	wifiInterface.hotspot.channel = channelFromNM(fields[3], fields[4]);
+
+	rememberHotspotCredentials(macAddress, {
+		ssid: fields[1],
+		password: fields[2],
+		conn: uuid,
+		channel: wifiInterface.hotspot.channel,
+	});
 
 	if (
 		fields[5] !== "no" ||
@@ -159,4 +233,184 @@ async function findMacAddressForConnection(uuid: string) {
 	}
 
 	return undefined;
+}
+
+// ─── deterministic profile lookup + duplicate consolidation ──────────────────
+
+const AP_PROFILE_FIELDS = [
+	"802-11-wireless.mode",
+	"802-11-wireless.ssid",
+	"802-11-wireless-security.psk",
+	"802-11-wireless.band",
+	"802-11-wireless.channel",
+	"802-11-wireless.mac-address",
+] as const;
+
+type ApProfile = ExistingHotspotConn & { macAddress: MacAddress };
+
+/** `mode, ssid, psk, band, channel, mac-address` — mirrors AP_PROFILE_FIELDS. */
+type ApProfileFieldValues = readonly [
+	string,
+	string,
+	string,
+	string,
+	string,
+	string,
+];
+
+export type HotspotProfileDeps = {
+	getApProfileFields: (
+		uuid: ConnectionUUID,
+	) => Promise<ApProfileFieldValues | undefined>;
+	listConnections: (fields: string) => Promise<string[] | undefined>;
+	deleteConnection: (uuid: ConnectionUUID) => Promise<boolean>;
+};
+
+export const defaultHotspotProfileDeps: HotspotProfileDeps = {
+	getApProfileFields: (uuid) => nmConnGetFields(uuid, AP_PROFILE_FIELDS),
+	listConnections: nmConnsGet,
+	deleteConnection: nmConnDelete,
+};
+
+async function readApProfile(
+	uuid: ConnectionUUID,
+	deps: HotspotProfileDeps,
+): Promise<ApProfile | undefined> {
+	const fields = await deps.getApProfileFields(uuid);
+	if (fields === undefined) return undefined;
+	if (fields[0] !== "ap" || !fields[1]) return undefined;
+
+	return {
+		uuid,
+		ssid: fields[1],
+		password: fields[2],
+		channel: channelFromNM(fields[3], fields[4]),
+		macAddress: fields[5].toLowerCase(),
+	};
+}
+
+async function listWirelessConns(
+	fields: string,
+	deps: HotspotProfileDeps,
+): Promise<Array<string[]> | undefined> {
+	const rows = await deps.listConnections(fields);
+	if (rows === undefined) return undefined;
+	return rows.map((row) => nmcliParseSep(row));
+}
+
+/**
+ * Resolve the NetworkManager AP profile that belongs to `macAddress` (an adapter
+ * PERMANENT address).
+ *
+ * Deterministic by construction: the persisted UUID is checked first, then the
+ * profile whose `802-11-wireless.mac-address` binds it to this exact adapter.
+ * The persisted SSID is only a last resort, for a profile CeraUI created before
+ * the MAC binding was trustworthy.
+ */
+export async function findHotspotConnForAdapter(
+	macAddress: MacAddress,
+	stored: HotspotCredentials | undefined,
+	deps: HotspotProfileDeps = defaultHotspotProfileDeps,
+): Promise<ExistingHotspotConn | undefined> {
+	if (stored?.conn) {
+		const profile = await readApProfile(stored.conn, deps);
+		if (profile) return profile;
+	}
+
+	const rows = await listWirelessConns("uuid,type", deps);
+	if (!rows) return undefined;
+
+	let ssidMatch: ExistingHotspotConn | undefined;
+	for (const [uuid, type] of rows) {
+		if (!uuid || type !== "802-11-wireless") continue;
+		const profile = await readApProfile(uuid, deps);
+		if (!profile) continue;
+		if (profile.macAddress === macAddress) return profile;
+		if (stored && profile.ssid === stored.ssid) ssidMatch ??= profile;
+	}
+
+	return ssidMatch;
+}
+
+/**
+ * `nmcli device wifi hotspot` names the profile it creates `Hotspot`, then
+ * `Hotspot-1`, `Hotspot-2`, … A profile carrying that generated id, in AP mode,
+ * that no adapter is using is a superseded CeraUI hotspot — the only kind this
+ * prunes.
+ */
+const GENERATED_HOTSPOT_ID_RE = /^Hotspot(?:-\d+)?$/;
+
+function collectConnsInUse(): Set<ConnectionUUID> {
+	const inUse = new Set<ConnectionUUID>();
+	for (const wifiInterface of Object.values(getWifiInterfacesByMacAddress())) {
+		if (!wifiInterface) continue;
+		if (wifiInterface.conn) inUse.add(wifiInterface.conn);
+		if (wifiInterface.activeConn) inUse.add(wifiInterface.activeConn);
+		if (canHotspot(wifiInterface) && wifiInterface.hotspot.conn) {
+			inUse.add(wifiInterface.hotspot.conn);
+		}
+	}
+	return inUse;
+}
+
+/** UUIDs another present adapter has claimed as its own hotspot identity. */
+function collectConnsReservedByOtherAdapters(
+	macAddress: MacAddress,
+): Set<ConnectionUUID> {
+	const reserved = new Set<ConnectionUUID>();
+	for (const mac of Object.keys(getWifiInterfacesByMacAddress())) {
+		if (mac === macAddress) continue;
+		const conn = getHotspotCredentials(mac)?.conn;
+		if (conn) reserved.add(conn);
+	}
+	return reserved;
+}
+
+/**
+ * Delete superseded hotspot profiles so exactly one survives per adapter. Best
+ * effort — a failure here never fails a hotspot start.
+ *
+ * A profile is only removed when it is provably THIS adapter's leftover: bound
+ * to this adapter's permanent address, or bound to an address no present adapter
+ * has (the randomized bindings that produced the duplicates in the first place).
+ * A profile bound to another present adapter — or claimed by another adapter's
+ * persisted identity — is always left alone, so a multi-radio device cannot lose
+ * its second hotspot to the first one's cleanup.
+ */
+export async function pruneDuplicateHotspotConns(
+	macAddress: MacAddress,
+	keepUuid: ConnectionUUID,
+	deps: HotspotProfileDeps = defaultHotspotProfileDeps,
+): Promise<ConnectionUUID[]> {
+	const rows = await listWirelessConns("uuid,type,name", deps);
+	if (!rows) return [];
+
+	const inUse = collectConnsInUse();
+	const reserved = collectConnsReservedByOtherAdapters(macAddress);
+	const presentAdapters = new Set(Object.keys(getWifiInterfacesByMacAddress()));
+	const removed: ConnectionUUID[] = [];
+
+	for (const [uuid, type, name] of rows) {
+		if (!uuid || type !== "802-11-wireless" || uuid === keepUuid) continue;
+		if (!name || !GENERATED_HOTSPOT_ID_RE.test(name)) continue;
+		if (inUse.has(uuid) || reserved.has(uuid)) continue;
+
+		const profile = await readApProfile(uuid, deps);
+		if (!profile) continue;
+		if (
+			profile.macAddress !== macAddress &&
+			presentAdapters.has(profile.macAddress)
+		) {
+			continue;
+		}
+
+		if (await deps.deleteConnection(uuid)) removed.push(uuid);
+	}
+
+	if (removed.length > 0) {
+		logger.info(
+			`Removed ${removed.length} superseded hotspot connection profile(s)`,
+		);
+	}
+	return removed;
 }

--- a/apps/backend/src/modules/wifi/wifi-hotspot-types.ts
+++ b/apps/backend/src/modules/wifi/wifi-hotspot-types.ts
@@ -15,6 +15,10 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import type {
+	HotspotCredentials,
+	HotspotCredentialsStore,
+} from "./hotspot-credentials.ts";
 import type { WifiChannel } from "./wifi-channels.ts";
 import type { BaseWifiInterface, WifiInterface } from "./wifi-interfaces.ts";
 
@@ -51,8 +55,59 @@ export type WifiInterfaceWithHotspot = BaseWifiInterface & {
 	hotspot: WifiHotspot;
 };
 
-/** nmcli activation timeout (seconds) for hotspot connect operations. */
-export const HOTSPOT_UP_TO = 10;
+/**
+ * nmcli activation timeout (seconds) for hotspot connect operations.
+ *
+ * Must exceed NetworkManager's OWN verdict on an AP activation, which it
+ * delivers at a fixed 25 s (`Activation: (wifi) Hotspot network creation took
+ * too long, failing activation`). At the previous 10 s, nmcli reported a
+ * timeout while NetworkManager was still working, so a slow-but-successful
+ * hotspot was recorded as a failure — and since autoconnect is only armed on a
+ * confirmed success, that profile was left unable to recover on its own. A
+ * successful AP start takes well under a second, so this costs nothing on the
+ * happy path.
+ */
+export const HOTSPOT_UP_TO = 30;
+
+/** An existing NetworkManager AP profile resolved back to its adapter. */
+export type ExistingHotspotConn = {
+	uuid: string;
+	ssid: string;
+	password: string;
+	channel: WifiChannel;
+};
+
+/**
+ * Settings that bind an AP profile to THIS adapter and make it joinable. Applied
+ * BEFORE activation, because NetworkManager matches `802-11-wireless.mac-address`
+ * against the adapter's permanent address and refuses a profile bound to
+ * anything else — so a profile written while the address was randomized has to
+ * be repaired first or the activation simply fails.
+ *
+ * `connection.interface-name` is deliberately cleared: the MAC binding is the
+ * stable one, and NetworkManager rejects a profile whose `interface-name` names
+ * a device the MAC binding excludes. The empty string (rather than an omitted
+ * arg) is required by the Bun runtime's CLI argument handling.
+ */
+export function hotspotBindingFields(
+	permanentMacAddress: string,
+): Record<string, string> {
+	return {
+		"connection.interface-name": "",
+		"802-11-wireless.mac-address": permanentMacAddress,
+		"802-11-wireless-security.pmf": "disable",
+	};
+}
+
+/**
+ * Applied only AFTER a confirmed activation. Arming autoconnect beforehand lets
+ * NetworkManager race its own auto-activation against the explicit `con up`, and
+ * would leave a profile that never came up trying again at every boot.
+ */
+export const HOTSPOT_AUTOCONNECT_FIELDS: Record<string, string> = {
+	"connection.autoconnect": "yes",
+	"connection.autoconnect-priority": "999",
+};
 
 /** Result of a hotspot start request. */
 export type HotspotStartResult =
@@ -82,6 +137,19 @@ export type HotspotActivationDeps = {
 	wifiUpdateSavedConns: () => Promise<void>;
 	broadcastState: () => void;
 	setDupIpSuppression: (ifname: string, suppressed: boolean) => void;
+	/** Durable per-adapter hotspot identity, keyed by permanent MAC address. */
+	credentials: HotspotCredentialsStore;
+	/**
+	 * Deterministic lookup of the NetworkManager AP profile that belongs to this
+	 * adapter. Runs BEFORE any credential generation so a restart reuses the
+	 * profile it already created instead of minting a new one.
+	 */
+	findHotspotConn: (
+		macAddress: string,
+		stored: HotspotCredentials | undefined,
+	) => Promise<ExistingHotspotConn | undefined>;
+	/** Best-effort removal of superseded CeraUI-generated AP profiles. */
+	pruneHotspotConns: (macAddress: string, keepUuid: string) => Promise<void>;
 	/**
 	 * Optional bounded confirmation poll. When provided, it is retried with
 	 * backoff until it returns `true` (confirming the hotspot is up) or attempts

--- a/apps/backend/src/modules/wifi/wifi-interfaces.ts
+++ b/apps/backend/src/modules/wifi/wifi-interfaces.ts
@@ -62,6 +62,10 @@ import {
 	type WifiHotspot,
 	type WifiInterfaceWithHotspot,
 } from "./wifi-hotspot-types.ts";
+import {
+	resolveWifiPermanentMac,
+	retainWifiPermanentMacs,
+} from "./wifi-permanent-mac.ts";
 
 export type SSID = string;
 export type WifiInterfaceId = number;
@@ -217,7 +221,7 @@ async function syncActiveConnection(
 		canHotspot(wifiInterface) &&
 		wifiInterface.hotspot.conn !== activeConn
 	) {
-		await handleHotspotConn(macAddress, activeConn);
+		await handleHotspotConn(macAddress, activeConn, { active: true });
 	}
 
 	return previousConn !== activeConn || previousMode !== mode;
@@ -241,6 +245,7 @@ export async function wifiUpdateDevices() {
 
 	// Rebuild the id to mac address map
 	wifiIdToMacAddress = {};
+	const seenIfnames: string[] = [];
 
 	for (const networkDevice of networkDevices) {
 		try {
@@ -263,8 +268,17 @@ export async function wifiUpdateDevices() {
 				activeConn !== null && wifiDeviceListGetInetAddress(ifname)
 					? activeConn
 					: null;
-			const macAddress = wifiDeviceListGetMacAddress(ifname);
-			if (!macAddress) continue;
+			const currentMac = wifiDeviceListGetMacAddress(ifname);
+			if (!currentMac) continue;
+
+			/*
+			  Adapters are keyed by their PERMANENT hardware address, never the
+			  operational one the ifconfig poll reports: NetworkManager randomizes
+			  that while scanning, and a re-keyed registry silently discards the
+			  adapter's adopted hotspot profile, saved-connection map and id.
+			*/
+			seenIfnames.push(ifname);
+			const macAddress = await resolveWifiPermanentMac(ifname, currentMac);
 
 			const wifiInterface = getWifiInterfaceByMacAddress(macAddress);
 
@@ -338,6 +352,8 @@ export async function wifiUpdateDevices() {
 			}
 		}
 	}
+
+	retainWifiPermanentMacs(seenIfnames);
 
 	// delete removed adapters
 	const wifiInterfacesByMacAddress = getWifiInterfacesByMacAddress();

--- a/apps/backend/src/modules/wifi/wifi-permanent-mac.ts
+++ b/apps/backend/src/modules/wifi/wifi-permanent-mac.ts
@@ -1,0 +1,157 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+  Permanent (hardware) MAC address resolution for WiFi adapters.
+
+  WHY THIS EXISTS. NetworkManager randomizes a WiFi device's OPERATIONAL MAC
+  while scanning (`wifi.scan-rand-mac-address`, enabled by default), and restores
+  the real one when it activates a connection. `ifconfig`/`ip link`/nmcli's
+  `GENERAL.HWADDR` all report that operational address, so the value CeraUI used
+  to key every adapter on changed several times an hour. Two things broke:
+
+    - the adapter registry (`wifiInterfacesByMacAddress`) re-keyed itself, so an
+      adapter's adopted hotspot profile, saved-connection map and numeric id were
+      silently discarded and rebuilt from empty; and
+    - `802-11-wireless.mac-address` — which NetworkManager matches against the
+      device's PERMANENT address, never its current one — was pinned to whatever
+      randomized value happened to be live, producing profiles no device can ever
+      activate ("device MAC address does not match the profile").
+
+  WHERE THE PERMANENT ADDRESS COMES FROM. `/sys/class/net/<ifname>/phy80211/
+  macaddress` is the cfg80211 wiphy's `perm_addr` — the radio's real, immutable
+  hardware address. It is a single file read (no spawn, no new allowed binary)
+  and was verified byte-equal to NetworkManager's own D-Bus `PermHwAddress`
+  property on the reference RK3588 board.
+
+  FALLBACK. A device with no `phy80211` node (or a non-Linux test host) resolves
+  to the caller-supplied current address — i.e. exactly the pre-fix behaviour, so
+  nothing regresses where the permanent address cannot be read.
+*/
+
+import { logger } from "../../helpers/logger.ts";
+import { ID_RE } from "../../helpers/run.ts";
+import type { MacAddress } from "../network/network-manager.ts";
+
+/** Canonical lowercase colon-separated MAC form. */
+const MAC_RE = /^[0-9a-f]{2}(?::[0-9a-f]{2}){5}$/;
+const ZERO_MAC = "00:00:00:00:00:00";
+
+/**
+ * Normalize a raw MAC string to the canonical lowercase form, rejecting
+ * anything malformed or all-zero (some drivers report `00:00:00:00:00:00` when
+ * they have no permanent address to give).
+ */
+export function normalizeMacAddress(
+	raw: string | undefined,
+): MacAddress | undefined {
+	if (!raw) return undefined;
+	const mac = raw.trim().toLowerCase();
+	if (!MAC_RE.test(mac) || mac === ZERO_MAC) return undefined;
+	return mac;
+}
+
+/** sysfs node exposing the radio's `wiphy->perm_addr`. */
+export function permanentMacSysfsPath(ifname: string): string {
+	return `/sys/class/net/${ifname}/phy80211/macaddress`;
+}
+
+export type PermanentMacReader = (
+	ifname: string,
+) => Promise<string | undefined>;
+
+const readPermanentMacFromSysfs: PermanentMacReader = async (ifname) => {
+	// `ifname` comes from nmcli output; validate before interpolating a path.
+	if (!ID_RE.test(ifname)) return undefined;
+	try {
+		return await Bun.file(permanentMacSysfsPath(ifname)).text();
+	} catch {
+		// No phy80211 node (non-cfg80211 driver) or an unreadable sysfs tree.
+		return undefined;
+	}
+};
+
+let activeReader: PermanentMacReader = readPermanentMacFromSysfs;
+
+/** Test seam (mirrors the other `set*Runner` seams). Pass `null` to restore. */
+export function setPermanentMacReaderForTest(
+	reader: PermanentMacReader | null,
+): void {
+	activeReader = reader ?? readPermanentMacFromSysfs;
+}
+
+/** Last successfully-read permanent address per interface name. */
+const permanentMacByIfname = new Map<string, MacAddress>();
+/** Interfaces already warned about, so the fallback logs once, not per poll. */
+const fallbackWarned = new Set<string>();
+
+/**
+ * Resolve the stable hardware identity of a WiFi adapter.
+ *
+ * Resolution order: the kernel's permanent address → the last permanent address
+ * successfully read for this interface → the caller's current (possibly
+ * randomized) address. The cached tier matters: a transient sysfs read failure
+ * must not re-key the adapter registry onto a scan-time address for one poll.
+ */
+export async function resolveWifiPermanentMac(
+	ifname: string,
+	currentMac: MacAddress,
+): Promise<MacAddress> {
+	const resolved = normalizeMacAddress(await activeReader(ifname));
+	if (resolved) {
+		if (permanentMacByIfname.get(ifname) !== resolved) {
+			permanentMacByIfname.set(ifname, resolved);
+			fallbackWarned.delete(ifname);
+		}
+		return resolved;
+	}
+
+	const cached = permanentMacByIfname.get(ifname);
+	if (cached) return cached;
+
+	if (!fallbackWarned.has(ifname)) {
+		fallbackWarned.add(ifname);
+		logger.warn(
+			`Could not read the permanent MAC address of ${ifname}; falling back to its current address. Hotspot identity may change if NetworkManager randomizes it.`,
+		);
+	}
+	return currentMac.toLowerCase();
+}
+
+/** The last permanent address resolved for `ifname`, if any. */
+export function getWifiPermanentMacCached(
+	ifname: string,
+): MacAddress | undefined {
+	return permanentMacByIfname.get(ifname);
+}
+
+/** Drop cached entries for interfaces that are no longer present. */
+export function retainWifiPermanentMacs(ifnames: Iterable<string>): void {
+	const keep = new Set(ifnames);
+	for (const ifname of [...permanentMacByIfname.keys()]) {
+		if (!keep.has(ifname)) {
+			permanentMacByIfname.delete(ifname);
+			fallbackWarned.delete(ifname);
+		}
+	}
+}
+
+/** Test seam: clear all cached permanent addresses. */
+export function resetWifiPermanentMacCache(): void {
+	permanentMacByIfname.clear();
+	fallbackWarned.clear();
+}

--- a/apps/backend/src/tests/wifi-hotspot-identity.test.ts
+++ b/apps/backend/src/tests/wifi-hotspot-identity.test.ts
@@ -1,0 +1,651 @@
+/*
+  Regression lock for per-adapter hotspot identity.
+
+  A test device accumulated SIX NetworkManager AP profiles (`Hotspot`,
+  `Hotspot-1` … `Hotspot-5`), each with a DIFFERENT SSID and password, because
+  every hotspot start took the "no hotspot connection yet" branch and generated a
+  fresh pair. Two independent causes, both reproduced below:
+
+    1. Adapters were keyed on the OPERATIONAL MAC address, which NetworkManager
+       randomizes while scanning. A backend restart (or a scan) re-keyed the
+       registry, so the adopted profile was lost and a new one was minted; the
+       SSID was also derived from whatever randomized value happened to be live.
+    2. `802-11-wireless.mac-address` was pinned to that same randomized value.
+       NetworkManager matches that property against the adapter's PERMANENT
+       address, so the profile could never be activated again — the board's
+       journal recorded `result="fail" reason="… device MAC address does not
+       match the profile"` on every start.
+*/
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+	getHotspotCredentials,
+	rememberHotspotCredentials,
+	resetHotspotCredentialsForTest,
+} from "../modules/wifi/hotspot-credentials.ts";
+import {
+	onWifiChange,
+	setWifiState,
+} from "../modules/wifi/state/wifi-state.ts";
+import {
+	addWifiInterface,
+	removeWifiInterface,
+} from "../modules/wifi/wifi-connections.ts";
+import { startHotspotForInterface } from "../modules/wifi/wifi-hotspot-activation.ts";
+import {
+	findHotspotConnForAdapter,
+	type HotspotProfileDeps,
+	pruneDuplicateHotspotConns,
+	shouldAdoptHotspotConn,
+} from "../modules/wifi/wifi-hotspot-discovery.ts";
+import type {
+	HotspotActivationDeps,
+	WifiInterfaceWithHotspot,
+} from "../modules/wifi/wifi-hotspot-types.ts";
+import {
+	normalizeMacAddress,
+	resetWifiPermanentMacCache,
+	resolveWifiPermanentMac,
+	setPermanentMacReaderForTest,
+} from "../modules/wifi/wifi-permanent-mac.ts";
+
+/** The reference board's real permanent address (D-Bus `PermHwAddress`). */
+const PERM_MAC = "58:02:05:e1:79:1c";
+/** One of the scan-time randomized addresses observed on that same board. */
+const RANDOM_MAC = "26:c3:93:b6:9c:a7";
+const SECOND_PERM_MAC = "dc:a6:32:aa:bb:cc";
+
+function makeHotspotIface(
+	over: { ifname?: string; hotspotConn?: string } = {},
+): WifiInterfaceWithHotspot {
+	return {
+		id: 0,
+		ifname: over.ifname ?? "wlan0",
+		conn: null,
+		hw: "Realtek RTL8852BE",
+		available: new Map(),
+		saved: {},
+		hotspot: {
+			...(over.hotspotConn ? { conn: over.hotspotConn } : {}),
+			availableChannels: ["auto"],
+			warnings: {},
+		},
+	};
+}
+
+type Recorder = {
+	deps: HotspotActivationDeps;
+	created: Array<{ ssid: string; password: string }>;
+	activated: string[];
+	setFields: Array<[string, Record<string, string>]>;
+	pruned: Array<[string, string]>;
+	store: Map<string, { ssid: string; password: string; conn?: string }>;
+};
+
+function makeRecorder(over: Partial<HotspotActivationDeps> = {}): Recorder {
+	const created: Recorder["created"] = [];
+	const activated: string[] = [];
+	const setFields: Recorder["setFields"] = [];
+	const pruned: Recorder["pruned"] = [];
+	const store: Recorder["store"] = new Map();
+
+	let generated = 0;
+	const deps: HotspotActivationDeps = {
+		nmConnect: async (uuid) => {
+			activated.push(uuid);
+			return true;
+		},
+		nmConnSetFields: async (uuid, fields) => {
+			setFields.push([uuid, fields]);
+			return true;
+		},
+		nmHotspot: async (_device, ssid, password) => {
+			created.push({ ssid, password });
+			generated += 1;
+			return `generated-uuid-${generated}`;
+		},
+		wifiUpdateSavedConns: async () => {},
+		broadcastState: () => {},
+		setDupIpSuppression: () => {},
+		credentials: {
+			get: (mac) => store.get(mac),
+			remember: (mac, creds) => {
+				store.set(mac, { ...creds });
+			},
+		},
+		findHotspotConn: async () => undefined,
+		pruneHotspotConns: async (mac, keep) => {
+			pruned.push([mac, keep]);
+		},
+		...over,
+	};
+
+	return { deps, created, activated, setFields, pruned, store };
+}
+
+beforeEach(() => {
+	setWifiState({});
+	onWifiChange(() => {});
+	resetHotspotCredentialsForTest();
+	resetWifiPermanentMacCache();
+});
+
+afterEach(() => {
+	setPermanentMacReaderForTest(null);
+	resetWifiPermanentMacCache();
+	resetHotspotCredentialsForTest();
+});
+
+// ─── 1. adapter identity is the PERMANENT address ────────────────────────────
+
+describe("permanent MAC resolution", () => {
+	test("prefers the kernel permanent address over the current one", async () => {
+		setPermanentMacReaderForTest(async () => `${PERM_MAC.toUpperCase()}\n`);
+
+		expect(await resolveWifiPermanentMac("wlan0", RANDOM_MAC)).toBe(PERM_MAC);
+	});
+
+	test("a randomized address never re-keys the adapter across polls", async () => {
+		setPermanentMacReaderForTest(async () => PERM_MAC);
+
+		const first = await resolveWifiPermanentMac("wlan0", PERM_MAC);
+		const duringScan = await resolveWifiPermanentMac("wlan0", RANDOM_MAC);
+
+		expect(duringScan).toBe(first);
+	});
+
+	test("a transient sysfs failure holds the last permanent address", async () => {
+		setPermanentMacReaderForTest(async () => PERM_MAC);
+		await resolveWifiPermanentMac("wlan0", PERM_MAC);
+
+		setPermanentMacReaderForTest(async () => undefined);
+		expect(await resolveWifiPermanentMac("wlan0", RANDOM_MAC)).toBe(PERM_MAC);
+	});
+
+	test("with no permanent address at all it degrades to the current one", async () => {
+		setPermanentMacReaderForTest(async () => undefined);
+
+		expect(await resolveWifiPermanentMac("wlan0", RANDOM_MAC)).toBe(RANDOM_MAC);
+	});
+
+	test("rejects malformed and all-zero addresses", () => {
+		expect(normalizeMacAddress("00:00:00:00:00:00")).toBeUndefined();
+		expect(normalizeMacAddress("not-a-mac")).toBeUndefined();
+		expect(normalizeMacAddress(" 58:02:05:E1:79:1C\n")).toBe(PERM_MAC);
+	});
+});
+
+// ─── 2. a restart reuses the identity instead of minting a new one ───────────
+
+describe("hotspot start — identity reuse", () => {
+	test("first-ever start generates from the permanent MAC and persists it", async () => {
+		const rec = makeRecorder();
+		const iface = makeHotspotIface();
+
+		const result = await startHotspotForInterface(PERM_MAC, iface, rec.deps);
+
+		expect(result.success).toBe(true);
+		expect(rec.created).toHaveLength(1);
+		// SSID suffix is the PERMANENT address's last two octets, never a scan value.
+		expect(rec.created[0]?.ssid).toBe("CERALIVE_791c");
+		expect(rec.store.get(PERM_MAC)?.ssid).toBe("CERALIVE_791c");
+		expect(rec.store.get(PERM_MAC)?.password).toBe(rec.created[0]?.password);
+	});
+
+	test("a backend restart reuses the SAME ssid/password and creates NO new profile", async () => {
+		const first = makeRecorder();
+		await startHotspotForInterface(PERM_MAC, makeHotspotIface(), first.deps);
+
+		const persisted = first.store.get(PERM_MAC);
+		expect(persisted).toBeDefined();
+
+		// Simulate the restart: fresh in-memory interface (no hotspot.conn), the
+		// durable store survives, and NetworkManager still holds the profile.
+		const second = makeRecorder({
+			findHotspotConn: async (mac, stored) => {
+				expect(mac).toBe(PERM_MAC);
+				expect(stored?.ssid).toBe(persisted?.ssid);
+				return {
+					uuid: "generated-uuid-1",
+					ssid: stored?.ssid ?? "",
+					password: stored?.password ?? "",
+					channel: "auto",
+				};
+			},
+		});
+		second.store.set(PERM_MAC, {
+			...(persisted as { ssid: string; password: string }),
+		});
+
+		const restarted = makeHotspotIface();
+		const result = await startHotspotForInterface(
+			PERM_MAC,
+			restarted,
+			second.deps,
+		);
+
+		expect(result.success).toBe(true);
+		// The decisive assertion: NO new NetworkManager profile was created.
+		expect(second.created).toHaveLength(0);
+		expect(second.activated).toEqual(["generated-uuid-1"]);
+		expect(restarted.hotspot.name).toBe(persisted?.ssid);
+		expect(restarted.hotspot.password).toBe(persisted?.password);
+	});
+
+	test("an externally deleted profile is recreated with the SAME credentials", async () => {
+		const rec = makeRecorder();
+		rec.store.set(PERM_MAC, {
+			ssid: "CERALIVE_791c",
+			password: "persisted-secret",
+			conn: "deleted-uuid",
+		});
+
+		const result = await startHotspotForInterface(
+			PERM_MAC,
+			makeHotspotIface(),
+			rec.deps,
+		);
+
+		expect(result.success).toBe(true);
+		expect(rec.created).toEqual([
+			{ ssid: "CERALIVE_791c", password: "persisted-secret" },
+		]);
+	});
+
+	test("the profile is pinned to the permanent MAC, and repaired BEFORE activation", async () => {
+		const order: string[] = [];
+		const rec = makeRecorder({
+			findHotspotConn: async () => ({
+				uuid: "orphan-uuid",
+				ssid: "CERALIVE_9ca7",
+				password: "old-secret",
+				channel: "auto",
+			}),
+			nmConnSetFields: async (uuid, fields) => {
+				const mac = fields["802-11-wireless.mac-address"];
+				order.push(mac ? `bind:${uuid}:${mac}` : `autoconnect:${uuid}`);
+				return true;
+			},
+			nmConnect: async (uuid) => {
+				order.push(`up:${uuid}`);
+				return true;
+			},
+		});
+
+		await startHotspotForInterface(PERM_MAC, makeHotspotIface(), rec.deps);
+
+		// NetworkManager matches mac-address against the PERMANENT address, so the
+		// repair has to land before the activation it would otherwise reject —
+		// while autoconnect must wait until the hotspot is proven to come up, or
+		// NetworkManager races its own auto-activation against the explicit up.
+		expect(order).toEqual([
+			`bind:orphan-uuid:${PERM_MAC}`,
+			"up:orphan-uuid",
+			"autoconnect:orphan-uuid",
+		]);
+	});
+
+	test("autoconnect is never armed on a profile that failed to come up", async () => {
+		const armed: string[] = [];
+		const rec = makeRecorder({
+			findHotspotConn: async () => ({
+				uuid: "orphan-uuid",
+				ssid: "CERALIVE_9ca7",
+				password: "old-secret",
+				channel: "auto",
+			}),
+			nmConnSetFields: async (uuid, fields) => {
+				if (fields["connection.autoconnect"] === "yes") armed.push(uuid);
+				return true;
+			},
+			nmConnect: async () => false,
+		});
+
+		await startHotspotForInterface(PERM_MAC, makeHotspotIface(), rec.deps);
+
+		expect(armed).toEqual([]);
+	});
+
+	test("a failed activation of an existing profile still rolls back", async () => {
+		const rec = makeRecorder({
+			findHotspotConn: async () => ({
+				uuid: "orphan-uuid",
+				ssid: "CERALIVE_9ca7",
+				password: "old-secret",
+				channel: "auto",
+			}),
+			nmConnect: async () => false,
+		});
+
+		const result = await startHotspotForInterface(
+			PERM_MAC,
+			makeHotspotIface(),
+			rec.deps,
+		);
+
+		expect(result.success).toBe(false);
+		if (!result.success) expect(result.error).toBe("activation-failed");
+		expect(rec.created).toHaveLength(0);
+	});
+});
+
+// ─── 3. multi-adapter isolation ──────────────────────────────────────────────
+
+describe("hotspot identity — multiple adapters", () => {
+	test("two adapters keep two independent, non-colliding identities", async () => {
+		const rec = makeRecorder();
+
+		await startHotspotForInterface(PERM_MAC, makeHotspotIface(), rec.deps);
+		await startHotspotForInterface(
+			SECOND_PERM_MAC,
+			makeHotspotIface({ ifname: "wlan1" }),
+			rec.deps,
+		);
+
+		const a = rec.store.get(PERM_MAC);
+		const b = rec.store.get(SECOND_PERM_MAC);
+
+		expect(a?.ssid).toBe("CERALIVE_791c");
+		expect(b?.ssid).toBe("CERALIVE_bbcc");
+		expect(a?.password).not.toBe(b?.password);
+		expect(a?.conn).not.toBe(b?.conn);
+	});
+
+	test("both identities survive a restart, each adapter keeping its own", async () => {
+		const rec = makeRecorder();
+		await startHotspotForInterface(PERM_MAC, makeHotspotIface(), rec.deps);
+		await startHotspotForInterface(
+			SECOND_PERM_MAC,
+			makeHotspotIface({ ifname: "wlan1" }),
+			rec.deps,
+		);
+		const before = new Map(rec.store);
+
+		const after = makeRecorder({
+			findHotspotConn: async (_mac, stored) =>
+				stored?.conn
+					? {
+							uuid: stored.conn,
+							ssid: stored.ssid,
+							password: stored.password,
+							channel: "auto",
+						}
+					: undefined,
+		});
+		for (const [mac, creds] of before) after.store.set(mac, { ...creds });
+
+		const ifaceA = makeHotspotIface();
+		const ifaceB = makeHotspotIface({ ifname: "wlan1" });
+		await startHotspotForInterface(PERM_MAC, ifaceA, after.deps);
+		await startHotspotForInterface(SECOND_PERM_MAC, ifaceB, after.deps);
+
+		expect(after.created).toHaveLength(0);
+		expect(ifaceA.hotspot.name).toBe(before.get(PERM_MAC)?.ssid);
+		expect(ifaceB.hotspot.name).toBe(before.get(SECOND_PERM_MAC)?.ssid);
+		expect(ifaceA.hotspot.password).not.toBe(ifaceB.hotspot.password);
+	});
+});
+
+// ─── 4. durable store round-trip ─────────────────────────────────────────────
+
+describe("hotspot credentials store", () => {
+	test("keys are normalized so a case difference is the same adapter", () => {
+		rememberHotspotCredentials(PERM_MAC.toUpperCase(), {
+			ssid: "CERALIVE_791c",
+			password: "secret",
+		});
+
+		expect(getHotspotCredentials(PERM_MAC)?.ssid).toBe("CERALIVE_791c");
+	});
+
+	test("an incomplete credential pair is never recorded", () => {
+		rememberHotspotCredentials(PERM_MAC, {
+			ssid: "CERALIVE_791c",
+			password: "",
+		});
+
+		expect(getHotspotCredentials(PERM_MAC)).toBeUndefined();
+	});
+
+	test("adapters do not overwrite each other", () => {
+		rememberHotspotCredentials(PERM_MAC, { ssid: "a", password: "pa" });
+		rememberHotspotCredentials(SECOND_PERM_MAC, { ssid: "b", password: "pb" });
+
+		expect(getHotspotCredentials(PERM_MAC)?.ssid).toBe("a");
+		expect(getHotspotCredentials(SECOND_PERM_MAC)?.ssid).toBe("b");
+	});
+});
+
+// ─── 5. deterministic profile lookup + duplicate consolidation ───────────────
+
+type FakeProfile = {
+	uuid: string;
+	name: string;
+	mode: string;
+	ssid: string;
+	psk: string;
+	mac: string;
+};
+
+function makeProfileDeps(profiles: FakeProfile[]): {
+	deps: HotspotProfileDeps;
+	deleted: string[];
+} {
+	const deleted: string[] = [];
+	const deps: HotspotProfileDeps = {
+		getApProfileFields: async (uuid) => {
+			const p = profiles.find((entry) => entry.uuid === uuid);
+			if (!p) return undefined;
+			return [p.mode, p.ssid, p.psk, "", "", p.mac] as const;
+		},
+		listConnections: async (fields) =>
+			profiles.map((p) =>
+				fields.includes("name")
+					? `${p.uuid}:802-11-wireless:${p.name}`
+					: `${p.uuid}:802-11-wireless`,
+			),
+		deleteConnection: async (uuid) => {
+			deleted.push(uuid);
+			return true;
+		},
+	};
+	return { deps, deleted };
+}
+
+describe("findHotspotConnForAdapter", () => {
+	test("matches on the adapter's permanent MAC, not on profile order or name", async () => {
+		const { deps } = makeProfileDeps([
+			{
+				uuid: "orphan",
+				name: "Hotspot-1",
+				mode: "ap",
+				ssid: "CERALIVE_ce62",
+				psk: "x",
+				mac: RANDOM_MAC,
+			},
+			{
+				uuid: "ours",
+				name: "Hotspot-5",
+				mode: "ap",
+				ssid: "CERALIVE_791c",
+				psk: "y",
+				mac: PERM_MAC.toUpperCase(),
+			},
+		]);
+
+		const found = await findHotspotConnForAdapter(PERM_MAC, undefined, deps);
+
+		expect(found?.uuid).toBe("ours");
+		expect(found?.password).toBe("y");
+	});
+
+	test("a station profile is never adopted as a hotspot", async () => {
+		const { deps } = makeProfileDeps([
+			{
+				uuid: "home",
+				name: "HomeWifi",
+				mode: "infrastructure",
+				ssid: "Home",
+				psk: "z",
+				mac: PERM_MAC,
+			},
+		]);
+
+		expect(
+			await findHotspotConnForAdapter(PERM_MAC, undefined, deps),
+		).toBeUndefined();
+	});
+
+	test("falls back to the persisted SSID for a profile with a stale binding", async () => {
+		const { deps } = makeProfileDeps([
+			{
+				uuid: "legacy",
+				name: "Hotspot",
+				mode: "ap",
+				ssid: "CERALIVE_eeca",
+				psk: "legacy-secret",
+				mac: RANDOM_MAC,
+			},
+		]);
+
+		const found = await findHotspotConnForAdapter(
+			PERM_MAC,
+			{ ssid: "CERALIVE_eeca", password: "legacy-secret" },
+			deps,
+		);
+
+		expect(found?.uuid).toBe("legacy");
+	});
+});
+
+describe("shouldAdoptHotspotConn", () => {
+	test("the persisted identity arbitrates between duplicate profiles", () => {
+		const stored = { ssid: "CERALIVE_791c", password: "p", conn: "ours" };
+
+		expect(shouldAdoptHotspotConn("ours", stored)).toBe(true);
+		// The exact regression: a sweep over duplicates must not let whichever
+		// profile nmcli enumerated first change the adapter's SSID.
+		expect(shouldAdoptHotspotConn("duplicate", stored)).toBe(false);
+	});
+
+	test("the connection NetworkManager is actually running always wins", () => {
+		const stored = { ssid: "CERALIVE_791c", password: "p", conn: "ours" };
+
+		expect(shouldAdoptHotspotConn("running", stored, { active: true })).toBe(
+			true,
+		);
+	});
+
+	test("with no persisted identity any AP profile may claim the adapter", () => {
+		expect(shouldAdoptHotspotConn("anything", undefined)).toBe(true);
+		expect(
+			shouldAdoptHotspotConn("anything", { ssid: "s", password: "p" }),
+		).toBe(true);
+	});
+});
+
+describe("pruneDuplicateHotspotConns", () => {
+	afterEach(() => {
+		removeWifiInterface(PERM_MAC);
+		removeWifiInterface(SECOND_PERM_MAC);
+	});
+
+	test("removes superseded generated profiles and keeps the active one", async () => {
+		addWifiInterface(PERM_MAC, makeHotspotIface({ hotspotConn: "keep" }));
+		const { deps, deleted } = makeProfileDeps([
+			{
+				uuid: "keep",
+				name: "Hotspot-5",
+				mode: "ap",
+				ssid: "CERALIVE_791c",
+				psk: "y",
+				mac: PERM_MAC,
+			},
+			{
+				uuid: "orphan-a",
+				name: "Hotspot-1",
+				mode: "ap",
+				ssid: "CERALIVE_ce62",
+				psk: "x",
+				mac: RANDOM_MAC,
+			},
+			{
+				uuid: "orphan-b",
+				name: "Hotspot",
+				mode: "ap",
+				ssid: "CERALIVE_eeca",
+				psk: "x",
+				mac: PERM_MAC,
+			},
+			{
+				uuid: "home",
+				name: "HomeWifi",
+				mode: "infrastructure",
+				ssid: "Home",
+				psk: "z",
+				mac: PERM_MAC,
+			},
+		]);
+
+		const removed = await pruneDuplicateHotspotConns(PERM_MAC, "keep", deps);
+
+		expect(removed.sort()).toEqual(["orphan-a", "orphan-b"]);
+		expect(deleted).not.toContain("keep");
+		expect(deleted).not.toContain("home");
+	});
+
+	test("never removes another present adapter's hotspot profile", async () => {
+		addWifiInterface(PERM_MAC, makeHotspotIface({ hotspotConn: "keep" }));
+		addWifiInterface(SECOND_PERM_MAC, makeHotspotIface({ ifname: "wlan1" }));
+		const { deps, deleted } = makeProfileDeps([
+			{
+				uuid: "keep",
+				name: "Hotspot",
+				mode: "ap",
+				ssid: "CERALIVE_791c",
+				psk: "y",
+				mac: PERM_MAC,
+			},
+			{
+				uuid: "other-adapter",
+				name: "Hotspot-1",
+				mode: "ap",
+				ssid: "CERALIVE_bbcc",
+				psk: "y",
+				mac: SECOND_PERM_MAC,
+			},
+		]);
+
+		const removed = await pruneDuplicateHotspotConns(PERM_MAC, "keep", deps);
+
+		expect(removed).toEqual([]);
+		expect(deleted).toEqual([]);
+	});
+
+	test("a hand-made AP profile is left alone", async () => {
+		addWifiInterface(PERM_MAC, makeHotspotIface({ hotspotConn: "keep" }));
+		const { deps, deleted } = makeProfileDeps([
+			{
+				uuid: "keep",
+				name: "Hotspot",
+				mode: "ap",
+				ssid: "CERALIVE_791c",
+				psk: "y",
+				mac: PERM_MAC,
+			},
+			{
+				uuid: "manual",
+				name: "My Field AP",
+				mode: "ap",
+				ssid: "FieldAP",
+				psk: "y",
+				mac: PERM_MAC,
+			},
+		]);
+
+		await pruneDuplicateHotspotConns(PERM_MAC, "keep", deps);
+
+		expect(deleted).toEqual([]);
+	});
+});

--- a/apps/backend/src/tests/wifi-hotspot.test.ts
+++ b/apps/backend/src/tests/wifi-hotspot.test.ts
@@ -50,6 +50,9 @@ function makeDeps(over: Partial<HotspotActivationDeps>): HotspotActivationDeps {
 		wifiUpdateSavedConns: async () => {},
 		broadcastState: () => {},
 		setDupIpSuppression: () => {},
+		credentials: { get: () => undefined, remember: () => {} },
+		findHotspotConn: async () => undefined,
+		pruneHotspotConns: async () => {},
 		...over,
 	};
 }

--- a/docs/CONFIG_PERSISTENCE.md
+++ b/docs/CONFIG_PERSISTENCE.md
@@ -41,6 +41,45 @@ any leftover from a prior crash, fail-soft, every boot.
 |------|--------|-----------|-------|
 | `config.json` | `saveConfig` (`modules/config.ts:93`) | Atomic (`writeFileAtomicSync`) | The single runtime state file: relay target, audio/video settings, kiosk state, add-on state, and (see below) the password/SSH hashes. Pre-dates T6 (E3 guardrail); unchanged by this wave. |
 | `notification_dismissals.json` | `NotificationDismissalStore.recordDismissal` (`modules/ui/notification-dismissals.ts`) | Atomic (`writeFileAtomicSync`) | Durable record of which persistent notifications the operator dismissed, keyed by SEMANTIC identity so a dismissal survives a page reload AND a backend restart. LRU-bounded, corruption-quarantined. Path overridable via `CERALIVE_DISMISSALS_FILE` (tests). See the dedicated subsection below. |
+| `hotspot_credentials.json` | `rememberHotspotCredentials` (`modules/wifi/hotspot-credentials.ts`) | Atomic (`writeFileAtomicSync`) | Per-adapter hotspot SSID/password, keyed by the radio's PERMANENT hardware address. A BACKSTOP behind NetworkManager's own `.nmconnection` files (which stay the source of truth) for the one case they cannot cover — a profile deleted outside CeraUI. Writes are inert until `initHotspotCredentials()` runs, so a test that never opts in writes nothing. See the dedicated subsection below. |
+
+#### Hotspot credentials store — why it exists alongside NetworkManager
+
+A hotspot's SSID and password must be generated once per physical adapter and
+reused forever; a phone told `CERALIVE_791c` once should never have to be told
+again. NetworkManager already persists that pair inside the AP profile, so the
+profile — not this file — is the source of truth, and CeraUI re-adopts it on
+every boot (`findHotspotConnForAdapter`, keyed on the adapter's permanent MAC).
+
+This file covers the gap NetworkManager cannot: if the profile is deleted out
+from under CeraUI (`nmcli con del`, a wiped `system-connections` directory, an
+image re-flash that preserves `/data`), the credentials the operator's phone
+already stores are gone and the next start would mint a new identity. With the
+store, the hotspot is recreated with the SAME SSID and password and only the
+NetworkManager object is new.
+
+On-disk format:
+
+```json
+{
+  "version": 1,
+  "adapters": {
+    "58:02:05:e1:79:1c": {
+      "ssid": "CERALIVE_791c",
+      "password": "…",
+      "conn": "18960239-bc9e-4820-8277-658608c8c697",
+      "channel": "auto",
+      "updatedAt": 1785169237000
+    }
+  }
+}
+```
+
+`conn` is a HINT — it is re-verified against NetworkManager before use and never
+trusted on its own. Keys are the permanent hardware address, lowercased, so a
+multi-radio device keeps one independent identity per radio. An unparseable file
+starts an empty store (`loadCacheFile`'s tolerant path): nothing is lost that
+re-adoption cannot recover.
 
 #### Notification dismissal store — on-disk format + semantics
 


### PR DESCRIPTION
## What

A hotspot's SSID and password are now generated **once per physical WiFi adapter and reused forever** — across station↔hotspot switches, backend restarts and reboots — instead of being regenerated on essentially every start.

The reference board had accumulated six NetworkManager AP profiles (`Hotspot`, `Hotspot-1` … `Hotspot-5`), each broadcasting a different SSID with a different password. None of them was an identity an operator's phone could be told about once and rely on.

## Why

Two independent causes, both confirmed from the board's own NetworkManager journal.

**1. Adapters were keyed on the operational MAC, which NetworkManager randomizes.** `wifiUpdateDevices` keyed the adapter registry on the address `ifconfig` reports. NetworkManager randomizes that while scanning (`wifi.scan-rand-mac-address`, on by default) — roughly every 7 minutes on this board:

```
17:17:18 device (wlan0): set-hw-addr: set MAC address to 26:C3:93:B6:9C:A7 (scanning)
```

Every randomization re-keyed the registry, so the adapter's adopted `hotspot.conn` was discarded and the next start fell into the "no hotspot connection yet" branch. The SSID suffix was read from that same transient value, which is why `CERALIVE_9ca7` matches a scan MAC rather than the hardware.

**2. That transient MAC was then pinned into the profile, making it permanently unactivatable.** NetworkManager matches `802-11-wireless.mac-address` against the device's **permanent** address, never its current one. The full failing sequence:

```
17:20:36 Activation: starting connection 'Hotspot-5'
17:20:36 audit: op="connection-add-activate" name="Hotspot-5" result="success"
17:20:36 set-hw-addr: reset MAC address to 58:02:05:E1:79:1C (preserve)
17:20:37 Started Wi-Fi Hotspot "CERALIVE_9ca7"
17:20:37 audit: op="connection-update" args="802-11-wireless.mac-address,…" result="success"
17:20:37 audit: op="connection-activate" result="fail"
         reason="No suitable device found … (device MAC address does not match the profile)."
```

`nmcli device wifi hotspot` created and activated the AP, CeraUI pinned a MAC no device has, the follow-up `con up` was refused, the start rolled back — and the next start repeated the whole thing against a new profile. That `result="fail"` line accompanied every otherwise-working hotspot start.

This also explains the mismatch *inside* a single profile (`Hotspot` pinned `…79:1C` but announced `CERALIVE_eeca`): the SSID came from the generation-time random MAC and `findMacAddressForConnection` later re-pinned the MAC from a different transient read.

## How

- **`wifi-permanent-mac.ts`** — `resolveWifiPermanentMac()` reads `/sys/class/net/<ifname>/phy80211/macaddress` (the cfg80211 `wiphy->perm_addr`), verified byte-equal to NetworkManager's D-Bus `PermHwAddress` on the board. Falls back to the last permanent address read, then to the current one, so nothing regresses where it cannot be read. Deliberately **not** `busctl` — it is not in `helpers/run.ts`'s ALLOWED set and a single sysfs read needs no spawn. nmcli cannot serve this: `GENERAL.PERM-HWADDR` is not in `device show`'s field allowlist on this NM version.
- **Every adapter-keyed structure uses that address** — registry, wifiState cache, id map, and the MAC pinned into profiles. `getWifiInterfaceByIfname()` is the new bridge for ifname-carrying monitor events.
- **Discovery runs before generation.** `findHotspotConnForAdapter()` resolves deterministically: persisted UUID → the profile bound to this permanent address → (last resort) the persisted SSID. No name guessing.
- **`hotspot_credentials.json`** — atomic JSON per `docs/CONFIG_PERSISTENCE.md`, **not** SQLite. It is a *backstop*, not a new source of truth: NetworkManager's own profile stays primary, and the store exists only so a profile deleted outside CeraUI is recreated with the SAME credentials. Written on generation (before activation), on adoption, and on operator rename.
- **Two ordering rules the live board proved load-bearing.** The MAC binding is repaired *before* `con up` (activating first is exactly what failed every time), and `connection.autoconnect` is armed only *after* a confirmed activation — arming it first lets NetworkManager race its own auto-activation and leaves a never-working profile retrying at every boot.
- **`HOTSPOT_UP_TO` 10s → 30s.** NetworkManager delivers its own AP verdict at a fixed 25s. At 10s nmcli reported a timeout while NM was still working, so a slow-but-successful hotspot was recorded as a failure — which now matters because autoconnect arming is gated on that verdict. A successful AP start takes under a second, so the happy path is unaffected.

### Which cleanup approach, and why

**Both (a) and (b) from the options considered:** no new duplicates can be created, *and* superseded ones are actively consolidated on the next start. The delete is deliberately narrow — a profile is removed only when it is AP mode, carries the nmcli-generated `Hotspot`/`Hotspot-N` id, is used by no adapter, is claimed by no other adapter's persisted identity, and is bound either to this adapter or to an address no present adapter has. Another radio's hotspot is never touched, and a hand-made AP profile is never touched.

### A flaw the tests could not have caught

The first build deployed to the board still changed the SSID across a restart: the boot saved-connection sweep walks every AP profile in nmcli order and adopted whichever came first, overwriting the store. Fixed with `shouldAdoptHotspotConn()` — the persisted identity arbitrates between duplicates, and only the connection NetworkManager is actually *running* overrides it. This only reproduces when several profiles already share a permanent MAC, which is why it needed hardware.

## How to verify

Unit (`apps/backend`):

```bash
bun test src/tests/wifi-hotspot-identity.test.ts
```

25 cases: the permanent-MAC ladder, first-ever generation from the permanent suffix, restart reuse with **zero** profile creation, recreate-after-external-delete, repair-before-activate ordering, autoconnect-not-armed-on-failure, multi-adapter isolation across a restart, store round-trip, deterministic lookup, adoption arbitration, and four prune negatives.

Rule E proof, captured in both directions: neutering discovery-before-generation reddens 5 tests; swapping the repair/activate order reddens the ordering test alone.

On hardware:

```bash
# note the SSID, then:
systemctl restart ceralive.service
# stop + start the hotspot from the Network page
nmcli -t -f NAME,UUID,DEVICE connection show | grep -i hotspot   # expect exactly ONE
```

Done three times on a Rock 5B+ over the product's own RPC: SSID and password identical every cycle (`CERALIVE_eeca` / `SN3ZM1q5NAvu`), profile count stayed at **1** (pre-fix: three new profiles, three SSIDs). Deleting the profile out from under CeraUI recreated it with byte-identical credentials under a new UUID. The six orphans were consolidated to one, whose `mac-address` is now the permanent `58:02:05:E1:79:1C`.

Gate: `biome check` 0 errors (35 pre-existing nursery warnings, none in changed files), `tsc --noEmit` clean, `bun test` 2420 pass / 0 fail, `check:tech-debt` OK.

## Risks

- **One-time identity churn on a device that already has duplicates.** The first start after upgrading picks one existing profile and locks onto it forever; on a device with several, that may not be the one it was last broadcasting. Unavoidable — before this change there was no stable identity to preserve — and it happens exactly once.
- **Adapter re-keying on first boot after upgrade.** Adapters previously keyed on an operational MAC are re-registered under their permanent address, so the numeric UI id can change once. Cosmetic and self-correcting.
- **Deleting NetworkManager profiles is destructive.** Mitigated by the five-way predicate above and covered by four negative tests. A profile with a non-generated id, in use, claimed by another adapter, or bound to another present radio is never a candidate.
- **`HOTSPOT_UP_TO` 30s means a genuinely failing start now reports failure after ~25s instead of 10s.** `wifiHotspotStart` is dispatched fire-and-forget, so the RPC still returns immediately and the UI shows `activating` throughout — the designed behaviour.
- **Autoconnect now works.** With the binding correct, a hotspot left on survives a reboot (`autoconnect=yes` + priority 999 previously could never match a device). `wifiHotspotStop` still sets `autoconnect=no`, so a hotspot turned off stays off. This is the documented intent finally taking effect, but it is a behaviour change on real devices.

## Out of scope — separate pre-existing defect found while verifying

NetworkManager auto-selects **channel 13** for an AP profile with no band/channel set, and channel 13 cannot host an AP once the radio's regulatory domain resets to WORLD (`wpa_supplicant: Failed to start AP functionality`). Isolated by controlled A/B on the *same* profile: 2472 MHz fails after exactly 25s (~8/8 attempts), 2412 MHz activates in 0.6s; `pmf`, the MAC binding and `interface-name` each made no difference.

Notably, **the old bug was masking this** — every failed start minted a new profile, and a fresh profile got a fresh legal channel, so the hotspot came up at the cost of a new SSID. Now that one profile is correctly reused, a bad channel pick sticks.

Not fixed here: constraining the AP channel is a product/regulatory decision, not a bug fix, and belongs in its own change. Full evidence and a recommendation are recorded in the team notepad.
