### PR TITLE
fix(live): absorb the libuvc release window; scope the HDMI no-signal raise

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1988,6 +1988,24 @@ re-asserts the preference through the SAME `null` escape hatch on the SAME once-
 floor. Full contract: `apps/backend/AGENTS.md` → "THE RECOVERY PATH MUST NOT BE GATED ON
 THE SIGNAL WHOSE ABSENCE IS THE FAILURE".
 
+**A momentary "No audio device" during a NORMAL libuvc rebind is a derived-state
+artifact, and it is now absorbed.** Opening a UVC-H.264 camera detaches `uvcvideo`
+from its USB interfaces (see LIBUVC-HELD DEVICES) — necessary, and no USB device
+reset is involved: measured on a board, `devnum` never changes and the camera's ALSA
+card and PCM node inode survive untouched. But on RELEASE the engine drops its held
+record ≈400 ms (up to 2 s) before it rediscovers the re-registered node, and "Auto"
+resolves audio by looking the VIDEO source up first. For that window the join key was
+gone, Auto answered `no-same-device-audio`, and the meter read "Meter unavailable ·
+No audio device" for a microphone that never moved. `resolveAutoAsrcFromLiveState()`
+now resolves the selection through a strictly-bounded absence grace
+(`capture-presence.ts`, 2 000 ms, keyed on stable identity) — a hysteresis on the
+VERDICT only. Nothing else changes: the `sources` payload, the `lost` row and routing
+are untouched, and a sustained absence still reports honestly. In the same window the
+`hdmi_error` no-signal RAISE is now scoped like its retraction, so a stream-start's
+incidental `/dev/video0` probe no longer shows HDMI text to a USB-camera session.
+Full contracts: `apps/backend/AGENTS.md` → "A DEBOUNCE IS NOT AN ABSENCE GRACE" and
+"…AND ITS RAISE MUST BE SCOPED LIKE ITS RETRACTION".
+
 **There is NO operator rename.** #206 briefly shipped an alias/rename UI backed by
 `config.audio_device_aliases`; #207 removed it in full — UI, `setAudioDeviceAlias`
 RPC, oRPC contract entry, `audio-aliases.schema.ts`, and the config field — by

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -24,7 +24,7 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 | Cerastream engine backend (structured IPC, `@ceralive/cerastream`) | `modules/streaming/cerastream-backend.ts` |
 | Structured engine error → notification (Task-7 table swap, no regex); `mapCerastreamError()` maps a `RuntimeErrorEvent` to a Tier-2 code string (T16) | `modules/streaming/cerastream-error-mapping.ts` |
 | srtla binding calls (flux — check `../../../srtla/AGENTS.md` first) | `modules/streaming/srtla.ts` |
-| srtla per-link telemetry → `status.linkTelemetry` | `modules/streaming/link-telemetry.ts` |
+| srtla per-link telemetry → `status.linkTelemetry` (incl. the MEASURED `bitrate_bps` per link + the summed `measured_bps` — the only honest live bitrate; `engine_bitrate.applied_kbps` is a setpoint) | `modules/streaming/link-telemetry.ts` (`buildLinkTelemetry`) |
 | Stream lifecycle (spawn supervision, start/stop, autostart, exec paths) | `modules/streaming/streamloop/` (barrel: `modules/streaming/streamloop.ts`) |
 | Authoritative stream-session lifecycle (UI/autostart/remote arbitration, cancellation generations, boot adoption) | `modules/streaming/stream-session-orchestrator.ts` |
 | **Apply-now config change (transaction seam, `reconfiguring` state, queued stop)** | `modules/streaming/stream-session-orchestrator.ts` (`changeConfig`, `noteConfigChangePhase`) + `modules/streaming/config-change-bridge.ts` |
@@ -74,10 +74,12 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 | Persisted country → apply → re-derive → hotspot restart | `modules/wifi/wifi-country.ts` (`setWifiCountry`, `reconcileHotspotChannels`) |
 | Policy-route self-check for bonded wifi/modem interfaces (`policy_route_missing`) | `modules/network/policy-route-check.ts` |
 | Retracting the `hdmi_error` "No HDMI signal detected" notification once the link relocks | `modules/system/hdmi-signal-notification.ts` (`clearHdmiSignalErrorOnRecovery`, hooked into `sources.ts` `commitEngineDevices`); contract below → A PERSISTENT NOTIFICATION MUST BE RETRACTABLE |
+| Scoping the `hdmi_error` "No HDMI signal detected" RAISE to a relevant selection | `modules/system/hdmi-signal-notification.ts` (`provesSelectionIsNotHdmi`) + `modules/system/sensors.ts` (`handleRk3588HdmiDmesg`); contract below → …AND ITS RAISE MUST BE SCOPED LIKE ITS RETRACTION |
 | Retracting the `cerastream` `capture_video_error` notification at a healthy session boundary | `modules/streaming/cerastream-backend.ts` (`standingEngineError`, `clearRecoveredEngineError`, `ENGINE_ERRORS_CLEARED_BY_HEALTHY_SESSION`) |
 | **Device-truth save guard + persisted-mode clamp (ADR-0008 §10)** | `modules/streaming/device-mode-guard.ts` (`verifySaveDeviceMode`, `clampPersistedDeviceMode`) + `modules/streaming/persisted-mode-clamp.ts` (`reconcilePersistedDeviceMode`); the RULE itself is `@ceraui/rpc` `capabilities/device-mode-truth.ts`, shared with the frontend |
 | **Unified device-first `sources` builder + engine-device cache + `config.source` routing seam** | `modules/streaming/sources.ts` (`buildSources`, `getSourcesMessage`, `deriveEngineRouting`, `resolveSourceRouting`) |
 | **Which capture kinds release their kernel v4l2 node while the engine holds them (libuvc)** | `modules/streaming/held-devices.ts` (`releasesV4l2Node`) — CeraUI-side mirror of cerastream `engine::held_devices` |
+| **Absence GRACE on the selected capture source (the libuvc release window)** | `modules/streaming/capture-presence.ts` (`resolveSelectedSourceWithGrace`, `CAPTURE_ABSENCE_GRACE_MS`), read by `auto-audio.ts` `resolveAutoAsrcFromLiveState`; contract below → A DEBOUNCE IS NOT AN ABSENCE GRACE |
 | **`config.source` legacy coercion (pipeline/selected_video_input → source, idempotent)** | `helpers/config-schemas.ts` (`coerceLegacySource`) |
 | **Audio-naming resolution (4-tier: static onboard rule → engine join → ALSA longname → generic alias) + name cleaning + tier-3 diagnostic** | `modules/streaming/audio-naming.ts` |
 | **Static onboard AUDIO display-name rules (`rockchip,hdmiin` → `HDMI Input`) — code-level, no operator surface** | `modules/streaming/audio-naming.ts` (`ONBOARD_AUDIO_DISPLAY_RULES`, `resolveOnboardDisplayName`) |
@@ -1300,6 +1302,103 @@ at a hold — the engine already tracks the hold authoritatively and reports it;
 CeraUI's job is only to stop overruling that answer with a scan that cannot see
 the device. Coverage: `tests/source-renumber-dedup.test.ts`.
 
