### PR TITLE
fix(frontend): remove ineffective dynamic imports

### DIFF
--- a/apps/frontend/src/lib/components/streaming/StreamingConfigService.ts
+++ b/apps/frontend/src/lib/components/streaming/StreamingConfigService.ts
@@ -8,6 +8,10 @@ import type {
 } from "@ceraui/rpc/schemas";
 import { toast } from "svelte-sonner";
 
+import {
+	startStreaming as systemStartStreaming,
+	stopStreaming as systemStopStreaming,
+} from "$lib/helpers/SystemHelper";
 import { pipelineAvailability } from "$lib/streaming/pipelineAvailability";
 
 type Properties = {
@@ -131,15 +135,11 @@ export function startStreamingWithConfig(config: Partial<ConfigMessage>): void {
 	) {
 		window.startStreamingWithNotificationClear(config);
 	} else {
-		import("$lib/helpers/SystemHelper")
-			.then((module) => {
-				module.startStreaming(
-					config as Parameters<typeof module.startStreaming>[0],
-				);
-			})
-			.catch((error) => {
-				console.error("Failed to load SystemHelper for streaming:", error);
-			});
+		void systemStartStreaming(
+			config as Parameters<typeof systemStartStreaming>[0],
+		).catch((error) => {
+			console.error("Failed to load SystemHelper for streaming:", error);
+		});
 	}
 }
 
@@ -153,16 +153,12 @@ export function stopStreaming(): void {
 	if (window.stopStreamingWithNotificationClear) {
 		window.stopStreamingWithNotificationClear();
 	} else {
-		import("$lib/helpers/SystemHelper")
-			.then((module) => {
-				module.stopStreaming();
-			})
-			.catch((error) => {
-				console.error(
-					"Failed to load SystemHelper for stopping streaming:",
-					error,
-				);
-			});
+		void systemStopStreaming().catch((error) => {
+			console.error(
+				"Failed to load SystemHelper for stopping streaming:",
+				error,
+			);
+		});
 	}
 }
 

--- a/apps/frontend/src/lib/rpc/streaming-optimism.svelte.ts
+++ b/apps/frontend/src/lib/rpc/streaming-optimism.svelte.ts
@@ -32,6 +32,7 @@ import {
 	STOP_WATCHDOG_TIMEOUT_MS,
 	type StopWatchdogDeps,
 } from "./streaming-stop-watchdog";
+import { ingestPulledStatus } from "./subscriptions.svelte";
 
 // ============================================
 // Types
@@ -323,7 +324,6 @@ function createReactiveOptimismStore(): ReactiveOptimismStore {
 		return {
 			pullStatus: async () => {
 				const status = await rpc.status.getStatus();
-				const { ingestPulledStatus } = await import("./subscriptions.svelte");
 				ingestPulledStatus(status);
 				return Boolean(
 					(status as { is_streaming?: unknown } | null | undefined)
@@ -342,7 +342,6 @@ function createReactiveOptimismStore(): ReactiveOptimismStore {
 		return {
 			pullStatus: async () => {
 				const status = await rpc.status.getStatus();
-				const { ingestPulledStatus } = await import("./subscriptions.svelte");
 				ingestPulledStatus(status);
 				return Boolean(
 					(status as { is_streaming?: unknown } | null | undefined)

--- a/apps/frontend/src/lib/stores/pwa.svelte.ts
+++ b/apps/frontend/src/lib/stores/pwa.svelte.ts
@@ -1,6 +1,8 @@
 // PWA Installation and Offline Status Store using pure Svelte 5 runes
 // Simplified version without legacy store compatibility
 
+import { toast } from "svelte-sonner";
+
 // ============================================
 // Device Detection
 // ============================================
@@ -163,12 +165,10 @@ if (typeof window !== "undefined") {
 export async function installApp(): Promise<boolean> {
 	if (!deferredPrompt) {
 		// No native prompt available, show manual instructions
-		void import("svelte-sonner").then(({ toast }) => {
-			toast.info("Install App", {
-				description:
-					'Use your browser\'s "Install" or "Add to Home Screen" option in the menu.',
-				duration: 5000,
-			});
+		toast.info("Install App", {
+			description:
+				'Use your browser\'s "Install" or "Add to Home Screen" option in the menu.',
+			duration: 5000,
 		});
 		return false;
 	}


### PR DESCRIPTION
## What
Convert five ineffective dynamic imports to static imports in the streaming config service, PWA store, and streaming optimism watchdog.

## Why
These modules were already statically bundled elsewhere, so the dynamic imports produced Vite/Rollup `INEFFECTIVE_DYNAMIC_IMPORT` warnings without code-splitting benefit.

## How to verify
- `bun run build`
- `bun run lint`
- `eval "$(mise env -s bash node@24.11.1)" && bun run test`
- The build retains only the intentional i18n locale, navigation cycle-breaker, and config jsdom-safety warnings.

## Risks
No runtime logic changed; the existing global-wrapper fallbacks, Promise rejection logging, and watchdog status ingestion paths are unchanged. Full workspace lint/test verification is currently blocked by concurrent uncommitted `ValidationAdapter.ts` changes on this checkout.