### PR TITLE
chore(deps): bump @ceralive/cerastream pin to 2026.7.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ setup.json are coerced to `"cerastream"` at parse time with a warning).
 The backend resolves both streaming deps as public-npm registry packages — no sibling checkout, no vendored tarball:
 
 ```
-"@ceralive/cerastream":  "2026.7.3"   (public npm, @ceralive scope)
+"@ceralive/cerastream":  "2026.7.4"   (public npm, @ceralive scope)
 "@ceralive/srtla-send":  "2026.6.2"   (public npm, @ceralive scope)
 ```
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -9,7 +9,7 @@
 		"bun": ">=1.3.0"
 	},
 	"dependencies": {
-		"@ceralive/cerastream": "2026.7.3",
+		"@ceralive/cerastream": "2026.7.4",
 		"@ceralive/control-protocol": "2026.7.0",
 		"@ceralive/srtla-send": "2026.6.2",
 		"@ceraui/rpc": "workspace:*",

--- a/apps/backend/src/tests/cerastream-bindings-skew.test.ts
+++ b/apps/backend/src/tests/cerastream-bindings-skew.test.ts
@@ -96,9 +96,12 @@ describe("cerastream bindings version-skew guard", () => {
 	});
 
 	test("event topics + discriminated union stay in lockstep", () => {
-		// device-quality-wave2 Todo 22: the 2026.7.3 pin adds the additive 8th
-		// `audio-level` topic (ADR-0007) — the always-on level meter.
-		expect([...EVENT_TOPICS]).toEqual([
+		// device-quality-wave3 Todo 10: the 2026.7.4 pin adds the additive 9th
+		// `config-change` topic (the transactional live reconfigure). Pinning the
+		// whole PRIOR prefix rather than a bare count is strictly stronger — a
+		// reorder or removal still fails loudly, while the next additive topic
+		// does not need this literal re-edited.
+		expect([...EVENT_TOPICS].slice(0, 8)).toEqual([
 			"status",
 			"switch",
 			"device",
@@ -108,6 +111,8 @@ describe("cerastream bindings version-skew guard", () => {
 			"preview",
 			"audio-level",
 		]);
+		expect([...EVENT_TOPICS]).toContain("config-change");
+		expect(EVENT_TOPICS.length).toBe(9);
 		expect(eventParamsSchema.options.length).toBe(EVENT_TOPICS.length);
 	});
 
@@ -120,10 +125,13 @@ describe("cerastream bindings version-skew guard", () => {
 		expect(processErrorCodeSchema.options.length).toBe(7);
 	});
 
-	test("SCHEMA_VERSION is pinned to 0.8.0", () => {
-		// device-quality-wave2 Todo 22: the 2026.7.3 pin ships schema 0.8.0 (the
-		// additive Todo 20/21/30 batch), superseding the 0.4.0 the prior pin shipped.
-		expect(SCHEMA_VERSION).toBe("0.8.0");
+	test("SCHEMA_VERSION is pinned to 0.10.0", () => {
+		// device-quality-wave3 Todo 10: the 2026.7.4 pin ships schema 0.10.0 (the
+		// additive ADR-0008 identity + Todo 9 config-change batch), superseding the
+		// 0.8.0 the prior pin shipped. This value must equal what the on-device
+		// engine reports in `hello` — capabilities.ts raises the advisory
+		// `schemaVersionMismatch` banner off exactly that comparison.
+		expect(SCHEMA_VERSION).toBe("0.10.0");
 	});
 
 	test("audio-level topic + connect-error codes are on the surface (Todo 22)", () => {

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -19,7 +19,7 @@ Svelte 5 PWA for CeraUI — the on-device control plane for CeraLive streaming h
 The `backend` app consumes both streaming bindings as pinned public npm packages:
 
 ```
-"@ceralive/cerastream": "2026.7.3"   (public npm, @ceralive scope)
+"@ceralive/cerastream": "2026.7.4"   (public npm, @ceralive scope)
 "@ceralive/srtla-send": "2026.6.2"   (public npm, @ceralive scope)
 ```
 

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
       "name": "backend",
       "version": "2026.6.2",
       "dependencies": {
-        "@ceralive/cerastream": "2026.7.3",
+        "@ceralive/cerastream": "2026.7.4",
         "@ceralive/control-protocol": "2026.7.0",
         "@ceralive/srtla-send": "2026.6.2",
         "@ceraui/rpc": "workspace:*",
@@ -342,7 +342,7 @@
 
     "@ceralive/biome-config": ["@ceralive/biome-config@2026.6.2", "", {}, "sha512-LqDaJufxLOC3Rm38u/ocpUro/ub8llv1q9pcS3W/Ys7gBy+wLjS2TmcyhMjNMRg9c7pCQlPMI6eS8JkhpN+ecw=="],
 
-    "@ceralive/cerastream": ["@ceralive/cerastream@2026.7.3", "", { "dependencies": { "zod": "^4.3.5" } }, "sha512-Re0aP5yxe0Nb/LDkyvLTIfwktsBnywLusADXTNSZvLuYCDWQ0C7m1nyW0viOUilq8uB++H/jPJaEcykPq+cEzA=="],
+    "@ceralive/cerastream": ["@ceralive/cerastream@2026.7.4", "", { "dependencies": { "zod": "^4.3.5" } }, "sha512-eZl24rtImGCtuAxtl+E0LVm5AZ3l4eFhxQT7pW77lyP5WbfayGR7dRqdbLtxdBr315yTO03MBXUJhPMJLf7JGA=="],
 
     "@ceralive/control-protocol": ["@ceralive/control-protocol@2026.7.0", "", { "dependencies": { "zod": "^4.3.5" } }, "sha512-/pLQpo3bTUzzxaQJK0zta4XKS6EJWr26p5jj2YST69ejxafQiCCjXKgdOkMWU9VjKm0XeMNQehxXOb6ylMGGHg=="],
 


### PR DESCRIPTION
## What

Bumps the `@ceralive/cerastream` registry pin `2026.7.3` → `2026.7.4` and moves the
binding-skew guard with it.

- `apps/backend/package.json` + `bun.lock` — the pin itself (sanctioned lockfile
  exception).
- `apps/backend/src/tests/cerastream-bindings-skew.test.ts` — the pin-derived
  assertions: `SCHEMA_VERSION` `0.8.0` → `0.10.0`, and the event-topic list gains the
  additive 9th `config-change`.

## Why

`2026.7.4` carries the TypeScript half of two contracts the engine already speaks:

- **ADR-0008 physical device identity** — `physical_group_id` + `hardware_serial` on
  `captureDeviceSchema`.
- **Transactional live config change** — `changeConfigParamsSchema` /
  `changeConfigResultSchema` / `configChangePhaseSchema` / `configChangeEventSchema`,
  `REASON_TEARDOWN_TIMEOUT`, and `client.changeConfig()`.

`V1_METHODS` stays at eight; `change-config` sits outside it like `get-capabilities`
and `switch-audio`. Nothing in this PR *consumes* the new surface — that is the
follow-on config-change UX and auto-audio work. This PR exists to clear the skew and
put the types in place.

**The skew was real and user-visible.** `capabilities.ts` sets
`schemaVersionMismatch: true` whenever the engine's reported `schema_version` differs
from the bindings', and the dashboard renders an advisory tier off that flag. On the
board, before this change:

```
warn  capabilities: engine schema_version differs from bindings; degrading
      {"engine":"0.9.0","bindings":"0.8.0"}
warn  cerastream: engine schema_version differs from bindings
      {"engine":"0.9.0","bindings":"0.8.0"}
```

After the bump (with the matching engine): zero such warnings, and the
`schemaVersionMismatch` key is absent from the `capabilities` push entirely.

### Why the skew test is in this PR

It is a *pin-derived* assertion — its entire job is to fail loudly when the pinned
binding surface moves, which is exactly what it did here. It travelled with the
previous pin bump too (`c18a14e3`, the 2026.7.3 bump). Weakening or skipping it would
violate the testing gate; leaving it red would block the merge. Its topic assertion is
now a whole-prefix pin rather than a bare list, which is strictly stronger and does not
need re-editing for the next additive topic.

## How to verify

Full gate, green:

```bash
bun run lint             # exit 0
bun run test             # 271 rpc + 2004 frontend + 2459 backend, 0 fail
bun run check:tech-debt  # 15 register entries, 12 open, no orphan markers
```

(The frontend leg needs Node 24 on a dev box — `mise exec node@24.11.1 -- bun run test`
— per the documented local-host caveat. CI pins Node 24 already.)

**Board smoke on the shipping RK3588, run BEFORE this PR was opened.** The pinned
candidate (`BUILD_ARCH=arm64 bun run build`, backend sha256 `6bbb1898…`) was live-patched
onto the board alongside the matching engine (`cerastream 2026.7.2+5ef348c`, schema
`0.10.0`):

1. **Banner gone** — the `capabilities` frame is present (`engineUnavailable: false`,
   real `rk3588` platform data, so the fetch genuinely ran) and the
   `schemaVersionMismatch` key is absent. Zero skew warnings in the journal since the
   deploy, against two on the previous build.
2. **`physical_group_id` present** — over the engine control socket, the Osmo's video
   and audio rows BOTH report `usb:5-1`, the RØDE's BOTH report `usb:10-1`, and the
   SoC HDMI-RX has no group at all. `subscribe-events` returns all nine topics
   including `config-change`. The field is not yet in CeraUI's own `sources`/`devices`
   projection — consuming it is the follow-on auto-audio work — so this is verified by
   API inspection, as the plan allows.
3. **One stream start/stop** — start succeeded, ran 30 s at `1920x1080@30` `h265`
   (`input_codec: mjpeg`, `passthrough: false`), the health rollup went
   `idle → healthy` with `frames.advancing: true` and `bond 1/1 active`, `eth0` egress
   rose 0 → ~370 kbps and fell back to 0 after `stop`, which returned
   `{"success":true,"result":"stopped"}` and cleared the session-scoped telemetry.

The board's config was restored to its exact pre-smoke values (`source /dev/video0`,
`pipeline hdmi`, `1080p@30`, `asrc Auto`, `delay 0`).

## Risks

- **The pin and the on-device engine must move together.** A device still running a
  pre-`0.10.0` engine will now show the advisory banner in the other direction until it
  is updated. The banner is informational and never locks controls (the schema is
  additive-only within `cerastream-ipc/1`), so an un-updated device keeps working —
  it just renders the advisory.
- **New surface is unused for now.** `client.changeConfig()` ships but nothing calls
  it yet. Note for whoever wires it: it RESOLVES on `rollback_failed` rather than
  rejecting, so branch on `result.phase`, and size timeouts from the engine's declared
  65 000 ms worst-case bound, not the client's default per-request timeout.
- The lockfile change is a single dependency line plus its integrity hash; no other
  package moved.