+## A DEBOUNCE IS NOT AN ABSENCE GRACE [EXISTS]
+
+The section above fixes the HOLD. The same rebind has a second half — the
+RELEASE — and nothing in the chain absorbed it.
+
+Measured on a Rock 5B+ (2026-07-30, DJI Osmo Pocket 3 `2ca3:0023` on `usb5`/EHCI)
+by polling cerastream's `list-devices` and the kernel together across one
+ordinary preview open/close. The rebind is emphatically NOT a device reset:
+`devnum` never changes, only interfaces `1.0`/`1.1` move `uvcvideo → usbfs →
+uvcvideo`, the camera's ALSA card stays bound with its PCM node inode unchanged,
+and `/proc/asound/card5/pcm0c/sub0/status` reads `RUNNING` throughout. During the
+HOLD, `held_devices.rs` reports `/dev/video1` with its `physical_group_id`
+intact — no UI impact, exactly as designed. **On RELEASE the engine drops the
+held record BEFORE it rediscovers the re-registered node**: `list-devices`
+answers with 2 devices instead of 3 while the kernel node already exists again.
+Measured at ≈400 ms, bounded above by the 2.0 s close→node-back re-registration,
+and observed firing spontaneously twice more within 30 s of the preview closing —
+so this is hit in ordinary operation, not only on operator action.
+
+**Every existing defence in the chain is an EVENT DEBOUNCE, and that is a
+different thing.** The `/dev` watch waits 200 ms for quiet before re-reading, the
+audio scan 500 ms, cerastream's registry debounces adds/removes by 250 ms. Those
+are all *wait-for-quiet-before-re-reading*. None of them is
+*wait-before-believing-it-is-gone*, so a hole of any length propagates straight
+to a verdict. Auto-audio resolution had no hysteresis at all
+(`auto-audio.ts`), and `lifecycle-indicators.ts` still flips `bad` the instant a
+selected id is missing from a non-empty scan.
+
+The operator-visible result was a derived-state artifact, not an audio fault.
+With `config.asrc = "Auto"`, `resolveAutoAsrcFromLiveState()` looks the VIDEO
+source up first and rule 5 joins it to its own card on `physical_group_id`. In
+the window that join has nothing to match, so Auto resolved
+`no-same-device-audio`, `resolveMeterPreference` returned `null`,
+`isMeterPreferenceDevicePresent` returned `false`, and the meter rendered
+**"Meter unavailable · No audio device"** for a microphone that was bound,
+enumerated and streaming into cerastream the entire time.
+
+`modules/streaming/capture-presence.ts` `resolveSelectedSourceWithGrace()` is the
+hysteresis, and it is deliberately NARROW — it is read by
+`resolveAutoAsrcFromLiveState()` and nothing else. The `sources` broadcast, the
+`lost` row, `resolveSourceRouting`, and the picker are all untouched.
+
+- **It is hysteresis on the VERDICT, not on the sampling.** Distinct from every
+  debounce above by construction: nothing here changes when the device list is
+  read or what it contains, only how long a degraded view is tolerated before it
+  is believed.
+- **There are TWO windows, and they are not interchangeable.** The board proved
+  why. `CAPTURE_ABSENCE_GRACE_MS` (2 000 ms) governs a row that is ABSENT or
+  `lost` — a real presence question, kept short because a genuine unplug must not
+  be held longer than the transient it absorbs. `CAPTURE_METADATA_GRACE_MS`
+  governs a row that is PRESENT but has lost its `physical_group_id`, which is
+  NOT a presence claim at all: CeraUI's own scan sees the node and the engine
+  listed it, so holding the remembered join key there **cannot** mask a
+  device-gone failure — the row's own presence is the positive evidence.
+- **`CAPTURE_METADATA_GRACE_MS` is DERIVED, not chosen**:
+  `VIDEO_SIGNAL_RECHECK_INTERVAL_MS + 1 500`. Nothing refills that field until
+  the next engine-authored commit, and while idle the only thing that produces
+  one is the `recheckSourceSignals` tick — so CeraUI's VIEW can stay
+  under-identified for a full recheck interval even though the engine's own hole
+  was ≈400 ms. Measured across three preview cycles on the board: 434 ms, 258 ms
+  and **5 077 ms**, the last being one interval plus a 77 ms probe round-trip. A
+  window sized from the engine-side measurement alone (2 000 ms) demonstrably
+  broke through on that third cycle — do not "simplify" the two constants back
+  into one, and do not re-derive this one from the engine-side gap.
+- **The clock starts at the FIRST DEGRADED OBSERVATION, never at the last healthy
+  one.** Our knowledge of the device is refreshed on someone else's cadence (the
+  5 s signal recheck, a hotplug tick), so a window measured from the memory's
+  AGE would be expired in steady state and would never fire when it is needed.
+  "How long we have tolerated a degraded view" is the quantity that matters.
+  Do NOT rewrite this as a staleness check on the remembered value.
+- **"Is the row there" is NOT the question.** `degradationOf()` answers `absent`
+  (row gone, or a `lost` placeholder) or `under-identified` (row present, join key
+  gone). The second is the one the window actually produces on this board — when
+  the `/dev` scan sees the node return first, the hotplug merge restores the row
+  through `withKnownEngineMetadata`, which restores durable IDENTITY
+  (`kind`/`stable_id`) and deliberately refuses to re-assert a same-moment
+  topology relation. That refusal is correct and must not be "fixed"; the row is
+  simply useless to rule 5, and the grace is what covers it.
+- **Bounded and self-clearing, with no renewal path.** After the applicable window
+  of UNINTERRUPTED degradation the memory is dropped and the live view is
+  reported verbatim — a true unplug reads exactly as it did before this module
+  existed. Only a genuinely healthy observation resets the run, so polling the
+  window at the meter's 5 Hz cadence extends nothing.
+- **Stable identity OUTRANKS the node path, in BOTH directions.** Two rows that
+  both carry a `stableId` settle the question outright: equal proves the renumber
+  (a libuvc camera renumbers on every cycle — the very cycle this exists for),
+  UNEQUAL proves a different device took the freed node and the memory is dropped
+  on the spot. A borrowed `physical_group_id` must never bind Auto audio to the
+  microphone of a device the operator is no longer pointing at. Only when the
+  evidence runs out does the node path decide.
+
+Coverage: `tests/capture-absence-grace.test.ts` — the real live-state resolver
+driven across the window with both degraded shapes, plus the negative controls
+that matter: a sustained absence resolving honestly again, a repeatedly-observed
+absence failing to renew the window, the boundary millisecond, a `lost` row, a
+substituted device, a renumber, and the coarse/unset selections.
+
 ## BROADCAST EVENTS
 
 The backend pushes typed events to all connected clients via `rpc/events.ts`. Each event type carries a monotonic `seq` counter (`Map<string, number>`) that resets to 0 on server restart.
@@ -2451,6 +2550,65 @@ idle-is-not-proof and shared-slot negatives, and the repeat-heartbeat idempotenc
 plus the frontend half `apps/frontend/src/tests/notification-recovery-ingestion.test.ts`
 (the `remove` frame drops the entry from the persistent panel).
 
+## …AND ITS RAISE MUST BE SCOPED LIKE ITS RETRACTION [EXISTS]
+
+The retraction above is scoped to `kind === "hdmi"`. The RAISE was scoped to
+nothing but the board resolving as `rk3588` — not to `config.source`, not to the
+active capture source, not to the pipeline, not to `status.active_encode`. The
+pair was asymmetric, and the asymmetry is reachable in ordinary use.
+
+Measured on a board (2026-07-30): **a `streaming.start` attempt probes EVERY
+capture input**, so it opens `/dev/video0` in passing. On a board whose HDMI-RX
+carries no cable — the normal state for an operator streaming a USB camera — that
+probe makes the kernel print `hdmirx-controller: Err, timing is invalid`, and the
+watcher raised "No HDMI signal detected" at an operator who was using a UVC camera
+and had asked nothing about HDMI. The CeraUI journal names the driver of the sweep
+exactly: `no capture input reached PLAYING (signal-less: /dev/video0,
+/dev/video1)`. The claim is TRUE about the HDMI-RX port; it is simply not addressed
+to anyone. And because a persistent notification never expires on a timer, the
+`duration: 3` on that raise buys nothing — it stands until something retracts it,
+which on a cable-less port is never.
+
+`provesSelectionIsNotHdmi()` is the gate, and it is a **SUPPRESSION-ONLY** test —
+the same discipline as the audio meter's foreign-card rule, for the same reason.
+It can only ever withhold a raise PROVEN irrelevant:
+
+| Selected source | Raise |
+|---|---|
+| a capture row whose engine-authored `kind` is not `hdmi` | SUPPRESSED |
+| a coarse/virtual/network row that is not the `hdmi` source | SUPPRESSED |
+| a capture row of `kind: "hdmi"`, or the coarse `hdmi` source | RAISED |
+| nothing selected, or a selection that resolves to no row at all | RAISED |
+
+- **Absence is never evidence.** An unset selection and an unresolvable one both
+  leave the raise armed, because neither proves the operator is not watching the
+  HDMI port. Do NOT "harden" this into a fail-closed check — that would silently
+  drop a genuine no-signal report, which is the exact fault the notification
+  exists for.
+- **It reads the persisted `kind` when the live row is missing.**
+  `last_seen_devices` is consulted as a fallback because the ONE moment this is
+  asked — mid stream-start sweep — is precisely when the live row may be
+  transiently degraded by the libuvc rebind the same sweep triggers (see A
+  DEBOUNCE IS NOT AN ABSENCE GRACE). `kind` is a durable hardware property, so
+  the snapshot can answer it; a live row always outranks the snapshot.
+- **A renumbered camera is still recognised**, through the `previousIds` aliases
+  the successor publishes — otherwise a libuvc camera would lose its own
+  selection on exactly the cycle that matters.
+- **The EMI/cable advisory is deliberately UNGATED.** Its two kernel lines are
+  emitted only while the receiver is actually locking or clocking a link, so they
+  already describe work somebody asked for. Do not extend this gate to it.
+- **`hdmiNoSignalRaiseAllowed()` (the production wiring in `sensors.ts`) is
+  FAIL-OPEN.** A throw reading config or the sources list is not evidence about
+  the operator, so it must never be the reason a real fault goes unreported.
+
+The dmesg callback was extracted to the exported `handleRk3588HdmiDmesg(data,
+deps)` so both raise conditions are drivable without a `dmesg -w` process.
+Coverage: `tests/hdmi-raise-scope.test.ts` (the pure verdict table incl. the
+coarse/renumber/persisted-fallback arms, the sweep raising nothing, and the
+negative controls: a selected HDMI input with no cable still raises, the EMI
+advisory still raises under the same gate, and the standing-advisory
+non-overwrite is unchanged).
+
 ## ANTI-PATTERNS
 
 - Don't add a persistent notification without a retraction path — `duration` does
