### PR TITLE
fix(encoder): stop showing `audio/x-raw` as a "detected capability"

### DIFF
--- a/apps/frontend/src/lib/components/streaming/ValidationAdapter.caps.test.ts
+++ b/apps/frontend/src/lib/components/streaming/ValidationAdapter.caps.test.ts
@@ -11,6 +11,7 @@ import {
 	clampBitrateToBounds,
 	deriveCodecOptions,
 	deriveUvcH265Sources,
+	formatProbedCap,
 	summarizeProbedCaps,
 } from "./ValidationAdapter";
 
@@ -55,6 +56,20 @@ function makeDevice(mediaType: string | undefined): CaptureDevice {
 		caps: mediaType
 			? [{ width: 1920, height: 1080, media_type: mediaType }]
 			: [],
+	};
+}
+
+// Shape a real board reports for an audio card: media_type and nothing else.
+function makeAudioDevice(
+	caps: CaptureDevice["caps"] = [{ media_type: "audio/x-raw" }],
+): CaptureDevice {
+	return {
+		input_id: "card:usbaudio",
+		device_path: "card:usbaudio",
+		display_name: "RØDE HDMI to USB-C",
+		media_class: "audio",
+		kind: "audio",
+		caps,
 	};
 }
 
@@ -170,6 +185,83 @@ describe("summarizeProbedCaps", () => {
 				caps: ["1920\u00d71080 H.265"],
 			},
 		]);
+	});
+
+	it("summarises an audio device as one plain-language label", () => {
+		expect(summarizeProbedCaps([makeAudioDevice()])).toEqual([
+			{
+				inputId: "card:usbaudio",
+				displayName: "RØDE HDMI to USB-C",
+				caps: ["Audio"],
+			},
+		]);
+	});
+
+	it("collapses several audio formats onto a single chip", () => {
+		expect(
+			summarizeProbedCaps([
+				makeAudioDevice([
+					{ media_type: "audio/x-raw" },
+					{ media_type: "audio/mpeg" },
+				]),
+			])[0]?.caps,
+		).toEqual(["Audio"]);
+	});
+
+	it("uses the localized audio label when a translator is supplied", () => {
+		expect(
+			summarizeProbedCaps([makeAudioDevice()], () => "オーディオ")[0]?.caps,
+		).toEqual(["オーディオ"]);
+	});
+});
+
+describe("formatProbedCap", () => {
+	it("renders resolution, framerate and codec for a video format", () => {
+		expect(
+			formatProbedCap({
+				width: 1920,
+				height: 1080,
+				framerate: "30/1",
+				media_type: MEDIA_TYPE_H264,
+			}),
+		).toBe("1920\u00d71080 @ 30 H.264");
+	});
+
+	it("renders an NTSC fraction framerate as decimal fps", () => {
+		expect(
+			formatProbedCap({
+				width: 1920,
+				height: 1080,
+				framerate: "60000/1001",
+				media_type: "video/x-raw",
+			}),
+		).toBe("1920\u00d71080 @ 59.94 Raw");
+	});
+
+	it("names an MJPEG format rather than its MIME token", () => {
+		expect(
+			formatProbedCap({ width: 3840, height: 2160, media_type: "image/jpeg" }),
+		).toBe("3840\u00d72160 MJPEG");
+	});
+
+	it("shortens an unmapped codec token instead of leaking the MIME string", () => {
+		expect(
+			formatProbedCap({ width: 1280, height: 720, media_type: "video/x-vp9" }),
+		).toBe("1280\u00d7720 VP9");
+	});
+
+	it.each([
+		"audio/x-raw",
+		"audio/mpeg",
+		"audio/x-alaw",
+	])("renders %s as a plain-language audio label", (mediaType) => {
+		const label = formatProbedCap({ media_type: mediaType });
+		expect(label).toBe("Audio");
+		expect(label).not.toContain("/");
+	});
+
+	it("renders nothing for a format carrying no information at all", () => {
+		expect(formatProbedCap({})).toBe("");
 	});
 });
 

