### PR TITLE
fix(sources): one row per camera, and don't call a held camera disconnected

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -69,6 +69,7 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 | WiFi AP-vs-client classification (`isApMode`, `activeConn`/`activeMode`) | `modules/wifi/wifi-hotspot-types.ts` + `modules/wifi/wifi-interfaces.ts` |
 | Policy-route self-check for bonded wifi/modem interfaces (`policy_route_missing`) | `modules/network/policy-route-check.ts` |
 | **Unified device-first `sources` builder + engine-device cache + `config.source` routing seam** | `modules/streaming/sources.ts` (`buildSources`, `getSourcesMessage`, `deriveEngineRouting`, `resolveSourceRouting`) |
+| **Which capture kinds release their kernel v4l2 node while the engine holds them (libuvc)** | `modules/streaming/held-devices.ts` (`releasesV4l2Node`) — CeraUI-side mirror of cerastream `engine::held_devices` |
 | **`config.source` legacy coercion (pipeline/selected_video_input → source, idempotent)** | `helpers/config-schemas.ts` (`coerceLegacySource`) |
 | **Audio-naming resolution (4-tier: static onboard rule → engine join → ALSA longname → generic alias) + name cleaning + tier-3 diagnostic** | `modules/streaming/audio-naming.ts` |
 | **Static onboard AUDIO display-name rules (`rockchip,hdmiin` → `HDMI Input`) — code-level, no operator surface** | `modules/streaming/audio-naming.ts` (`ONBOARD_AUDIO_DISPLAY_RULES`, `resolveOnboardDisplayName`) |
