### PR TITLE
fix(audio): a launch owns the audio card — the idle meter's watchdogs must yield

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -536,6 +536,53 @@ un-retracted state lives in the ENGINE's meter sidecar.
 - **A missing client is the one case that does NOT re-arm** — there is nothing to
   re-assert against, and the next connect's first frame arms it again.
   `stopAudioMeterBridge` clears it.
+- **It yields to a stream LAUNCH** (`launchInFlight()`), and so does the
+  content watchdog — see the section below.
+
+**A RE-ASSERT IS AN ACQUISITION, SO IT MUST NEVER RACE A LAUNCH.** Both watchdogs
+recover through the same `reassertPreference`, which re-OPENS the selected card.
+A launch RELEASES the idle meter on purpose (`audio_meter_begin_stream()`), so
+levels legitimately stop — and `noteFrameAbsence` read those ~12 missed frames as
+a stuck feed and grabbed the card back while the start's pre-flight was still
+opening it. Measured on a Rock 5B+ with a DJI Osmo Pocket 3:
+
+```
+20:03:22.466  streaming.start issued
+20:03:25.024  audio-meter bridge: no audio level for 2500 ms … re-asserting
+20:03:25.026  audio-meter bridge: re-asserted the preference hw:CARD=DJIPocket3
+20:03:27.142  audio-device-unavailable: ALSA capture device 'hw:CARD=DJIPocket3'
+              is busy or unavailable   class=start_invalid retry=not_retriable
+```
+
+`deferReassertToLaunch()` gates both watchdogs on
+`launchIsAcquiringAudio(getStreamLifecycleState())` — the lifecycle the
+orchestrator already publishes, NOT a parallel signal. Three properties are
+load-bearing:
+
+- **`starting` is the ONLY gated state.** A successful launch leaves for
+  `streaming` and a failed one for `idle`, so BOTH outcomes re-arm the watchdog
+  immediately, and the state is bounded by the launch phase deadlines — the
+  deferral can never become a permanent suppression. `reconfiguring` is excluded
+  because it runs from `streaming`, where the idle meter does not hold the card.
+- **The gate sits immediately BEFORE `lastReassertAt` is stamped**, so a deferred
+  window does not spend the 30 s floor. Moving it one line later silently turns a
+  deferral into half a minute of real suppression after the launch resolved.
+- **The re-arm still happens above every gate** (unchanged), so a genuinely dead
+  feed is watched throughout the launch and recovers on the very next window.
+
+**This is necessary but NOT sufficient, and the remainder is engine-side.** It
+removes ONE of two acquirers. The other is the idle meter's ordinary hold:
+`syncAudioMeterPreference` pushes the preference on a source/`asrc` change, the
+engine opens the card for the idle meter, and a launch seconds later needs that
+same card. Board measurement with the watchdog gated and cerastream's bounded
+1.5 s self-release retry deployed: 0/5 clean starts when the source is re-selected
+just before starting, 2/5 when it is not — the same rate as before the gate. CeraUI
+cannot close it: the engine has no "meter nothing" value (`meter_device: null`
+means *auto-pick*, which re-opens a card rather than releasing one), so the
+idle-meter → stream handoff can only be made atomic inside cerastream. Do NOT
+"fix" the remainder by widening this gate to `streaming`, and do NOT delete the
+gate because the start still fails — the watchdog re-acquisition is a real,
+separately-proven racer.
 
 **"No audio" is NOT "Auto", and only the picker value can tell them apart.**
 `resolveMeterPreference` answered `null` for both, and `null` on the wire means
