### PR TITLE
fix(streaming): one node path, one owner; bound the engine close and let a failed stop recover

### DIFF
--- a/apps/backend/src/modules/streaming/cerastream-backend.ts
+++ b/apps/backend/src/modules/streaming/cerastream-backend.ts
@@ -128,6 +128,7 @@ import {
 	createLaunchTransaction,
 	type LaunchTransaction,
 } from "./launch-transaction.ts";
+import { ENGINE_CLOSE_DEADLINE_MS } from "./start-lifecycle-timing.ts";
 import type {
 	BackendErrorListener,
 	BitrateParams,
@@ -724,6 +725,28 @@ export class CerastreamBackend implements StreamingBackend {
 		return client.start(params as StartParams);
 	}
 
+	// A close that never answers is no more informative than one that rejects —
+	// which this path already treats as "proceed" — so bound it and let the stop
+	// complete either way rather than stranding the session.
+	private closeWithinDeadline(
+		client: CerastreamClient | undefined,
+	): Promise<void> {
+		if (client === undefined) return Promise.resolve();
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const bound = new Promise<void>((resolve) => {
+			timer = this.deps.scheduleTimeout(() => {
+				this.deps.logger.warn(
+					"cerastream: the engine did not close its control socket within the bound; completing the stop anyway",
+					{ deadlineMs: ENGINE_CLOSE_DEADLINE_MS },
+				);
+				resolve();
+			}, ENGINE_CLOSE_DEADLINE_MS);
+		});
+		return Promise.race([client.close(), bound]).finally(() => {
+			if (timer !== undefined) this.deps.cancelTimeout(timer);
+		});
+	}
+
 	stop(onStopped: () => void): boolean {
 		if (!this.active) return false;
 		this.active = false;
@@ -740,7 +763,7 @@ export class CerastreamBackend implements StreamingBackend {
 				});
 			});
 			try {
-				await client?.close();
+				await this.closeWithinDeadline(client);
 			} catch {
 				// already closing
 			} finally {

--- a/apps/backend/src/modules/streaming/sources.ts
+++ b/apps/backend/src/modules/streaming/sources.ts
@@ -360,9 +360,20 @@ function identityKey(device: LastSeenDevice): string {
 		: `id:${device.id}`;
 }
 
-/** Does this remembered device answer to `id`, currently or under a retired path? */
-function remembersId(device: LastSeenDevice, id: string): boolean {
-	return device.id === id || (device.previousIds?.includes(id) ?? false);
+/**
+ * Resolve `id` against remembered devices, preferring whoever CURRENTLY holds
+ * the node path over anyone who merely retired it. `/dev/videoN` is reused
+ * across replugs, so several devices can legitimately remember the same path —
+ * a retired alias is only trustworthy when nobody holds the path outright.
+ */
+function findRememberingId(
+	devices: readonly LastSeenDevice[],
+	id: string,
+): LastSeenDevice | undefined {
+	return (
+		devices.find((d) => d.id === id) ??
+		devices.find((d) => d.previousIds?.includes(id) === true)
+	);
 }
 
 /**
@@ -414,8 +425,9 @@ function collectLostCandidates(input: BuildSourcesInput): LastSeenDevice[] {
 	}
 	const configSource = input.configSource;
 	if (configSource !== undefined) {
-		const persisted = (input.lastSeenDevices ?? []).find((d) =>
-			remembersId(d, configSource),
+		const persisted = findRememberingId(
+			input.lastSeenDevices ?? [],
+			configSource,
 		);
 		if (persisted !== undefined && !candidates.has(identityKey(persisted)))
 			candidates.set(identityKey(persisted), persisted);
@@ -612,9 +624,7 @@ export function resolveSourceIdentity(
 	lastSeenDevices?: readonly LastSeenDevice[],
 ): string {
 	if (sources.some((s) => s.id === sourceId)) return sourceId;
-	const stableId = (lastSeenDevices ?? []).find((d) =>
-		remembersId(d, sourceId),
-	)?.stableId;
+	const stableId = findRememberingId(lastSeenDevices ?? [], sourceId)?.stableId;
 	if (stableId === undefined || stableId === "") return sourceId;
 	const successor = sources.find(
 		(s) => s.origin === "capture" && s.stableId === stableId,
@@ -735,6 +745,45 @@ function dedupeByIdentity(
 }
 
 /**
+ * Give every node path exactly ONE owner, freshest-first-wins.
+ *
+ * Identity folding deliberately keeps two physically different devices as two
+ * rows — but each may have occupied `/dev/videoN` at different times, and both
+ * then go on claiming it as their current `id`. Every consumer resolving a
+ * persisted `config.source` takes the first row answering to that id, so the
+ * operator's selected camera can silently become whichever device was seen
+ * most recently.
+ *
+ * The first claimant (the freshest, since observations lead the merge) keeps
+ * the path; a later one demotes it to a retired alias so it stays resolvable
+ * once nobody holds it outright. A row with no stable identity has no other
+ * name to fall back on, so it is dropped rather than left ambiguous.
+ */
+function claimNodePathsOnce(
+	devices: readonly LastSeenDevice[],
+): LastSeenDevice[] {
+	const claimed = new Set<string>();
+	const kept: LastSeenDevice[] = [];
+	for (const device of devices) {
+		if (!claimed.has(device.id)) {
+			claimed.add(device.id);
+			kept.push(device);
+			continue;
+		}
+		if (device.stableId === undefined || device.stableId === "") continue;
+		claimed.add(device.stableId);
+		kept.push({
+			...device,
+			id: device.stableId,
+			previousIds: [
+				...new Set([device.id, ...(device.previousIds ?? [])]),
+			].slice(0, RETIRED_ID_MEMORY),
+		});
+	}
+	return kept;
+}
+
+/**
  * LRU-merge freshly-observed snapshots into the persisted last-seen list:
  * most-recently-observed first, then prior entries whose device was not
  * re-observed. Over the cap, evict least-recent from the tail — EXCEPT the
@@ -746,7 +795,9 @@ function mergeLastSeenLru(
 	observed: readonly LastSeenDevice[],
 	configSource: string | undefined,
 ): LastSeenDevice[] {
-	const ordered = dedupeByIdentity([...observed, ...current]);
+	const ordered = claimNodePathsOnce(
+		dedupeByIdentity([...observed, ...current]),
+	);
 	if (ordered.length <= LAST_SEEN_DEVICES_CAP) return ordered;
 
 	const configuredIndex =

--- a/apps/backend/src/modules/streaming/start-lifecycle-timing.ts
+++ b/apps/backend/src/modules/streaming/start-lifecycle-timing.ts
@@ -21,6 +21,15 @@ export const START_PHASE_DEADLINES_MS: Readonly<
 export const STOP_DEADLINE_MS = 12_000;
 
 /**
+ * Bound on the engine control-socket `close()` the stop path awaits. An engine
+ * still handing `/dev/videoN` back to `uvcvideo` can leave that close pending
+ * forever, and the callback that clears the session runs in its `finally` — so
+ * unbounded, one such stop never completes. Kept well inside `STOP_DEADLINE_MS`
+ * so a slow-but-alive engine still stops normally rather than `stop_failed`.
+ */
+export const ENGINE_CLOSE_DEADLINE_MS = 5_000;
+
+/**
  * Outer bound on `reconfiguring`: the engine's declared worst-case transaction
  * PLUS one stop bound, because a stop requested mid-transaction queues behind it
  * and must still get its own full deadline afterwards. Never apply

--- a/apps/backend/src/modules/streaming/stream-session-orchestrator.ts
+++ b/apps/backend/src/modules/streaming/stream-session-orchestrator.ts
@@ -384,7 +384,16 @@ export function createStreamSessionOrchestrator(
 	};
 
 	const reconcile = async (): Promise<LifecycleState> => {
-		if (state !== "idle" && state !== "streaming" && state !== "reconciling")
+		// `stop_failed` is included deliberately: a stop we could not confirm
+		// leaves the engine's real state UNKNOWN to us, and adopting its truth is
+		// the only way out. Without this the state latches — `start` refuses while
+		// the stale streaming status stands, and every later cycle is lost.
+		if (
+			state !== "idle" &&
+			state !== "streaming" &&
+			state !== "reconciling" &&
+			state !== "stop_failed"
+		)
 			return state;
 		if (state !== "reconciling") transition("reconciling");
 		const epoch = ++reconciliationEpoch;

--- a/apps/backend/src/tests/source-renumber-dedup.test.ts
+++ b/apps/backend/src/tests/source-renumber-dedup.test.ts
@@ -195,6 +195,74 @@ describe("last_seen_devices — one entry per physical device", () => {
 		);
 	});
 
+	it("two devices that took turns on one node path do not both claim it", async () => {
+		// The live board's state, verbatim: the DJI and the RØDE each occupied
+		// /dev/video1 at some point, so folding by stable identity (correctly)
+		// keeps two rows — and both went on claiming the same id.
+		getConfig().last_seen_devices = [
+			{
+				...osmoSnapshot("/dev/video1"),
+				previousIds: ["/dev/video2", "/dev/video3"],
+			},
+			{
+				id: "/dev/video1",
+				displayName: "RØDE HDMI to USB-C: RØDE HDMI",
+				kind: "mjpeg",
+				pipelineId: "usb_mjpeg",
+				devicePath: "/dev/video1",
+				stableId: RODE_STABLE_ID,
+				previousIds: ["/dev/video4", "/dev/video3"],
+			},
+		];
+
+		// Only the DJI is plugged in, and it holds /dev/video1.
+		await observe([engineDevice("/dev/video1", "uvc_h264", OSMO_STABLE_ID)]);
+
+		const persisted = getConfig().last_seen_devices ?? [];
+		const ids = persisted.map((d) => d.id);
+		expect(new Set(ids).size).toBe(ids.length);
+
+		// Both devices are still remembered — this is a path handover, not an
+		// eviction — and the absent one keeps the path as a retired alias.
+		const osmo = persisted.find((d) => d.stableId === OSMO_STABLE_ID);
+		const rode = persisted.find((d) => d.stableId === RODE_STABLE_ID);
+		expect(osmo?.id).toBe("/dev/video1");
+		expect(rode).toBeDefined();
+		expect(rode?.id).not.toBe("/dev/video1");
+		expect(rode?.previousIds).toContain("/dev/video1");
+	});
+
+	it("a stale config.source resolves to the device that HOLDS the path, not one that retired it", async () => {
+		// The operator selected the DJI at /dev/video1. It is now unplugged, and
+		// the RØDE — which once held /dev/video1 too — is live on a new path.
+		const sources = buildSources({
+			sources: capSources(),
+			devices: [captureDevice("/dev/video5", "mjpeg", RODE_STABLE_ID)],
+			networkIngest: NO_INGEST,
+		});
+		// The RØDE row is listed FIRST, so a first-match lookup adopts its stable
+		// identity and silently re-points the operator's selection at the wrong
+		// camera. Only the DJI actually holds /dev/video1.
+		const persisted: LastSeenDevice[] = [
+			{
+				id: RODE_STABLE_ID,
+				displayName: "RØDE HDMI to USB-C: RØDE HDMI",
+				kind: "mjpeg",
+				pipelineId: "usb_mjpeg",
+				devicePath: "/dev/video5",
+				stableId: RODE_STABLE_ID,
+				previousIds: ["/dev/video1"],
+			},
+			osmoSnapshot("/dev/video1"),
+		];
+
+		// The selected camera is absent, so the selection fails closed rather
+		// than being handed to a different device.
+		expect(resolveSourceIdentity("/dev/video1", sources, persisted)).toBe(
+			"/dev/video1",
+		);
+	});
+
 	it("previousIds round-trips through the persisted config schema", () => {
 		const config = {
 			...runtimeConfigSchema.parse({}),

--- a/apps/backend/src/tests/stop-wedge-recovery.test.ts
+++ b/apps/backend/src/tests/stop-wedge-recovery.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+
+import type { CerastreamClient } from "@ceralive/cerastream";
+import type { RuntimeConfig } from "../helpers/config-schemas.ts";
+import { CerastreamBackend } from "../modules/streaming/cerastream-backend.ts";
+import { createStreamSessionOrchestrator } from "../modules/streaming/stream-session-orchestrator.ts";
+import type { StreamRunOptions } from "../modules/streaming/streaming-backend.ts";
+
+// device-quality-wave3: a stop that never settles used to POISON the session.
+//
+// Board symptom: after a successful stream, `streaming.stop` never completed,
+// the board kept reporting `healthy`/streaming, and every later start was
+// refused — recoverable only with `systemctl restart cerastream`.
+//
+// Two independent defects compose into that wedge:
+//   (1) the engine `client.close()` on the stop path had no bound, so
+//       `stopGeneration` never resolved; and
+//   (2) once the 12 s stop deadline fired, `stop_failed` was UNESCAPABLE —
+//       `start()` only leaves it when the streaming status already reads
+//       false (the failed stop never cleared it) and `reconcile()` refused to
+//       run at all in that state, so the `stop_failed → idle` recovery the
+//       lifecycle table declares was unreachable.
+
+const silentLogger = {
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+};
+
+const RUN_OPTS: StreamRunOptions = {
+	pipeline: "hdmi",
+	host: "127.0.0.1",
+	port: 9000,
+	streamid: "sid",
+};
+
+function makeConfig(): RuntimeConfig {
+	return {
+		pipeline: "hdmi",
+		max_br: 8000,
+		srt_latency: 2000,
+		balancer: "adaptive",
+		selected_video_input: "/dev/video0",
+		acodec: "opus",
+		delay: 0,
+	};
+}
+
+/**
+ * A client whose `close()` NEVER settles — the board's wedged libuvc release,
+ * where the engine stops answering while it hands `/dev/videoN` back to
+ * `uvcvideo`.
+ */
+function makeHangingCloseClient(): CerastreamClient {
+	return {
+		hello: {
+			protocol: "cerastream-ipc/1",
+			schema_version: "0.4.0",
+			engine_version: "test",
+		},
+		start: async () => ({ session_id: "s1", state: "streaming" as const }),
+		stop: async () => new Promise<never>(() => {}),
+		reloadConfig: async (params: unknown) => ({ applied: params }),
+		setBitrate: async (params: { max_bitrate: number }) => ({
+			applied: { max_bitrate: params.max_bitrate },
+		}),
+		switchInput: async (params: { input_id: string; mode: string }) => ({
+			active_input: params.input_id,
+			mode: params.mode as "manual" | "auto",
+		}),
+		listDevices: async () => ({ devices: [] }),
+		subscribeEvents: async () => ({
+			result: { subscribed: [] as never[] },
+			close: () => {},
+		}),
+		// The defect under test: this promise never settles.
+		close: () => new Promise<void>(() => {}),
+	} as unknown as CerastreamClient;
+}
+
+describe("a stop that never settles must not poison the session", () => {
+	test("the engine close is bounded, so the stop still reports completion", async () => {
+		// Given a started session whose engine will never answer the close.
+		const deadlines: Array<{ callback: () => void; delayMs: number }> = [];
+		const backend = new CerastreamBackend({
+			connect: async () => makeHangingCloseClient(),
+			connectOptions: {},
+			getConfig: makeConfig,
+			saveConfig: () => {},
+			bridge: {
+				notify: () => {},
+				notificationExists: () => false,
+				removeNotification: () => {},
+				broadcastStatus: () => {},
+				broadcastBuffering: () => {},
+			},
+			execPath: "cerastream",
+			configPath: "/tmp/stop-wedge-recovery.json",
+			logger: silentLogger,
+			getActiveInput: () => undefined,
+			isEmbeddedAudioActive: () => false,
+			scheduleTimeout: (callback, delayMs) => {
+				deadlines.push({ callback, delayMs });
+				return 1 as unknown as ReturnType<typeof setTimeout>;
+			},
+			cancelTimeout: () => {},
+		});
+		await backend.start(makeConfig(), RUN_OPTS);
+		await backend.settle();
+
+		// When the session is stopped and the engine never closes the socket.
+		let stopped = false;
+		expect(
+			backend.stop(() => {
+				stopped = true;
+			}),
+		).toBe(true);
+		await Promise.resolve();
+
+		// Then a bound was armed for the close...
+		const closeDeadline = deadlines.at(-1);
+		expect(closeDeadline).toBeDefined();
+		closeDeadline?.callback();
+		for (let i = 0; i < 10; i += 1) await Promise.resolve();
+
+		// ...and the stop completes rather than hanging forever.
+		expect(stopped).toBe(true);
+	});
+
+	test("a stop that missed its deadline is recoverable, not terminal", async () => {
+		// Given a runtime stop that never settles (defect 1 above), so the
+		// orchestrator's own 12 s bound is what answers the RPC.
+		let streamingStatus = false;
+		let deadlineCallback: (() => void) | undefined;
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: (() => {
+				let n = 0;
+				return () => `attempt-${++n}`;
+			})(),
+			setStreamingStatus: (value) => {
+				streamingStatus = value;
+			},
+			getStreamingStatus: () => streamingStatus,
+			stopRuntime: () => new Promise<void>(() => {}),
+			// The engine, asked directly, reports it is NOT streaming.
+			queryRuntime: async () => "idle",
+			stopDeadlineMs: 12_000,
+			scheduleTimeout: (callback) => {
+				deadlineCallback = callback;
+				return 1;
+			},
+			cancelTimeout: () => {},
+		});
+		await orchestrator.start({ origin: "ui", launch: async () => {} });
+		expect(streamingStatus).toBe(true);
+
+		const stopping = orchestrator.stop();
+		deadlineCallback?.();
+		expect(await stopping).toEqual({
+			result: "stop_failed",
+			reason: "stop_timeout",
+		});
+		expect(orchestrator.snapshot().state).toBe("stop_failed");
+
+		// When the session reconciles against the engine's actual truth.
+		const reconciled = await orchestrator.reconcile();
+
+		// Then `stop_failed` is escaped rather than latched forever.
+		expect(reconciled).toBe("idle");
+		expect(streamingStatus).toBe(false);
+
+		// And the next start is admissible — one wedged stop no longer costs
+		// the operator every subsequent cycle.
+		expect(
+			await orchestrator.start({ origin: "ui", launch: async () => {} }),
+		).toMatchObject({ result: "started" });
+	});
+});