@@ -1088,6 +1089,53 @@ successful probe never masks the observed set`, which covers the replug-vs-empty
 probe case, the removal-vs-pre-removal-probe case, metadata preference, the audio
 cache, and both out-of-order fences).
 
+## LIBUVC-HELD DEVICES — THE `/dev` SCAN IS NOT ALWAYS A PRESENCE ORACLE [EXISTS]
+
+Everything above rests on one premise: the device registry's own
+`/sys/class/video4linux` scan truthfully answers "is this device plugged in".
+For ONE family of capture devices that premise is simply false, and CeraUI kept
+reporting a working camera as disconnected because of it.
+
+`libuvch264src` never opens a v4l2 node. It drives its camera through **libuvc**,
+i.e. through **usbfs**, which unbinds the kernel `uvcvideo` driver from the USB
+interface for the whole session. So while the engine is streaming or previewing
+such a camera, `/dev/videoN` is **legitimately gone** — and on release the device
+comes back under a DIFFERENT number. Absence from `/dev` is what a *working*
+libuvc capture looks like.
+
+cerastream already knows this about itself: a leg whose resolved `InputKind` is
+`UvcH264`/`UvcH265` records the device it holds, and both `capture_rebind_tick`
+and `list_devices` union that set over the v4l2 registry (cerastream PR #84 for
+the streaming leg, PR #86 for the idle preview). Its `list-devices` is therefore
+**correct** — proven live, retaining `/dev/video1` for a whole session.
+
+CeraUI has a **second, independent** presence signal that had no such notion, and
+`mergeObservedWithProbe` takes video membership from it. So the engine answered
+"present, I am holding it", the local scan said "no such node", membership won,
+and the row was dropped — surfacing as a `Lost` / "Device disconnected" badge on
+a camera whose preview was live on screen at that moment.
+
+- **`modules/streaming/held-devices.ts` `releasesV4l2Node(kind)`** is the
+  CeraUI-side mirror, scoped exactly like the engine's rule: on the resolved
+  device **KIND** (`uvc_h264` / `uvc_h265` — the two kinds
+  `DEVICE_KIND_TO_PIPELINE_ID` bridges to `libuvch264`), **never** on a vendor
+  id, product id, serial, or display name. Every UVC-H.264/H.265 camera behaves
+  this way and no other kind does.
+- **A probe-listed device of such a kind survives the membership filter.** Every
+  other kind keeps the byte-identical observation-wins rule, including the two
+  cases that rule exists for (a failing probe must not mask a removal; a stale
+  probe must not mask a replug) — this only ever ADDS a device the engine
+  positively vouches for.
+- **A real unplug still reports lost.** An unplugged camera is in neither the
+  engine's v4l2 registry nor its held set, so it is absent from the probe too.
+  The exemption cannot manufacture a device the engine did not name.
+
+Do NOT try to fix this class of symptom by suppressing the `lost` badge, by
+special-casing a model, or by having CeraUI track preview/stream state to guess
+at a hold — the engine already tracks the hold authoritatively and reports it;
+CeraUI's job is only to stop overruling that answer with a scan that cannot see
+the device. Coverage: `tests/source-renumber-dedup.test.ts`.
+
 ## BROADCAST EVENTS
 
 The backend pushes typed events to all connected clients via `rpc/events.ts`. Each event type carries a monotonic `seq` counter (`Map<string, number>`) that resets to 0 on server restart.
@@ -1480,6 +1528,31 @@ Every row is one of four `origin` variants (`capture`/`coarse`/`virtual`/
   and an engine that never emits `stable_id` degrades to the prior node-path
   behavior. Coverage: `tests/sources.test.ts` ("hotplug re-enumeration
   reconciliation (Todo 34)").
+- **A REMEMBERED device is keyed by stable identity too, not just the live row.**
+  Todo 34 reconciled the rendered row; the persisted memory behind it was still
+  keyed on the node path, so `mergeLastSeenLru` and the session-seen snapshot map
+  treated every renumber as a NEW device. That was harmless while renumbering was
+  rare — and stopped being rare the moment libuvc capture landed, because a
+  libuvc-driven camera renumbers on EVERY open/close cycle. Confirmed from a live
+  board's own `config.json`: THREE `last_seen_devices` entries (`/dev/video1`,
+  `/dev/video2`, `/dev/video3`) under one identical
+  `stableId: "usb:2ca3:0023:…"` — one camera, three operator-visible rows, and
+  three separate `lost` candidates when it was absent.
+  `identityKey()` (stableId when present, else the node path) is now the key for
+  BOTH the persisted merge and `collectLostCandidates`, so a renumber updates the
+  existing entry's `id`/`devicePath` IN PLACE. Two properties are load-bearing:
+  - **It self-heals.** The fold runs over the observed AND persisted halves
+    together, so a `config.json` that already carries duplicates collapses on the
+    next observation — a device does NOT need a hand-edited config.
+  - **The retired paths are KEPT, on `previousIds`.** Folding without them would
+    strand a `config.source` still holding a retired path: `resolveSourceIdentity`
+    looks the id up in `last_seen_devices` to recover its stable identity, and a
+    folded-away entry answers nothing. This is the persisted twin of the
+    `previousIds` already published on the live capture row, for the same reason.
+    Capped at `RETIRED_ID_MEMORY` (8) — a libuvc camera renumbers indefinitely.
+  Scoped on the engine's `stableId` alone: a device the engine gives no stable
+  identity for still keys on its node path, byte-identically to before.
+  Coverage: `tests/source-renumber-dedup.test.ts`.
 - **Source-routing self-heal across a renumber (PR #197)**: Todo 34 migrates the
   source-list ROW by stable identity, but the persisted operator selection
   (`config.source`) is a literal engine id (e.g. `video1`). When that device
@@ -1908,7 +1981,8 @@ error and operator-stop negatives are the controls, green on both trees).
 - Don't key an adapter on the MAC `ifconfig`/`GENERAL.HWADDR` reports — NetworkManager randomizes it while scanning, and pinning it into `802-11-wireless.mac-address` produces a profile no device can ever activate. Route through `resolveWifiPermanentMac()`, and bridge an ifname-carrying monitor event with `getWifiInterfaceByIfname()`.
 - Don't generate a hotspot SSID/password without asking `findHotspotConnForAdapter()` and the credential store first — that ordering IS the fix for the six orphaned `Hotspot-N` profiles. And don't move the `nmConnSetFields` repair after the `nmConnect`: NetworkManager rejects a profile whose pinned MAC does not match the adapter's permanent address, so the activation is what fails.
 - Don't render `netif.tp` as a rate — it is a byte delta over an unstated window. Use `tx_bps`/`rx_bps`.
-- Don't let a `list-devices` probe decide device MEMBERSHIP on the hotplug path, and don't drop the generation fence — a probe that answers can still be stale or out of order, and both have already stranded a real device on a board. Membership comes from the registry's observation (`mergeObservedWithProbe`); the probe supplies metadata.
+- Don't let a `list-devices` probe decide device MEMBERSHIP on the hotplug path, and don't drop the generation fence — a probe that answers can still be stale or out of order, and both have already stranded a real device on a board. Membership comes from the registry's observation (`mergeObservedWithProbe`); the probe supplies metadata. The ONE exemption is a kind that `releasesV4l2Node()` — for a libuvc-driven camera the `/dev` scan is not an observation at all (see LIBUVC-HELD DEVICES). Don't widen that exemption to any other kind, and don't "simplify" it into a blanket probe-wins membership rule.
+- Don't key a REMEMBERED device (`last_seen_devices`, the session-seen snapshot map) on its node path — a libuvc camera renumbers on every open/close cycle, so that appends a new entry per cycle and renders one camera as N rows with N `lost` candidates. Route through `identityKey()`. And when folding, don't drop the retired paths: `resolveSourceIdentity` resolves a stale `config.source` THROUGH `last_seen_devices`, so a fold that forgets them strands the operator's selection — that is what `previousIds` is for.
 - Don't record a device's `stable_id` into `liveStableIds` before the bridge check in `buildSources` — an unbridged device renders no row, so letting it suppress the remembered `lost` row erases the device from the list entirely.
 - Don't leave a re-enumerated `config.source`/`config.asrc` unrepaired, and don't repair either by name, slot, or "whichever id resolves" — migration is by STABLE IDENTITY only (`reconcileConfiguredSourceIdentity` / `reconcileConfiguredAudioIdentity`), and the retired id must be published as `previousIds` so consumers can tell MOVED from GONE.
 - Don't let the v4l2 scan's `deriveKind()` guess overwrite a kind the engine has already reported for that device, and don't clear `lastEngineVideoDevices` when a device leaves the list — a `usb` guess bridges to no pipeline, so the row is dropped and its coarse slot renders "not connected" for a device that is physically present. Don't relax the display-name gate on the restore to an `input_id`-only lookup either: node paths are recycled, and a fabricated identity is worse than a coarse one. And don't widen that restore past IDENTITY (`kind`/`stable_id`) back onto the remembered `caps`/`signal` — re-asserting a past probe's verdict is how a device that loses its signal keeps claiming it has one, forever.

--- a/apps/backend/src/helpers/config-schemas.ts
+++ b/apps/backend/src/helpers/config-schemas.ts
@@ -171,6 +171,13 @@ export const lastSeenDeviceSchema = z.object({
 	// absent. Lets a re-enumerated device (video1→video2) migrate its row instead
 	// of leaving a stuck `lost` row (Todo 34).
 	stableId: z.string().optional(),
+	// Node paths this same physical device previously answered to, most recent
+	// first. Written only when two snapshots are folded onto one stable identity
+	// (a libuvc camera renumbers `/dev/videoN` on every open/close cycle), so the
+	// id→identity lookup that `resolveSourceIdentity` needs survives the fold —
+	// without it, deduping the list would strand a `config.source` still holding
+	// a retired path. Additive + optional: an older config parses unchanged.
+	previousIds: z.array(z.string()).optional(),
 });
 
 export type LastSeenDevice = z.infer<typeof lastSeenDeviceSchema>;

--- a/apps/backend/src/modules/streaming/held-devices.ts
+++ b/apps/backend/src/modules/streaming/held-devices.ts
@@ -1,0 +1,63 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Which capture kinds make the local `/dev/videoN` scan an INVALID presence
+ * oracle — the CeraUI-side mirror of cerastream's `engine::held_devices`.
+ *
+ * `libuvch264src` does not open a v4l2 node at all: it drives its camera through
+ * libuvc, i.e. through usbfs, which unbinds the kernel `uvcvideo` driver from the
+ * USB interface for the whole session. So while the engine is capturing or
+ * previewing such a camera the node is LEGITIMATELY gone, and on release the
+ * device comes back under a DIFFERENT number (`/dev/video1` → `/dev/video2` → …).
+ * For those kinds, absence from `/dev` is what a working capture looks like —
+ * not a disconnect.
+ *
+ * cerastream already knows this on its own side: a leg whose resolved
+ * `InputKind` is `UvcH264`/`UvcH265` records the device it holds, and both
+ * `capture_rebind_tick` and `list_devices` union that set over the v4l2 registry
+ * (cerastream PR #84 for the streaming leg, PR #86 for the idle preview). CeraUI
+ * has a SECOND, independent presence signal — the device registry's own
+ * `/sys/class/video4linux` scan — which had no such notion, so it kept reporting
+ * a camera the engine was actively serving as `lost`.
+ *
+ * SCOPING: keyed on the resolved device KIND, exactly like the engine's rule.
+ * Never on a vendor id, product id, serial, or display name — every UVC-H.264 /
+ * H.265 camera behaves this way, and no other kind does.
+ */
+
+import type { DeviceKind } from "@ceraui/rpc/schemas";
+
+/**
+ * The kinds `deviceKindToPipelineId` bridges to the `libuvch264` pipeline — the
+ * one pipeline whose source element is libuvc-driven rather than v4l2-driven.
+ */
+const V4L2_NODE_RELEASING_KINDS: ReadonlySet<DeviceKind> = new Set<DeviceKind>([
+	"uvc_h264",
+	"uvc_h265",
+]);
+
+/**
+ * Does opening this device release (unbind) its kernel v4l2 node?
+ *
+ * `true` means CeraUI's own `/dev` scan cannot answer "is it plugged in" for
+ * this device, and only the engine can. `false` — every other kind, and an
+ * absent/unknown kind — keeps the byte-identical observation-wins behaviour.
+ */
+export function releasesV4l2Node(kind: DeviceKind | undefined): boolean {
+	return kind !== undefined && V4L2_NODE_RELEASING_KINDS.has(kind);
+}

--- a/apps/backend/src/modules/streaming/sources.ts
+++ b/apps/backend/src/modules/streaming/sources.ts
@@ -74,6 +74,7 @@ import {
 	groupDeviceCaps,
 } from "./capabilities.ts";
 import { fromEngineDevice } from "./devices.ts";
+import { releasesV4l2Node } from "./held-devices.ts";
 import { applyOnboardVideoDisplayRule } from "./onboard-display-names.ts";
 import { getEffectiveHardware } from "./pipelines.ts";
 import { getConfiguredEngine } from "./streaming-engine.ts";
@@ -333,23 +334,85 @@ export interface BuildSourcesInput {
 }
 
 /**
+ * The identity two snapshots describe the SAME PHYSICAL DEVICE under: the
+ * engine's `stableId` when it gave one, else the node-path id.
+ *
+ * A libuvc-driven camera renumbers its `/dev/videoN` node on every open/close
+ * cycle (see `held-devices.ts`), so keying a remembered device on its id alone
+ * treats each renumber as a NEW device. Live proof from a board's own
+ * `config.json`: THREE `last_seen_devices` entries — `/dev/video1`,
+ * `/dev/video2`, `/dev/video3` — all carrying the identical
+ * `stableId: "usb:2ca3:0023:…"`, i.e. one camera rendered as three rows.
+ *
+ * Nothing here reads a vendor, product, serial, or display name: a device the
+ * engine gives a stable identity for is folded by that identity, and one it does
+ * not still keys on its node path exactly as before.
+ */
+function identityKey(device: LastSeenDevice): string {
+	return device.stableId !== undefined && device.stableId !== ""
+		? `stable:${device.stableId}`
+		: `id:${device.id}`;
+}
+
+/** Does this remembered device answer to `id`, currently or under a retired path? */
+function remembersId(device: LastSeenDevice, id: string): boolean {
+	return device.id === id || (device.previousIds?.includes(id) ?? false);
+}
+
+/**
+ * How many retired node paths one remembered device carries. A libuvc camera
+ * renumbers on every open/close cycle, so this is unbounded churn without a cap;
+ * 8 comfortably covers the window in which a stale `config.source` can still be
+ * in play, and the list is most-recent-first so the cap drops the oldest.
+ */
+const RETIRED_ID_MEMORY = 8;
+
+/**
+ * Fold a superseded snapshot into the one that keeps the row: the survivor's
+ * current identity wins, and the retired node path is remembered so a consumer
+ * still holding it (a persisted `config.source`, the engine's `active_input`)
+ * can still resolve this device instead of failing closed.
+ */
+function foldIdentity(
+	survivor: LastSeenDevice,
+	superseded: LastSeenDevice,
+): LastSeenDevice {
+	const previousIds = [
+		...new Set([
+			superseded.id,
+			...(superseded.previousIds ?? []),
+			...(survivor.previousIds ?? []),
+		]),
+	]
+		.filter((id) => id !== survivor.id)
+		.slice(0, RETIRED_ID_MEMORY);
+	return previousIds.length > 0 ? { ...survivor, previousIds } : survivor;
+}
+
+/**
  * The remembered snapshots eligible to become a lost row: every in-session
  * snapshot, plus the configured id's persisted snapshot across a restart (the
- * session map is empty then). Deduped by id — a session snapshot wins over its
- * persisted twin (same metadata; the session copy is the freshest).
+ * session map is empty then).
+ *
+ * Deduped by IDENTITY, not by id. Within the session map (which is keyed by
+ * `input_id` and deliberately monotonic) the LAST entry for an identity wins —
+ * insertion order makes that the freshest node path. The persisted snapshot is
+ * still only consulted when the identity is not already represented, so a
+ * session snapshot keeps winning over its persisted twin.
  */
 function collectLostCandidates(input: BuildSourcesInput): LastSeenDevice[] {
 	const candidates = new Map<string, LastSeenDevice>();
 	if (input.sessionSnapshots !== undefined) {
-		for (const [id, snapshot] of input.sessionSnapshots)
-			candidates.set(id, snapshot);
+		for (const snapshot of input.sessionSnapshots.values())
+			candidates.set(identityKey(snapshot), snapshot);
 	}
 	const configSource = input.configSource;
-	if (configSource !== undefined && !candidates.has(configSource)) {
-		const persisted = (input.lastSeenDevices ?? []).find(
-			(d) => d.id === configSource,
+	if (configSource !== undefined) {
+		const persisted = (input.lastSeenDevices ?? []).find((d) =>
+			remembersId(d, configSource),
 		);
-		if (persisted !== undefined) candidates.set(configSource, persisted);
+		if (persisted !== undefined && !candidates.has(identityKey(persisted)))
+			candidates.set(identityKey(persisted), persisted);
 	}
 	return [...candidates.values()];
 }
@@ -543,8 +606,8 @@ export function resolveSourceIdentity(
 	lastSeenDevices?: readonly LastSeenDevice[],
 ): string {
 	if (sources.some((s) => s.id === sourceId)) return sourceId;
-	const stableId = (lastSeenDevices ?? []).find(
-		(d) => d.id === sourceId,
+	const stableId = (lastSeenDevices ?? []).find((d) =>
+		remembersId(d, sourceId),
 	)?.stableId;
 	if (stableId === undefined || stableId === "") return sourceId;
 	const successor = sources.find(
@@ -641,21 +704,43 @@ function snapshotFromDevice(device: CaptureDevice): LastSeenDevice | undefined {
 }
 
 /**
+ * Collapse a snapshot list to ONE entry per physical device, freshest-first-wins.
+ *
+ * Applied to the observed and persisted halves TOGETHER, which gives the merge
+ * below two properties at once: a device that came back on a new node path
+ * updates its existing entry's `id`/`devicePath` IN PLACE instead of appending a
+ * second row, and a list that ALREADY carries duplicates — persisted by a build
+ * that predates this rule — self-heals on the next observation rather than
+ * needing a hand-edited `config.json`.
+ */
+function dedupeByIdentity(
+	devices: readonly LastSeenDevice[],
+): LastSeenDevice[] {
+	const byIdentity = new Map<string, LastSeenDevice>();
+	for (const device of devices) {
+		const key = identityKey(device);
+		const kept = byIdentity.get(key);
+		byIdentity.set(
+			key,
+			kept === undefined ? device : foldIdentity(kept, device),
+		);
+	}
+	return [...byIdentity.values()];
+}
+
+/**
  * LRU-merge freshly-observed snapshots into the persisted last-seen list:
- * most-recently-observed first, then prior entries not re-observed. Over the cap,
- * evict least-recent from the tail — EXCEPT the configured id, which is pulled out
- * and always kept so the configured device's snapshot survives any churn.
+ * most-recently-observed first, then prior entries whose device was not
+ * re-observed. Over the cap, evict least-recent from the tail — EXCEPT the
+ * configured id, which is pulled out and always kept so the configured device's
+ * snapshot survives any churn.
  */
 function mergeLastSeenLru(
 	current: readonly LastSeenDevice[],
 	observed: readonly LastSeenDevice[],
 	configSource: string | undefined,
 ): LastSeenDevice[] {
-	const observedIds = new Set(observed.map((d) => d.id));
-	const ordered: LastSeenDevice[] = [
-		...observed,
-		...current.filter((d) => !observedIds.has(d.id)),
-	];
+	const ordered = dedupeByIdentity([...observed, ...current]);
 	if (ordered.length <= LAST_SEEN_DEVICES_CAP) return ordered;
 
 	const configuredIndex =
@@ -1106,6 +1191,21 @@ export async function refreshAndBroadcastSources(
  * `/dev/<card>`, byte-identical to the engine's own path-preferred id (verified
  * on a real Rock 5B+), so the two lists share one id namespace.
  *
+ * ONE kind of device is exempt from the membership rule, and the exemption is
+ * what the rule's own premise requires. `observed` is authoritative because the
+ * `/dev` scan is a truthful presence oracle — but for a libuvc-driven camera it
+ * is not one at all: the engine opens it through usbfs, which unbinds
+ * `uvcvideo`, so the node is ABSENT for exactly as long as the capture works
+ * (`held-devices.ts`). Confirmed live: the engine's own `list-devices` retained
+ * `/dev/video1` for a whole streaming session and a whole idle preview
+ * (cerastream PR #84/#86), while CeraUI's scan could not see it — so the merge
+ * dropped the row and the operator's Source list badged a camera `Lost` and
+ * "Device disconnected" while its preview was on screen. A probe-listed device
+ * whose KIND releases its v4l2 node is therefore kept on the engine's word.
+ * Safe in the other direction too: a genuinely unplugged camera is in neither
+ * the engine's v4l2 registry nor its held set, so it is absent from the probe
+ * and still yields its `lost` row.
+ *
  * NON-VIDEO entries follow the probe verbatim. The observed list's audio rows
  * live in CeraUI's own `audio:<id>` namespace, not the engine's, so they are not
  * comparable — and `buildSources` overlays video only.
@@ -1122,7 +1222,10 @@ export function mergeObservedWithProbe(
 		probed.filter((d) => d.media_class === "video").map((d) => d.input_id),
 	);
 	const confirmed = probed.filter(
-		(d) => d.media_class !== "video" || observedVideoIds.has(d.input_id),
+		(d) =>
+			d.media_class !== "video" ||
+			observedVideoIds.has(d.input_id) ||
+			releasesV4l2Node(d.kind),
 	);
 	const unprobed = observed
 		.filter((d) => d.media_class === "video" && !probedVideoIds.has(d.input_id))

--- a/apps/backend/src/tests/source-renumber-dedup.test.ts
+++ b/apps/backend/src/tests/source-renumber-dedup.test.ts
@@ -1,0 +1,331 @@
+/*
+ * One physical camera must be ONE remembered device, and a camera the engine is
+ * holding open must not be reported as disconnected.
+ *
+ * Both defects were captured live on a Rock 5B+ running a DJI Osmo Pocket 3
+ * (`uvc_h264` → `libuvch264`). `libuvch264src` drives its camera through libuvc,
+ * i.e. usbfs, which unbinds the kernel `uvcvideo` driver — so every open/close
+ * cycle makes `/dev/videoN` vanish and come back under a NEW number. Two things
+ * followed:
+ *
+ *   1. `config.last_seen_devices` grew a NEW entry per renumber. The board's own
+ *      file carried THREE entries — `/dev/video1`, `/dev/video2`, `/dev/video3`
+ *      — under one identical `stableId`, rendering one camera as three rows.
+ *   2. The rows were badged `Lost` / "Device disconnected" WHILE that camera was
+ *      previewing, because the merge took device membership from CeraUI's own
+ *      `/dev` scan — which cannot see a libuvc-held camera by construction —
+ *      and discarded the engine's correct answer (cerastream PR #84/#86).
+ *
+ * Every rule below is keyed on the engine's `stableId` or on the device KIND.
+ * The negative controls pin that: a device with no stable identity, and a device
+ * of any other kind, keep their byte-identical previous behaviour.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { ListDevicesResult } from "@ceralive/cerastream";
+import type {
+	CaptureDevice,
+	DeviceKind,
+	NetworkIngest,
+} from "@ceraui/rpc/schemas";
+
+import type { LastSeenDevice } from "../helpers/config-schemas.ts";
+import { runtimeConfigSchema } from "../helpers/config-schemas.ts";
+import { getConfig } from "../modules/config.ts";
+import { releasesV4l2Node } from "../modules/streaming/held-devices.ts";
+import {
+	buildSources,
+	getEngineDeviceCache,
+	getSessionSeenDeviceSnapshots,
+	mergeObservedWithProbe,
+	refreshEngineDeviceCache,
+	refreshSourcesForHotplug,
+	resetEngineDeviceCache,
+	resolveSourceIdentity,
+} from "../modules/streaming/sources.ts";
+
+const NO_INGEST: NetworkIngest = { rtmp: null, srt: null };
+
+const OSMO_STABLE_ID = "usb:2ca3:0023:DJI_DJIPocket3_123456789ABCDEF";
+const RODE_STABLE_ID = "usb:19f7:0080:RODE_RODE_HDMI_to_USB-C_OC0001967";
+
+const CAP_SOURCE_IDS = ["hdmi", "usb_mjpeg", "libuvch264", "test"] as const;
+
+function capSources() {
+	return CAP_SOURCE_IDS.map((id) => ({
+		id,
+		supports_audio: false,
+		supports_resolution_override: true,
+		supports_framerate_override: true,
+		default_resolution: "1080p",
+		default_framerate: 30,
+	}));
+}
+
+function engineDevice(
+	input_id: string,
+	kind: DeviceKind,
+	stable_id?: string,
+): ListDevicesResult["devices"][number] {
+	return {
+		input_id,
+		device_path: input_id,
+		display_name: kind === "uvc_h264" ? "DJIPocket3: OsmoPocket3" : input_id,
+		media_class: "video",
+		kind,
+		...(stable_id !== undefined ? { stable_id } : {}),
+	} as ListDevicesResult["devices"][number];
+}
+
+function captureDevice(
+	input_id: string,
+	kind: DeviceKind,
+	stable_id?: string,
+): CaptureDevice {
+	return {
+		input_id,
+		device_path: input_id,
+		display_name: kind === "uvc_h264" ? "DJIPocket3: OsmoPocket3" : input_id,
+		media_class: "video",
+		kind,
+		...(stable_id !== undefined ? { stable_id } : {}),
+	};
+}
+
+function osmoSnapshot(id: string): LastSeenDevice {
+	return {
+		id,
+		displayName: "DJIPocket3: OsmoPocket3",
+		kind: "uvc_h264",
+		pipelineId: "libuvch264",
+		devicePath: id,
+		stableId: OSMO_STABLE_ID,
+	};
+}
+
+async function observe(devices: ListDevicesResult["devices"]): Promise<void> {
+	await refreshEngineDeviceCache({
+		fetchEngineDevices: async () => ({ devices }),
+	});
+}
+
+function resetState(): void {
+	resetEngineDeviceCache();
+	getConfig().last_seen_devices = [];
+	delete getConfig().source;
+}
+
+describe("last_seen_devices — one entry per physical device", () => {
+	beforeEach(resetState);
+	afterEach(resetState);
+
+	it("a camera that renumbers /dev/video1 → 2 → 3 updates ONE entry in place instead of appending three", async () => {
+		for (const id of ["/dev/video1", "/dev/video2", "/dev/video3"]) {
+			await observe([engineDevice(id, "uvc_h264", OSMO_STABLE_ID)]);
+		}
+
+		const persisted = getConfig().last_seen_devices ?? [];
+		expect(persisted).toHaveLength(1);
+		expect(persisted[0]?.id).toBe("/dev/video3");
+		expect(persisted[0]?.devicePath).toBe("/dev/video3");
+		expect(persisted[0]?.stableId).toBe(OSMO_STABLE_ID);
+		expect(persisted[0]?.previousIds).toEqual(["/dev/video2", "/dev/video1"]);
+	});
+
+	it("self-heals a config that ALREADY carries the duplicates, with no manual edit", async () => {
+		// The live board's exact corrupted state, verbatim in shape.
+		getConfig().last_seen_devices = [
+			{
+				id: "/dev/video0",
+				displayName: "HDMI Input",
+				kind: "hdmi",
+				pipelineId: "hdmi",
+				devicePath: "/dev/video0",
+				stableId: "port:fdee0000.hdmirx-controller",
+			},
+			osmoSnapshot("/dev/video1"),
+			osmoSnapshot("/dev/video2"),
+			osmoSnapshot("/dev/video3"),
+		];
+
+		await observe([engineDevice("/dev/video4", "mjpeg", RODE_STABLE_ID)]);
+
+		const persisted = getConfig().last_seen_devices ?? [];
+		const osmoRows = persisted.filter((d) => d.stableId === OSMO_STABLE_ID);
+		expect(osmoRows).toHaveLength(1);
+		expect(osmoRows[0]?.id).toBe("/dev/video1");
+		expect(osmoRows[0]?.previousIds).toEqual(["/dev/video3", "/dev/video2"]);
+		expect(persisted).toHaveLength(3);
+	});
+
+	it("NEGATIVE CONTROL — distinct stable identities are never folded together", async () => {
+		await observe([
+			engineDevice("/dev/video1", "uvc_h264", OSMO_STABLE_ID),
+			engineDevice("/dev/video4", "mjpeg", RODE_STABLE_ID),
+		]);
+
+		const persisted = getConfig().last_seen_devices ?? [];
+		expect(persisted).toHaveLength(2);
+		expect(persisted.every((d) => d.previousIds === undefined)).toBe(true);
+	});
+
+	it("NEGATIVE CONTROL — a device the engine gives NO stable id still keys on its node path", async () => {
+		for (const id of ["/dev/video1", "/dev/video2", "/dev/video3"]) {
+			await observe([engineDevice(id, "uvc_h264")]);
+		}
+
+		expect(getConfig().last_seen_devices ?? []).toHaveLength(3);
+	});
+
+	it("the retired node paths stay resolvable, so a stale config.source is not stranded by the fold", async () => {
+		for (const id of ["/dev/video1", "/dev/video2"]) {
+			await observe([engineDevice(id, "uvc_h264", OSMO_STABLE_ID)]);
+		}
+		const persisted = getConfig().last_seen_devices ?? [];
+
+		const sources = buildSources({
+			sources: capSources(),
+			devices: [captureDevice("/dev/video2", "uvc_h264", OSMO_STABLE_ID)],
+			networkIngest: NO_INGEST,
+		});
+
+		expect(resolveSourceIdentity("/dev/video1", sources, persisted)).toBe(
+			"/dev/video2",
+		);
+	});
+
+	it("previousIds round-trips through the persisted config schema", () => {
+		const config = {
+			...runtimeConfigSchema.parse({}),
+			last_seen_devices: [
+				{ ...osmoSnapshot("/dev/video3"), previousIds: ["/dev/video1"] },
+			],
+		};
+		const parsed = runtimeConfigSchema.safeParse(config);
+		expect(parsed.success).toBe(true);
+		if (parsed.success) {
+			expect(parsed.data.last_seen_devices?.[0]?.previousIds).toEqual([
+				"/dev/video1",
+			]);
+		}
+	});
+});
+
+describe("lost rows — a renumbered camera is one candidate, not one per path", () => {
+	beforeEach(resetState);
+	afterEach(resetState);
+
+	it("three session-seen node paths for one camera synthesize EXACTLY one lost row", async () => {
+		for (const id of ["/dev/video1", "/dev/video2", "/dev/video3"]) {
+			await observe([engineDevice(id, "uvc_h264", OSMO_STABLE_ID)]);
+		}
+		expect(getSessionSeenDeviceSnapshots().size).toBe(3);
+
+		const sources = buildSources({
+			sources: capSources(),
+			devices: [],
+			networkIngest: NO_INGEST,
+			lastSeenDevices: getConfig().last_seen_devices ?? [],
+			sessionSnapshots: getSessionSeenDeviceSnapshots(),
+		});
+
+		const osmoRows = sources.filter(
+			(s) => s.origin === "capture" && s.pipelineId === "libuvch264",
+		);
+		expect(osmoRows).toHaveLength(1);
+		expect(osmoRows[0]?.lost).toBe(true);
+		expect(osmoRows[0]?.id).toBe("/dev/video3");
+	});
+
+	it("NEGATIVE CONTROL — two genuinely different cameras still yield two lost rows", async () => {
+		await observe([
+			engineDevice("/dev/video1", "uvc_h264", OSMO_STABLE_ID),
+			engineDevice("/dev/video4", "mjpeg", RODE_STABLE_ID),
+		]);
+
+		const sources = buildSources({
+			sources: capSources(),
+			devices: [],
+			networkIngest: NO_INGEST,
+			lastSeenDevices: getConfig().last_seen_devices ?? [],
+			sessionSnapshots: getSessionSeenDeviceSnapshots(),
+		});
+
+		expect(sources.filter((s) => s.lost === true)).toHaveLength(2);
+	});
+});
+
+describe("held devices — the /dev scan is not a presence oracle for a libuvc camera", () => {
+	beforeEach(resetState);
+	afterEach(resetState);
+
+	it("releasesV4l2Node is scoped to the libuvc-driven kinds and nothing else", () => {
+		expect(releasesV4l2Node("uvc_h264")).toBe(true);
+		expect(releasesV4l2Node("uvc_h265")).toBe(true);
+		for (const kind of [
+			"hdmi",
+			"mjpeg",
+			"camlink",
+			"test",
+			"network",
+			"audio",
+			"usb",
+			"other",
+		] as DeviceKind[]) {
+			expect(releasesV4l2Node(kind)).toBe(false);
+		}
+		expect(releasesV4l2Node(undefined)).toBe(false);
+	});
+
+	it("mergeObservedWithProbe keeps a probe-listed UVC camera the /dev scan cannot see", () => {
+		const merged = mergeObservedWithProbe(
+			[captureDevice("/dev/video0", "hdmi")],
+			[
+				captureDevice("/dev/video0", "hdmi"),
+				captureDevice("/dev/video1", "uvc_h264", OSMO_STABLE_ID),
+			],
+		);
+		expect(merged.map((d) => d.input_id)).toEqual([
+			"/dev/video0",
+			"/dev/video1",
+		]);
+	});
+
+	it("NEGATIVE CONTROL — a probe-listed device of any OTHER kind is still dropped when the scan no longer sees it", () => {
+		const merged = mergeObservedWithProbe(
+			[captureDevice("/dev/video0", "hdmi")],
+			[
+				captureDevice("/dev/video0", "hdmi"),
+				captureDevice("/dev/video4", "mjpeg", RODE_STABLE_ID),
+			],
+		);
+		expect(merged.map((d) => d.input_id)).toEqual(["/dev/video0"]);
+	});
+
+	it("a camera the engine is holding open renders LIVE, not lost, on a hotplug rebuild", async () => {
+		await observe([engineDevice("/dev/video1", "uvc_h264", OSMO_STABLE_ID)]);
+
+		// The engine still reports the held camera; CeraUI's own scan cannot —
+		// libuvc has unbound uvcvideo for the duration of the preview.
+		await refreshSourcesForHotplug([captureDevice("/dev/video0", "hdmi")], {
+			fetchEngineDevices: async () => ({
+				devices: [
+					engineDevice("/dev/video0", "hdmi"),
+					engineDevice("/dev/video1", "uvc_h264", OSMO_STABLE_ID),
+				],
+			}),
+		});
+
+		const sources = buildSources({
+			sources: capSources(),
+			devices: getEngineDeviceCache(),
+			networkIngest: NO_INGEST,
+			lastSeenDevices: getConfig().last_seen_devices ?? [],
+			sessionSnapshots: getSessionSeenDeviceSnapshots(),
+		});
+
+		const osmo = sources.find((s) => s.id === "/dev/video1");
+		expect(osmo?.lost).toBeUndefined();
+		expect(osmo?.available).toBe(true);
+	});
+});


### PR DESCRIPTION
## What

Two operator-visible defects on the Live source list, both triggered by the same thing and both fixed backend-side:

1. **A single camera rendered as several rows.** A live board's `config.json` held three `last_seen_devices` entries — `/dev/video1`, `/dev/video2`, `/dev/video3` — all carrying one identical `stableId`.
2. **Those rows were badged `Lost` / "Device disconnected" while that exact camera was previewing.**

## Why

Both come from one fact: `libuvch264src` does not open a v4l2 node. It drives its camera through libuvc, i.e. **usbfs**, which unbinds the kernel `uvcvideo` driver for the whole session. So a UVC-H.264/H.265 camera's `/dev/videoN` **disappears while it is working** and comes back under a new number on release.

- **Defect 1:** remembered devices (`mergeLastSeenLru`, the session-seen snapshot map) were keyed on that node path, so every open/close cycle appended a *new* entry for the same camera — and produced one `lost` candidate per retired path.
- **Defect 2:** `mergeObservedWithProbe` takes device membership from CeraUI's own `/dev` scan. That is the right rule for every other kind, but for a libuvc camera the scan cannot see the device *by construction* — absence from `/dev` is what a working capture looks like. cerastream already tracks what it holds and reports the device correctly (PR #84 streaming leg, #86 idle preview); CeraUI was overruling that correct answer with a scan that has no way to know.

## How

- **`identityKey()`** — stableId when the engine gave one, else the node path — now keys both the persisted merge and `collectLostCandidates`, so a renumber updates the existing entry's `id`/`devicePath` in place. The fold runs over the observed **and** persisted halves together, so a config that *already* carries duplicates self-heals on the next observation rather than needing a hand-edit.
- **`previousIds` on `lastSeenDeviceSchema`** (additive-optional). This is load-bearing, not bookkeeping: `resolveSourceIdentity` recovers a stale `config.source` by looking the id up **in `last_seen_devices`**, so folding the retired paths away would have stranded the operator's selection as `unknown_source` — a regression the dedup itself would have introduced. Capped at 8.
- **`modules/streaming/held-devices.ts` `releasesV4l2Node(kind)`** — the CeraUI-side mirror of cerastream's `engine::held_devices`, scoped the same way: on the resolved device **kind** (`uvc_h264`/`uvc_h265`), never a vendor, product id, serial, or display name. A probe-listed device of such a kind survives the membership filter.

Deliberately narrow: every other kind keeps the byte-identical observation-wins rule, **including the two cases that rule exists for** (a failing probe must not mask a removal; a stale probe must not mask a replug) — this only ever *adds* a device the engine positively vouches for. A genuinely unplugged camera is in neither the engine's v4l2 registry nor its held set, so it is absent from the probe too and still gets its `lost` row.

## How to verify

Deployed to a Rock 5B+ (sha256-verified) and driven through the real web UI.

**Self-heal, on the actual corrupted config** — `last_seen_devices` went 5 entries → 3, one per physical device, the camera at `/dev/video1` with `previousIds:["/dev/video3","/dev/video2"]`. It survived a subsequent full preview open/close renumber cycle without re-appending.

**No false `Lost`** — 12 samples over 30 s of continuous preview: rendered frames 391 → 1341 (~31.7 fps), `Lost`/"Device disconnected" absent from the DOM **12/12**, camera rows in the source list **1, 12/12**. On stop the badge went cleanly `Selected` → `Active`.

**The precondition, sampled during that same preview** — this is what proves the fix did work rather than the node happening to survive:

```
/dev/video*     -> video0, video4, video5   (video1 + video2 GONE)
5-1:1.0 driver  -> usbfs
5-1:1.1 driver  -> usbfs
```

The camera was invisible to CeraUI's own scan for the entire 30 s and the row stayed live and un-badged. Pre-fix, that is exactly the state that produced the reported screenshot.

**Gate:** biome 0 errors (35 pre-existing nursery warnings, none in changed files), `tsc` clean, backend `bun test` **2436 pass / 0 fail** (2424 + exactly the 12 new), frontend **1973 pass / 187 files**, `svelte-check` 0 errors, `check:tech-debt` OK.

**Rule E proof captured in both directions:** neutering `identityKey` reddens the three dedup/lost-collapse tests; neutering `releasesV4l2Node` reddens the three held-device tests. The four negative controls (distinct stable ids, no-stable-id, other-kind still dropped, two real cameras still two rows) pass **both** ways. No existing test changed, skipped, or weakened.

## Risks

- **The membership exemption is the one real risk**, so it is bounded on both sides: it can only *add* a device the engine named, and it is keyed on kind rather than on any device identity, so it cannot be widened by a vendor quirk. If cerastream ever reported a stale libuvc device, its row would linger — but the engine's held set is per-leg and revoked at teardown, so that window is the same ~0.8 s registry debounce that already exists.
- **`previousIds` must stay additive-optional.** An older config parses unchanged; a new config read by an older build simply ignores the field.
- No cerastream / libuvc / gstlibuvch264src change is needed or included.

## Out of scope, found while verifying

A UVC-H.264 preview-latency report was investigated with real measurements and the obvious explanation is **wrong**: on the board, the UVC path's pipeline latency is p50 **13.6 ms** versus HDMI's **37.0 ms** and MJPEG's **23.7 ms** — the lowest of the three. The real source-asymmetric term is in cerastream's MSE sidecar, which stamps a fixed synthetic 30 fps timeline, making `fragment-duration=250` cost 7.5 access units regardless of framerate — ~250 ms of wall-clock wait at 30 fps versus ~125 ms at 60. That is a separate, properly-scoped cerastream change and is not touched here.
