### PR TITLE
fix(notifications): retract hdmi_error and capture_video_error when the condition clears

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -68,6 +68,8 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 | Measured per-interface throughput (`tx_bps`/`rx_bps`, bits/s) | `modules/network/network-interfaces.ts` (`computeInterfaceRate`, `processIfconfigOutput`) |
 | WiFi AP-vs-client classification (`isApMode`, `activeConn`/`activeMode`) | `modules/wifi/wifi-hotspot-types.ts` + `modules/wifi/wifi-interfaces.ts` |
 | Policy-route self-check for bonded wifi/modem interfaces (`policy_route_missing`) | `modules/network/policy-route-check.ts` |
+| Retracting the `hdmi_error` "No HDMI signal detected" notification once the link relocks | `modules/system/hdmi-signal-notification.ts` (`clearHdmiSignalErrorOnRecovery`, hooked into `sources.ts` `commitEngineDevices`); contract below → A PERSISTENT NOTIFICATION MUST BE RETRACTABLE |
+| Retracting the `cerastream` `capture_video_error` notification at a healthy session boundary | `modules/streaming/cerastream-backend.ts` (`standingEngineError`, `clearRecoveredEngineError`, `ENGINE_ERRORS_CLEARED_BY_HEALTHY_SESSION`) |
 | **Device-truth save guard + persisted-mode clamp (ADR-0008 §10)** | `modules/streaming/device-mode-guard.ts` (`verifySaveDeviceMode`, `clampPersistedDeviceMode`) + `modules/streaming/persisted-mode-clamp.ts` (`reconcilePersistedDeviceMode`); the RULE itself is `@ceraui/rpc` `capabilities/device-mode-truth.ts`, shared with the frontend |
 | **Unified device-first `sources` builder + engine-device cache + `config.source` routing seam** | `modules/streaming/sources.ts` (`buildSources`, `getSourcesMessage`, `deriveEngineRouting`, `resolveSourceRouting`) |
 | **Which capture kinds release their kernel v4l2 node while the engine holds them (libuvc)** | `modules/streaming/held-devices.ts` (`releasesV4l2Node`) — CeraUI-side mirror of cerastream `engine::held_devices` |
@@ -1996,8 +1998,105 @@ operator action, a fresh start dials a NEW client and works, reconciliation stop
 re-affirming the phantom session, and the orchestrator re-admits a start; the RPC
 error and operator-stop negatives are the controls, green on both trees).
 
