### PR TITLE
fix(devices): a libuvc camera's release gap is not a disconnect — stop clearing the operator's selection

### DIFF
--- a/apps/backend/src/modules/streaming/devices.ts
+++ b/apps/backend/src/modules/streaming/devices.ts
@@ -50,6 +50,7 @@ import {
 	VIDEO_HOTPLUG_POLL_INTERVAL_MS,
 	VIDEO_SIGNAL_RECHECK_INTERVAL_MS,
 } from "./constants.ts";
+import { releasesV4l2Node } from "./held-devices.ts";
 import { reportActiveVideoSource } from "./lifecycle-indicators.ts";
 import { applyOnboardVideoDisplayRule } from "./onboard-display-names.ts";
 import { getConfiguredEngine } from "./streaming-engine.ts";
@@ -78,6 +79,11 @@ export interface DeviceRegistryDeps {
 	// engine-up reconciliation stays unit-testable without config singletons.
 	getSelectedVideoInput: () => string | undefined;
 	clearSelectedVideoInput: () => void;
+	// The KIND `last_seen_devices` remembers for a persisted selection, matched
+	// by current id or by a retired `previousIds` path. It is the only way to
+	// ask whether an id that is ABSENT from the engine list is one whose absence
+	// can even be evidence — see `reconcileSelectedInput`.
+	getRememberedDeviceKind: (inputId: string) => DeviceKind | undefined;
 	notify: (
 		name: string,
 		type: "success" | "warning" | "error",
@@ -310,6 +316,13 @@ function defaultClearSelectedVideoInput(): void {
 	);
 }
 
+function defaultRememberedDeviceKind(inputId: string): DeviceKind | undefined {
+	const remembered = getConfig().last_seen_devices?.find(
+		(d) => d.id === inputId || d.previousIds?.includes(inputId),
+	);
+	return remembered?.kind;
+}
+
 function defaultDeps(): DeviceRegistryDeps {
 	return {
 		listVideoCards: () => readdir(VIDEO_DIR).catch(() => []),
@@ -321,6 +334,7 @@ function defaultDeps(): DeviceRegistryDeps {
 		getEngineDevices: defaultGetEngineDevices,
 		getSelectedVideoInput: () => getConfig().selected_video_input,
 		clearSelectedVideoInput: defaultClearSelectedVideoInput,
+		getRememberedDeviceKind: defaultRememberedDeviceKind,
 		notify: notificationBroadcast,
 		broadcast: (type, data) => {
 			void import("../ui/websocket-server.ts").then(({ broadcastMsg }) =>
@@ -362,6 +376,7 @@ export function createDeviceRegistry(
 	let devWatcher: fs.FSWatcher | undefined;
 	let stopped = false;
 	let engineWasReachable = false;
+	let unconfirmedAbsentSelection: string | undefined;
 
 	async function v4l2Scan(): Promise<CaptureDevice[]> {
 		const cards = (await deps.listVideoCards()).sort();
@@ -377,10 +392,39 @@ export function createDeviceRegistry(
 	// A persisted operator selection that the engine's freshly-reported device
 	// list no longer contains is stale; clear it (never keep an invalid stale
 	// selection silently) and surface a broadcast + user-facing notification.
+	//
+	// EXCEPT for a kind that RELEASES its v4l2 node. This runs on the
+	// unreachable→reachable EDGE, and for a libuvc-driven camera that edge IS the
+	// engine letting go of the device: the session's control socket closes, and
+	// the node is re-registered only after libuvc reattaches `uvcvideo` (measured
+	// 0.4-2.0 s). The first list the engine answers with in that window
+	// truthfully omits a camera that is perfectly healthy — so clearing on it
+	// DESTROYS a working selection, and the operator is then locked out with
+	// "your selected video input is no longer available" plus a start that can
+	// never succeed. Observed on the board after every failed start.
+	//
+	// Absence at this edge is therefore not evidence for such a kind; it takes a
+	// SECOND consecutive engine-authored observation to become one. Every other
+	// kind keeps the byte-identical clear-on-first-absence behaviour, because for
+	// them a missing node genuinely is a disconnect.
 	function reconcileSelectedInput(engineDevices: CaptureDevice[]): void {
 		const selected = deps.getSelectedVideoInput();
 		if (!selected) return;
-		if (engineDevices.some((d) => d.input_id === selected)) return;
+		if (engineDevices.some((d) => d.input_id === selected)) {
+			unconfirmedAbsentSelection = undefined;
+			return;
+		}
+		if (releasesV4l2Node(deps.getRememberedDeviceKind(selected))) {
+			if (unconfirmedAbsentSelection !== selected) {
+				unconfirmedAbsentSelection = selected;
+				deps.logger.debug(
+					"device discovery: selected input absent while the engine may still be releasing it — awaiting confirmation before clearing",
+					{ selected },
+				);
+				return;
+			}
+		}
+		unconfirmedAbsentSelection = undefined;
 		deps.clearSelectedVideoInput();
 		deps.logger.warn(
 			"device discovery: persisted selected_video_input is absent from the engine device list — clearing stale selection",

--- a/apps/backend/src/tests/devices.test.ts
+++ b/apps/backend/src/tests/devices.test.ts
@@ -31,6 +31,7 @@ function makeDeps(
 		getEngineDevices: async () => null,
 		getSelectedVideoInput: () => undefined,
 		clearSelectedVideoInput: () => undefined,
+		getRememberedDeviceKind: () => undefined,
 		notify: () => undefined,
 		broadcast: () => undefined,
 		onDevicesChanged: () => undefined,
@@ -263,5 +264,99 @@ describe("device registry", () => {
 			activeSourceId: "/dev/video63",
 			presentSourceIds: ["/dev/video0"],
 		});
+	});
+});
+
+describe("reconcileSelectedInput — the libuvc release gap is not a disconnect", () => {
+	const OSMO = {
+		input_id: "/dev/video1",
+		device_path: "/dev/video1",
+		display_name: "DJIPocket3: OsmoPocket3",
+		kind: "uvc_h264",
+		media_class: "video",
+	} as const;
+
+	// The engine answers `null` (unreachable) and then a list, reproducing the
+	// unreachable→reachable edge every stream start/stop crosses when the
+	// session's control socket closes.
+	function engineSequence(lists: (readonly unknown[] | null)[]) {
+		let i = 0;
+		return async () => {
+			const next = lists[Math.min(i, lists.length - 1)];
+			i += 1;
+			return next as never;
+		};
+	}
+
+	test("a uvc_h264 selection absent for ONE observation is NOT cleared", async () => {
+		const clearSelectedVideoInput = mock(() => undefined);
+		const notify = mock(() => undefined);
+		const registry = createDeviceRegistry(
+			makeDeps({
+				getEngineDevices: engineSequence([null, []]),
+				getSelectedVideoInput: () => "/dev/video1",
+				getRememberedDeviceKind: () => "uvc_h264",
+				clearSelectedVideoInput,
+				notify,
+			}),
+		);
+
+		await registry.rescan(); // engine unreachable
+		await registry.rescan(); // reachable, camera still in its release gap
+
+		expect(clearSelectedVideoInput).not.toHaveBeenCalled();
+		expect(notify).not.toHaveBeenCalled();
+	});
+
+	test("a uvc_h264 selection that comes BACK clears the pending absence", async () => {
+		const clearSelectedVideoInput = mock(() => undefined);
+		const registry = createDeviceRegistry(
+			makeDeps({
+				getEngineDevices: engineSequence([null, [], null, [OSMO], null, []]),
+				getSelectedVideoInput: () => "/dev/video1",
+				getRememberedDeviceKind: () => "uvc_h264",
+				clearSelectedVideoInput,
+			}),
+		);
+
+		for (let i = 0; i < 6; i += 1) await registry.rescan();
+
+		expect(clearSelectedVideoInput).not.toHaveBeenCalled();
+	});
+
+	test("a uvc_h264 selection absent across TWO consecutive edges is cleared", async () => {
+		const clearSelectedVideoInput = mock(() => undefined);
+		const notify = mock(() => undefined);
+		const registry = createDeviceRegistry(
+			makeDeps({
+				getEngineDevices: engineSequence([null, [], null, []]),
+				getSelectedVideoInput: () => "/dev/video1",
+				getRememberedDeviceKind: () => "uvc_h264",
+				clearSelectedVideoInput,
+				notify,
+			}),
+		);
+
+		for (let i = 0; i < 4; i += 1) await registry.rescan();
+
+		expect(clearSelectedVideoInput).toHaveBeenCalledTimes(1);
+		expect(notify).toHaveBeenCalledTimes(1);
+	});
+
+	test("a v4l2-driven kind still clears on the FIRST absence (control)", async () => {
+		const clearSelectedVideoInput = mock(() => undefined);
+		const registry = createDeviceRegistry(
+			makeDeps({
+				getEngineDevices: engineSequence([null, []]),
+				getSelectedVideoInput: () => "/dev/video0",
+				getRememberedDeviceKind: () => "hdmi",
+				clearSelectedVideoInput,
+			}),
+		);
+
+		await registry.rescan();
+		await registry.rescan();
+
+		expect(clearSelectedVideoInput).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
## What

`reconcileSelectedInput` no longer clears the operator's persisted
`selected_video_input` the first time a **libuvc-driven** camera is missing from the
engine's device list. For a kind that releases its v4l2 node, absence now takes a
SECOND consecutive engine-authored observation before it counts as a disconnect.

Every other device kind keeps byte-identical clear-on-first-absence behaviour.

## Why

This is the first half of the user's "my stream won't start" bug.

`reconcileSelectedInput` runs on the engine's **unreachable → reachable edge**. For a
libuvc camera that edge *is* the engine letting go of the device: a stream start/stop
closes the session's control socket (so `getEngineDevices()` answers `null`), and the
camera's `/dev/videoN` is re-registered only after libuvc reattaches `uvcvideo` — a gap
measured at **0.4–2.0 s** on this hardware.

The first list the engine answers inside that window truthfully omits a camera that is
perfectly healthy. Clearing on it destroyed a working selection and told the operator
*"Your selected video input is no longer available and has been cleared"*. Every
subsequent start then had **no video input at all** — which is how a device ends up
unable to stream.

Confirmed in the production journal (Rock 5B+, DJI Osmo Pocket 3):

```
device discovery: persisted selected_video_input is absent from the engine device list
  — clearing stale selection {"selected":"/dev/video1"}
```

fired within 20 ms of every failed start, repeatedly, for a camera that both `lsusb` and
the engine still had.

The rule that answers this already exists in CeraUI: `releasesV4l2Node(kind)`
(`held-devices.ts`), the mirror of cerastream's `engine::held_devices`. The selection's
kind is resolved from the `last_seen_devices` memory, matched by current id or by a
retired `previousIds` path, so a renumbered camera still resolves.

## How to verify

```bash
bun test src/tests/devices.test.ts     # 19 pass, 4 new
bun tsc --noEmit
```

The four new tests cover: absence-once does not clear for a releasing kind; absence-twice
does clear; a reappearance between the two observations resets the run; and the control —
a v4l2 kind still clears on first absence.

**Board proof** (Rock 5B+ `192.168.78.131`, DJI Osmo Pocket 3): **12 → 0** false
`clearing stale selection` events across 6 rapid select/start cycles, 3 engine restarts,
a mid-stream restart, and a forced `uvcvideo` unbind/rebind. `selected_video_input` read
`/dev/video1` before, during and after every one of those edges — including while the
node genuinely did not exist.

## Risks

- A genuinely unplugged UVC-H.264/H.265 camera keeps its stale selection until a second
  engine reconnect confirms the absence. Deliberate, and strictly safer than the previous
  behaviour: the source row already renders `lost`, and the operator picking any other
  source overwrites the selection immediately.
- Scoped to one function in `devices.ts`. No wire change, no schema change, no new
  dependency, no engine change.
- The deferral is not renewable — a single healthy observation resets the run, so polling
  cannot extend it indefinitely.