--- a/apps/frontend/src/lib/components/streaming/ValidationAdapter.ts
+++ b/apps/frontend/src/lib/components/streaming/ValidationAdapter.ts
@@ -3,6 +3,7 @@ import {
 	intersectCaps,
 	MEDIA_TYPE_H264,
 	MEDIA_TYPE_H265,
+	MEDIA_TYPE_RAW,
 	mediaTypeToSourceKind,
 	type OfferedSet,
 	type PlatformCaps,
@@ -940,19 +941,77 @@ export interface ProbedCapsSummary {
 	caps: string[];
 }
 
+// Matched by PREFIX, not an exact token list, so every audio-capable device
+// (HDMI embedded, USB Audio Class, ALSA card) is covered without a codec table.
+const AUDIO_MEDIA_PREFIX = "audio/";
+const MEDIA_TYPE_MJPEG = "image/jpeg";
+
+const AUDIO_CAP_LABEL = "Audio";
+const AUDIO_CAP_LABEL_KEY = "live.encoder.probedCapAudio";
+
+export type CapLabelTranslator = (key: string) => string;
+
+function audioCapLabel(t?: CapLabelTranslator): string {
+	if (t) {
+		const translated = t(AUDIO_CAP_LABEL_KEY);
+		if (translated && !translated.includes(AUDIO_CAP_LABEL_KEY)) {
+			return translated;
+		}
+	}
+	return AUDIO_CAP_LABEL;
+}
+
+function isAudioMediaType(mediaType: string): boolean {
+	return mediaType.startsWith(AUDIO_MEDIA_PREFIX);
+}
+
+/** `video/x-vp9` → `VP9` — an unmapped token still reads as a codec name. */
+function genericMediaLabel(mediaType: string): string {
+	const slash = mediaType.indexOf("/");
+	const subtype = slash === -1 ? mediaType : mediaType.slice(slash + 1);
+	const bare = subtype.startsWith("x-") ? subtype.slice(2) : subtype;
+	return bare === "" ? mediaType : bare.toUpperCase();
+}
+
 function shortMediaType(mediaType: string): string {
 	if (mediaType === MEDIA_TYPE_H265) return "H.265";
 	if (mediaType === MEDIA_TYPE_H264) return "H.264";
-	return mediaType;
+	if (mediaType === MEDIA_TYPE_MJPEG) return "MJPEG";
+	if (mediaType === MEDIA_TYPE_RAW) return "Raw";
+	return genericMediaLabel(mediaType);
 }
 
-/** Render one probed format as a compact spec string (e.g. `1920×1080 @ 30 H.265`). */
-export function formatProbedCap(cap: CaptureCap): string {
+/** `30/1` → `30`, `60000/1001` → `59.94`. A non-fraction value passes through. */
+function shortFramerate(framerate: string): string {
+	const fraction = framerate.match(/^(\d+)\s*\/\s*(\d+)$/);
+	if (!fraction) return framerate;
+	const denominator = Number(fraction[2]);
+	if (denominator === 0) return framerate;
+	const fps = Number(fraction[1]) / denominator;
+	if (!Number.isFinite(fps)) return framerate;
+	return String(Math.round(fps * 100) / 100);
+}
+
+/**
+ * Render one probed format as a compact spec string (e.g. `1920×1080 @ 59.94 H.264`).
+ *
+ * An AUDIO format collapses to one plain-language label: the engine's `CaptureCap`
+ * carries ONLY `media_type` for audio (its GStreamer probe never reads
+ * `rate`/`channels`/`format`), so `audio/x-raw` is byte-identical for every audio
+ * device — it distinguishes nothing and reads as a diagnostic string.
+ */
+export function formatProbedCap(
+	cap: CaptureCap,
+	t?: CapLabelTranslator,
+): string {
+	if (cap.media_type && isAudioMediaType(cap.media_type)) {
+		return audioCapLabel(t);
+	}
 	const parts: string[] = [];
 	if (cap.width !== undefined && cap.height !== undefined) {
 		parts.push(`${cap.width}\u00d7${cap.height}`);
 	}
-	if (cap.framerate) parts.push(`@ ${cap.framerate}`);
+	if (cap.framerate) parts.push(`@ ${shortFramerate(cap.framerate)}`);
 	if (cap.media_type) parts.push(shortMediaType(cap.media_type));
 	return parts.join(" ");
 }
@@ -964,14 +1023,21 @@ export function formatProbedCap(cap: CaptureCap): string {
  */
 export function summarizeProbedCaps(
 	devices: readonly CaptureDevice[] | undefined,
+	t?: CapLabelTranslator,
 ): ProbedCapsSummary[] {
 	if (!devices) return [];
 	const out: ProbedCapsSummary[] = [];
 	for (const device of devices) {
 		if (!device.caps || device.caps.length === 0) continue;
-		const caps = device.caps
-			.map(formatProbedCap)
-			.filter((label) => label.length > 0);
+		// Identical labels carry identical information; a device advertising two
+		// audio formats would otherwise render the same chip twice.
+		const caps = [
+			...new Set(
+				device.caps
+					.map((cap) => formatProbedCap(cap, t))
+					.filter((label) => label.length > 0),
+			),
+		];
 		if (caps.length === 0) continue;
 		out.push({
 			inputId: device.input_id,

--- a/apps/frontend/src/main/dialogs/EncoderDialog.svelte
+++ b/apps/frontend/src/main/dialogs/EncoderDialog.svelte
@@ -146,9 +146,6 @@ const h265Option = $derived(codecOptions.find((codec) => codec.value === 'h265')
 const h265Supported = $derived(h265Option !== undefined);
 const h265SoftwareOnly = $derived(h265Option?.softwareWarning ?? false);
 const uvcH265Sources = $derived(deriveUvcH265Sources(devices));
-// Probed hardware formats (resolution/framerate/media-type) surfaced inline.
-const probedCaps = $derived(summarizeProbedCaps(devices));
-
 // ── i18n key resolver (mirrors the legacy EncoderCard helper) ──────────────────
 const t = (key: string): string => {
 	const parts = key.split('.');
@@ -162,6 +159,9 @@ const t = (key: string): string => {
 	}
 	return typeof result === 'function' ? (result as () => string)() : key;
 };
+
+// Probed hardware formats (resolution/framerate/media-type) surfaced inline.
+const probedCaps = $derived(summarizeProbedCaps(devices, t));
 
 // A disabled framerate option's title = its capability reason plus its OWN
 // "available elsewhere" hint (per-option: different rates disabled at the same

--- a/packages/i18n/src/ar/index.ts
+++ b/packages/i18n/src/ar/index.ts
@@ -1488,6 +1488,7 @@ const ar = {
 			bitrateClamped: "تم الضبط إلى النطاق المدعوم",
 			sourceChangedNote: "تم تغيير المصدر — تم تحديث الإعدادات للإدخال الجديد.",
 			probedCaps: "القدرات المكتشفة",
+			probedCapAudio: "صوت",
 			codecAuto: "Auto (recommended)",
 			codecAutoResolvedH265: "Auto — H.265 on this device",
 			codecAutoResolvedH264: "Auto — H.264 on this device",

--- a/packages/i18n/src/de/index.ts
+++ b/packages/i18n/src/de/index.ts
@@ -791,6 +791,7 @@ const de = {
 			sourceChangedNote:
 				"Quelle geändert – Einstellungen für die neue Eingabe aktualisiert.",
 			probedCaps: "Erkannte Fähigkeiten",
+			probedCapAudio: "Audio",
 			codecAuto: "Auto (recommended)",
 			codecAutoResolvedH265: "Auto — H.265 on this device",
 			codecAutoResolvedH264: "Auto — H.264 on this device",

--- a/packages/i18n/src/en/index.ts
+++ b/packages/i18n/src/en/index.ts
@@ -771,6 +771,7 @@ const en = {
 			sourceChangedNote:
 				"Source changed \u2014 settings updated for the new input.",
 			probedCaps: "Detected capabilities",
+			probedCapAudio: "Audio",
 			codecAuto: "Auto (recommended)",
 			codecAutoResolvedH265: "Auto — H.265 on this device",
 			codecAutoResolvedH264: "Auto — H.264 on this device",

--- a/packages/i18n/src/es/index.ts
+++ b/packages/i18n/src/es/index.ts
@@ -795,6 +795,7 @@ const es = {
 			sourceChangedNote:
 				"La fuente cambió: ajustes actualizados para la nueva entrada.",
 			probedCaps: "Capacidades detectadas",
+			probedCapAudio: "Audio",
 			codecAuto: "Auto (recommended)",
 			codecAutoResolvedH265: "Auto — H.265 on this device",
 			codecAutoResolvedH264: "Auto — H.264 on this device",

--- a/packages/i18n/src/fr/index.ts
+++ b/packages/i18n/src/fr/index.ts
@@ -1555,6 +1555,7 @@ const fr = {
 			sourceChangedNote:
 				"Source modifiée — réglages mis à jour pour la nouvelle entrée.",
 			probedCaps: "Capacités détectées",
+			probedCapAudio: "Audio",
 			codecAuto: "Auto (recommended)",
 			codecAutoResolvedH265: "Auto — H.265 on this device",
 			codecAutoResolvedH264: "Auto — H.264 on this device",

--- a/packages/i18n/src/hi/index.ts
+++ b/packages/i18n/src/hi/index.ts
@@ -1351,6 +1351,7 @@ const hi = {
 			bitrateClamped: "समर्थित सीमा में समायोजित",
 			sourceChangedNote: "स्रोत बदला गया — नए इनपुट के लिए सेटिंग्स अपडेट की गईं।",
 			probedCaps: "पहचानी गई क्षमताएँ",
+			probedCapAudio: "ऑडियो",
 			codecAuto: "Auto (recommended)",
 			codecAutoResolvedH265: "Auto — H.265 on this device",
 			codecAutoResolvedH264: "Auto — H.264 on this device",

--- a/packages/i18n/src/ja/index.ts
+++ b/packages/i18n/src/ja/index.ts
@@ -1393,6 +1393,7 @@ const ja = {
 			sourceChangedNote:
 				"ソースが変更されました — 新しい入力に合わせて設定を更新しました。",
 			probedCaps: "検出された機能",
+			probedCapAudio: "オーディオ",
 			codecAuto: "Auto (recommended)",
 			codecAutoResolvedH265: "Auto — H.265 on this device",
 			codecAutoResolvedH264: "Auto — H.264 on this device",

--- a/packages/i18n/src/ko/index.ts
+++ b/packages/i18n/src/ko/index.ts
@@ -1368,6 +1368,7 @@ const ko = {
 			sourceChangedNote:
 				"소스가 변경됨 — 새 입력에 맞게 설정이 업데이트되었습니다.",
 			probedCaps: "감지된 기능",
+			probedCapAudio: "오디오",
 			codecAuto: "Auto (recommended)",
 			codecAutoResolvedH265: "Auto — H.265 on this device",
 			codecAutoResolvedH264: "Auto — H.264 on this device",

--- a/packages/i18n/src/pt-BR/index.ts
+++ b/packages/i18n/src/pt-BR/index.ts
@@ -1531,6 +1531,7 @@ const ptBR = {
 			sourceChangedNote:
 				"Fonte alterada — configurações atualizadas para a nova entrada.",
 			probedCaps: "Capacidades detectadas",
+			probedCapAudio: "Áudio",
 			codecAuto: "Auto (recommended)",
 			codecAutoResolvedH265: "Auto — H.265 on this device",
 			codecAutoResolvedH264: "Auto — H.264 on this device",

--- a/packages/i18n/src/zh/index.ts
+++ b/packages/i18n/src/zh/index.ts
@@ -1301,6 +1301,7 @@ const zh = {
 			bitrateClamped: "已调整到支持范围",
 			sourceChangedNote: "源已更改 — 已为新输入更新设置。",
 			probedCaps: "检测到的能力",
+			probedCapAudio: "音频",
 			codecAuto: "Auto (recommended)",
 			codecAutoResolvedH265: "Auto — H.265 on this device",
 			codecAutoResolvedH264: "Auto — H.264 on this device",


### PR DESCRIPTION
## What

The Encoder Settings → **Detected capabilities** panel showed an audio device's raw GStreamer media type verbatim. On the test board, both connected audio devices rendered the identical, meaningless string:

```
DJI DJIPocket3 at usb-fc880000.usb-1, high speed
  audio/x-raw
RØDE RØDE HDMI to USB-C at usb-xhci-hcd.17.auto-1, super speed
  audio/x-raw
```

An audio capability now renders one localized word — **Audio** — and three other raw tokens that leaked into the same panel are cleaned up alongside.

| Before | After |
|--------|-------|
| `audio/x-raw` | `Audio` |
| `1920×1080 @ 60000/1001 video/x-raw` | `1920×1080 @ 59.94 Raw` |
| `3840×2160 @ 30/1 image/jpeg` | `3840×2160 @ 30 MJPEG` |
| `video/x-vp9` (any unmapped token) | `VP9` |

## Why

`formatProbedCap()` only ever pushed label parts for `width` / `height` / `framerate` / `media_type`. An audio capability has none of the first three, so it fell straight through to the bare media-type token.

**The engine has nothing richer to give, and that was verified before designing the fix** — three independent ways:

1. **Rust wire type** — `cerastream-ipc/src/messages.rs`: `CaptureCap` is exactly `{width, height, framerate, media_type}`.
2. **The probe itself** — `cerastream-core/src/sources/monitor.rs` reads only `s.name()`, `width`, `height`, `framerate`. It never reads `rate`, `channels`, `format`, or `layout` from an audio structure. The published `@ceralive/cerastream` TS binding matches the Rust shape exactly, so CeraUI's Zod schema is not stripping anything either.
3. **The live board, over its own control socket** — `hello` + `list-devices` returns, verbatim, `{"alsa_card_id":"usbaudio","caps":[{"media_type":"audio/x-raw"}], …}`. One field, byte-identical for both devices.

So `audio/x-raw` distinguishes nothing between an Osmo Pocket's embedded mic and a RØDE interface. It is not a capability summary; it is a diagnostic string. Since there is no richer data to render, the honest thing is a clean plain-language label. Surfacing real sample rate / channel count would need an additive wire-contract change across the cerastream probe, `CapsEntry`, `CaptureCap`, the TS binding, and the conformance fixtures — deliberately out of scope here.

The other three fixes are the same bug class in the same function, visible on the same panel on the same board, so they are fixed in the same place rather than left to leak.

## How

- Audio is matched on the **`audio/` prefix**, not a codec list — HDMI embedded audio, USB Audio Class devices, and ALSA cards are all covered with no per-device or per-vendor table.
- The label is localized via a new `live.encoder.probedCapAudio` key across **all 10 locales**. `summarizeProbedCaps` takes the same optional `t` translator that `PipelineHelper`'s label helpers already use, with an English constant fallback — the existing convention, no new pattern.
- Labels are de-duplicated per device. That is newly reachable: a device advertising two audio formats would otherwise render the same "Audio" chip twice.
- `EncoderDialog`'s surrounding `probedCaps` / `summarizeProbedCaps` structure is otherwise untouched; only the translator argument was threaded through.

## How to verify

```bash
bun run --filter frontend test -- ValidationAdapter.caps
```

On a device, open **Encoder Settings** with any audio-capable device attached and read the "Detected capabilities" panel — no entry should contain a `/`.

Verified live on the RK3588 board with a DJI Osmo Pocket 3 and a RØDE HDMI-to-USB-C attached, running this build (`BUILD_ARCH=arm64 bun run build`, sha256-verified on install):

```
Detected capabilities
HDMI Input
  1920×1080 @ 59.94 Raw
DJIPocket3: OsmoPocket3
  3840×2160 @ 30 MJPEG   3840×2160 @ 60 H.264   1920×1080 @ 24 H.264
RØDE HDMI to USB-C: RØDE HDMI
  1920×1080 @ 60 Raw   1280×720 @ 30 MJPEG
DJI DJIPocket3 at usb-fc880000.usb-1, high speed
  Audio
RØDE RØDE HDMI to USB-C at usb-xhci-hcd.17.auto-1, super speed
  Audio
```

One caveat worth stating plainly: the panel only renders when the `devices` broadcast carries `caps`, and `listDevicesIfActive()` returns non-null only while a control client is live — idle falls back to the capless v4l2 scan. A real stream could not be started on that board (cerastream fails `set PLAYING` with an MPP buffer error on every source — pre-existing and unrelated to this change), so the deployed build was driven with the board's own verbatim `list-devices` payload injected over the page socket, the same technique `truthfulness.spec.ts` uses. Real board, real build, real engine data.

## Tests

Nothing was deleted, skipped, or weakened. The existing video-formatting case is untouched and still passes.

New: 5 `formatProbedCap` cases — video regression (resolution + framerate + codec), NTSC fraction humanization, MJPEG naming, unmapped-token fallback, and a parameterized case over `audio/x-raw` / `audio/mpeg` / `audio/x-alaw` asserting the label is "Audio" **and** contains no `/`. Plus 3 `summarizeProbedCaps` cases: audio device summary, multi-format collapse, and the localized-translator path.

Gate: Biome clean on changed files · `svelte-check` 0 errors · backend `check` 0 errors · frontend vitest 1984 passed (187 files) · `@ceraui/rpc` 238 passed · backend 2424 passed · `check:tech-debt` OK.

## Risks

Low, and display-only — no RPC, schema, config, or engine behaviour changes.

The one behaviour change beyond labelling is per-device label de-duplication. Identical labels carry identical information, so a collapsed repeat cannot hide a distinct capability.

`shortMediaType`'s default branch no longer returns the raw token. A future codec CeraUI does not map will read as its bare uppercase subtype (`VP9`, `AV1`) rather than `video/x-vp9` — less precise for a developer reading a log, but this panel is an operator surface and the resolution/framerate beside it carries the detail.