--- a/packages/rpc/src/schemas/streaming-lifecycle.schema.ts
+++ b/packages/rpc/src/schemas/streaming-lifecycle.schema.ts
@@ -165,6 +165,7 @@ export const LEGAL_LIFECYCLE_TRANSITIONS: ReadonlyArray<readonly [LifecycleState
 		// stop recovery
 		['stop_failed', 'stopping'], // retry the stop
 		['stop_failed', 'idle'], // reconciled/abandoned to idle
+		['stop_failed', 'reconciling'], // ask the engine what is actually true
 		// reconcile outcomes — adopt the engine truth
 		['reconciling', 'streaming'],
 		['reconciling', 'idle'],


### PR DESCRIPTION
Two defects reported from the board this session. One is fully closed and board-proven; the other turned out to be two real bugs that are worth fixing on their own merits but do **not** close the reported symptom. Both outcomes are stated plainly below.

## What

**1. `last_seen_devices` let two devices claim the same `/dev/videoN` — FIXED, board-proven.**

The board's `config.json` carried two entries both claiming `id: "/dev/video1"`: the DJI Osmo Pocket 3 and the RØDE, which had each held that node path at different times. Folding by stable identity correctly keeps them as two rows — but nothing stopped both from going on claiming the same `id`, and the condition does **not** self-heal. The next observation re-folds each row into its own identity and leaves the collision standing, which is why the board's config still had it.

Every consumer resolves a persisted `config.source` by first match, so with the selected camera unplugged the lookup adopted the *other* device's stable identity and silently re-pointed the operator's selection at a different camera.

- Freshest claimant keeps the path; a later one demotes it to a retired alias so it stays resolvable once nobody holds it outright.
- Resolution now ranks a device that currently *holds* a path above one that merely *retired* it, so an already-persisted collision resolves correctly before the fold heals it.

**2. Two real unbounded/unrecoverable paths in stop — FIXED, but they do NOT close the reported hang.**

- The engine control-socket `close()` the stop path awaits had no bound. The callback that clears the session runs in its `finally`, so an engine that never answers strands the whole stop. A close that never answers is no more informative than one that rejects — which this path already treated as "proceed" — so it is now bounded and treated identically.
- Once the 12 s stop deadline fired, `stop_failed` was **unescapable**. `start()` only leaves that state when the streaming status already reads false, and a failed stop never cleared it; `reconcile()` refused to run there at all, so the `stop_failed -> idle` recovery the lifecycle table already declares was unreachable. `reconcile()` now accepts `stop_failed` and adopts the engine's truth.

## Why

Both are correctness problems in their own right: a persisted list whose primary key is not unique, and a declared recovery route that no code path can reach.

## How to verify

Red-first, all four new tests fail without the fix:

- `stop-wedge-recovery.test.ts` — a client whose `close()` never settles must still complete the stop; a stop that missed its deadline must be recoverable rather than terminal.
- `source-renumber-dedup.test.ts` — two devices that took turns on one node path must not both claim it (seeded with the board's verbatim state); a stale `config.source` must resolve to the device that *holds* the path. Before the fix `/dev/video1` resolved to the RØDE on `/dev/video5`.

Gate: `tsc --noEmit` clean, `bun run lint` clean, **2660 backend tests pass**, **282 rpc tests pass**.

**Board proof (defect 1)** — the deployed build healed the real corrupt config on its next observation:

```
PRE : 4 rows / 3 unique ids   DUPLICATE_IDS=['/dev/video1']
POST: 4 rows / 4 unique ids   DUPLICATE_IDS=NONE
```

The RØDE moved to its stable id keeping `/dev/video1` as its first retired alias; the DJI kept the path it actually holds; no device was forgotten.

## Risks

**The reported stop-hang is NOT closed by this PR, and I want that on the record.** With these changes deployed I ran five real start/stop cycles on the board: four stopped cleanly in ~5 ms, one hung. In the hang the stream kept advancing frames for **94 s** after the stop, the RPC never answered, and the backend logged **nothing** on the stop path while its event loop kept ticking normally.

Neither defect fixed here explains that signature — both would have produced either a bounded completion or a logged `stop_failed` at 12 s. Two open leads, neither yet proven:

- the queued-stop branch taken while `reconfiguring`, which returns a promise with **no deadline and no logging** — the only path in `stop()` matching "no response, no log";
- stale generation bookkeeping across a restart, since the hang hit the FIRST stream after a `ceralive` restart and none of the four that followed.

I did not guess at a fix for it. Separately, the `params`-phase start rejection seen while testing was confirmed **pre-existing** by A/B against the previous binary — it is an artifact of calling `streaming.start` with an empty payload, not a regression.

Behaviour changes to be aware of: a `last_seen_devices` row that loses a node-path collision and has no stable identity is dropped rather than kept ambiguous, and `stop_failed -> reconciling` is a new legal lifecycle transition.