+## A PERSISTENT NOTIFICATION MUST BE RETRACTABLE [EXISTS]
+
+The third instance of the same latched-stale class as `policy_route_missing` (a
+flag raised but never lowered) and `active_encode` (engine truth that outlived its
+session). Here the mechanism is blunter: `notificationRemaining()`
+(`modules/ui/notification-liveness.ts`) returns `NOTIFICATION_LIVES_FOREVER` for
+EVERY persistent notification by deliberate design — `duration` does not apply to
+one — so a raise site with no matching retraction is **permanent by
+construction**. `duration: 3` on the raise reads like an expiry and is not one.
+
+Two notifications shipped that way, and both were confirmed on a board.
+
+| Notification | Raised by | Why it could never clear |
+|---|---|---|
+| `hdmi_error` / "No HDMI signal detected" | `modules/system/sensors.ts`, off the RK3588 dmesg line `hdmirx-controller: Err, timing is invalid` | the kernel logs the failure and prints NOTHING when the link relocks, so the only event the watcher can see is the bad one |
+| the `cerastream` channel carrying `capture_video_error` | `cerastream-backend.ts` `handleErrorEvent()` | the engine reports the Tier-2 error and never revokes it; the condition cleared and the engine returned to idle/healthy with the error still on screen |
+
+**The retraction runs on the same evidence the source list already trusts, never
+on a timer.** A timeout would hide a genuinely-still-broken condition exactly as
+readily as it clears a resolved one, which is a worse bug than the one being
+fixed. Both retractions therefore demand a POSITIVE, engine-authored statement
+that contradicts the notification's own claim; every other outcome — an
+unreachable engine, a fallback v4l2 row, an idle engine — leaves the notification
+standing.
+
+**`hdmi_error` retracts on `signal: "present"` for an HDMI-RX capture device**
+(`modules/system/hdmi-signal-notification.ts`
+`clearHdmiSignalErrorOnRecovery`). That verdict is stamped at `fromEngineDevice`
+— the one seam that knows the ENGINE authored the row (see "THREE capture-row
+states") — so it is the engine's own `VIDIOC_QUERY_DV_TIMINGS` projection saying
+the port carries a picture. A row with `signal` unset reads `unknown` and proves
+nothing. Four properties are load-bearing:
+
+- **It hangs off `commitEngineDevices` (`sources.ts`), not off a broadcast.** That
+  is the ONE seam every engine-authored device view flows through — the 5 s
+  `recheckSourceSignals` tick, the hotplug refresh, the boot seed, the reconnect
+  heal — so no path can commit a recovery the notification does not see. It runs
+  on EVERY commit, deliberately NOT gated on a changed payload: a transient
+  `timing is invalid` line raises the notification while the engine's own view
+  never varies, and a change-gated hook would then never fire at all.
+- **Scoped to `kind === "hdmi"`.** The kind heuristic tests usb/uvc BEFORE hdmi
+  precisely so a "RØDE HDMI to USB-C" dongle is not mislabelled, so a working
+  webcam can never retract a claim about the board's HDMI-RX port.
+- **Scoped to the EXACT message.** The name `hdmi_error` is SHARED with the
+  EMI/cable-quality advisory ("HDMI signal issues detected…"), which describes a
+  different condition a relocked link does not falsify — the raise site already
+  keys on the same string to avoid overwriting it. Retracting by name alone would
+  silently drop it.
+- **Idempotent.** `notificationExists` answers `undefined` once it is gone, so the
+  healthy steady state costs one map lookup and broadcasts nothing.
+
+**`capture_video_error` retracts at a healthy SESSION boundary** — a concordant
+`state:"streaming" + streaming:true` status frame (the engine is delivering video
+right now), or the start of a new session, which must not inherit the previous
+one's failure. That second rule is the same session-boundary discipline
+`active_encode` follows in `startStream()`. An IDLE engine is deliberately NOT
+proof: idle means "not streaming", not "the capture card works".
+`ENGINE_ERRORS_CLEARED_BY_HEALTHY_SESSION` is the membership table and holds
+`capture_video_error` alone — `capture_audio_error`, `pipeline_stall` and the two
+SRT codes stay latched until each has an established recovery signal of its own.
+The table is required because `resolved.channel` (`"cerastream"`) is ONE
+notification slot shared by every non-srtla engine error, so
+`standingEngineError` records which code currently occupies it; a blind
+remove-by-name would retract whichever error happened to be standing.
+
+**Both are now `isDismissable: true`, and that is a safety net, not the fix.**
+`active_encode`'s precedent argues for leaving a status signal non-dismissable
+when its automatic clear is reliable, and the automatic clears above ARE the
+primary mechanism. But each depends on the engine being reachable and speaking:
+`hdmi_error` needs cerastream to enumerate the HDMI-RX node, and
+`capture_video_error` needs a later status frame or a new session. A masked or
+crashed engine emits neither, and the pre-existing `isDismissable: false` left the
+operator with no escape at all from a notification the device could no longer
+retract. The manual affordance costs nothing when the automatic path works and is
+the only recourse when it cannot run.
+
+Coverage: `tests/notification-recovery-clearing.test.ts` (the pure verdict, the
+persists-while-severed and unreachable-engine controls, the real `remove` frame
+pushed to a connected client, the EMI-advisory and foreign-device negatives, the
+idle-is-not-proof and shared-slot negatives, and the repeat-heartbeat idempotence)
+plus the frontend half `apps/frontend/src/tests/notification-recovery-ingestion.test.ts`
+(the `remove` frame drops the entry from the persistent panel).
+
 ## ANTI-PATTERNS
 
+- Don't add a persistent notification without a retraction path — `duration` does
+  NOT expire one (`notificationRemaining()` returns "lives forever" for every
+  persistent notification by design), so a raise-only site latches for the whole
+  session. And don't "fix" a latched one with a timeout: that hides a
+  still-broken condition just as readily as it clears a resolved one. Find the
+  authoritative recovery signal (see A PERSISTENT NOTIFICATION MUST BE RETRACTABLE).
+- Don't retract a notification whose NAME is shared by more than one claim without
+  discriminating WHICH claim is standing — `hdmi_error` carries both the no-signal
+  and the EMI/cable advisory, and the `cerastream` channel carries every non-srtla
+  engine error. Key on the message (`HDMI_NO_SIGNAL_MSG`) or on the recorded code
+  (`standingEngineError`), never on the bare name.
+- Don't move the HDMI recovery hook off `commitEngineDevices` or gate it on a
+  changed payload — it must see every engine-authored device view, including the
+  ones that are byte-identical to the last.
 - Don't import from `@ceralive/srtla` — that package is retired from CeraUI. Use `@ceralive/srtla-send` (the `srtla-send-rs` binding, registry dep). Check `../../../srtla-send-rs/AGENTS.md` before touching call sites.
 - Don't add HTTP REST endpoints — all device control goes through oRPC over WebSocket.
 - Don't re-serialise the DNS health check ahead of the caller's query in `dnsCacheResolve`, and don't share one `Resolver` between them — the check only GATES the answer, and a shared c-ares channel's `cancel()` would abort the sibling leg. Both legs sit inside the per-attempt launch deadline (see DNS ON THE STREAM-START CRITICAL PATH).

--- a/apps/backend/src/modules/streaming/cerastream-backend.ts
+++ b/apps/backend/src/modules/streaming/cerastream-backend.ts
@@ -109,8 +109,10 @@ import { setup } from "../setup.ts";
 import {
 	notificationBroadcast,
 	notificationExists,
+	notificationRemove,
 } from "../ui/notifications.ts";
 import { type AudioMode, resolveAudioMode } from "./audio.ts";
+import type { ResolvedCerastreamError } from "./cerastream-error-mapping.ts";
 import { resolveCerastreamError } from "./cerastream-error-mapping.ts";
 import { SRTLA_LISTEN_PORT } from "./constants.ts";
 import { deviceRegistry } from "./devices.ts";
@@ -128,8 +130,18 @@ import type {
 	StreamingBackend,
 	StreamRunOptions,
 } from "./streaming-backend.ts";
+import { PROCESS_ERROR_CODES } from "./streamloop/process-error-patterns.ts";
 
 const CERASTREAM_PIPELINE_PATH = "/tmp/cerastream-pipeline.txt";
+
+/**
+ * Engine error codes a healthy session boundary PROVES are history. Membership
+ * requires an engine-authored recovery signal that contradicts the error's own
+ * claim — not merely that the error looks transient.
+ */
+const ENGINE_ERRORS_CLEARED_BY_HEALTHY_SESSION: ReadonlySet<string> = new Set([
+	PROCESS_ERROR_CODES.CAPTURE_VIDEO_ERROR,
+]);
 
 /** The status/notification surface the backend bridges engine events onto. */
 export interface CerastreamBridge {
@@ -142,6 +154,7 @@ export interface CerastreamBridge {
 		isDismissable: boolean,
 	): void;
 	notificationExists(name: string): boolean;
+	removeNotification(name: string): void;
 	broadcastStatus(): void;
 	broadcastBuffering(payload: BufferingStatus): void;
 }
@@ -187,6 +200,9 @@ function defaultBridge(): CerastreamBridge {
 	return {
 		notify: notificationBroadcast,
 		notificationExists: (name) => Boolean(notificationExists(name)),
+		removeNotification: (name) => {
+			notificationRemove(name);
+		},
 		broadcastStatus: () => {
 			// Lazy import keeps the websocket/streaming graph out of this module's
 			// import cycle; the nudge fires long after boot so a dynamic import is fine.
@@ -544,6 +560,11 @@ export class CerastreamBackend implements StreamingBackend {
 	private subscription: Subscription | undefined;
 	private active = false;
 	private telemetry: EngineTelemetry | null = null;
+	// The engine error currently occupying the shared `cerastream` notification
+	// slot. Tracked because that slot is shared by every non-srtla engine error,
+	// so a blind remove-by-name would retract whichever error happens to be
+	// standing rather than the one the recovery signal actually falsifies.
+	private standingEngineError: ResolvedCerastreamError | undefined;
 	// Serializes non-stop IPC ops; stop interrupts a pending start through its client.
 	private queue: Promise<void> = Promise.resolve();
 	private interrupt: Promise<void> = Promise.resolve();
@@ -594,6 +615,7 @@ export class CerastreamBackend implements StreamingBackend {
 		transaction?: LaunchTransaction,
 	): Promise<void> {
 		this.active = true;
+		this.clearRecoveredEngineError();
 		const params = this.buildStartParams(config, opts);
 		const launchTransaction =
 			transaction ?? createLaunchTransaction("backend-start");
@@ -965,6 +987,11 @@ export class CerastreamBackend implements StreamingBackend {
 				this.deps.bridge.broadcastStatus();
 				break;
 			case "status": {
+				if (
+					classifyRuntimeState(event.state, event.streaming) === "streaming"
+				) {
+					this.clearRecoveredEngineError();
+				}
 				const buffering = extractBufferingStatus(event);
 				const activeEncode = extractActiveEncode(event);
 				// A partial mid-stream frame keeps the last known encode, but an
@@ -1027,14 +1054,34 @@ export class CerastreamBackend implements StreamingBackend {
 				resolved.message,
 				5,
 				true,
-				false,
+				true,
 			);
+			this.standingEngineError = resolved;
 		}
 
 		const raw = `cerastream ${event.source} error [${event.code}]${
 			event.reason ? `: ${event.reason}` : ""
 		}`;
 		for (const listener of this.errorListeners) listener(raw);
+	}
+
+	/**
+	 * Retract a standing engine error the current session boundary falsifies.
+	 *
+	 * `capture_video_error` claims the capture card failed and that no restart is
+	 * scheduled — a claim about ONE session. Two engine-authored events prove it is
+	 * history, and neither is a timer: a concordant `streaming` status frame (the
+	 * engine is delivering video right now), and the start of a NEW session (which
+	 * must not inherit the previous one's failure — the same session-boundary rule
+	 * `active_encode` follows). Codes whose recovery signal has not been
+	 * established are deliberately absent from the table and stay latched.
+	 */
+	private clearRecoveredEngineError(): void {
+		const standing = this.standingEngineError;
+		if (standing === undefined) return;
+		if (!ENGINE_ERRORS_CLEARED_BY_HEALTHY_SESSION.has(standing.code)) return;
+		this.standingEngineError = undefined;
+		this.deps.bridge.removeNotification(standing.channel);
 	}
 
 	private enqueue(op: () => Promise<void>, label: string): Promise<void> {

--- a/apps/backend/src/modules/streaming/sources.ts
+++ b/apps/backend/src/modules/streaming/sources.ts
@@ -67,6 +67,7 @@ import { logger } from "../../helpers/logger.ts";
 import { broadcastMsg } from "../../rpc/compat.ts";
 import { getConfig, saveConfig } from "../config.ts";
 import { getNetworkIngestInfo } from "../network/network-ingest.ts";
+import { clearHdmiSignalErrorOnRecovery } from "../system/hdmi-signal-notification.ts";
 import type { EngineAudioDevice } from "./audio-naming.ts";
 import {
 	defaultFetchEngineDevices,
@@ -990,6 +991,10 @@ function commitEngineDevices(
 		engineAudioDeviceCache = [...audio];
 	}
 	recordObservedDevices(engineDeviceCache);
+	// Deliberately on EVERY commit, not only a changed one: a transient
+	// `timing is invalid` dmesg line raises the notification while the engine's
+	// own view never varies, so a change-gated hook would never retract it.
+	clearHdmiSignalErrorOnRecovery(engineDeviceCache);
 	if (audioChanged) engineAudioChangeHandler();
 }
 

--- a/apps/backend/src/modules/system/hdmi-signal-notification.ts
+++ b/apps/backend/src/modules/system/hdmi-signal-notification.ts
@@ -1,0 +1,108 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+// The retraction half of the `hdmi_error` "No HDMI signal detected" notification.
+//
+// `sensors.ts`'s RK3588 dmesg watcher RAISES it off the kernel line
+// `hdmirx-controller: Err, timing is invalid`. The kernel prints nothing when
+// the link comes back, and a persistent notification never expires on a timer
+// (`notification-liveness.ts`), so the raise was permanent: the operator read
+// "No HDMI signal detected" for a port that had relocked minutes earlier.
+//
+// The recovery evidence is the SAME one the source list already trusts: the
+// engine's own `VIDIOC_QUERY_DV_TIMINGS` projection, stamped as
+// `CaptureDevice.signal` at `fromEngineDevice` — the one seam that knows the
+// ENGINE authored the row. `signal: "present"` on an HDMI-RX capture device is a
+// positive, engine-authored statement that the port is carrying a picture, which
+// is precisely the claim the notification denies. NOTHING here is a timer: an
+// unreachable engine, a fallback v4l2 scan row (`signal` unset ⇒ `unknown`), and
+// a still-severed link all fail the test and leave the notification standing.
+
+import { notificationExists, notificationRemove } from "../ui/notifications.ts";
+
+/** Persistent-notification name shared by both `sensors.ts` HDMI raise sites. */
+export const HDMI_ERROR_NOTIFICATION = "hdmi_error";
+
+/**
+ * The EXACT wire message of the no-signal raise. It is the discriminator, not
+ * decoration: the name `hdmi_error` is shared with the EMI/cable-quality advisory
+ * ("HDMI signal issues detected…"), which describes a DIFFERENT condition that a
+ * relocked link does not falsify — the raise site already keys on this same
+ * string to avoid overwriting that advisory. Retracting on anything less
+ * specific would silently drop it.
+ */
+export const HDMI_NO_SIGNAL_MSG = "No HDMI signal detected";
+
+/** The two device fields the verdict reads; `CaptureDevice` satisfies it. */
+export interface HdmiSignalObservation {
+	kind: string;
+	signal?: string | undefined;
+}
+
+/**
+ * Does this device view PROVE an HDMI receiver is carrying a signal again?
+ *
+ * Scoped to `kind === "hdmi"` — the engine's own typed capture kind, carried
+ * verbatim through `mapEngineDeviceKind`. A USB/UVC dongle that captures HDMI
+ * reports `usb` (the kind heuristic tests usb/uvc BEFORE hdmi precisely so such
+ * dongles are not mislabelled), so a working webcam can never retract a claim
+ * about the board's HDMI-RX port.
+ */
+export function provesHdmiSignalRecovered(
+	devices: readonly HdmiSignalObservation[],
+): boolean {
+	return devices.some((d) => d.kind === "hdmi" && d.signal === "present");
+}
+
+/** Injected effectful surface (defaults wire the real notification store). */
+export interface HdmiSignalRecoveryDeps {
+	peek: (name: string) => { msg: string } | undefined;
+	remove: (name: string) => unknown;
+}
+
+function defaultDeps(): HdmiSignalRecoveryDeps {
+	return { peek: notificationExists, remove: notificationRemove };
+}
+
+let recoveryDeps: HdmiSignalRecoveryDeps = defaultDeps();
+
+/** Test seam: swap the peek/remove surface (`null` restores production wiring). */
+export function setHdmiSignalRecoveryDepsForTest(
+	deps: HdmiSignalRecoveryDeps | null,
+): void {
+	recoveryDeps = deps ?? defaultDeps();
+}
+
+/**
+ * Retract the standing "No HDMI signal detected" notification once an HDMI
+ * receiver reports a locked signal again. Returns whether a removal was emitted,
+ * so a caller (and a test) can assert the edge without inspecting the broadcast.
+ *
+ * Idempotent by construction: `notificationExists` answers `undefined` once the
+ * notification is gone, so a steady stream of healthy device commits costs one
+ * map lookup and broadcasts nothing.
+ */
+export function clearHdmiSignalErrorOnRecovery(
+	devices: readonly HdmiSignalObservation[],
+	deps: HdmiSignalRecoveryDeps = recoveryDeps,
+): boolean {
+	if (!provesHdmiSignalRecovered(devices)) return false;
+	const standing = deps.peek(HDMI_ERROR_NOTIFICATION);
+	if (standing?.msg !== HDMI_NO_SIGNAL_MSG) return false;
+	deps.remove(HDMI_ERROR_NOTIFICATION);
+	return true;
+}

--- a/apps/backend/src/modules/system/sensors.ts
+++ b/apps/backend/src/modules/system/sensors.ts
@@ -39,6 +39,10 @@ import {
 } from "../ui/notifications.ts";
 import { broadcastMsg } from "../ui/websocket-server.ts";
 import { getHardwareKindCached } from "./hardware-kind.ts";
+import {
+	HDMI_ERROR_NOTIFICATION,
+	HDMI_NO_SIGNAL_MSG,
+} from "./hdmi-signal-notification.ts";
 
 const bootconfigService = "ceralive-firstboot-bootconfig";
 
@@ -262,23 +266,29 @@ export function initHardwareMonitoring() {
 						"Try to move any modems away from the HDMI cable and the encoder. " +
 						"If that fails, try out a different HDMI cable or to manually set a lower HDMI resolution/framerate on your camera";
 					notificationBroadcast(
-						"hdmi_error",
+						HDMI_ERROR_NOTIFICATION,
 						"error",
 						msg,
 						8,
 						true,
-						false,
+						true,
 						true,
 						"notifications.hdmiError",
 					);
 				}
 
 				if (data.match("hdmirx-controller: Err, timing is invalid")) {
-					const hdmiNotif = notificationExists("hdmi_error");
-					const msg = "No HDMI signal detected";
+					const hdmiNotif = notificationExists(HDMI_ERROR_NOTIFICATION);
 
-					if (!hdmiNotif || hdmiNotif.msg === msg) {
-						notificationBroadcast("hdmi_error", "error", msg, 3, true, false);
+					if (!hdmiNotif || hdmiNotif.msg === HDMI_NO_SIGNAL_MSG) {
+						notificationBroadcast(
+							HDMI_ERROR_NOTIFICATION,
+							"error",
+							HDMI_NO_SIGNAL_MSG,
+							3,
+							true,
+							true,
+						);
 					}
 				}
 			});

--- a/apps/backend/src/tests/active-encode-status.test.ts
+++ b/apps/backend/src/tests/active-encode-status.test.ts
@@ -48,6 +48,7 @@ function makeBackend(): {
 	const bridge: CerastreamBackendDeps["bridge"] = {
 		notify: () => {},
 		notificationExists: () => false,
+		removeNotification: () => {},
 		broadcastStatus: () => {
 			statusBroadcasts.count += 1;
 		},

--- a/apps/backend/src/tests/auto-audio.test.ts
+++ b/apps/backend/src/tests/auto-audio.test.ts
@@ -911,6 +911,7 @@ async function startParamsFor(
 		bridge: {
 			notify: () => {},
 			notificationExists: () => false,
+			removeNotification: () => {},
 			broadcastStatus: () => {},
 			broadcastBuffering: () => {},
 		},

--- a/apps/backend/src/tests/buffering-status.test.ts
+++ b/apps/backend/src/tests/buffering-status.test.ts
@@ -35,6 +35,7 @@ function makeBridge(): BridgeHarness {
 		bridge: {
 			notify: () => {},
 			notificationExists: () => false,
+			removeNotification: () => {},
 			broadcastStatus: () => {
 				statusBroadcasts.count += 1;
 			},

--- a/apps/backend/src/tests/cerastream-start-assembly.test.ts
+++ b/apps/backend/src/tests/cerastream-start-assembly.test.ts
@@ -126,6 +126,7 @@ function makeBackend(
 		bridge: {
 			notify: () => {},
 			notificationExists: () => false,
+			removeNotification: () => {},
 			broadcastStatus: () => {},
 			broadcastBuffering: () => {},
 		},

--- a/apps/backend/src/tests/config-source-migration.test.ts
+++ b/apps/backend/src/tests/config-source-migration.test.ts
@@ -245,6 +245,7 @@ async function dispatchStartParams(
 		bridge: {
 			notify: () => {},
 			notificationExists: () => false,
+			removeNotification: () => {},
 			broadcastStatus: () => {},
 			broadcastBuffering: () => {},
 		},

--- a/apps/backend/src/tests/engine-bitrate-status.test.ts
+++ b/apps/backend/src/tests/engine-bitrate-status.test.ts
@@ -47,6 +47,7 @@ function makeBackend(): CerastreamBackend {
 	const bridge: CerastreamBackendDeps["bridge"] = {
 		notify: () => {},
 		notificationExists: () => false,
+		removeNotification: () => {},
 		broadcastStatus: () => {},
 		broadcastBuffering: () => {},
 	};

--- a/apps/backend/src/tests/engine-session-connection-loss.test.ts
+++ b/apps/backend/src/tests/engine-session-connection-loss.test.ts
@@ -179,6 +179,7 @@ function makeHarness(): Harness {
 		bridge: {
 			notify: () => undefined,
 			notificationExists: () => false,
+			removeNotification: () => {},
 			broadcastStatus: () => {
 				broadcasts += 1;
 			},

--- a/apps/backend/src/tests/media-path-contract.test.ts
+++ b/apps/backend/src/tests/media-path-contract.test.ts
@@ -105,6 +105,7 @@ function makeCerastreamHarness(): {
 		bridge: {
 			notify() {},
 			notificationExists: () => false,
+			removeNotification: () => {},
 			broadcastStatus() {},
 			broadcastBuffering() {},
 		},

--- a/apps/backend/src/tests/mock-cerastream-errors.test.ts
+++ b/apps/backend/src/tests/mock-cerastream-errors.test.ts
@@ -66,6 +66,7 @@ function makeBackend(): BackendHarness {
 				notifications.push({ name, type, msg });
 			},
 			notificationExists: () => false,
+			removeNotification: () => {},
 			broadcastStatus: () => {},
 			broadcastBuffering: () => {},
 		},

--- a/apps/backend/src/tests/notification-recovery-clearing.test.ts
+++ b/apps/backend/src/tests/notification-recovery-clearing.test.ts
@@ -1,0 +1,461 @@
+/*
+ * Raise-only notifications: the two that could never be retracted.
+ *
+ * A PERSISTENT notification never expires on a timer (`notification-liveness.ts`),
+ * so a raise with no matching retraction is permanent. Two of them shipped that
+ * way and both were confirmed on a board:
+ *
+ *   * `hdmi_error` / "No HDMI signal detected" — raised from the RK3588 dmesg line
+ *     `hdmirx-controller: Err, timing is invalid`. The kernel prints nothing when
+ *     the link relocks, so the notification outlived the outage indefinitely.
+ *   * the `cerastream` channel carrying `capture_video_error` — the condition
+ *     cleared and the engine went back to idle/healthy, and the error stayed up.
+ *
+ * Both were also `isDismissable: false`, so there was no manual escape either.
+ *
+ * These tests pin the retraction on REAL recovery evidence — never a timer — and
+ * the negatives that keep it honest.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type {
+	GetCapabilitiesResult,
+	ListDevicesResult,
+	RuntimeErrorEvent,
+} from "@ceralive/cerastream";
+import { SCHEMA_VERSION } from "@ceralive/cerastream";
+import type { CaptureDevice } from "@ceraui/rpc/schemas";
+
+import type { RuntimeConfig } from "../helpers/config-schemas.ts";
+import { getConfig } from "../modules/config.ts";
+import {
+	clearCapabilitiesCache,
+	getCapabilities,
+} from "../modules/streaming/capabilities.ts";
+import {
+	CerastreamBackend,
+	type CerastreamBackendDeps,
+} from "../modules/streaming/cerastream-backend.ts";
+import {
+	recheckSourceSignals,
+	resetEngineDeviceCache,
+} from "../modules/streaming/sources.ts";
+import {
+	HDMI_ERROR_NOTIFICATION,
+	HDMI_NO_SIGNAL_MSG,
+	provesHdmiSignalRecovered,
+} from "../modules/system/hdmi-signal-notification.ts";
+import {
+	notificationBroadcast,
+	notificationExists,
+	notificationRemove,
+} from "../modules/ui/notifications.ts";
+import { addClient, removeClient } from "../rpc/events.ts";
+import type { AppWebSocket } from "../rpc/types.ts";
+
+const HDMI_RX_ID = "/dev/video0";
+
+const EMI_ADVISORY_MSG =
+	"HDMI signal issues detected. This is usually caused either by EMI or a by a faulty cable.";
+
+const LOCKED_1080P5994: ListDevicesResult["devices"][number]["caps"] = [
+	{ width: 1920, height: 1080, framerate: "60000/1001" },
+];
+
+/** The engine's HDMI-RX entry; `caps` absent is the signal-less shape it emits. */
+function hdmiRxEntry(
+	caps?: ListDevicesResult["devices"][number]["caps"],
+): ListDevicesResult["devices"][number] {
+	return {
+		input_id: HDMI_RX_ID,
+		device_path: HDMI_RX_ID,
+		display_name: "rk_hdmirx",
+		media_class: "video",
+		kind: "hdmi",
+		stable_id: "port:fdee0000.hdmirx-controller",
+		...(caps !== undefined ? { caps } : {}),
+	};
+}
+
+/** A USB capture dongle: it can carry a picture without saying anything at all
+ *  about the board's HDMI-RX port. */
+function usbDongleEntry(): ListDevicesResult["devices"][number] {
+	return {
+		input_id: "/dev/video3",
+		device_path: "/dev/video3",
+		display_name: "RØDE HDMI to USB-C: RØDE HDMI",
+		media_class: "video",
+		kind: "uvc_h264",
+		caps: LOCKED_1080P5994,
+	};
+}
+
+/** The local v4l2 scan's view: the node is present either way. */
+function observedHdmiRx(): CaptureDevice[] {
+	return [
+		{
+			input_id: HDMI_RX_ID,
+			device_path: HDMI_RX_ID,
+			display_name: "HDMI Input",
+			media_class: "video",
+			kind: "hdmi",
+		},
+	];
+}
+
+function recordingClient(sink: string[]): AppWebSocket {
+	return {
+		data: { isAuthenticated: true, lastActive: Date.now() },
+		send: (message: string) => sink.push(message),
+	} as unknown as AppWebSocket;
+}
+
+async function captureFrames(
+	run: () => Promise<void>,
+): Promise<Array<Record<string, unknown>>> {
+	const sink: string[] = [];
+	const client = recordingClient(sink);
+	addClient(client);
+	try {
+		await run();
+	} finally {
+		removeClient(client);
+	}
+	return sink.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+}
+
+function removedIds(frames: Array<Record<string, unknown>>): string[] {
+	return frames.flatMap((frame) => {
+		const payload = frame.notification as
+			| { remove?: Array<{ id: string }> }
+			| undefined;
+		return (payload?.remove ?? []).map((entry) => entry.id);
+	});
+}
+
+async function seedHdmiCaps(): Promise<void> {
+	const caps: GetCapabilitiesResult = {
+		platform: {
+			supports_h265: true,
+			hardware_accelerated: true,
+			max_resolution: "1080p",
+		},
+		encoder: {
+			codecs: ["h264"],
+			bitrate_range: { min: 500, max: 20000, unit: "kbps" },
+		},
+		sources: [
+			{
+				id: "hdmi",
+				supports_audio: false,
+				supports_resolution_override: true,
+				supports_framerate_override: true,
+				default_resolution: "1080p",
+				default_framerate: 30,
+			},
+		],
+	};
+	await getCapabilities({
+		fetchEngineCapabilities: async () => ({
+			caps,
+			schemaVersion: SCHEMA_VERSION,
+		}),
+		fetchEngineDevices: async () => ({ devices: [] }),
+	});
+}
+
+function raiseNoHdmiSignal(): void {
+	notificationBroadcast(
+		HDMI_ERROR_NOTIFICATION,
+		"error",
+		HDMI_NO_SIGNAL_MSG,
+		3,
+		true,
+		true,
+	);
+}
+
+function probe(
+	devices: ListDevicesResult["devices"],
+): Promise<void> | ReturnType<typeof recheckSourceSignals> {
+	return recheckSourceSignals(observedHdmiRx(), {
+		fetchEngineDevices: async () => ({ devices }),
+	});
+}
+
+describe("provesHdmiSignalRecovered — the pure verdict", () => {
+	test("an HDMI receiver reporting a locked signal is recovery", () => {
+		expect(
+			provesHdmiSignalRecovered([{ kind: "hdmi", signal: "present" }]),
+		).toBe(true);
+	});
+
+	test("a severed link, an unprobed row and an empty list are all NOT recovery", () => {
+		expect(
+			provesHdmiSignalRecovered([{ kind: "hdmi", signal: "absent" }]),
+		).toBe(false);
+		expect(
+			provesHdmiSignalRecovered([{ kind: "hdmi", signal: "unknown" }]),
+		).toBe(false);
+		expect(provesHdmiSignalRecovered([{ kind: "hdmi" }])).toBe(false);
+		expect(provesHdmiSignalRecovered([])).toBe(false);
+	});
+
+	test("another device carrying a picture says nothing about the HDMI-RX port", () => {
+		expect(
+			provesHdmiSignalRecovered([
+				{ kind: "usb", signal: "present" },
+				{ kind: "uvc_h264", signal: "present" },
+				{ kind: "hdmi", signal: "absent" },
+			]),
+		).toBe(false);
+	});
+});
+
+describe("hdmi_error clears when the HDMI link relocks", () => {
+	beforeEach(async () => {
+		notificationRemove(HDMI_ERROR_NOTIFICATION);
+		resetEngineDeviceCache();
+		clearCapabilitiesCache();
+		getConfig().last_seen_devices = [];
+		delete getConfig().source;
+		await seedHdmiCaps();
+	});
+
+	afterEach(() => {
+		notificationRemove(HDMI_ERROR_NOTIFICATION);
+		resetEngineDeviceCache();
+		clearCapabilitiesCache();
+		getConfig().last_seen_devices = [];
+		delete getConfig().source;
+	});
+
+	test("it survives every recheck for as long as the link is genuinely severed", async () => {
+		raiseNoHdmiSignal();
+
+		await probe([hdmiRxEntry()]);
+		await probe([hdmiRxEntry()]);
+
+		expect(notificationExists(HDMI_ERROR_NOTIFICATION)?.msg).toBe(
+			HDMI_NO_SIGNAL_MSG,
+		);
+	});
+
+	test("an unreachable engine leaves it standing — absence of news is not recovery", async () => {
+		raiseNoHdmiSignal();
+
+		await recheckSourceSignals(observedHdmiRx(), {
+			fetchEngineDevices: async () => {
+				throw new Error("engine unreachable");
+			},
+		});
+
+		expect(notificationExists(HDMI_ERROR_NOTIFICATION)).toBeDefined();
+	});
+
+	test("the locked-signal probe retracts it AND pushes a remove frame to connected clients", async () => {
+		raiseNoHdmiSignal();
+		await probe([hdmiRxEntry()]);
+		expect(notificationExists(HDMI_ERROR_NOTIFICATION)).toBeDefined();
+
+		const frames = await captureFrames(() =>
+			Promise.resolve(probe([hdmiRxEntry(LOCKED_1080P5994)])),
+		);
+
+		expect(removedIds(frames)).toContain(HDMI_ERROR_NOTIFICATION);
+		expect(notificationExists(HDMI_ERROR_NOTIFICATION)).toBeUndefined();
+	});
+
+	test("a different device's picture never retracts it", async () => {
+		raiseNoHdmiSignal();
+
+		await probe([hdmiRxEntry(), usbDongleEntry()]);
+
+		expect(notificationExists(HDMI_ERROR_NOTIFICATION)).toBeDefined();
+	});
+
+	test("the EMI/cable advisory sharing the name is left alone — it is a different claim", async () => {
+		notificationBroadcast(
+			HDMI_ERROR_NOTIFICATION,
+			"error",
+			EMI_ADVISORY_MSG,
+			8,
+			true,
+			true,
+			true,
+			"notifications.hdmiError",
+		);
+
+		const frames = await captureFrames(() =>
+			Promise.resolve(probe([hdmiRxEntry(LOCKED_1080P5994)])),
+		);
+
+		expect(removedIds(frames)).not.toContain(HDMI_ERROR_NOTIFICATION);
+		expect(notificationExists(HDMI_ERROR_NOTIFICATION)?.msg).toBe(
+			EMI_ADVISORY_MSG,
+		);
+	});
+
+	test("a healthy device set with nothing standing broadcasts no removal at all", async () => {
+		const frames = await captureFrames(() =>
+			Promise.resolve(probe([hdmiRxEntry(LOCKED_1080P5994)])),
+		);
+
+		expect(removedIds(frames)).toHaveLength(0);
+	});
+});
+
+const silentLogger: CerastreamBackendDeps["logger"] = {
+	debug() {},
+	info() {},
+	warn() {},
+	error() {},
+};
+
+interface EngineHarness {
+	backend: CerastreamBackend;
+	notified: Array<{ name: string; msg: string; isDismissable: boolean }>;
+	removed: string[];
+}
+
+function makeEngineHarness(): EngineHarness {
+	const notified: Array<{
+		name: string;
+		msg: string;
+		isDismissable: boolean;
+	}> = [];
+	const removed: string[] = [];
+	const backend = new CerastreamBackend({
+		connect: async () => {
+			throw new Error("connect is unused on the event path");
+		},
+		connectOptions: {},
+		getConfig: () => ({}) as RuntimeConfig,
+		saveConfig: () => {},
+		bridge: {
+			notify: (name, _type, msg, _duration, _isPersistent, isDismissable) => {
+				notified.push({ name, msg, isDismissable });
+			},
+			notificationExists: () => false,
+			removeNotification: (name) => {
+				removed.push(name);
+			},
+			broadcastStatus: () => {},
+			broadcastBuffering: () => {},
+		},
+		execPath: "cerastream",
+		configPath: "/tmp/cerastream-notification-recovery.json",
+		logger: silentLogger,
+	});
+	return { backend, notified, removed };
+}
+
+function engineError(code: string): RuntimeErrorEvent {
+	return {
+		type: "error",
+		seq: 0,
+		code,
+		source: "engine",
+	} as unknown as RuntimeErrorEvent;
+}
+
+function statusEvent(
+	state: string,
+	streaming: boolean,
+): Parameters<CerastreamBackend["handleEvent"]>[0] {
+	return {
+		type: "status",
+		seq: 1,
+		state,
+		streaming,
+	} as Parameters<CerastreamBackend["handleEvent"]>[0];
+}
+
+describe("capture_video_error clears when the engine proves capture is healthy", () => {
+	test("it is raised dismissable, so the operator is never trapped by it", () => {
+		const { backend, notified } = makeEngineHarness();
+
+		backend.handleEvent(engineError("capture_video_error"));
+
+		expect(notified).toHaveLength(1);
+		expect(notified[0]?.name).toBe("cerastream");
+		expect(notified[0]?.msg).toBe(
+			"Capture card error (video). No automatic restart is scheduled.",
+		);
+		expect(notified[0]?.isDismissable).toBe(true);
+	});
+
+	test("an idle engine is NOT proof — idle only means not streaming", () => {
+		const { backend, removed } = makeEngineHarness();
+		backend.handleEvent(engineError("capture_video_error"));
+
+		backend.handleEvent(statusEvent("idle", false));
+		backend.handleEvent(statusEvent("starting", false));
+
+		expect(removed).toHaveLength(0);
+	});
+
+	test("a concordant streaming status frame retracts it", () => {
+		const { backend, removed } = makeEngineHarness();
+		backend.handleEvent(engineError("capture_video_error"));
+
+		backend.handleEvent(statusEvent("streaming", true));
+
+		expect(removed).toEqual(["cerastream"]);
+	});
+
+	test("a repeated healthy heartbeat does not re-emit the removal", () => {
+		const { backend, removed } = makeEngineHarness();
+		backend.handleEvent(engineError("capture_video_error"));
+
+		backend.handleEvent(statusEvent("streaming", true));
+		backend.handleEvent(statusEvent("streaming", true));
+		backend.handleEvent(statusEvent("streaming", true));
+
+		expect(removed).toEqual(["cerastream"]);
+	});
+
+	test("a new session start does not inherit the previous session's failure", async () => {
+		const { backend, removed } = makeEngineHarness();
+		backend.handleEvent(engineError("capture_video_error"));
+
+		await backend
+			.start({} as RuntimeConfig, {} as never)
+			.catch(() => undefined);
+
+		expect(removed).toEqual(["cerastream"]);
+	});
+
+	test("an engine error whose recovery signal is not established stays latched", () => {
+		for (const code of [
+			"capture_audio_error",
+			"pipeline_stall",
+			"srt_connection_lost",
+		]) {
+			const { backend, removed } = makeEngineHarness();
+			backend.handleEvent(engineError(code));
+
+			backend.handleEvent(statusEvent("streaming", true));
+
+			expect(removed).toEqual([]);
+		}
+	});
+
+	test("a later error occupying the shared slot is not retracted by the earlier one's recovery", () => {
+		const { backend, removed } = makeEngineHarness();
+		backend.handleEvent(engineError("capture_video_error"));
+		backend.handleEvent(engineError("srt_connection_lost"));
+
+		backend.handleEvent(statusEvent("streaming", true));
+
+		expect(removed).toEqual([]);
+	});
+
+	test("nothing standing means nothing removed", () => {
+		const { backend, removed } = makeEngineHarness();
+
+		backend.handleEvent(statusEvent("streaming", true));
+
+		expect(removed).toEqual([]);
+	});
+});

--- a/apps/backend/src/tests/streaming-backend-contract.test.ts
+++ b/apps/backend/src/tests/streaming-backend-contract.test.ts
@@ -283,6 +283,7 @@ function makeBridge(): BridgeHarness {
 				notifications.push({ name, msg });
 			},
 			notificationExists: (name) => name === "srtla" && srtlaNotified.value,
+			removeNotification: () => undefined,
 			broadcastStatus: () => {
 				broadcasts.count += 1;
 			},

--- a/apps/frontend/src/tests/notification-recovery-ingestion.test.ts
+++ b/apps/frontend/src/tests/notification-recovery-ingestion.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Regression lock: a backend `remove` frame must drop the notification from the
+ * PERSISTENT panel, not just the transient toast stream.
+ *
+ * The two raise-only notifications this covers — `hdmi_error` ("No HDMI signal
+ * detected") and the `cerastream` channel carrying `capture_video_error` — never
+ * emitted a `remove` at all, so the panel entry outlived the condition for the
+ * whole session. The backend half now retracts on real recovery evidence; this
+ * pins the frontend half that makes the retraction visible, driven through the
+ * REAL `subscriptions.svelte` ingestion handler rather than the store directly.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const handlers: { message?: (t: string, d: unknown, s?: number) => void } = {};
+
+vi.mock("$lib/rpc/client", () => ({
+	rpc: {},
+	rpcClient: {
+		onMessage: (fn: (t: string, d: unknown, s?: number) => void) => {
+			handlers.message = fn;
+		},
+		onConnectionChange: () => undefined,
+		connect: () => undefined,
+		getSocket: () => undefined,
+		sendLegacy: () => undefined,
+	},
+}));
+
+import { initSubscriptions, resetState } from "$lib/rpc/subscriptions.svelte";
+import {
+	clearNotifications,
+	getPersistent,
+} from "$lib/stores/notifications.svelte";
+
+function show(name: string, msg: string, revision: number): void {
+	handlers.message?.("notification", {
+		show: [
+			{
+				name,
+				type: "error",
+				msg,
+				is_dismissable: true,
+				is_persistent: true,
+				duration: 0,
+				revision,
+			},
+		],
+	});
+}
+
+function remove(name: string, revision: number): void {
+	handlers.message?.("notification", { remove: [{ id: name, revision }] });
+}
+
+function persistentNames(): string[] {
+	return getPersistent().map((n) => n.name);
+}
+
+describe("persistent notifications are retractable", () => {
+	beforeEach(() => {
+		resetState();
+		clearNotifications();
+		initSubscriptions();
+	});
+
+	it("drops hdmi_error from the panel when the backend retracts it", () => {
+		show("hdmi_error", "No HDMI signal detected", 1);
+		expect(persistentNames()).toContain("hdmi_error");
+
+		remove("hdmi_error", 2);
+
+		expect(persistentNames()).not.toContain("hdmi_error");
+	});
+
+	it("drops the cerastream capture error from the panel when the backend retracts it", () => {
+		show(
+			"cerastream",
+			"Capture card error (video). No automatic restart is scheduled.",
+			1,
+		);
+		expect(persistentNames()).toContain("cerastream");
+
+		remove("cerastream", 2);
+
+		expect(persistentNames()).not.toContain("cerastream");
+	});
+
+	it("retracts only the named notification, leaving the rest of the panel intact", () => {
+		show("hdmi_error", "No HDMI signal detected", 1);
+		show("no_internet", "No internet connection", 2);
+
+		remove("hdmi_error", 3);
+
+		expect(persistentNames()).toEqual(["no_internet"]);
+	});
+});


### PR DESCRIPTION
## What

Two backend-emitted persistent notifications could be raised but never lowered:

| Notification | Raised by |
|---|---|
| `hdmi_error` — "No HDMI signal detected" | `modules/system/sensors.ts`, off the RK3588 dmesg line `hdmirx-controller: Err, timing is invalid` |
| the `cerastream` channel carrying `capture_video_error` — "Capture card error (video). No automatic restart is scheduled." | `cerastream-backend.ts` `handleErrorEvent()` |

Both now retract when the underlying condition genuinely resolves, and both gain a manual dismiss affordance as a safety net.

## Why

`notificationRemaining()` returns "lives forever" for **every** persistent notification by deliberate design — `duration` does not apply to one. So a raise site with no matching retraction is permanent by construction; the `duration: 3` on the HDMI raise reads like an expiry and is not one. Neither notification had a removal call anywhere in the backend.

Both were confirmed stuck on a board: the `capture_video_error` condition cleared, cerastream returned to idle/healthy, and the error stayed on screen. Both were also emitted with `isDismissable: false`, so the operator had no escape either — they were left staring at a stale, misleading error indefinitely.

This is the third instance of the latched-stale class this repo has already fixed twice, for `policy_route_missing` (tristate, explicit-false-not-omitted) and `active_encode` (explicit clear on both ends). Same discipline applied here.

## How

**Recovery is detected, never assumed.** A timeout would hide a genuinely-still-broken condition exactly as readily as it clears a resolved one, so both retractions demand a positive, engine-authored statement that contradicts the notification's own claim. An unreachable engine, a fallback v4l2 row, or an idle engine all leave the notification standing.

**`hdmi_error`** clears when an HDMI-RX capture device reports `signal: "present"` — the verdict stamped at `fromEngineDevice`, i.e. the engine's own `VIDIOC_QUERY_DV_TIMINGS` projection, which is already the source list's truth for exactly this question. New module `modules/system/hdmi-signal-notification.ts`; hooked into `sources.ts` `commitEngineDevices`, the one seam every engine-authored device view flows through (the 5 s `recheckSourceSignals` tick, the hotplug refresh, the boot seed, the reconnect heal). Three scoping rules:

- runs on **every** commit, not only a changed one — a transient dmesg line can raise the notification while the engine's view never varies;
- scoped to `kind === "hdmi"`, so a working USB dongle cannot retract a claim about the board's HDMI-RX port;
- scoped to the **exact** no-signal message, because the `hdmi_error` name is shared with the EMI/cable advisory, which a relocked link does not falsify.

**`capture_video_error`** clears at a healthy session boundary: a concordant `state:"streaming" + streaming:true` status frame, or the start of a new session (which must not inherit the previous one's failure — the same rule `active_encode` follows). An idle engine is deliberately not proof: idle means "not streaming", not "the capture card works". `resolved.channel` is one notification slot shared by every non-srtla engine error, so the backend records which code currently occupies it and a membership table keeps the retraction scoped to `capture_video_error` alone — `capture_audio_error`, `pipeline_stall` and the two SRT codes stay latched until each has an established recovery signal of its own.

**Dismissability.** Following `active_encode`'s precedent, the automatic clear is the primary mechanism and the argument for keeping a status signal non-dismissable holds *when that clear is reliable*. Here it is not unconditionally: `hdmi_error` needs cerastream to enumerate the HDMI-RX node, and `capture_video_error` needs a later status frame or a new session — a masked or crashed engine emits neither. So both are flipped to `isDismissable: true`. The manual affordance costs nothing when the automatic path works and is the only recourse when it cannot run. Reasoning recorded in `apps/backend/AGENTS.md`.

## How to verify

Red-first: with the two hook calls neutered, 4 of the new backend tests fail; restored, all pass.

```
bun test apps/backend/src/tests/notification-recovery-clearing.test.ts   # 17 pass
bunx vitest run apps/frontend/src/tests/notification-recovery-ingestion.test.ts   # 3 pass
```

Full gate green on this branch:

- `biome check .` — clean
- `bun run --filter backend check` — clean
- `bun run check:tech-debt` — OK
- `bun run test` — `@ceraui/rpc` 271 pass, frontend 2013 pass (190 files), backend 2476 pass, 0 fail

`bun run --filter frontend check` reports 18 errors / 5 warnings, all in `node_modules/@ceraui/i18n` locale files and the CLI-managed shadcn slider — byte-identical on `origin/main` with this branch stashed, so pre-existing and untouched here.

On hardware: pull the HDMI cable on an RK3588 board until "No HDMI signal detected" appears, plug it back in, and the notification should disappear within one 5 s signal-recheck tick rather than persisting for the session.

## Risks

- **The HDMI hook runs on every engine-device commit** (every 5 s while idle). It is one `Array.some()` plus one map lookup and broadcasts nothing in the steady state, but it is on a hot-ish path.
- **`CerastreamBridge` gained a required `removeNotification` method.** Ten existing test doubles were updated; any out-of-tree implementer of that interface would need the same one-line addition.
- **Every `cerastream`-channel engine error is now dismissable**, not just `capture_video_error` — dismissability is per notification name and the name is shared. This only adds an escape hatch; nothing auto-clears that did not before.
- **The scoping is deliberately narrow.** `capture_audio_error` and `pipeline_stall` share the same raise-only pathology and are knowingly left latched (documented in `AGENTS.md`) rather than retracted on a signal that has not been established for them.