@@ -2467,6 +2625,25 @@ plus the frontend half `apps/frontend/src/tests/notification-recovery-ingestion.
 - Don't move the HDMI recovery hook off `commitEngineDevices` or gate it on a
   changed payload — it must see every engine-authored device view, including the
   ones that are byte-identical to the last.
+- Don't raise the `hdmi_error` NO-SIGNAL notification off the kernel line alone —
+  a stream-start attempt probes every capture input, so `/dev/video0` gets opened
+  on an operator's behalf who never asked about HDMI. Route it through
+  `provesSelectionIsNotHdmi()`, and don't turn that suppression-only test into a
+  fail-closed one: absence of evidence is not evidence, and refusing to raise on
+  an unset/unresolvable selection would drop a genuine no-signal report. The
+  EMI/cable advisory stays UNGATED.
+- Don't answer "is the selected capture device present" with a bare
+  `sources.find(...)` on the Auto-audio path — the engine's device view has a
+  real, NORMAL hole on every libuvc release (≈400 ms, up to 2 s), and resolving
+  it literally reported a bound, streaming microphone as "No audio device". Route
+  through `resolveSelectedSourceWithGrace()` (see A DEBOUNCE IS NOT AN ABSENCE
+  GRACE). And don't confuse that grace with the existing debounces: those wait
+  for quiet before RE-READING, this waits before BELIEVING. Don't re-measure the
+  window from the memory's age instead of from the first degraded observation
+  (it would be expired in steady state), don't let anything but a genuinely
+  healthy observation reset the run, and don't widen it past `physical_group_id`
+  absence into re-asserting a remembered `caps`/`signal` — that is the latch
+  `withKnownEngineMetadata` already refuses for good reason.
 - Don't import from `@ceralive/srtla` — that package is retired from CeraUI. Use `@ceralive/srtla-send` (the `srtla-send-rs` binding, registry dep). Check `../../../srtla-send-rs/AGENTS.md` before touching call sites.
 - Don't add HTTP REST endpoints — all device control goes through oRPC over WebSocket.
 - Don't re-serialise the DNS health check ahead of the caller's query in `dnsCacheResolve`, and don't share one `Resolver` between them — the check only GATES the answer, and a shared c-ares channel's `cancel()` would abort the sibling leg. Both legs sit inside the per-attempt launch deadline (see DNS ON THE STREAM-START CRITICAL PATH).

--- a/apps/backend/src/modules/streaming/auto-audio.ts
+++ b/apps/backend/src/modules/streaming/auto-audio.ts
@@ -57,6 +57,10 @@ import { broadcastMsg } from "../ui/websocket-server.ts";
 import { getAudioDevices } from "./audio.ts";
 import type { EngineAudioDevice } from "./audio-naming.ts";
 import { getLastCapabilities } from "./capabilities.ts";
+import {
+	resetCapturePresence,
+	resolveSelectedSourceWithGrace,
+} from "./capture-presence.ts";
 import { getEngineAudioDevices, getSourcesMessage } from "./sources.ts";
 import { getIsStreaming } from "./streaming.ts";
 
@@ -294,14 +298,24 @@ export function buildAutoLaunchConfig(
 	return { ...config, asrc: launchAsrc };
 }
 
-/** Gather live state and resolve — the shared start-path / preview resolver. */
+/**
+ * Gather live state and resolve — the shared start-path / preview resolver.
+ *
+ * The selected source is resolved through an ABSENCE GRACE WINDOW rather than a
+ * plain `find`, because the device view this reads has a real, normal hole in it.
+ * libuvc's reattach guard rebinds the camera's USB interfaces around every
+ * open/close, and on RELEASE the engine drops its held record before the
+ * successor node is rediscovered — for up to 2 s the camera's video row is
+ * missing, or present but stripped of the `physical_group_id` rule 5 joins on.
+ * Resolving that window literally reported a bound, streaming microphone as "no
+ * audio device". Only the VERDICT is held; the device list, the `lost` row and
+ * routing are untouched, and a sustained absence still resolves honestly.
+ * Contract: `capture-presence.ts`.
+ */
 export function resolveAutoAsrcFromLiveState(): AutoAsrcResolution {
 	const config = getConfig();
 	const sources = getSourcesMessage().sources;
-	const source =
-		config.source !== undefined
-			? sources.find((s) => s.id === config.source)
-			: undefined;
+	const source = resolveSelectedSourceWithGrace(config.source, sources);
 	return resolveAutoAsrc({
 		source,
 		audioDevices: getAudioDevices(),
@@ -421,4 +435,5 @@ export function resetAutoAudioState(): void {
 	resolvedAsrcReason = null;
 	resolvedAsrcCandidates = null;
 	pendingAudioFollowAsrc = null;
+	resetCapturePresence();
 }

--- a/apps/backend/src/modules/streaming/capture-presence.ts
+++ b/apps/backend/src/modules/streaming/capture-presence.ts
@@ -1,0 +1,285 @@
+/*
+    CeraUI - web UI for the CERALIVE project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * ABSENCE HYSTERESIS for the selected capture source — the Auto-audio half.
+ *
+ * Every existing timing defence in this chain is an EVENT DEBOUNCE: the `/dev`
+ * watch waits 200 ms for quiet before re-reading, the audio scan waits 500 ms,
+ * cerastream's registry debounces adds/removes by 250 ms. Not one of them is an
+ * ABSENCE GRACE PERIOD — a wait-before-believing-it-is-gone — so a hole in the
+ * device view of any length at all propagates straight to a verdict.
+ *
+ * libuvc opens a UVC-H.264 camera through usbfs, which detaches `uvcvideo` from
+ * the device's VideoControl + VideoStreaming interfaces for the session. That
+ * rebind is NORMAL and necessary — measured on a board (2026-07-30, DJI Osmo
+ * Pocket 3 `2ca3:0023` on `usb5`/EHCI), it involves NO USB device reset: `devnum`
+ * is unchanged, only interfaces `1.0`/`1.1` move `uvcvideo → usbfs → uvcvideo`,
+ * the camera's ALSA card stays bound throughout, and even its PCM node inode is
+ * preserved. While the engine HOLDS the device its own `held_devices` record
+ * masks the gap correctly. On RELEASE it does not: the engine drops the held
+ * record before the successor node is rediscovered, and `list-devices` answers
+ * without the camera's video row for a window measured at ≈400 ms and bounded
+ * above by the 2.0 s worst-case node re-registration. The same window was
+ * observed firing spontaneously twice more within 30 s of an ordinary preview
+ * closing, so it is hit during normal operation, not only on operator action.
+ *
+ * `resolveAutoAsrc` rule 5 joins a USB/UVC camera to its OWN audio card on
+ * `physical_group_id` equality. During the window that join has nothing to match:
+ * either the video row is absent outright, or CeraUI's hotplug merge has restored
+ * it from `lastEngineVideoDevices` — which deliberately restores durable IDENTITY
+ * (`kind`/`stable_id`) and NEVER a same-moment topology relation like
+ * `physical_group_id`. Auto therefore resolved `no-same-device-audio`, the meter
+ * preference went `null`, and the operator read "Meter unavailable · No audio
+ * device" for a microphone that was bound and streaming the whole time.
+ *
+ * FOUR properties are load-bearing:
+ *
+ *  - It is hysteresis on the VERDICT, not on the sampling. Nothing here changes
+ *    when the device list is read, what it contains, or what `sources` puts on
+ *    the wire — the `lost` row, the source picker, and routing are untouched.
+ *    Only the answer to "is the selected camera present RIGHT NOW" is held.
+ *  - The clock starts at the FIRST DEGRADED OBSERVATION, never at the last
+ *    healthy one. Our knowledge of the device is refreshed on someone else's
+ *    cadence (the 5 s signal recheck, a hotplug tick), so a window measured from
+ *    the memory's age would expire in steady state and never fire when needed.
+ *    "How long we have tolerated a degraded view" is the quantity that matters.
+ *  - It is STRICTLY BOUNDED and self-clearing. After
+ *    `CAPTURE_ABSENCE_GRACE_MS` of UNINTERRUPTED degradation the memory is
+ *    dropped and the live view is reported verbatim, so a true unplug is
+ *    reported exactly as it was before this module existed. A grace period that
+ *    can be renewed by anything other than a genuinely healthy observation would
+ *    be a permanent suppression wearing a timer's clothes.
+ *  - It follows the DEVICE, not the node path. The memory is matched by stable
+ *    identity (`stableId`, or the retired ids the successor publishes as
+ *    `previousIds`) before its node id, because a libuvc camera renumbers
+ *    `/dev/videoN` on every open/close cycle — the very cycle this exists for.
+ *    A different device that merely took the freed node never inherits it.
+ */
+
+import type { StreamSource } from "@ceraui/rpc/schemas";
+import { logger } from "../../helpers/logger.ts";
+import { getms } from "../../helpers/time.ts";
+import { VIDEO_SIGNAL_RECHECK_INTERVAL_MS } from "./constants.ts";
+
+/**
+ * How long an ABSENT (or `lost`) selected capture source is tolerated before it
+ * is believed gone.
+ *
+ * Sized against the measured rebind: comfortably over the ≈400 ms engine release
+ * hole and at the 2.0 s ceiling of the close→node-back re-registration. It is
+ * deliberately SHORT because this is the window in which a device really might
+ * be gone, and a genuine unplug must not be held any longer than the transient
+ * it exists to absorb.
+ */
+export const CAPTURE_ABSENCE_GRACE_MS = 2_000;
+
+/**
+ * How long a PRESENT-but-under-identified row is tolerated — a strictly longer,
+ * strictly safer window, and the two are not interchangeable.
+ *
+ * This is not an absence at all. The row IS there: CeraUI's own `/dev` scan sees
+ * the node and the engine listed it. What is missing is one metadata field
+ * (`physical_group_id`), because the hotplug merge restored the row through
+ * `withKnownEngineMetadata`, which restores durable identity and deliberately
+ * refuses to re-assert a same-moment topology relation. So holding the
+ * remembered join key here CANNOT mask a device-gone failure — the row's own
+ * presence is positive evidence the device is not gone.
+ *
+ * The bound is DERIVED, not chosen: nothing refills that field until the next
+ * engine-authored commit, and while idle the only thing that produces one is the
+ * `recheckSourceSignals` tick. So CeraUI's VIEW can stay under-identified for a
+ * full recheck interval even though the engine's own hole was ≈400 ms — measured
+ * on a board across three preview cycles at 434 ms, 258 ms and **5.077 s**, the
+ * last being one interval plus a 77 ms probe round-trip. A window sized from the
+ * engine-side measurement alone (2 000 ms) demonstrably broke through on that
+ * third cycle. The margin covers the probe round-trip with room to spare.
+ */
+export const CAPTURE_METADATA_GRACE_MS =
+	VIDEO_SIGNAL_RECHECK_INTERVAL_MS + 1_500;
+
+/** The remembered last-known-good view, plus the current degraded run's start. */
+interface CapturePresenceMemory {
+	source: StreamSource;
+	/** Set on the FIRST degraded observation; cleared by any healthy one. */
+	degradedSince: number | undefined;
+}
+
+let memory: CapturePresenceMemory | undefined;
+
+let clock: () => number = getms;
+
+/** Test seam: pin the monotonic clock (`undefined` restores `getms`). */
+export function setCapturePresenceClockForTest(
+	fn: (() => number) | undefined,
+): void {
+	clock = fn ?? getms;
+}
+
+/** Drop the remembered view — test isolation and explicit re-arm only. */
+export function resetCapturePresence(): void {
+	memory = undefined;
+}
+
+/** Whether a grace window is currently being served (diagnostics + tests). */
+export function isCaptureAbsenceGraceActive(): boolean {
+	return memory?.degradedSince !== undefined;
+}
+
+/**
+ * The Auto-audio join key a row carries. Only a capture row can have one — a
+ * coarse/virtual/network row is a static offering with no USB topology at all.
+ */
+function joinKey(source: StreamSource | undefined): string | undefined {
+	if (source === undefined || source.origin !== "capture") return undefined;
+	const group = source.physicalGroupId;
+	return group === undefined || group === "" ? undefined : group;
+}
+
+function stableIdOf(source: StreamSource | undefined): string | undefined {
+	if (source === undefined || source.origin !== "capture") return undefined;
+	const id = source.stableId;
+	return id === undefined || id === "" ? undefined : id;
+}
+
+/**
+ * Does the remembered view describe the SAME PHYSICAL DEVICE the selection now
+ * names?
+ *
+ * Stable identity OUTRANKS the node path, in BOTH directions, and the second
+ * direction is the one that matters: the kernel recycles `/dev/videoN`, so a
+ * different camera can be sitting on the exact id the memory was recorded
+ * under. Two rows that BOTH carry a stable id therefore settle the question
+ * outright — equal proves the renumber, unequal proves the substitution — and a
+ * borrowed `physical_group_id` can never bind Auto audio to the microphone of a
+ * device the operator is no longer pointing at.
+ *
+ * Only when the evidence runs out (nothing live to compare, or an engine that
+ * emits no `stable_id`) does the node path decide, which is byte-identical to
+ * the behaviour before stable ids existed.
+ */
+function isSameDevice(
+	remembered: StreamSource,
+	selectedId: string,
+	live: StreamSource | undefined,
+): boolean {
+	const rememberedStableId = stableIdOf(remembered);
+	const liveStableId = stableIdOf(live);
+	if (rememberedStableId !== undefined && liveStableId !== undefined) {
+		return rememberedStableId === liveStableId;
+	}
+	if (
+		rememberedStableId !== undefined &&
+		live?.origin === "capture" &&
+		(live.previousIds?.includes(remembered.id) ?? false)
+	) {
+		return true;
+	}
+	return remembered.id === selectedId;
+}
+
+/**
+ * How this live view is WORSE at answering the Auto-audio question than the one
+ * we remember — and the two answers carry different windows, because they are
+ * different claims.
+ *
+ * `absent` is a real presence question: the row is gone, or it is a remembered
+ * `lost` placeholder. `under-identified` is not: the row is THERE and merely
+ * missing the `physical_group_id` rule 5 joins on, which is what the libuvc
+ * window actually produces (`withKnownEngineMetadata` restores durable identity
+ * and refuses to re-assert a same-moment topology relation, by design). "The row
+ * is there" is simply not the question rule 5 asks.
+ */
+type Degradation = "absent" | "under-identified" | undefined;
+
+function degradationOf(
+	live: StreamSource | undefined,
+	remembered: StreamSource | undefined,
+): Degradation {
+	if (live === undefined || live.lost === true) return "absent";
+	if (remembered === undefined) return undefined;
+	return joinKey(remembered) !== undefined && joinKey(live) === undefined
+		? "under-identified"
+		: undefined;
+}
+
+function graceFor(degradation: Exclude<Degradation, undefined>): number {
+	return degradation === "absent"
+		? CAPTURE_ABSENCE_GRACE_MS
+		: CAPTURE_METADATA_GRACE_MS;
+}
+
+/**
+ * Resolve the operator's selected source for AUTO-AUDIO purposes, holding a
+ * last-known-good view across a sub-`CAPTURE_ABSENCE_GRACE_MS` degradation.
+ *
+ * Returns the live row whenever the live row is at least as good as what we
+ * remember, the remembered row while a bounded degraded run is in progress, and
+ * the live row again — honestly, degraded or absent — the moment the window
+ * closes.
+ */
+export function resolveSelectedSourceWithGrace(
+	selectedId: string | undefined,
+	sources: readonly StreamSource[],
+	now: number = clock(),
+): StreamSource | undefined {
+	if (selectedId === undefined || selectedId === "") {
+		memory = undefined;
+		return undefined;
+	}
+
+	const live = sources.find((s) => s.id === selectedId);
+
+	// A coarse/virtual/network selection has no presence verdict to hold: it is
+	// an offering, not a device, and it cannot blink out under a USB rebind.
+	if (live !== undefined && live.origin !== "capture") {
+		memory = undefined;
+		return live;
+	}
+
+	const remembered =
+		memory !== undefined && isSameDevice(memory.source, selectedId, live)
+			? memory
+			: undefined;
+	// A memory that no longer describes the selected device is not evidence
+	// about it, and holding it would let one camera vouch for another.
+	if (remembered === undefined) memory = undefined;
+
+	const degradation = degradationOf(live, remembered?.source);
+	if (degradation === undefined) {
+		memory =
+			live === undefined
+				? undefined
+				: { source: live, degradedSince: undefined };
+		return live;
+	}
+
+	// Degraded with nothing to fall back on: the live view IS our best answer.
+	if (remembered === undefined) return live;
+
+	const since = remembered.degradedSince ?? now;
+	remembered.degradedSince = since;
+	const grace = graceFor(degradation);
+	if (now - since <= grace) return remembered.source;
+
+	memory = undefined;
+	logger.debug(
+		`capture presence: selected source ${degradation} for more than ${grace} ms — reporting the live view`,
+		{ selectedId, present: live !== undefined },
+	);
+	return live;
+}

--- a/apps/backend/src/modules/system/hdmi-signal-notification.ts
+++ b/apps/backend/src/modules/system/hdmi-signal-notification.ts
@@ -32,7 +32,14 @@
 // unreachable engine, a fallback v4l2 scan row (`signal` unset ⇒ `unknown`), and
 // a still-severed link all fail the test and leave the notification standing.
 
+import { deviceKindToPipelineId } from "@ceraui/rpc";
 import { notificationExists, notificationRemove } from "../ui/notifications.ts";
+
+/** The engine's typed capture kind for a board HDMI receiver. */
+const HDMI_DEVICE_KIND = "hdmi";
+
+/** The coarse source id every HDMI-kind device bridges to. */
+const HDMI_PIPELINE_ID = deviceKindToPipelineId(HDMI_DEVICE_KIND);
 
 /** Persistent-notification name shared by both `sensors.ts` HDMI raise sites. */
 export const HDMI_ERROR_NOTIFICATION = "hdmi_error";
@@ -66,6 +73,91 @@ export function provesHdmiSignalRecovered(
 	devices: readonly HdmiSignalObservation[],
 ): boolean {
 	return devices.some((d) => d.kind === "hdmi" && d.signal === "present");
+}
+
+// ─── The RAISE half: the same scoping, applied symmetrically ─────────────────
+//
+// The recovery above is scoped to `kind === "hdmi"`. The raise was scoped to
+// nothing but the board being an rk3588 — not to `config.source`, not to the
+// active capture source, not to the pipeline, not to `status.active_encode`. The
+// pair was asymmetric, and that asymmetry is reachable in ordinary use.
+//
+// Measured on a board (2026-07-30, `192.168.78.131`): a `streaming.start`
+// attempt PROBES EVERY CAPTURE INPUT, which opens `/dev/video0` in passing. On a
+// board whose HDMI-RX has no cable — the normal state for an operator streaming
+// a USB camera — that probe makes the kernel print `hdmirx-controller: Err,
+// timing is invalid`, and the watcher raised "No HDMI signal detected" at an
+// operator who was not using HDMI at all and had asked nothing about it. The
+// journal names the driver exactly: `no capture input reached PLAYING
+// (signal-less: /dev/video0, /dev/video1)`. The statement is TRUE about the
+// HDMI-RX port; it is simply not addressed to anyone.
+//
+// The gate below is deliberately a SUPPRESSION-ONLY test, mirroring the audio
+// meter's foreign-card rule: it can only ever withhold a raise PROVEN
+// irrelevant. Both sides must be known — the selection must resolve to a row,
+// and that row's own engine-authored `kind` (or coarse source id) must be
+// something other than HDMI. An unset selection, a selection that resolves to
+// nothing, and any HDMI-bearing selection all leave the raise armed, because
+// none of them proves the operator is not watching the HDMI port. A genuine
+// no-signal on a selected HDMI input is reported exactly as before.
+
+/** The selection fields the raise gate reads; `StreamSource` satisfies it. */
+export interface HdmiSelectionObservation {
+	id: string;
+	origin: string;
+	pipelineId: string;
+	kind?: string | undefined;
+	previousIds?: readonly string[] | undefined;
+}
+
+/** A persisted device snapshot; `LastSeenDevice` satisfies it. */
+export interface HdmiRememberedDevice {
+	id: string;
+	kind: string;
+	previousIds?: readonly string[] | undefined;
+}
+
+/**
+ * Does this candidate answer to `id`, currently or under a retired node path?
+ * A libuvc camera renumbers `/dev/videoN` on every open/close cycle, so an id
+ * match alone would lose the selection exactly when the probe sweep runs.
+ */
+function answersTo(
+	candidate: { id: string; previousIds?: readonly string[] | undefined },
+	id: string,
+): boolean {
+	return candidate.id === id || (candidate.previousIds?.includes(id) ?? false);
+}
+
+/**
+ * Is the operator's selected source PROVABLY not an HDMI input?
+ *
+ * The live source list decides when it can; otherwise the persisted
+ * `last_seen_devices` snapshot does, because `kind` is a durable property of the
+ * hardware and the one moment this is asked — mid stream-start sweep — is
+ * precisely when the live row may be transiently degraded by the libuvc rebind
+ * the same sweep triggers.
+ */
+export function provesSelectionIsNotHdmi(
+	selectedId: string | undefined,
+	sources: readonly HdmiSelectionObservation[],
+	remembered: readonly HdmiRememberedDevice[] = [],
+): boolean {
+	if (selectedId === undefined || selectedId === "") return false;
+
+	const live = sources.find((s) => answersTo(s, selectedId));
+	if (live !== undefined) {
+		if (live.origin !== "capture") return live.pipelineId !== HDMI_PIPELINE_ID;
+		return (
+			live.kind !== undefined &&
+			live.kind !== "" &&
+			live.kind !== HDMI_DEVICE_KIND
+		);
+	}
+
+	const snapshot = remembered.find((d) => answersTo(d, selectedId));
+	if (snapshot === undefined) return false;
+	return snapshot.kind !== "" && snapshot.kind !== HDMI_DEVICE_KIND;
 }
 
 /** Injected effectful surface (defaults wire the real notification store). */

