### PR TITLE
fix(audio): make "Auto" follow the selected camera's own card

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -166,6 +166,59 @@ broadcast instead of falling back to the bare asrc key.
 
 Coverage: `tests/audio-device-naming-cleanup.test.ts`, `tests/audio-naming.test.ts`.
 
+**The resolved label/identity maps are re-resolved when the ENGINE list changes,
+not only on a udev hotplug.** `lastAudioDisplays` / `lastAudioIdentities` are built
+inside `broadcastAudioSources()`, which only `updateAudioDevices()` called — and
+that runs on the SIGUSR2 udev hotplug and at boot. The engine's own audio
+enumeration lands on ITS schedule, seconds later, through `sources.ts`
+`commitEngineDevices` (the 5 s signal recheck and the video-hotplug probe both
+commit it). Nothing re-ran the join, so whatever the maps resolved to at plug time
+LATCHED. Confirmed live on a Rock 5B+: a DJI Osmo Pocket 3 plugged in mid-session
+rendered with no `transport` and no `stable_id` for the rest of the session while
+the engine had been reporting `alsa_card_id: "DJIPocket3"`, `transport: "usb"`,
+`stable_id: "card:DJIPocket3"` within seconds of the plug; one manual SIGUSR2
+filled both in instantly. Same latched-stale class as `policy_route_missing` and
+the video signal recheck.
+
+`commitEngineDevices` now fires an injected handler when the SERIALIZED audio list
+changes (default: a lazy `import("./audio.ts")` — `audio.ts` imports `sources.ts`,
+so a static import would cycle; the same shape `devices.ts` uses for
+`onDevicesChanged`). The handler is `reresolveAudioForEngineChange()`, deliberately
+NOT the whole of `updateAudioDevices()`: the sysfs card scan has not changed
+(nothing was plugged), so re-walking it would raise a spurious lost-device verdict
+and re-blink the meter through `noteMeterSelection`. Only the engine JOIN goes
+stale, so only `broadcastAudioSources()` + `refreshResolvedAsrcPreview()` are
+redone; `syncAudioMeterPreference()` is skipped because the meter preference
+resolves from the sysfs card map. Keyed on the serialized list, so the 5 s recheck's
+steady state costs one string compare and broadcasts nothing.
+`setEngineAudioChangeHandler()` is the test seam. Coverage:
+`tests/lost-device-retention.test.ts`.
+
+## "AUTO" AUDIO — THE SAME-DEVICE JOIN [EXISTS]
+
+`resolveAutoAsrc` rule 5(i) (`modules/streaming/auto-audio.ts`) picks the audio card
+belonging to the SAME chassis as the selected USB/UVC camera, by matching names with
+a `MIN_COMMON_PREFIX` (4-character) shared-prefix floor.
+
+**It must compare EVERY engine-given name, not `display_name` alone.** cerastream
+sets an audio entry's `display_name` to the ALSA longname verbatim, and the kernel
+puts the manufacturer on the front of that string. The DJI Osmo Pocket 3 is the
+worked example: audio `"DJI DJIPocket3 at usb-fc880000.usb-1, high speed"` vs video
+`"DJIPocket3: OsmoPocket3"` share only `"DJI"` — 3 characters, ONE short of the
+floor. The join missed, rule 5(ii) fired, and "Auto" served the generic `usbaudio`
+card, i.e. a **different physical device's microphone** (a still-enumerated RØDE
+whose video interface had already died). `engineAudioJoinNames()` therefore also
+offers `product_name` and `alsa_card_id` (both `"DJIPocket3"`, both already on the
+wire), which carry no manufacturer prefix and align from the first character.
+
+**The BEST match wins, not the first.** Several cards can clear a 4-character floor
+(`DJIPro` vs `DJIPocket3`), and taking whichever the engine happened to list first is
+exactly the coin-flip this rule exists to remove.
+
+Do NOT add the asrc key or any CeraUI-side alias to the candidate list — those are
+our own strings, not names the hardware chose, and would join a card to a device it
+shares nothing with. Coverage: `tests/auto-audio.test.ts`.
+
 **An unavailable selected input fails the start ONCE, as itself.** `asrcProbe()`
 polls for `AUDIO_PROBE_TIMEOUT_MS` (15 s) — a deliberate "give the device a moment
 to come back" grace window that also wakes early on a hotplug re-enumeration. That