@@ -2490,6 +2537,7 @@ plus the frontend half `apps/frontend/src/tests/notification-recovery-ingestion.
 - Don't re-push the meter preference only when `asrc` changed — under "Auto" the resolved card is a function of the selected VIDEO source (rule 3) and of the ENGINE's audio list (rule 5), so `input.source` changes and `reresolveAudioForEngineChange` must re-push too. An unchanged pick is deduped by the bridge and costs nothing; a missed changed one is permanent, because `set_preferred_device` early-returns on an unchanged value.
 - Don't leave a pick change to be corrected by the next engine frame — the level already broadcast belongs to the previous pick, so `noteMeterSelection()` must retire it immediately (and must stay silent on an unchanged pick, or every re-enumeration blinks the meter).
 - Don't let the meter's ONLY recovery path be driven by arriving frames — that gates the retraction on the very signal whose absence IS the failure, and a feed that stops leaves a bare `Meter unavailable` forever. Keep BOTH watchdogs: `noteForeignCardLevel` for frame CONTENT and `armFrameAbsenceWatchdog`/`noteFrameAbsence` for frame ABSENCE. And don't "simplify" the absence one into a poll that compares `now()` against a last-frame stamp: the debounce-on-arrival shape is what makes expiry *proof* of absence and an unarmed watchdog *proof* that no baseline frame has arrived yet — a poll needs a second flag for the first-connect case and gets it wrong. Don't move the re-arm below the silenced/Auto gates either (a silenced feed would stop being watched and never resume), and don't give it its own reassert cadence — it shares `lastReassertAt` so the two triggers can never double up.
+- Don't let either audio-meter watchdog re-assert while a stream launch is in flight — a re-assert is an ACQUISITION of the selected card, and the engine's bounded self-release retry cannot beat a peer that is actively taking the device back (the start dies `audio-device-unavailable … not_retriable`). Gate both on `launchInFlight()`, keep the check immediately BEFORE `lastReassertAt` is stamped (or a deferral silently becomes 30 s of suppression), and keep the re-arm above every gate. Don't widen the gate past `starting` either: `streaming`/`idle` are where a genuinely dead feed must still be recovered.
 - Don't fold `active_encode` into telemetry preserve-on-omission past the end of a session, and don't let `stop()` rely on a final engine status frame to clear it — a crashed engine sends none, and the stale encode then renders the stopped session under a "Live" badge.
 - Don't clear the raw bridge's `cachedLiveness`/`cachedPassthrough` from its own socket `close`/`error` — that is a CONNECTION blip, not a session boundary, and wiping there hands `collectRealLiveness()` an `undefined` it can only read as a cold start, so a dead stream reports `healthy` off raw process liveness. Let `FRAMES_FRESHNESS_MS` age the retained reading out instead.
 - Don't apply that same rule to the SESSION-scoped control client — it is the inverse case. Losing `cerastream-backend.ts`'s `this.client` retires the session (the published client cannot reconnect and a restarted engine has no session to resume), so route every session RPC through `withSessionClient` and never swallow a `CerastreamConnectionError` without calling `noteConnectionLoss`. And don't treat `this.client !== undefined` as evidence the engine is reachable — that is exactly how `reconcileRuntimeState()` re-affirmed a phantom "streaming" state off stale telemetry until the backend was restarted.

--- a/apps/backend/src/modules/streaming/audio-meter-bridge.ts
+++ b/apps/backend/src/modules/streaming/audio-meter-bridge.ts
@@ -47,7 +47,7 @@ import type {
 	Subscription,
 } from "@ceralive/cerastream";
 import { connect as defaultConnect } from "@ceralive/cerastream";
-import type { AudioLevelMessage } from "@ceraui/rpc/schemas";
+import type { AudioLevelMessage, LifecycleState } from "@ceraui/rpc/schemas";
 import { logger as defaultLogger } from "../../helpers/logger.ts";
 import { getConfig } from "../config.ts";
 import { setup } from "../setup.ts";
@@ -58,6 +58,7 @@ import {
 	resolveMeterPreference,
 } from "./audio.ts";
 import { supportsMeterDevicePreference } from "./cerastream-backend.ts";
+import { getStreamLifecycleState } from "./stream-lifecycle-status.ts";
 
 /** Backoff bounds for the initial-connect retry. Mirrors `engine-reconnect.ts`. */
 export const AUDIO_METER_CONNECT_BASE_MS = 2_000;
@@ -106,6 +107,12 @@ export interface AudioMeterBridgeDeps {
 	 * yourself" and the engine has no "meter nothing" value.
 	 */
 	meterSilenced: () => boolean;
+	/**
+	 * Whether a stream launch is currently acquiring the audio card. A launch
+	 * RELEASES the idle meter on purpose, so the level feed stopping is the
+	 * handoff working — not the fault either watchdog exists to recover.
+	 */
+	launchInFlight: () => boolean;
 	logger: AudioMeterBridgeLogger;
 	random: () => number;
 	now: () => number;
@@ -183,6 +190,18 @@ export function toAudioLevelMessage(
 	};
 }
 
+/**
+ * `starting` is the ONE lifecycle state in which the launch — not the idle meter
+ * — owns the audio card. It is also the only one that is BOUNDED by the launch
+ * phase deadlines, so deferring here can never become a permanent suppression:
+ * a successful launch leaves for `streaming`, a failed one for `idle`, and the
+ * watchdog is live again in both. `reconfiguring` is deliberately NOT included —
+ * it runs from `streaming`, where the meter is not holding the card anyway.
+ */
+export function launchIsAcquiringAudio(lifecycle: LifecycleState): boolean {
+	return lifecycle === "starting";
+}
+
 function defaultDeps(): AudioMeterBridgeDeps {
 	return {
 		connect: defaultConnect,
@@ -199,6 +218,7 @@ function defaultDeps(): AudioMeterBridgeDeps {
 		meterPreference: () => resolveMeterPreference(getConfig().asrc),
 		meterPreferencePresent: () => isMeterPreferenceDevicePresent(),
 		meterSilenced: () => isMeterSilencedByPick(getConfig().asrc),
+		launchInFlight: () => launchIsAcquiringAudio(getStreamLifecycleState()),
 		logger: defaultLogger,
 		random: Math.random,
 		now: Date.now,
@@ -277,6 +297,26 @@ function foreignCardReason(
  * that is simply permanent — a selected card with no capture PCM — costs one
  * cheap pair of reloads per interval and never a loop.
  */
+/**
+ * Both watchdogs re-assert through the SAME `reassertPreference`, which re-OPENS
+ * the selected card. While a launch is acquiring that card the re-assert is not a
+ * recovery, it is a competing acquisition — the engine's own bounded self-release
+ * retry cannot win against a peer actively taking the device back, so the start
+ * fails `audio-device-unavailable … not_retriable` (board, 2026-07-30, 2/6 starts).
+ *
+ * Checked immediately before `lastReassertAt` is stamped, so a deferred window
+ * never spends the 30 s floor: the instant the launch resolves the next window
+ * re-asserts for real. The watchdog is already re-armed by then, so this defers
+ * the recovery, it never disables it.
+ */
+function deferReassertToLaunch(deps: AudioMeterBridgeDeps): boolean {
+	if (!deps.launchInFlight()) return false;
+	deps.logger.debug(
+		"audio-meter bridge: a stream launch is acquiring the audio card — deferring the idle-meter re-assert until it resolves",
+	);
+	return true;
+}
+
 function noteForeignCardLevel(deps: AudioMeterBridgeDeps): void {
 	if (!state || state.stopped) return;
 	const now = deps.now();
@@ -294,6 +334,7 @@ function noteForeignCardLevel(deps: AudioMeterBridgeDeps): void {
 	) {
 		return;
 	}
+	if (deferReassertToLaunch(deps)) return;
 	state.lastReassertAt = now;
 	void reassertPreference("a sustained foreign-card reading");
 }
@@ -355,6 +396,7 @@ function noteFrameAbsence(): void {
 	) {
 		return;
 	}
+	if (deferReassertToLaunch(deps)) return;
 	state.lastReassertAt = now;
 	deps.logger.warn(
 		`audio-meter bridge: no audio level for ${AUDIO_METER_FRAME_ABSENCE_MS} ms while ${meter_device} is selected — re-asserting the preference`,

--- a/apps/backend/src/tests/audio-meter-bridge.test.ts
+++ b/apps/backend/src/tests/audio-meter-bridge.test.ts
@@ -5,7 +5,7 @@ import type {
 	EventParams,
 	Subscription,
 } from "@ceralive/cerastream";
-import type { AudioLevelMessage } from "@ceraui/rpc/schemas";
+import { type AudioLevelMessage, LIFECYCLE_STATES } from "@ceraui/rpc/schemas";
 import {
 	AUDIO_METER_FRAME_ABSENCE_MS,
 	AUDIO_METER_MISMATCH_GRACE_MS,
@@ -15,6 +15,7 @@ import {
 	alsaCardKey,
 	initAudioMeterBridge,
 	isForeignCardLevel,
+	launchIsAcquiringAudio,
 	settleAudioMeterBridge,
 	stopAudioMeterBridge,
 	syncAudioMeterPreference,
@@ -55,6 +56,7 @@ function harness(connectOutcomes: boolean[], schemaVersion = "0.9.0") {
 	let preference: string | null = "hw:CARD=usbaudio";
 	let preferencePresent = false;
 	let silenced = false;
+	let launching = false;
 	let clock = 1_000;
 	let reloadRejects = false;
 
@@ -95,6 +97,7 @@ function harness(connectOutcomes: boolean[], schemaVersion = "0.9.0") {
 		meterPreference: () => preference,
 		meterPreferencePresent: () => preferencePresent,
 		meterSilenced: () => silenced,
+		launchInFlight: () => launching,
 		logger: silent,
 		random: () => 0.5,
 		now: () => clock,
@@ -133,6 +136,9 @@ function harness(connectOutcomes: boolean[], schemaVersion = "0.9.0") {
 		},
 		setSilenced: (next: boolean) => {
 			silenced = next;
+		},
+		setLaunching: (next: boolean) => {
+			launching = next;
 		},
 		advance: async (ms: number) => {
 			clock += ms;
@@ -671,6 +677,144 @@ describe("audio-meter bridge — a feed that STOPS is re-asserted, not left dead
 
 		h.emit(levelEvent);
 		expect(h.broadcasts.at(-1)).toEqual(toAudioLevelMessage(levelEvent));
+	});
+});
+
+// The board race (live QA, 2026-07-30, Rock 5B+ / DJI Osmo Pocket 3). A stream
+// start releases the idle meter ON PURPOSE, so levels legitimately stop — and the
+// frame-absence watchdog read that as a stuck feed and re-opened the very card the
+// launch was mid-way through acquiring:
+//
+//   20:03:22.466  streaming.start issued
+//   20:03:25.024  audio-meter bridge: no audio level for 2500 ms … re-asserting
+//   20:03:25.026  audio-meter bridge: re-asserted the preference hw:CARD=DJIPocket3
+//   20:03:27.142  audio-device-unavailable … 'hw:CARD=DJIPocket3' is busy … not_retriable
+//
+// cerastream's own bounded 1.5 s self-release retry (b6f40ea) cannot win that —
+// it is not racing a lagging release, it is racing a PEER that is actively
+// re-acquiring. 2/6 starts still failed with the retry in place. The ordering has
+// to be fixed here: absence of levels is not evidence of a stuck feed while a
+// launch is in flight, because the launch is precisely what silenced them.
+describe("audio-meter bridge — a launch owns the card; the watchdog yields to it", () => {
+	async function connectedAndMetering() {
+		const h = harness([true]);
+		h.setPreference("hw:CARD=DJIPocket3");
+		h.setPreferencePresent(true);
+		initAudioMeterBridge(h.deps);
+		await settleAudioMeterBridge();
+		h.emit(levelEvent);
+		h.reloads.length = 0;
+		return h;
+	}
+
+	test("never re-asserts while a launch is acquiring the card", async () => {
+		const h = await connectedAndMetering();
+
+		// `streaming.start` issued: the idle meter is released for the handoff, so
+		// the level feed goes quiet for a reason that is CORRECT, not broken.
+		h.setLaunching(true);
+
+		await h.advance(AUDIO_METER_FRAME_ABSENCE_MS);
+		await h.fireNextTimer();
+		await h.advance(0);
+
+		expect(h.reloads).toEqual([]);
+	});
+
+	test("stays ARMED while suppressed — a launch defers the watchdog, never disables it", async () => {
+		const h = await connectedAndMetering();
+		h.setLaunching(true);
+
+		await h.advance(AUDIO_METER_FRAME_ABSENCE_MS);
+		await h.fireNextTimer();
+		await h.advance(0);
+
+		expect(h.pendingTimers()).toBe(1);
+	});
+
+	// The whole point of deferring rather than dropping: a feed that is genuinely
+	// dead must still be recovered the moment the launch stops owning the card.
+	test("re-asserts on the very next window once the launch resolves", async () => {
+		const h = await connectedAndMetering();
+		h.setLaunching(true);
+
+		await h.advance(AUDIO_METER_FRAME_ABSENCE_MS);
+		await h.fireNextTimer();
+		await h.advance(0);
+		expect(h.reloads).toEqual([]);
+
+		// Launch settled (either way) and no frame has arrived — now it IS a fault.
+		h.setLaunching(false);
+		await h.advance(AUDIO_METER_FRAME_ABSENCE_MS);
+		await h.fireNextTimer();
+		await h.advance(0);
+
+		expect(h.reloads).toEqual([
+			{ audio: { meter_device: null } },
+			{ audio: { meter_device: "hw:CARD=DJIPocket3" } },
+		]);
+	});
+
+	// A suppressed window must not consume the 30 s floor: that would convert a
+	// deferral into a half-minute of real suppression AFTER the launch resolved.
+	test("a suppressed window does not spend the re-assert interval floor", async () => {
+		const h = await connectedAndMetering();
+		h.setLaunching(true);
+
+		await h.advance(AUDIO_METER_FRAME_ABSENCE_MS);
+		await h.fireNextTimer();
+		await h.advance(0);
+
+		h.setLaunching(false);
+		// Deliberately well inside AUDIO_METER_REASSERT_INTERVAL_MS of the
+		// suppressed window — if that window had stamped `lastReassertAt`, this
+		// would be floored out and the meter would stay dead.
+		await h.advance(AUDIO_METER_FRAME_ABSENCE_MS);
+		await h.fireNextTimer();
+		await h.advance(0);
+
+		expect(h.reloads).toHaveLength(2);
+	});
+
+	// The content watchdog shares `reassertPreference`, so it re-opens the same
+	// card by the same path and carries the identical risk.
+	test("the foreign-card watchdog yields to a launch too", async () => {
+		const h = await connectedAndMetering();
+		const foreign = {
+			...levelEvent,
+			source: { identity: "card:Rx", owner: "sidecar" as const },
+		};
+
+		h.setLaunching(true);
+		h.emit(foreign);
+		await h.advance(AUDIO_METER_MISMATCH_GRACE_MS);
+		h.emit(foreign);
+		await h.advance(0);
+
+		expect(h.reloads).toEqual([]);
+
+		// And it recovers on the next foreign frame once the launch is done.
+		h.setLaunching(false);
+		h.emit(foreign);
+		await h.advance(0);
+
+		expect(h.reloads).toHaveLength(2);
+	});
+});
+
+// The production binding of the gate. "Resolves" must mean BOTH outcomes: a
+// successful launch lands in `streaming`, a failed one in `idle`, and the
+// watchdog has to be live again in each. Only the launch window itself defers.
+describe("audio-meter bridge — launchIsAcquiringAudio maps the lifecycle", () => {
+	test("defers during `starting` and in NO other lifecycle state", () => {
+		const deferred = LIFECYCLE_STATES.filter((s) => launchIsAcquiringAudio(s));
+
+		expect(deferred).toEqual(["starting"]);
+	});
+
+	test("a resolved launch — success OR failure — re-arms the watchdog", () => {
+		expect(launchIsAcquiringAudio("streaming")).toBe(false);
+		expect(launchIsAcquiringAudio("idle")).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## What

Both idle audio-meter watchdogs (`noteFrameAbsence` — frame absence, and
`noteForeignCardLevel` — frame content) now stand down while a stream launch is
acquiring the audio card, and resume the moment the launch resolves either way.

> **Necessary, but not sufficient on its own.** This closes one of two racers for
> the ALSA card. It does **not** by itself fix the operator-facing "stream won't
> start" failure — see *Board result* below. Please read that section before
> assuming this resolves the bug.

## Why

Both watchdogs recover a dead meter feed by re-asserting the engine preference
through `null`, which **re-opens the selected ALSA card**. Neither knew anything
about a stream launch — and a launch is precisely when re-opening that card is
destructive. `audio_meter_begin_stream()` releases the idle meter *on purpose*,
so levels legitimately stop; `noteFrameAbsence` read those ~12 missed frames as a
stuck feed and grabbed the card back while the start's pre-flight was still trying
to open it.

Measured on a Rock 5B+ with a DJI Osmo Pocket 3 — failing cycle 5 of 6:

```
20:03:22.466  streaming.start issued
20:03:25.024  audio-meter bridge: no audio level for 2500 ms … re-asserting the preference
20:03:25.026  audio-meter bridge: re-asserted the idle-meter preference hw:CARD=DJIPocket3
20:03:27.142  audio-device-unavailable: ALSA capture device 'hw:CARD=DJIPocket3'
              is busy or unavailable   class=start_invalid code=-32602 retry=not_retriable