--- a/apps/backend/src/modules/system/sensors.ts
+++ b/apps/backend/src/modules/system/sensors.ts
@@ -30,8 +30,10 @@ import {
 	shouldMockSensors,
 } from "../../mocks/providers/sensors.ts";
 
+import { getConfig } from "../config.ts";
 import { getRTMPIngestStats } from "../ingest/rtmp.ts";
 import { getSRTIngestStats } from "../ingest/srt.ts";
+import { getSourcesMessage } from "../streaming/sources.ts";
 import {
 	notificationBroadcast,
 	notificationExists,
@@ -42,6 +44,7 @@ import { getHardwareKindCached } from "./hardware-kind.ts";
 import {
 	HDMI_ERROR_NOTIFICATION,
 	HDMI_NO_SIGNAL_MSG,
+	provesSelectionIsNotHdmi,
 } from "./hdmi-signal-notification.ts";
 
 const bootconfigService = "ceralive-firstboot-bootconfig";
@@ -170,6 +173,97 @@ export function stopDmesgWatchers(): void {
 	for (const watcher of dmesgWatchers.splice(0)) watcher.abort();
 }
 
+/** The effectful surface the RK3588 HDMI dmesg handler drives. */
+export interface HdmiDmesgDeps {
+	peek: (name: string) => { msg: string } | undefined;
+	raise: (
+		name: string,
+		type: "error",
+		msg: string,
+		duration: number,
+		isPersistent: boolean,
+		isDismissable: boolean,
+		authedOnly?: boolean,
+		key?: string,
+	) => void;
+	noSignalRaiseAllowed: () => boolean;
+}
+
+const EMI_ADVISORY_MSG =
+	"HDMI signal issues detected. This is usually caused either by EMI or a by a faulty cable. " +
+	"Try to move any modems away from the HDMI cable and the encoder. " +
+	"If that fails, try out a different HDMI cable or to manually set a lower HDMI resolution/framerate on your camera";
+
+/**
+ * FAIL-OPEN by construction: only a selection this device can positively read
+ * AND positively identify as non-HDMI withholds the raise. A throw here (config
+ * not loaded, sources not yet built) is not evidence about the operator, so it
+ * must never be the reason a real no-signal fault goes unreported.
+ */
+function hdmiNoSignalRaiseAllowed(): boolean {
+	try {
+		const config = getConfig();
+		return !provesSelectionIsNotHdmi(
+			config.source,
+			getSourcesMessage().sources,
+			config.last_seen_devices ?? [],
+		);
+	} catch (err) {
+		logger.debug("sensors: HDMI raise scope unreadable — raising", { err });
+		return true;
+	}
+}
+
+const defaultHdmiDmesgDeps: HdmiDmesgDeps = {
+	peek: notificationExists,
+	raise: notificationBroadcast,
+	noSignalRaiseAllowed: hdmiNoSignalRaiseAllowed,
+};
+
+/**
+ * The RK3588 kernel-log HDMI handler, driving two INDEPENDENT notifications off
+ * the same watcher. Extracted from the watcher callback so the raise conditions
+ * are drivable without a `dmesg -w` process.
+ */
+export function handleRk3588HdmiDmesg(
+	data: string,
+	deps: HdmiDmesgDeps = defaultHdmiDmesgDeps,
+): void {
+	// The EMI/cable advisory is deliberately UNGATED: the kernel emits these two
+	// lines only while the receiver is actually locking or clocking a link, so
+	// they already describe work somebody asked for.
+	if (
+		data.match("hdmirx_wait_lock_and_get_timing signal not lock") ||
+		data.match("hdmirx_delayed_work_audio: audio underflow")
+	) {
+		deps.raise(
+			HDMI_ERROR_NOTIFICATION,
+			"error",
+			EMI_ADVISORY_MSG,
+			8,
+			true,
+			true,
+			true,
+			"notifications.hdmiError",
+		);
+	}
+
+	if (data.match("hdmirx-controller: Err, timing is invalid")) {
+		if (!deps.noSignalRaiseAllowed()) return;
+		const hdmiNotif = deps.peek(HDMI_ERROR_NOTIFICATION);
+		if (!hdmiNotif || hdmiNotif.msg === HDMI_NO_SIGNAL_MSG) {
+			deps.raise(
+				HDMI_ERROR_NOTIFICATION,
+				"error",
+				HDMI_NO_SIGNAL_MSG,
+				3,
+				true,
+				true,
+			);
+		}
+	}
+}
+
 export function initHardwareMonitoring() {
 	// Use mock sensors in development mode
 	if (shouldMockSensors()) {
@@ -256,42 +350,7 @@ export function initHardwareMonitoring() {
 		}
 
 		case "rk3588": {
-			startDmesgWatcher((data) => {
-				if (
-					data.match("hdmirx_wait_lock_and_get_timing signal not lock") ||
-					data.match("hdmirx_delayed_work_audio: audio underflow")
-				) {
-					const msg =
-						"HDMI signal issues detected. This is usually caused either by EMI or a by a faulty cable. " +
-						"Try to move any modems away from the HDMI cable and the encoder. " +
-						"If that fails, try out a different HDMI cable or to manually set a lower HDMI resolution/framerate on your camera";
-					notificationBroadcast(
-						HDMI_ERROR_NOTIFICATION,
-						"error",
-						msg,
-						8,
-						true,
-						true,
-						true,
-						"notifications.hdmiError",
-					);
-				}
-
-				if (data.match("hdmirx-controller: Err, timing is invalid")) {
-					const hdmiNotif = notificationExists(HDMI_ERROR_NOTIFICATION);
-
-					if (!hdmiNotif || hdmiNotif.msg === HDMI_NO_SIGNAL_MSG) {
-						notificationBroadcast(
-							HDMI_ERROR_NOTIFICATION,
-							"error",
-							HDMI_NO_SIGNAL_MSG,
-							3,
-							true,
-							true,
-						);
-					}
-				}
-			});
+			startDmesgWatcher((data) => handleRk3588HdmiDmesg(data));
 			break;
 		}
 	}

--- a/apps/backend/src/tests/capture-absence-grace.test.ts
+++ b/apps/backend/src/tests/capture-absence-grace.test.ts
@@ -1,0 +1,451 @@
+/*
+ * The transient libuvc-rebind gap must not surface as "no audio device".
+ *
+ * Root cause (board session 2026-07-30 17:20 UTC, `192.168.78.131`): libuvc's
+ * reattach guard rebinds USB interfaces `1.0`/`1.1` around every open/close of a
+ * UVC-H.264 camera. That is a NORMAL, necessary part of the detach-recovery
+ * mechanism — no USB device reset, no `devnum` change, and the camera's ALSA card
+ * never moves. But on RELEASE there is a real window (measured ≈400 ms, bounded
+ * above by 2.0 s) in which the engine has already dropped its `held_devices`
+ * record and has NOT yet rediscovered the re-registered node. During it,
+ * `list-devices` returns the camera's audio row and NOT its video row.
+ *
+ * `resolveAutoAsrcFromLiveState()` resolves `asrc: "Auto"` by looking the VIDEO
+ * source up first and joining it to its own audio card on `physical_group_id`
+ * (rule 5). With the video row missing — or present but restored from the local
+ * `/dev` scan, which carries no `physical_group_id` — the join has nothing to
+ * match, so Auto resolved to `no-same-device-audio`, the meter preference went
+ * `null`, and the operator read "Meter unavailable · No audio device" for a
+ * camera whose microphone was bound and streaming the entire time.
+ *
+ * These fixtures drive the REAL live-state resolver across that window.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { type ListDevicesResult, SCHEMA_VERSION } from "@ceralive/cerastream";
+import { AUDIO_SOURCE_AUTO, type StreamSource } from "@ceraui/rpc/schemas";
+
+import { getConfig } from "../modules/config.ts";
+import { setMockAudioDevicesProvider } from "../modules/streaming/audio.ts";
+import {
+	resetAutoAudioState,
+	resolveAutoAsrcFromLiveState,
+} from "../modules/streaming/auto-audio.ts";
+import {
+	clearCapabilitiesCache,
+	getCapabilities,
+} from "../modules/streaming/capabilities.ts";
+import {
+	CAPTURE_ABSENCE_GRACE_MS,
+	CAPTURE_METADATA_GRACE_MS,
+	isCaptureAbsenceGraceActive,
+	resetCapturePresence,
+	resolveSelectedSourceWithGrace,
+	setCapturePresenceClockForTest,
+} from "../modules/streaming/capture-presence.ts";
+import { VIDEO_SIGNAL_RECHECK_INTERVAL_MS } from "../modules/streaming/constants.ts";
+import {
+	refreshEngineDeviceCache,
+	resetEngineDeviceCache,
+} from "../modules/streaming/sources.ts";
+import { updateStatus } from "../modules/streaming/streaming.ts";
+
+// ─── Fixtures: the DJI Osmo Pocket 3 topology measured on the board ──────────
+//
+// Video and audio sit on DIFFERENT USB interfaces of ONE physical device, so
+// both rows carry the same `physical_group_id` (`usb:5-1` on the board).
+
+const CAMERA_GROUP = "usb:5-1";
+const CAMERA_ID = "/dev/video1";
+const CAMERA_STABLE_ID = "usb:2ca3:0023:DJI_DJIPocket3_123456789ABCDEF";
+
+type EngineDevice = Record<string, unknown>;
+
+function cameraVideoRow(withGroup: boolean): EngineDevice {
+	return {
+		input_id: CAMERA_ID,
+		device_path: CAMERA_ID,
+		display_name: "DJIPocket3: OsmoPocket3",
+		media_class: "video",
+		kind: "uvc_h264",
+		stable_id: CAMERA_STABLE_ID,
+		...(withGroup ? { physical_group_id: CAMERA_GROUP } : {}),
+	};
+}
+
+const CAMERA_AUDIO_ROW: EngineDevice = {
+	input_id: "audio:DJIPocket3",
+	device_path: "",
+	display_name: "DJI DJIPocket3",
+	media_class: "audio",
+	kind: "audio",
+	alsa_card_id: "DJIPocket3",
+	physical_group_id: CAMERA_GROUP,
+};
+
+async function seedCapabilities(): Promise<void> {
+	await getCapabilities({
+		fetchEngineCapabilities: async () => ({
+			caps: {
+				platform: {
+					supports_h265: true,
+					hardware_accelerated: true,
+					max_resolution: "1080p",
+				},
+				encoder: {
+					codecs: ["h264"],
+					bitrate_range: { min: 500, max: 20000, unit: "kbps" },
+				},
+				sources: [
+					{
+						id: "libuvch264",
+						supports_audio: true,
+						supports_resolution_override: true,
+						supports_framerate_override: true,
+						default_resolution: "1080p",
+						default_framerate: 30,
+					},
+				],
+			},
+			schemaVersion: SCHEMA_VERSION,
+		}),
+		fetchEngineDevices: async () => ({ devices: [] }),
+	});
+}
+
+/** Commit ONE engine view into the device cache the sources builder reads. */
+async function commitEngineView(
+	devices: readonly EngineDevice[],
+): Promise<void> {
+	await refreshEngineDeviceCache({
+		fetchEngineDevices: async () =>
+			({ devices: [...devices] }) as unknown as ListDevicesResult,
+	});
+}
+
+/** The healthy steady state: camera video + its own audio card, both grouped. */
+const HEALTHY_VIEW = [cameraVideoRow(true), CAMERA_AUDIO_ROW];
+
+/**
+ * The RELEASE gap: the engine dropped its held video record and has not yet
+ * rediscovered the successor node. Audio never moves — that is the whole point.
+ */
+const GAP_VIEW_VIDEO_ABSENT = [CAMERA_AUDIO_ROW];
+
+/**
+ * The other half of the same window: the `/dev` scan HAS seen the node come back,
+ * so CeraUI's hotplug merge restores the row from `lastEngineVideoDevices` — which
+ * deliberately restores durable IDENTITY (`kind`/`stable_id`) and NEVER the
+ * same-moment `physical_group_id`. The row is present and useless to rule 5.
+ */
+const GAP_VIEW_GROUP_STRIPPED = [cameraVideoRow(false), CAMERA_AUDIO_ROW];
+
+describe("Auto audio — absence hysteresis across a libuvc interface rebind", () => {
+	let clockMs: number;
+
+	beforeEach(async () => {
+		clockMs = 1_000_000;
+		setCapturePresenceClockForTest(() => clockMs);
+		resetAutoAudioState();
+		updateStatus(false);
+		clearCapabilitiesCache();
+		resetEngineDeviceCache();
+		await seedCapabilities();
+		setMockAudioDevicesProvider(() => ({ "DJI DJIPocket3": "DJIPocket3" }));
+		getConfig().asrc = AUDIO_SOURCE_AUTO;
+		getConfig().source = CAMERA_ID;
+	});
+
+	afterEach(() => {
+		setCapturePresenceClockForTest(undefined);
+		setMockAudioDevicesProvider(undefined);
+		resetEngineDeviceCache();
+		clearCapabilitiesCache();
+		resetAutoAudioState();
+		updateStatus(false);
+		delete getConfig().asrc;
+		delete getConfig().source;
+		delete getConfig().last_seen_devices;
+	});
+
+	test("baseline: the healthy view resolves Auto to the camera's OWN card", async () => {
+		await commitEngineView(HEALTHY_VIEW);
+		const r = resolveAutoAsrcFromLiveState();
+		expect(r.reason).toBe("usb-same-device");
+		expect(r.asrcKey).toBe("DJI DJIPocket3");
+		expect(r.cardId).toBe("DJIPocket3");
+	});
+
+	test("the video row VANISHING for < 2 s keeps the same-device resolution", async () => {
+		await commitEngineView(HEALTHY_VIEW);
+		expect(resolveAutoAsrcFromLiveState().reason).toBe("usb-same-device");
+
+		await commitEngineView(GAP_VIEW_VIDEO_ABSENT);
+		const during = resolveAutoAsrcFromLiveState();
+		expect(during.reason).toBe("usb-same-device");
+		expect(during.asrcKey).toBe("DJI DJIPocket3");
+	});
+
+	test("a restored row STRIPPED of its physical_group_id keeps the resolution", async () => {
+		await commitEngineView(HEALTHY_VIEW);
+		expect(resolveAutoAsrcFromLiveState().reason).toBe("usb-same-device");
+
+		await commitEngineView(GAP_VIEW_GROUP_STRIPPED);
+		const during = resolveAutoAsrcFromLiveState();
+		expect(during.reason).toBe("usb-same-device");
+		expect(during.asrcKey).toBe("DJI DJIPocket3");
+	});
+
+	test("the 5.077 s under-identified window MEASURED on the board is covered", async () => {
+		await commitEngineView(HEALTHY_VIEW);
+		expect(resolveAutoAsrcFromLiveState().reason).toBe("usb-same-device");
+
+		// Board trace, preview cycle 3: SOURCES went NOGRP at t=51.403 and back to
+		// grp at t=56.480 — one VIDEO_SIGNAL_RECHECK_INTERVAL_MS plus a 77 ms probe
+		// round-trip, because only that tick refills the join key.
+		await commitEngineView(GAP_VIEW_GROUP_STRIPPED);
+		clockMs += 5_077;
+		expect(resolveAutoAsrcFromLiveState().reason).toBe("usb-same-device");
+
+		await commitEngineView(HEALTHY_VIEW);
+		expect(resolveAutoAsrcFromLiveState().reason).toBe("usb-same-device");
+	});
+
+	test("the successor node re-registers and resolution follows it, no stale hold", async () => {
+		await commitEngineView(HEALTHY_VIEW);
+		resolveAutoAsrcFromLiveState();
+		await commitEngineView(GAP_VIEW_VIDEO_ABSENT);
+		expect(resolveAutoAsrcFromLiveState().reason).toBe("usb-same-device");
+
+		await commitEngineView(HEALTHY_VIEW);
+		const after = resolveAutoAsrcFromLiveState();
+		expect(after.reason).toBe("usb-same-device");
+		expect(after.asrcKey).toBe("DJI DJIPocket3");
+	});
+
+	// ─── NEGATIVE CONTROL: a real unplug must still be reported ──────────────
+
+	test("a SUSTAINED absence past the window resolves honestly again", async () => {
+		await commitEngineView(HEALTHY_VIEW);
+		expect(resolveAutoAsrcFromLiveState().reason).toBe("usb-same-device");
+
+		await commitEngineView(GAP_VIEW_VIDEO_ABSENT);
+		expect(resolveAutoAsrcFromLiveState().reason).toBe("usb-same-device");
+
+		clockMs += CAPTURE_ABSENCE_GRACE_MS + 1;
+		const after = resolveAutoAsrcFromLiveState();
+		expect(after.reason).toBe("no-same-device-audio");
+		expect(after.asrcKey).toBeNull();
+	});
+
+	test("a repeatedly-observed absence cannot RENEW the window", async () => {
+		await commitEngineView(HEALTHY_VIEW);
+		resolveAutoAsrcFromLiveState();
+		await commitEngineView(GAP_VIEW_VIDEO_ABSENT);
+
+		// Poll the whole window at the audio meter's own 5 Hz cadence: the run is
+		// continuous, so every one of these observations extends nothing.
+		for (let elapsed = 0; elapsed <= CAPTURE_ABSENCE_GRACE_MS; elapsed += 200) {
+			expect(resolveAutoAsrcFromLiveState().reason).toBe("usb-same-device");
+			clockMs += 200;
+		}
+		expect(resolveAutoAsrcFromLiveState().reason).toBe("no-same-device-audio");
+	});
+
+	test("the camera's own audio is still refused once it, too, is gone", async () => {
+		await commitEngineView(HEALTHY_VIEW);
+		resolveAutoAsrcFromLiveState();
+
+		// A true unplug takes BOTH interfaces with it — the libuvc rebind never did.
+		await commitEngineView([]);
+		clockMs += CAPTURE_ABSENCE_GRACE_MS + 1;
+		const after = resolveAutoAsrcFromLiveState();
+		expect(after.asrcKey).toBeNull();
+		expect(after.cardId).toBeNull();
+	});
+});
+
+// ─── The pure verdict, driven directly ───────────────────────────────────────
+
+function captureRow(overrides: Partial<StreamSource> = {}): StreamSource {
+	return {
+		id: CAMERA_ID,
+		pipelineId: "libuvch264",
+		modes: [],
+		supportsAudio: true,
+		supportsResolutionOverride: true,
+		supportsFramerateOverride: true,
+		audioKind: "selectable",
+		available: true,
+		origin: "capture",
+		kind: "uvc_h264",
+		displayName: "DJIPocket3: OsmoPocket3",
+		devicePath: CAMERA_ID,
+		stableId: CAMERA_STABLE_ID,
+		physicalGroupId: CAMERA_GROUP,
+		...overrides,
+	} as StreamSource;
+}
+
+describe("resolveSelectedSourceWithGrace — the bounded verdict", () => {
+	beforeEach(() => resetCapturePresence());
+	afterEach(() => resetCapturePresence());
+
+	test("the metadata window is DERIVED from the recheck tick that refills it", () => {
+		// Nothing else refills `physical_group_id` while idle, so the bound has to
+		// come from that tick — not from the engine-side gap measurement.
+		expect(CAPTURE_METADATA_GRACE_MS).toBeGreaterThan(
+			VIDEO_SIGNAL_RECHECK_INTERVAL_MS,
+		);
+		expect(CAPTURE_METADATA_GRACE_MS).toBe(
+			VIDEO_SIGNAL_RECHECK_INTERVAL_MS + 1_500,
+		);
+		expect(CAPTURE_ABSENCE_GRACE_MS).toBeLessThan(CAPTURE_METADATA_GRACE_MS);
+	});
+
+	test("an ABSENT row gets the SHORT window, not the metadata one", () => {
+		resolveSelectedSourceWithGrace(CAMERA_ID, [captureRow()], 0);
+		// The run starts at the FIRST degraded observation, so expiry is measured
+		// from here — not from the last healthy one.
+		const since = 1_000;
+		expect(resolveSelectedSourceWithGrace(CAMERA_ID, [], since)).toBeDefined();
+		expect(
+			resolveSelectedSourceWithGrace(
+				CAMERA_ID,
+				[],
+				since + CAPTURE_ABSENCE_GRACE_MS,
+			),
+		).toBeDefined();
+		expect(
+			resolveSelectedSourceWithGrace(
+				CAMERA_ID,
+				[],
+				since + CAPTURE_ABSENCE_GRACE_MS + 1,
+			),
+		).toBeUndefined();
+	});
+
+	test("an UNDER-IDENTIFIED row gets the long window, then reports honestly", () => {
+		resolveSelectedSourceWithGrace(CAMERA_ID, [captureRow()], 0);
+		const stripped = [captureRow({ physicalGroupId: undefined })];
+		const since = 1_000;
+
+		expect(
+			resolveSelectedSourceWithGrace(CAMERA_ID, stripped, since)
+				?.physicalGroupId,
+		).toBe(CAMERA_GROUP);
+		// Past the ABSENCE window, and still held — the row is present, so this is
+		// not a presence claim and the short window does not govern it.
+		expect(
+			resolveSelectedSourceWithGrace(
+				CAMERA_ID,
+				stripped,
+				since + CAPTURE_ABSENCE_GRACE_MS + 1,
+			)?.physicalGroupId,
+		).toBe(CAMERA_GROUP);
+		expect(
+			resolveSelectedSourceWithGrace(
+				CAMERA_ID,
+				stripped,
+				since + CAPTURE_METADATA_GRACE_MS,
+			)?.physicalGroupId,
+		).toBe(CAMERA_GROUP);
+		expect(
+			resolveSelectedSourceWithGrace(
+				CAMERA_ID,
+				stripped,
+				since + CAPTURE_METADATA_GRACE_MS + 1,
+			)?.physicalGroupId,
+		).toBeUndefined();
+	});
+
+	test("holds at the window boundary and releases one millisecond past it", () => {
+		const healthy = [captureRow()];
+		expect(resolveSelectedSourceWithGrace(CAMERA_ID, healthy, 0)).toBe(
+			healthy[0] as StreamSource,
+		);
+
+		expect(resolveSelectedSourceWithGrace(CAMERA_ID, [], 100)?.id).toBe(
+			CAMERA_ID,
+		);
+		expect(
+			resolveSelectedSourceWithGrace(
+				CAMERA_ID,
+				[],
+				100 + CAPTURE_ABSENCE_GRACE_MS,
+			),
+		).toBeDefined();
+		expect(
+			resolveSelectedSourceWithGrace(
+				CAMERA_ID,
+				[],
+				100 + CAPTURE_ABSENCE_GRACE_MS + 1,
+			),
+		).toBeUndefined();
+		expect(isCaptureAbsenceGraceActive()).toBe(false);
+	});
+
+	test("a `lost` row is a degradation, not a healthy observation", () => {
+		resolveSelectedSourceWithGrace(CAMERA_ID, [captureRow()], 0);
+		const lost = [captureRow({ available: false, lost: true })];
+		expect(
+			resolveSelectedSourceWithGrace(CAMERA_ID, lost, 500)?.physicalGroupId,
+		).toBe(CAMERA_GROUP);
+		expect(resolveSelectedSourceWithGrace(CAMERA_ID, lost, 5_000)?.lost).toBe(
+			true,
+		);
+	});
+
+	test("a DIFFERENT device on the freed node never inherits the memory", () => {
+		resolveSelectedSourceWithGrace(CAMERA_ID, [captureRow()], 0);
+		const intruder = captureRow({
+			stableId: "usb:1234:5678:OTHER",
+			displayName: "RØDE HDMI to USB-C",
+			physicalGroupId: undefined,
+		});
+		const resolved = resolveSelectedSourceWithGrace(CAMERA_ID, [intruder], 100);
+		expect(resolved).toBe(intruder);
+		expect(resolved?.physicalGroupId).toBeUndefined();
+		expect(isCaptureAbsenceGraceActive()).toBe(false);
+	});
+
+	test("the memory follows the device across a renumber, by stable identity", () => {
+		resolveSelectedSourceWithGrace(CAMERA_ID, [captureRow()], 0);
+		const successor = captureRow({
+			id: "/dev/video2",
+			devicePath: "/dev/video2",
+			previousIds: [CAMERA_ID],
+			physicalGroupId: undefined,
+		});
+		expect(
+			resolveSelectedSourceWithGrace("/dev/video2", [successor], 100)
+				?.physicalGroupId,
+		).toBe(CAMERA_GROUP);
+	});
+
+	test("a coarse selection holds nothing — it is an offering, not a device", () => {
+		resolveSelectedSourceWithGrace(CAMERA_ID, [captureRow()], 0);
+		const coarse = {
+			id: "hdmi",
+			pipelineId: "hdmi",
+			modes: [],
+			supportsAudio: true,
+			supportsResolutionOverride: true,
+			supportsFramerateOverride: true,
+			audioKind: "selectable",
+			available: true,
+			origin: "coarse",
+			labelKey: "settings.sources.hdmi",
+		} as StreamSource;
+		expect(resolveSelectedSourceWithGrace("hdmi", [coarse], 100)).toBe(coarse);
+		expect(isCaptureAbsenceGraceActive()).toBe(false);
+		// The camera's memory is gone with it, so its next absence starts cold.
+		expect(resolveSelectedSourceWithGrace(CAMERA_ID, [], 200)).toBeUndefined();
+	});
+
+	test("an unset selection resolves to nothing and forgets", () => {
+		resolveSelectedSourceWithGrace(CAMERA_ID, [captureRow()], 0);
+		expect(resolveSelectedSourceWithGrace(undefined, [], 10)).toBeUndefined();
+		expect(resolveSelectedSourceWithGrace(CAMERA_ID, [], 20)).toBeUndefined();
+	});
+});

--- a/apps/backend/src/tests/hdmi-raise-scope.test.ts
+++ b/apps/backend/src/tests/hdmi-raise-scope.test.ts
@@ -1,0 +1,217 @@
+/*
+ * The "No HDMI signal detected" RAISE must be scoped like its RECOVERY.
+ *
+ * `clearHdmiSignalErrorOnRecovery` has always required a `kind === "hdmi"`
+ * capture row reporting an engine-authored `signal: "present"`. The raise had no
+ * equivalent: it fired on the kernel line alone, gated only on the board being an
+ * rk3588. Measured on `192.168.78.131` (2026-07-30): a `streaming.start` attempt
+ * probes EVERY capture input, so it opens `/dev/video0` in passing, and on a board
+ * whose HDMI-RX carries no cable the kernel prints `hdmirx-controller: Err, timing
+ * is invalid` — raising "No HDMI signal detected" at an operator streaming a USB
+ * camera who had asked nothing about HDMI.
+ *
+ * The gate is SUPPRESSION-ONLY: it may withhold a raise only when the selection is
+ * PROVEN to be something other than an HDMI input. Every test below that asserts a
+ * raise is a negative control for that rule.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { LastSeenDevice } from "../helpers/config-schemas.ts";
+import {
+	HDMI_ERROR_NOTIFICATION,
+	HDMI_NO_SIGNAL_MSG,
+	type HdmiSelectionObservation,
+	provesSelectionIsNotHdmi,
+} from "../modules/system/hdmi-signal-notification.ts";
+import {
+	type HdmiDmesgDeps,
+	handleRk3588HdmiDmesg,
+} from "../modules/system/sensors.ts";
+
+const NO_SIGNAL_LINE =
+	"[  812.443001] hdmirx-controller: Err, timing is invalid\n";
+const EMI_LINE =
+	"[  812.443001] hdmirx_wait_lock_and_get_timing signal not lock\n";
+
+interface RaisedNotification {
+	name: string;
+	msg: string;
+}
+
+function harness(
+	noSignalRaiseAllowed: boolean,
+	standing?: { msg: string },
+): { deps: HdmiDmesgDeps; raised: RaisedNotification[] } {
+	const raised: RaisedNotification[] = [];
+	return {
+		raised,
+		deps: {
+			peek: () => standing,
+			raise: (name, _type, msg) => {
+				raised.push({ name, msg });
+			},
+			noSignalRaiseAllowed: () => noSignalRaiseAllowed,
+		},
+	};
+}
+
+// ─── Fixtures: the two rows the board actually reports ───────────────────────
+
+const USB_CAMERA: HdmiSelectionObservation = {
+	id: "/dev/video1",
+	origin: "capture",
+	pipelineId: "libuvch264",
+	kind: "uvc_h264",
+};
+
+const HDMI_INPUT: HdmiSelectionObservation = {
+	id: "/dev/video0",
+	origin: "capture",
+	pipelineId: "hdmi",
+	kind: "hdmi",
+};
+
+const COARSE_HDMI: HdmiSelectionObservation = {
+	id: "hdmi",
+	origin: "coarse",
+	pipelineId: "hdmi",
+};
+
+const COARSE_USB: HdmiSelectionObservation = {
+	id: "usb_mjpeg",
+	origin: "coarse",
+	pipelineId: "usb_mjpeg",
+};
+
+function remembered(id: string, kind: string): LastSeenDevice {
+	return {
+		id,
+		displayName: "DJIPocket3: OsmoPocket3",
+		kind: kind as LastSeenDevice["kind"],
+		pipelineId: "libuvch264",
+		devicePath: id,
+	};
+}
+
+describe("provesSelectionIsNotHdmi — suppression needs POSITIVE evidence", () => {
+	test("a selected USB camera proves the HDMI claim is not addressed to anyone", () => {
+		expect(
+			provesSelectionIsNotHdmi("/dev/video1", [USB_CAMERA, HDMI_INPUT]),
+		).toBe(true);
+	});
+
+	test("a selected HDMI input proves nothing of the sort", () => {
+		expect(
+			provesSelectionIsNotHdmi("/dev/video0", [USB_CAMERA, HDMI_INPUT]),
+		).toBe(false);
+	});
+
+	test("a coarse selection is decided by its source id, both ways", () => {
+		expect(provesSelectionIsNotHdmi("usb_mjpeg", [COARSE_USB])).toBe(true);
+		expect(provesSelectionIsNotHdmi("hdmi", [COARSE_HDMI])).toBe(false);
+	});
+
+	test("no selection at all is not evidence", () => {
+		expect(provesSelectionIsNotHdmi(undefined, [USB_CAMERA])).toBe(false);
+		expect(provesSelectionIsNotHdmi("", [USB_CAMERA])).toBe(false);
+	});
+
+	test("a selection nothing can resolve is not evidence", () => {
+		expect(provesSelectionIsNotHdmi("/dev/video7", [USB_CAMERA])).toBe(false);
+	});
+
+	test("a renumbered camera is still recognised through previousIds", () => {
+		const successor: HdmiSelectionObservation = {
+			...USB_CAMERA,
+			id: "/dev/video2",
+			previousIds: ["/dev/video1"],
+		};
+		expect(provesSelectionIsNotHdmi("/dev/video1", [successor])).toBe(true);
+	});
+
+	test("a live row missing mid-sweep falls back to the persisted kind", () => {
+		expect(
+			provesSelectionIsNotHdmi(
+				"/dev/video1",
+				[HDMI_INPUT],
+				[remembered("/dev/video1", "uvc_h264")],
+			),
+		).toBe(true);
+		expect(
+			provesSelectionIsNotHdmi(
+				"/dev/video0",
+				[],
+				[remembered("/dev/video0", "hdmi")],
+			),
+		).toBe(false);
+	});
+
+	test("the LIVE row outranks a stale persisted snapshot", () => {
+		expect(
+			provesSelectionIsNotHdmi(
+				"/dev/video0",
+				[HDMI_INPUT],
+				[remembered("/dev/video0", "uvc_h264")],
+			),
+		).toBe(false);
+	});
+});
+
+describe("handleRk3588HdmiDmesg — the raise it is allowed to make", () => {
+	let h: ReturnType<typeof harness>;
+
+	describe("the stream-start sweep incidentally probing /dev/video0", () => {
+		beforeEach(() => {
+			h = harness(false);
+		});
+
+		test("raises NOTHING", () => {
+			handleRk3588HdmiDmesg(NO_SIGNAL_LINE, h.deps);
+			expect(h.raised).toEqual([]);
+		});
+
+		test("does not disturb the EMI/cable advisory, which stays ungated", () => {
+			handleRk3588HdmiDmesg(EMI_LINE, h.deps);
+			expect(h.raised).toHaveLength(1);
+			expect(h.raised[0]?.name).toBe(HDMI_ERROR_NOTIFICATION);
+			expect(h.raised[0]?.msg).toContain("HDMI signal issues detected");
+		});
+	});
+
+	// ─── NEGATIVE CONTROL: a genuine no-signal must still reach the operator ──
+
+	describe("a genuinely selected HDMI input with no cable", () => {
+		beforeEach(() => {
+			h = harness(true);
+		});
+
+		test("raises the no-signal notification, unchanged", () => {
+			handleRk3588HdmiDmesg(NO_SIGNAL_LINE, h.deps);
+			expect(h.raised).toEqual([
+				{ name: HDMI_ERROR_NOTIFICATION, msg: HDMI_NO_SIGNAL_MSG },
+			]);
+		});
+
+		test("still refuses to overwrite a standing EMI advisory", () => {
+			const scoped = harness(true, { msg: "HDMI signal issues detected. …" });
+			handleRk3588HdmiDmesg(NO_SIGNAL_LINE, scoped.deps);
+			expect(scoped.raised).toEqual([]);
+		});
+
+		test("re-raises over its own standing no-signal notification", () => {
+			const scoped = harness(true, { msg: HDMI_NO_SIGNAL_MSG });
+			handleRk3588HdmiDmesg(NO_SIGNAL_LINE, scoped.deps);
+			expect(scoped.raised).toHaveLength(1);
+			expect(scoped.raised[0]?.msg).toBe(HDMI_NO_SIGNAL_MSG);
+		});
+	});
+
+	test("an unrelated kernel line raises nothing either way", () => {
+		const scoped = harness(true);
+		handleRk3588HdmiDmesg(
+			"[  99.0] usb 5-1: Found UVC 1.00 device\n",
+			scoped.deps,
+		);
+		expect(scoped.raised).toEqual([]);
+	});
+});


### PR DESCRIPTION
## What

Two related operator-facing defects on the same board, both surfacing during the
**normal** libuvc interface rebind that happens on every UVC-H.264 camera
open/close:

1. **"Meter unavailable · No audio device"** for a microphone that never moved.
2. **"No HDMI signal detected"** shown to an operator streaming a USB camera.

## Why

Measured on `192.168.78.131` (Rock 5B+, DJI Osmo Pocket 3 `2ca3:0023`).

**The rebind itself is not a bug and is not a USB reset.** `devnum` never
changes, only interfaces `1.0`/`1.1` move `uvcvideo → usbfs → uvcvideo`, and the
camera's ALSA card stays bound with its PCM node inode unchanged. While the
engine *holds* the device, `held_devices` masks the gap correctly.

**On release it does not.** The engine drops the held record before it
rediscovers the re-registered node. `resolveAutoAsrcFromLiveState()` resolves
`asrc: "Auto"` by looking the **video** source up first and joining it to its own
audio card on `physical_group_id` — so in that window the join has nothing to
match and Auto answers `no-same-device-audio`, which the meter renders as "No
audio device".

Every existing defence in the chain is an **event debounce** (wait for quiet
before *re-reading*). None is an **absence grace** (wait before *believing it is
gone*), so a hole of any length propagates straight to a verdict.

Separately, a stream-start attempt **probes every capture input**, opening
`/dev/video0` in passing. On a cable-less HDMI-RX that makes the kernel print
`hdmirx-controller: Err, timing is invalid`, and the watcher raised
"No HDMI signal detected" globally. The *retraction* was already scoped to
`kind === "hdmi"`; the *raise* was scoped to nothing but the board being rk3588.
The pair was asymmetric. And because a persistent notification never expires on a
timer, the `duration: 3` on that raise buys nothing — it stood until dismissed.

## How

**`capture-presence.ts` — hysteresis on the VERDICT, not on the sampling.** Read
only by `resolveAutoAsrcFromLiveState()`. The `sources` payload, the `lost` row,
routing and the picker are untouched.

- The clock starts at the **first degraded observation**, never at the last
  healthy one — our knowledge is refreshed on someone else's cadence, so a window
  measured from the memory's *age* would be expired in steady state.
- **Two windows, because they are different claims.** An `absent`/`lost` row is a
  real presence question → short 2 s. A row that is **present** but stripped of
  its `physical_group_id` is not an absence at all (the scan sees the node, the
  engine listed it), so holding its join key *cannot* mask a device-gone failure;
  its bound is **derived** from the `recheckSourceSignals` tick that refills the
  field — the only thing that does, while idle.
- Matched by **stable identity in both directions**: equal proves the renumber,
  unequal proves a different device took the freed node and the memory is dropped.

**`provesSelectionIsNotHdmi()` — a suppression-only raise gate**, mirroring the
audio meter's foreign-card discipline. It withholds the raise *only* when the
selection is PROVEN to be something other than HDMI. An unset selection, an
unresolvable one, and any HDMI-bearing selection all leave the raise armed. The
EMI/cable advisory is deliberately left ungated. Production wiring is fail-open.

## How to verify

```bash
cd apps/backend && bun test src/tests/capture-absence-grace.test.ts \
                           src/tests/hdmi-raise-scope.test.ts
```

Red-first was captured in both directions: the absence fixtures fail on `main`
with exactly `no-same-device-audio`, and removing the one-line HDMI gate
re-raises `{"name":"hdmi_error","msg":"No HDMI signal detected"}`.

**Board A/B**, five preview open/close cycles per binary, identical driver:

| metric | before | after |
|---|---|---|
| `no-same-device-audio` verdicts | **10** (5/5 cycles) | **0** |
| `audio-level` GAP frames | **10** | **0** |
| spurious `hdmi_error` raises | **1** | **0** |
| verdict samples total | 250 | 249 |

The degraded window was observed at 434 ms, 258 ms, 5077 ms, and 2.9–3.8 s across
runs — the 5077 ms case is one recheck interval plus a 77 ms probe round-trip, and
is exactly why the metadata window is derived rather than taken from the
engine-side gap measurement.

**Negative controls** (all on the fixed binary, kernel trigger confirmed in
`dmesg` on every run so "no notification" can never be mistaken for "no trigger"):

- HDMI input genuinely selected, no cable → **raises**, 75 ms after the probe.
- USB `5-1` de-authorized for 26 s (a clean software unplug) → resolves
  `no-same-device-audio` for **59 consecutive samples**, and recovers when the
  device returns.

## Risks

- Scoped to the Auto-audio resolver and the one HDMI raise site. No engine, no
  `sources` wire change, no schema change, no new dependency.
- The grace is strictly bounded with **no renewal path** — only a genuinely
  healthy observation resets a run, so polling it at the meter's 5 Hz cadence
  extends nothing, and a true unplug reads exactly as it did before.
- `handleRk3588HdmiDmesg` is an extraction of the existing dmesg callback so both
  raise conditions are drivable without a `dmesg -w` process; the EMI advisory's
  behaviour is byte-unchanged.
- One pre-existing cross-file test-pollution flake on `main`
  (`audio-meter-bridge … re-asserts through null only after the grace window`)
  reproduces on a clean `origin/main` checkout with none of this branch applied,
  and passes in isolation (46/46). Not introduced here.

Board left on the fixed build, `asrc: "Auto"`, `source: /dev/video1`, all three
services active, `/api/health` idle and not degraded.