@@ -1846,6 +1899,8 @@ error and operator-stop negatives are the controls, green on both trees).
 - Don't multiplex the control channel onto the BCRPT relay socket — the two channels are independent by design (different token audiences, different endpoints, different authority models).
 - Don't add secret-bearing event types to `RELAYABLE_TYPES` — the no-secrets contract test will catch it.
 - Don't delete the `devices`/`pipelines` broadcasts or the `capabilities.device_modes` field yet — they're deprecation shims kept for one release (`TD-legacy-source-broadcasts`); route new consumers through `getSources()`/the `sources` broadcast instead.
+- Don't resolve the rule-5(i) same-device join from `display_name` alone — it is the ALSA longname, and the manufacturer prefix the kernel puts on it can push the shared prefix under the 4-character floor for a device whose `product_name`/`alsa_card_id` match perfectly. Route through `engineAudioJoinNames()`, and don't feed it CeraUI-side strings.
+- Don't assume the audio label/identity maps are fresh because a hotplug ran — the ENGINE's audio list arrives later and separately, so `commitEngineDevices` must keep firing the re-resolve on a changed list. And don't "simplify" that handler into a full `updateAudioDevices()` call: the sysfs scan has not changed, so it would raise a spurious lost verdict and blink the meter.
 - Don't re-add an operator audio-device rename/alias surface (RPC, contract entry, or config field) — device naming is code-level only (`ONBOARD_AUDIO_DISPLAY_RULES` + `cleanAudioDeviceName`); the #206 alias layer was removed in #207 by product decision. The same holds for VIDEO (`ONBOARD_VIDEO_DISPLAY_RULES`) — no rename affordance for any device, of any media type.
 - Don't re-apply an onboard display-name rule at a render site (a Svelte label, a summary derivation) — it belongs at the device-construction seam (`fromEngineDevice`), which is why the row and the "Configured" label are both fixed by one call.
 - Don't re-derive `pipeline`/`selected_video_input` resolution inline in a new procedure — route through `resolveSourceRouting()`/`deriveEngineRouting()` in `modules/streaming/sources.ts`.

--- a/apps/backend/src/modules/streaming/audio.ts
+++ b/apps/backend/src/modules/streaming/audio.ts
@@ -425,6 +425,23 @@ export async function broadcastAudioSources(): Promise<void> {
 	});
 }
 