```

cerastream's bounded 1.5 s self-release retry cannot win this from its side: it
demonstrably runs (failing starts grew from ~3.5 s to 4.68 s / 4.99 s, i.e. the
whole window is spent) but it is not racing a lagging release — it is racing a peer
that is *actively re-acquiring* the device.

## How it works

`launchInFlight` joins the existing `meterSilenced` family of "reasons we refuse to
act today" gates, wired to the lifecycle the orchestrator **already** publishes
(`getStreamLifecycleState() === "starting"`) rather than a new parallel signal.

Three properties are load-bearing:

- **`starting` is the only gated state.** A successful launch leaves for
  `streaming`, a failed one for `idle`, so both outcomes re-arm the watchdog
  immediately; the state is bounded by the launch phase deadlines, so the deferral
  can never become permanent suppression. `reconfiguring` is excluded — it runs
  from `streaming`, where the idle meter isn't holding the card.
- **The gate sits immediately before `lastReassertAt` is stamped**, so a deferred
  window doesn't spend the 30 s interval floor. One line later would silently turn
  a deferral into half a minute of real suppression after the launch resolved.
- **The re-arm still happens above every gate** (unchanged), so a genuinely dead
  feed stays watched throughout the launch and recovers on the very next window.

## How to verify

```bash
bun test src/tests/audio-meter-bridge.test.ts    # 53 pass, 7 new
bun tsc --noEmit
```

Five behavioural tests reproduce the race directly. **Three of them fail against
the pre-fix tree** (the watchdog re-asserts `hw:CARD=DJIPocket3` mid-launch) and
pass with the gate, so the fix is proven necessary rather than plausible. Two more
pin the production binding: `starting` is the only lifecycle state that defers, and
both `streaming` (success) and `idle` (failure) re-arm.

Full backend suite: **2614 pass**. The single failure (`status asrcs coherence`) is
pre-existing and reproduces identically on a clean `origin/main` checkout.

## Board result — necessary, not sufficient

On the board the gate fires on **every** launch, at the same +2.6 s offset as the
original failure, and the watchdog resumes as soon as the launch resolves:

```
20:38:20.730  streaming.start issued
20:38:23.320  a stream launch is acquiring the audio card — deferring the re-assert
20:38:26.677  no audio level for 2500 ms … re-asserting the preference
20:38:26.678  re-asserted the idle-meter preference hw:CARD=DJIPocket3
```

No post-fix launch re-acquired the card. That defect is closed.

The start can still fail, because this removed only **one** of two acquirers. The
other is the idle meter's ordinary hold: `syncAudioMeterPreference` pushes the
preference, the engine opens the card for the idle meter, and a launch seconds
later needs that same card. With this gate **and** cerastream's 1.5 s self-release
retry deployed:

| Run (meter confirmed armed on `card:DJIPocket3` every attempt) | Clean starts |
|---|---|
| Re-select the source, then start | **0/5** |
| Selection already persisted, start only | **2/5** |

— the same rate as before the gate. CeraUI cannot close the remainder: the engine
exposes no "meter nothing" value (`meter_device: null` means *auto-pick*, which
re-opens a card rather than releasing one), so the idle-meter → stream handoff can
only be made atomic inside cerastream (`audio_meter_begin_stream()` releasing
before the capture leg acquires, instead of racing it). That is engine-side work
and deliberately out of scope here.

## Risks

- While a launch is in flight, a genuinely dead meter feed is not recovered until
  the launch resolves. That window is bounded by the launch phase deadlines and is
  strictly preferable to the alternative, which is failing the start outright.
- Scoped to `audio-meter-bridge.ts` — one new injected dep and two call sites. No
  wire change, no schema change, no engine change, no new dependency.
- Do **not** "fix" the remaining failure by widening the gate to `streaming`, and
  do not drop the gate because the start can still fail — the watchdog
  re-acquisition is a real, separately-proven racer.