+/**
+ * Re-run the parts of `updateAudioDevices` that read the ENGINE's audio list,
+ * after `sources.ts` commits a changed one.
+ *
+ * Deliberately NOT the whole of `updateAudioDevices()`: the sysfs card scan has
+ * not changed (nothing was plugged), so re-walking `/sys/class/sound` would raise
+ * a spurious lost-device verdict and re-blink the meter through
+ * `noteMeterSelection`. What genuinely goes stale is the engine JOIN — the
+ * label/identity maps and what "Auto" resolves to — so only those are redone.
+ * `syncAudioMeterPreference()` is likewise skipped: the meter preference resolves
+ * from the sysfs card map, which this change cannot have touched.
+ */
+export async function reresolveAudioForEngineChange(): Promise<void> {
+	await broadcastAudioSources();
+	refreshResolvedAsrcPreview();
+}
+
 // A card can disappear mid-scan (hotplug); an unreadable card simply reports no
 // capture PCM rather than aborting the whole audio refresh.
 async function readCardEntries(path: string): Promise<string[]> {

--- a/apps/backend/src/modules/streaming/auto-audio.ts
+++ b/apps/backend/src/modules/streaming/auto-audio.ts
@@ -114,6 +114,33 @@ function commonPrefixLength(a: string, b: string): number {
 	return i;
 }
 
+/**
+ * Every name the engine gives for ONE audio card, for the rule-5(i) prefix join.
+ *
+ * `display_name` alone is not enough, and the DJI Osmo Pocket 3 is the proof: the
+ * engine reports its audio card as the ALSA LONGNAME
+ * `"DJI DJIPocket3 at usb-fc880000.usb-1, high speed"` while the same chassis'
+ * video device is the V4L2 card name `"DJIPocket3: OsmoPocket3"`. Those share only
+ * `"DJI"` — 3 characters, one short of {@link MIN_COMMON_PREFIX} — so the join
+ * missed and Auto fell through to whatever generic `usbaudio` card happened to be
+ * enumerated, i.e. a DIFFERENT physical device's microphone. The manufacturer
+ * prefix the kernel puts on the longname is exactly what breaks the alignment.
+ *
+ * `product_name` (`"DJIPocket3"`) and `alsa_card_id` (`"DJIPocket3"`) do not carry
+ * it, so they align with the video name from the first character. Both are already
+ * on the wire; nothing new is asked of the engine.
+ *
+ * Order is irrelevant — the caller takes the longest match — but every candidate
+ * must be a NAME the hardware chose. Do not add the asrc key or a CeraUI alias:
+ * those are our own strings and would join a card to a device it shares nothing
+ * with.
+ */
+function engineAudioJoinNames(entry: EngineAudioDevice): string[] {
+	return [entry.product_name, entry.alsa_card_id, entry.display_name].filter(
+		(name): name is string => name !== undefined && name.length > 0,
+	);
+}
+
 /** The first asrcKey whose card-id VALUE equals `cardId` (dual-space join). */
 function findAsrcKeyByCardId(
 	audioDevices: Record<string, string>,
@@ -155,8 +182,10 @@ function pipelineDefault(): AutoAsrcResolution {
  *   3. HDMI capture → the `rockchiphdmiin` card, when it is enumerated.
  *   4. Cam Link capture → the `C4K` card, when it is enumerated.
  *   5. USB/UVC capture →
- *        (i)  an engine audio entry sharing a >=4-char name prefix with the video
- *             device AND whose `alsa_card_id` is enumerated here (same device);
+ *        (i)  the engine audio entry whose BEST engine-given name (`product_name`
+ *             / `alsa_card_id` / `display_name`) shares the longest >=4-char
+ *             prefix with the video device, AND whose `alsa_card_id` is
+ *             enumerated here (same device);
  *        (ii) else the generic `usbaudio` card, when enumerated;
  *        (iii) else the first enumerated non-HDMI / non-analog device card.
  *   6. nothing matched → the pipeline-default pseudo source.
@@ -197,27 +226,38 @@ export function resolveAutoAsrc(
 
 		// Rule 5 — the USB/UVC camera family.
 		if (USB_VIDEO_KINDS.has(source.kind)) {
-			// (i) same-device join: an engine audio entry whose name shares a
-			//     >=4-char prefix with the video device AND whose card is
-			//     enumerated here. First in engine list order wins. Falls through
-			//     gracefully when `alsa_card_id` is absent (pre-T18 pin).
+			// (i) same-device join: an engine audio entry ANY of whose engine-given
+			//     names shares a >=4-char prefix with the video device AND whose
+			//     card is enumerated here. The BEST match across the whole list
+			//     wins, not the first: several cards can clear the 4-char floor
+			//     (`DJI…` vs `DJIPocket3`), and taking whichever the engine
+			//     happened to list first is the coin-flip this rule exists to
+			//     remove. Falls through gracefully when `alsa_card_id` is absent
+			//     (pre-T18 pin).
 			const cardValues = new Set(Object.values(audioDevices));
+			let best: { asrcKey: string; cardId: string; score: number } | undefined;
 			for (const entry of engineAudio) {
 				if (entry.alsa_card_id === undefined) continue;
 				if (!cardValues.has(entry.alsa_card_id)) continue;
-				if (
-					commonPrefixLength(entry.display_name, source.displayName) >=
-					MIN_COMMON_PREFIX
-				) {
-					const asrcKey = findAsrcKeyByCardId(audioDevices, entry.alsa_card_id);
-					if (asrcKey !== undefined) {
-						return {
-							asrcKey,
-							cardId: entry.alsa_card_id,
-							reason: "usb-same-device",
-						};
-					}
+				const asrcKey = findAsrcKeyByCardId(audioDevices, entry.alsa_card_id);
+				if (asrcKey === undefined) continue;
+				const score = Math.max(
+					...engineAudioJoinNames(entry).map((name) =>
+						commonPrefixLength(name, source.displayName),
+					),
+					0,
+				);
+				if (score < MIN_COMMON_PREFIX) continue;
+				if (best === undefined || score > best.score) {
+					best = { asrcKey, cardId: entry.alsa_card_id, score };
 				}
+			}
+			if (best !== undefined) {
+				return {
+					asrcKey: best.asrcKey,
+					cardId: best.cardId,
+					reason: "usb-same-device",
+				};
 			}
 
 			// (ii) the generic USB audio card alias, when enumerated.

--- a/apps/backend/src/modules/streaming/sources.ts
+++ b/apps/backend/src/modules/streaming/sources.ts
@@ -846,14 +846,65 @@ function withKnownEngineMetadata(
 	};
 }
 
-/** Make a device list the current view, remembering every device it proves live. */
+/**
+ * Re-resolve the audio labels/identities and the "Auto" preview after the engine
+ * audio list CHANGED. Lazily imported to break the `audio.ts → sources.ts` cycle
+ * (the same shape `devices.ts` uses for `onDevicesChanged`); never rejects.
+ */
+type EngineAudioChangeHandler = () => void;
+
+const defaultEngineAudioChangeHandler: EngineAudioChangeHandler = () => {
+	void import("./audio.ts")
+		.then(({ reresolveAudioForEngineChange }) =>
+			reresolveAudioForEngineChange(),
+		)
+		.catch((err) =>
+			logger.debug("sources: audio re-resolve after engine change failed", {
+				err,
+			}),
+		);
+};
+
+let engineAudioChangeHandler: EngineAudioChangeHandler =
+	defaultEngineAudioChangeHandler;
+
+/** Test seam: swap the engine-audio-change handler (`undefined` restores). */
+export function setEngineAudioChangeHandler(
+	fn: EngineAudioChangeHandler | undefined,
+): void {
+	engineAudioChangeHandler = fn ?? defaultEngineAudioChangeHandler;
+}
+
+/**
+ * Make a device list the current view, remembering every device it proves live.
+ *
+ * A CHANGED audio list also re-resolves the audio surface, and that is the whole
+ * point rather than a nicety: `audio.ts` caches the resolved label/identity maps
+ * and only ever rebuilds them inside `updateAudioDevices()`, which runs on the
+ * udev SIGUSR2 hotplug and at boot. The engine's own audio enumeration catches up
+ * on ITS schedule — seconds later, via this commit — and nothing re-ran the join.
+ * Confirmed live on a Rock 5B+: a DJI Osmo Pocket 3 plugged in mid-session showed
+ * no `transport` and no `stable_id` for its card for the rest of the session,
+ * while the engine had been reporting both within seconds of the plug; one
+ * SIGUSR2 filled them in instantly. Same latched-stale class as
+ * `policy_route_missing` and the video signal recheck.
+ *
+ * Keyed on the SERIALIZED list, so the 5 s signal recheck's steady state costs one
+ * string compare and re-broadcasts nothing.
+ */
 function commitEngineDevices(
 	devices: readonly CaptureDevice[],
 	audio?: readonly EngineAudioDevice[],
 ): void {
 	engineDeviceCache = [...devices];
-	if (audio !== undefined) engineAudioDeviceCache = [...audio];
+	let audioChanged = false;
+	if (audio !== undefined) {
+		const next = JSON.stringify(audio);
+		audioChanged = next !== JSON.stringify(engineAudioDeviceCache);
+		engineAudioDeviceCache = [...audio];
+	}
 	recordObservedDevices(engineDeviceCache);
+	if (audioChanged) engineAudioChangeHandler();
 }
 
 /**

--- a/apps/backend/src/tests/auto-audio.test.ts
+++ b/apps/backend/src/tests/auto-audio.test.ts
@@ -301,6 +301,91 @@ describe("resolveAutoAsrc — deterministic rules", () => {
 		});
 	});
 
+	// The exact payload a Rock 5B+ reports with a DJI Osmo Pocket 3 and a RØDE
+	// HDMI-to-USB-C attached. The Osmo's engine audio `display_name` is the ALSA
+	// LONGNAME, whose manufacturer prefix leaves only "DJI" (3 chars) in common
+	// with the V4L2 video card name — one short of the 4-char floor — so the
+	// same-device join missed and Auto served the RØDE's microphone instead.
+	const OSMO_VIDEO_NAME = "DJIPocket3: OsmoPocket3";
+	const OSMO_AUDIO_LONGNAME =
+		"DJI DJIPocket3 at usb-fc880000.usb-1, high speed";
+	const RODE_AUDIO_LONGNAME =
+		"RØDE RØDE HDMI to USB-C at usb-xhci-hcd.17.auto-1, super speed";
+	const OSMO_BOARD_MAP = {
+		HDMI: "rockchiphdmiin",
+		"USB audio": "usbaudio",
+		DJIPocket3: "DJIPocket3",
+		"No audio": "No audio",
+		"Pipeline default": "Pipeline default",
+	};
+
+	test("Rule 5i: the engine product_name joins when the longname display_name cannot", () => {
+		expect(
+			resolveAutoAsrc({
+				source: captureSource("uvc_h264", OSMO_VIDEO_NAME),
+				audioDevices: OSMO_BOARD_MAP,
+				engineAudio: [
+					{
+						input_id: OSMO_AUDIO_LONGNAME,
+						display_name: OSMO_AUDIO_LONGNAME,
+						alsa_card_id: "DJIPocket3",
+						product_name: "DJIPocket3",
+					},
+					{
+						input_id: RODE_AUDIO_LONGNAME,
+						display_name: RODE_AUDIO_LONGNAME,
+						alsa_card_id: "usbaudio",
+						product_name: "usbaudio",
+					},
+				],
+				networkEmbeddedAudio: undefined,
+			}),
+		).toEqual({
+			asrcKey: "DJIPocket3",
+			cardId: "DJIPocket3",
+			reason: "usb-same-device",
+		});
+	});
+
+	test("Rule 5i: the alsa_card_id joins even with no product_name at all", () => {
+		expect(
+			resolveAutoAsrc({
+				source: captureSource("uvc_h264", OSMO_VIDEO_NAME),
+				audioDevices: OSMO_BOARD_MAP,
+				engineAudio: [engineAudio(OSMO_AUDIO_LONGNAME, "DJIPocket3")],
+				networkEmbeddedAudio: undefined,
+			}),
+		).toEqual({
+			asrcKey: "DJIPocket3",
+			cardId: "DJIPocket3",
+			reason: "usb-same-device",
+		});
+	});
+
+	test("Rule 5i: the LONGEST-prefix card wins, not the first the engine listed", () => {
+		// Both clear the 4-char floor against "DJIPocket3: OsmoPocket3": the decoy
+		// shares "DJIP" (4), the real card shares all 10. Listing the decoy FIRST
+		// is what a first-match-wins scan would take.
+		expect(
+			resolveAutoAsrc({
+				source: captureSource("uvc_h264", OSMO_VIDEO_NAME),
+				audioDevices: {
+					...OSMO_BOARD_MAP,
+					DJIPro: "DJIPro",
+				},
+				engineAudio: [
+					engineAudio("DJIPro Headset", "DJIPro"),
+					engineAudio(OSMO_AUDIO_LONGNAME, "DJIPocket3"),
+				],
+				networkEmbeddedAudio: undefined,
+			}),
+		).toEqual({
+			asrcKey: "DJIPocket3",
+			cardId: "DJIPocket3",
+			reason: "usb-same-device",
+		});
+	});
+
 	test("Rule 5ii: USB capture + usbaudio present → USB audio card", () => {
 		expect(
 			resolveAutoAsrc({

--- a/apps/backend/src/tests/lost-device-retention.test.ts
+++ b/apps/backend/src/tests/lost-device-retention.test.ts
@@ -45,6 +45,7 @@ import {
 	refreshEngineDeviceCache,
 	refreshSourcesForHotplug,
 	resetEngineDeviceCache,
+	setEngineAudioChangeHandler,
 } from "../modules/streaming/sources.ts";
 import { addClient, removeClient } from "../rpc/events.ts";
 import type { AppWebSocket } from "../rpc/types.ts";
@@ -811,6 +812,65 @@ describe("refreshSourcesForHotplug — a stale successful probe never masks the 
 			"video0",
 			"audio:card0",
 		]);
+	});
+
+	it("re-resolves the audio surface when the engine audio list CHANGES, and only then", async () => {
+		// Found live: `audio.ts` caches the resolved label/identity maps and rebuilds
+		// them only inside `updateAudioDevices()` (udev SIGUSR2 / boot). The engine's
+		// own audio enumeration lands later, through this path — so a card plugged
+		// mid-session kept rendering with no `transport`/`stable_id` for the rest of
+		// the session even though the engine had reported both within seconds.
+		let reresolves = 0;
+		setEngineAudioChangeHandler(() => {
+			reresolves++;
+		});
+		try {
+			await seedHdmiCaps();
+			const observed = [
+				captureDevice("video0", "hdmi", { display_name: "Studio HDMI" }),
+			];
+			const withCards = (cards: string[]) => ({
+				fetchEngineDevices: async () => ({
+					devices: [
+						engineDevice("video0", "Studio HDMI"),
+						...cards.map(
+							(card) =>
+								({
+									input_id: `audio:${card}`,
+									device_path: `alsa:${card}`,
+									display_name: card,
+									media_class: "audio",
+									kind: "audio",
+									alsa_card_id: card,
+								}) as ListDevicesResult["devices"][number],
+						),
+					],
+				}),
+			});
+
+			await refreshSourcesForHotplug(observed, withCards(["usbaudio"]));
+			expect(reresolves).toBe(1);
+
+			// The steady state of the 5 s signal recheck: identical list, no work.
+			await refreshSourcesForHotplug(observed, withCards(["usbaudio"]));
+			expect(reresolves).toBe(1);
+
+			// A card appears — exactly the DJI-plugged-mid-session case.
+			await refreshSourcesForHotplug(
+				observed,
+				withCards(["usbaudio", "DJIPocket3"]),
+			);
+			expect(reresolves).toBe(2);
+			expect(getEngineAudioDevices().map((d) => d.alsa_card_id)).toEqual([
+				"usbaudio",
+				"DJIPocket3",
+			]);
+
+			await refreshSourcesForHotplug(observed, withCards(["usbaudio"]));
+			expect(reresolves).toBe(3);
+		} finally {
+			setEngineAudioChangeHandler(undefined);
+		}
 	});
 
 	it("an OLDER hotplug refresh answering late never clobbers a NEWER one's result", async () => {


### PR DESCRIPTION
## What

Two independent defects that together made the **"Auto (follows source)"** audio
selector report a different physical device's microphone.

1. `resolveAutoAsrc` rule 5(i) — the same-device join — now compares every name the
   engine gives an audio card (`product_name`, `alsa_card_id`, `display_name`), and
   takes the longest match rather than the first the engine listed.
2. `sources.ts` `commitEngineDevices` now re-resolves the audio labels/identities
   when the engine's audio list actually changes, instead of leaving them latched at
   whatever the last udev hotplug produced.

## Why

Both were reproduced live on a Rock 5B+ with a DJI Osmo Pocket 3 selected as the
video source. `status.getStatus` reported:

```
resolved_asrc:        "USB audio"
resolved_asrc_reason: "usb-alias"
```

— i.e. the generic `usbaudio` card, which on that board is a RØDE HDMI-to-USB-C
whose video interface had already died. The operator's camera has its own perfectly
good microphone (`DJIPocket3`) and it was enumerated the whole time.

### 1. The join compared the wrong string

cerastream sets an audio entry's `display_name` to the ALSA longname verbatim, and
the kernel puts the manufacturer on the front of it. So the two halves of one
chassis read:

```
audio  "DJI DJIPocket3 at usb-fc880000.usb-1, high speed"
video  "DJIPocket3: OsmoPocket3"
```

They share exactly `"DJI"` — **3 characters, one short of the 4-character
`MIN_COMMON_PREFIX` floor**. The join missed, rule 5(ii) fired, and Auto served the
generic card. `product_name` and `alsa_card_id` are both `"DJIPocket3"`, both
already on the wire, and neither carries the manufacturer prefix, so they align from
the first character.

Taking the **longest** match rather than the first also matters: several cards can
clear a 4-character floor (`DJIPro` vs `DJIPocket3`), and picking whichever the
engine happened to list first is the coin-flip this rule exists to remove.

### 2. The resolved maps latched

`lastAudioDisplays` / `lastAudioIdentities` are built in `broadcastAudioSources()`,
which only `updateAudioDevices()` called — and that runs on the udev SIGUSR2 hotplug
and at boot. The engine's own audio enumeration lands later and separately, through
`commitEngineDevices` (the 5 s signal recheck and the video-hotplug probe both commit
it). Nothing re-ran the join, so the maps kept whatever they held at plug time.

Proven on the board: the Osmo's card rendered with **no `transport` and no
`stable_id`** for the whole session, while a direct `list-devices` probe showed the
engine had been reporting `alsa_card_id: "DJIPocket3"`, `transport: "usb"`,
`stable_id: "card:DJIPocket3"` all along. One manual SIGUSR2 filled both in
instantly — which is what identified the latch. Same class as `policy_route_missing`
and the video signal recheck.

The re-resolve is deliberately **not** a full `updateAudioDevices()`: the sysfs card
scan has not changed (nothing was plugged), so re-walking it would raise a spurious
lost-device verdict and blink the meter through `noteMeterSelection`. Only the
engine join goes stale, so only `broadcastAudioSources()` +
`refreshResolvedAsrcPreview()` are redone. It is keyed on the serialized list, so
the 5 s recheck's steady state costs one string compare and broadcasts nothing.
The handler is injected (lazy `import("./audio.ts")`) because `audio.ts` imports
`sources.ts` — the same shape `devices.ts` uses for `onDevicesChanged`.

## How to verify

```bash
bunx biome check .                 # exit 0 (35 pre-existing nursery warnings)
cd apps/backend && bun run check   # tsc clean
cd apps/backend && bun test        # 2424 pass / 0 fail
bun run check:tech-debt            # OK
```

On hardware, with a UVC camera that has its own audio card selected and `asrc` set
to `Auto`, `status.getStatus` must report that camera's card with
`resolved_asrc_reason: "usb-same-device"`.

Verified on the board after deploying this build:

```
BUG 2 =>  resolved_asrc = 'DJIPocket3' | reason = 'usb-same-device'
DJI entry: {"id":"DJIPocket3","label":"DJI DJIPocket3","transport":"usb",
            "stable_id":"card:DJIPocket3", ...}
```

Rule E proof captured in both directions:

- Narrowing `engineAudioJoinNames()` back to `display_name` only reddens all three
  new rule-5(i) tests, each printing the exact live symptom (`reason: "usb-alias"`).
- Removing the `engineAudioChangeHandler()` call reddens the re-resolve test
  (`Expected: 1, Received: 0`).

No existing test was changed, skipped, or weakened.

## Risks

Low, and bounded on both sides.

The join is still gated on `alsa_card_id` being present AND enumerated locally, so a
card the engine mentions but CeraUI cannot see is never selected; the rules 5(ii) /
5(iii) / 6 fallbacks are untouched. The new candidates are only names the **hardware**
chose — the asrc key and CeraUI-side aliases are deliberately excluded, since joining
on our own strings could bind a card to a device it shares nothing with.

The re-resolve cannot loop: it fires only on a changed serialized list, and it does
not touch the sysfs scan, the meter preference, or `config.asrc`.

Not addressed here (engine-side, tracked separately): the UVC-H.264 **video** path on
this board still degrades to HDMI because libuvc detaches the kernel `uvcvideo`
driver while it holds the camera. That is CERALIVE/cerastream#83 and its follow-up;
it does not affect this audio change, which was verified with the Osmo selected.
