### PR TITLE
fix(streaming): a stop parked behind a config change gets a deadline and a voice

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -1873,6 +1873,38 @@ transaction reports healthy hardware as `stop_failed`. `stop()` therefore return
 a deferred promise while `reconfiguring` and is answered against whatever state
 the transaction settled into. Concurrent stops share one queued resolution.
 
+**But QUEUED is not UNBOUNDED, and it is never silent.** Only a settling
+transaction releases a parked stop, so a transaction that breaks its own contract
+strands the operator's Stop with nothing left to answer it. Measured on a Rock
+5B+ (2026-07-31): a stop fired 0.7 s into an apply-now change sat **3.5–4.4 s**
+unanswered while `stream_lifecycle` stayed frozen on `reconfiguring`, an
+independent probe RPC on the same socket answered in 2–5 ms throughout, and
+`journalctl -u ceralive` carried **not one line** about the stop for the whole
+window — the exact "RPC never answered, nothing logged, event loop fine"
+signature a previous investigation could not place. Unbounded, that silence had
+no ceiling at all.
+
+`parkStop()` therefore gives the wait its own deadline of
+`RECONFIGURE_DEADLINE_MS + STOP_DEADLINE_MS` (89 s). That total is DERIVED, not
+tuned: it is the transaction's full declared bound plus the one stop bound the
+released stop still gets afterwards, i.e. by construction the latest instant a
+healthy queued stop can answer — so it can only ever fire on a transaction that
+already broke its contract, never on slow-but-working hardware. On expiry the
+orchestrator logs, transitions `reconfiguring → reconciling` and adopts the
+engine's truth (the same rule `settleConfigChangeState` applies to the
+transaction's own deadline — the engine's state is unknown, so ask rather than
+assert), and answers `stop_failed` with the distinct
+`RECONFIGURE_STOP_TIMEOUT_REASON` (`reconfigure_stop_timeout`) — distinct from
+`stop_timeout`, which means the engine WAS asked and did not finish.
+
+Parking is announced at `warn` with the attempt id and the budget, and a release
+cancels the deadline so a late tick can never overwrite the honest answer. `warn`
+is deliberate: the production console transport runs at `warn`, so an `info` line
+reaches the log FILE but never the journal the in-app Logs dialog downloads — an
+`info` here would have been invisible in exactly the investigation that needed it.
+The ordinary stop's `stop_failed` catch logs for the same reason; a 12 s
+`stop_timeout` used to produce zero journal output.
+
 **The BUS settles the transaction, not only the RPC.** When the engine publishes
 `rollback_failed{teardown_timeout}` and then exits, the in-flight RPC rejects on
 a dead control socket. `noteStreamSessionConfigChangePhase` (fed from
@@ -2719,6 +2751,8 @@ non-overwrite is unchanged).
 - Don't clear the raw bridge's `cachedLiveness`/`cachedPassthrough` from its own socket `close`/`error` — that is a CONNECTION blip, not a session boundary, and wiping there hands `collectRealLiveness()` an `undefined` it can only read as a cold start, so a dead stream reports `healthy` off raw process liveness. Let `FRAMES_FRESHNESS_MS` age the retained reading out instead.
 - Don't apply that same rule to the SESSION-scoped control client — it is the inverse case. Losing `cerastream-backend.ts`'s `this.client` retires the session (the published client cannot reconnect and a restarted engine has no session to resume), so route every session RPC through `withSessionClient` and never swallow a `CerastreamConnectionError` without calling `noteConnectionLoss`. And don't treat `this.client !== undefined` as evidence the engine is reachable — that is exactly how `reconcileRuntimeState()` re-affirmed a phantom "streaming" state off stale telemetry until the backend was restarted.
 - Don't apply `STOP_DEADLINE_MS` to a config-change transaction, and don't "simplify" the queued-stop branch in `stop()` into the normal stop path — a 12 s deadline against a 65 s worst-case change reports healthy hardware as `stop_failed`. Size anything bounding a change from `RECONFIGURE_DEADLINE_MS`.
+- Don't drop `parkStop()`'s deadline or its `warn`, and don't demote that `warn` to `info` — only a settling transaction can release a parked stop, so without the deadline a broken transaction strands the operator's Stop with no ceiling and no journal line, and the production console transport hides `info` (see "But QUEUED is not UNBOUNDED"). Board-measured pre-fix: 4.4 s of an unanswered Stop with a frozen lifecycle and an empty journal.
+- Don't measure a board stop/start cycle with a WebSocket client that stays silent between RPC calls — `pruneStaleClients()` closes any socket with no INBOUND frame for `HEARTBEAT_STALE_THRESHOLD_MS` (15 s, swept every 5 s), and the pending call then resolves as a phantom "the backend hung". Reproduced exactly: 1 apparent hang in 5 cycles with a silent harness, 0 in 10 with the same harness answering `ping` with `pong`, same binary and same trigger. Answer the heartbeat, and assert on `socketClosed` before believing a hang.
 - Don't hardcode `65000` (or `60000`) anywhere — the bound is DERIVED in `@ceraui/rpc` `config-change.schema.ts` from cerastream `docs/adr/schema.md` §11's phase table, so a shrunken engine budget fails a test instead of silently invalidating the number. The published bindings deliberately do NOT ship this constant.
 - Don't delete `handleEvent`'s `config-change` case as a duplicate of the RPC return path — it is the ONLY thing that settles a transaction whose engine escalates and then exits (the RPC then rejects on a dead socket), and dropping it strands the UI in `applying`.
 - Don't send a UI resolution rung on the apply-now path — the engine speaks `WxH` pixels and rejects `'720p'` outright. Route it through `toEngineResolution`, the same map the START path uses, and don't "simplify" the unknown-token branch into dropping the axis.

--- a/apps/backend/src/modules/streaming/stream-session-orchestrator.ts
+++ b/apps/backend/src/modules/streaming/stream-session-orchestrator.ts
@@ -148,7 +148,15 @@ type ActiveConfigChange = {
 type QueuedStop = {
 	readonly promise: Promise<StopResult>;
 	readonly release: (result: StopResult | Promise<StopResult>) => void;
+	readonly cancelDeadline: () => void;
 };
+
+/**
+ * A stop that waited out the whole transaction budget and still had nothing to
+ * answer it. Distinct from `stop_timeout`, which means the engine was asked and
+ * did not finish.
+ */
+export const RECONFIGURE_STOP_TIMEOUT_REASON = "reconfigure_stop_timeout";
 
 export type StreamSessionOrchestrator = {
 	readonly start: (request: StreamStartRequest) => Promise<StartResult>;
@@ -330,19 +338,61 @@ export function createStreamSessionOrchestrator(
 		return { result: "started", attemptId };
 	};
 
+	/**
+	 * A parked stop is released by the settling transaction and by NOTHING else,
+	 * so the wait is bounded by that transaction's own declared budget: its full
+	 * bound, plus the one stop bound the released stop still gets afterwards.
+	 * That is by construction the latest instant a healthy queued stop can
+	 * answer, so this deadline can only ever fire on a transaction that broke
+	 * its own contract — never on slow-but-working hardware.
+	 *
+	 * Measured on a live board (2026-07-31): an operator Stop parked here sat
+	 * unanswered while the lifecycle stayed frozen on `reconfiguring` and the
+	 * journal carried not one line about it. Unbounded and unlogged, that
+	 * silence had no ceiling at all.
+	 */
+	const parkStop = (): QueuedStop => {
+		let release!: (result: StopResult | Promise<StopResult>) => void;
+		const promise = new Promise<StopResult>((resolve) => {
+			release = resolve;
+		});
+		const attemptId = activeChange?.attemptId;
+		const budgetMs = reconfigureDeadlineMs + stopDeadlineMs;
+
+		const timer = scheduleTimeout(() => {
+			if (queuedStop?.promise !== promise) return;
+			queuedStop = undefined;
+			logger.error(
+				"stream stop parked behind a config change was never released",
+				{
+					attemptId,
+					budgetMs,
+					state,
+				},
+			);
+			// The transaction outlived every bound it declared, so the engine's
+			// real state is unknown to us — adopt its truth rather than assert one.
+			if (transition("reconciling")) void reconcile();
+			release({
+				result: "stop_failed",
+				reason: RECONFIGURE_STOP_TIMEOUT_REASON,
+			});
+		}, budgetMs);
+
+		logger.warn("stream stop parked behind an in-flight config change", {
+			attemptId,
+			budgetMs,
+		});
+		return { promise, release, cancelDeadline: () => cancelTimeout(timer) };
+	};
+
 	const stop = async (): Promise<StopResult> => {
 		// A change transaction already owns the engine's lifecycle mutex and the
 		// capture hardware. Racing a 12 s stop deadline against it would report a
 		// healthy 65 s transaction as `stop_failed`, so the stop WAITS and is then
 		// answered against whatever state the transaction actually settled into.
 		if (state === "reconfiguring") {
-			if (queuedStop === undefined) {
-				let release!: (result: StopResult | Promise<StopResult>) => void;
-				const promise = new Promise<StopResult>((resolve) => {
-					release = resolve;
-				});
-				queuedStop = { promise, release };
-			}
+			if (queuedStop === undefined) queuedStop = parkStop();
 			return queuedStop.promise;
 		}
 		if (state === "idle") return { result: "stopped" };
@@ -376,10 +426,13 @@ export function createStreamSessionOrchestrator(
 			return { result: "stopped" };
 		} catch (error) {
 			transition("stop_failed");
-			return {
-				result: "stop_failed",
-				reason: error instanceof Error ? error.message : "stop_failed",
-			};
+			const reason = error instanceof Error ? error.message : "stop_failed";
+			logger.error("stream stop did not settle within its deadline", {
+				generation: stoppedGeneration,
+				deadlineMs: stopDeadlineMs,
+				reason,
+			});
+			return { result: "stop_failed", reason };
 		}
 	};
 
@@ -409,6 +462,7 @@ export function createStreamSessionOrchestrator(
 		const pending = queuedStop;
 		if (pending === undefined) return false;
 		queuedStop = undefined;
+		pending.cancelDeadline();
 		pending.release(stop());
 		return true;
 	};

--- a/apps/backend/src/tests/config-change-orchestrator.test.ts
+++ b/apps/backend/src/tests/config-change-orchestrator.test.ts
@@ -1,4 +1,12 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	spyOn,
+	test,
+} from "bun:test";
 import { CerastreamRpcError } from "@ceralive/cerastream";
 import {
 	CHANGE_CONFIG_WORST_CASE_BOUND_MS,
@@ -6,8 +14,10 @@ import {
 	CONFIG_CHANGE_REASON_REJECTED,
 	CONFIG_CHANGE_REASON_TEARDOWN_TIMEOUT,
 	type LifecycleState,
+	type StopResult,
 } from "@ceraui/rpc/schemas";
 
+import { logger } from "../helpers/logger.ts";
 import {
 	RECONFIGURE_DEADLINE_MS,
 	STOP_DEADLINE_MS,
@@ -16,6 +26,7 @@ import {
 	type ConfigChangePhaseEvent,
 	createStreamSessionOrchestrator,
 	type EngineConfigChangeOutcome,
+	RECONFIGURE_STOP_TIMEOUT_REASON,
 	type StreamSessionOrchestrator,
 } from "../modules/streaming/stream-session-orchestrator.ts";
 
@@ -79,6 +90,7 @@ type Harness = {
 	rejectChange: (error: unknown) => void;
 	readonly changeCalls: string[];
 	runtimeState: "idle" | "streaming" | "unknown";
+	stopRuntimeSettles: boolean;
 };
 
 function harness(): Harness {
@@ -98,6 +110,7 @@ function harness(): Harness {
 		streamingStatus,
 		changeCalls,
 		runtimeState: "idle",
+		stopRuntimeSettles: true,
 		settleChange: () => {},
 		rejectChange: () => {},
 		orchestrator: undefined as unknown as StreamSessionOrchestrator,
@@ -108,6 +121,7 @@ function harness(): Harness {
 		setStreamingStatus: (streaming) => streamingStatus.push(streaming),
 		stopRuntime: async (generation) => {
 			stopCalls.push(generation);
+			if (!state.stopRuntimeSettles) await new Promise<void>(() => {});
 		},
 		queryRuntime: async () => state.runtimeState,
 		setLifecycleState: (next) => lifecycle.push(next),
@@ -376,6 +390,124 @@ describe("stop during a config-change transaction", () => {
 		expect(await first).toEqual({ result: "stopped" });
 		expect(await second).toEqual({ result: "stopped" });
 		expect(h.stopCalls).toHaveLength(1);
+	});
+});
+
+describe("a parked stop is bounded and announced", () => {
+	let h: Harness;
+	let warns: Array<[string, unknown]>;
+	let errors: Array<[string, unknown]>;
+
+	beforeEach(() => {
+		h = harness();
+		warns = [];
+		errors = [];
+		spyOn(logger, "warn").mockImplementation((message, meta) => {
+			warns.push([String(message), meta]);
+			return logger;
+		});
+		spyOn(logger, "error").mockImplementation((message, meta) => {
+			errors.push([String(message), meta]);
+			return logger;
+		});
+	});
+
+	afterEach(() => {
+		mock.restore();
+	});
+
+	test("a transaction that never settles no longer strands the stop forever", async () => {
+		// Given a live stream, a change in flight, and an operator stop parked
+		// behind it.
+		await bringToStreaming(h);
+		void h.orchestrator.changeConfig({ resolution: "3840x2160" });
+		await settleMicrotasks();
+		let settled: StopResult | undefined;
+		const stop = h.orchestrator.stop().then((result) => {
+			settled = result;
+			return result;
+		});
+		await settleMicrotasks();
+		expect(settled).toBeUndefined();
+
+		// When the transaction breaks every bound it declared and never settles.
+		expect(
+			h.clock.fire(RECONFIGURE_DEADLINE_MS + STOP_DEADLINE_MS),
+		).toBeGreaterThan(0);
+		await settleMicrotasks();
+
+		// Then the operator gets a truthful answer instead of silence, and the
+		// orchestrator asks the engine what is actually true rather than
+		// asserting a state of its own.
+		expect(await stop).toEqual({
+			result: "stop_failed",
+			reason: RECONFIGURE_STOP_TIMEOUT_REASON,
+		});
+		expect(h.lifecycle).toContain("reconciling");
+	});
+
+	test("parking a stop is written to the log — the pre-fix path said nothing at all", async () => {
+		// Given a live stream mid-change.
+		await bringToStreaming(h);
+		void h.orchestrator.changeConfig({ framerate: 30 });
+		await settleMicrotasks();
+
+		// When a stop is parked behind the transaction.
+		void h.orchestrator.stop();
+		await settleMicrotasks();
+
+		// Then the wait is named, with the budget it is allowed.
+		const parked = warns.find(([message]) =>
+			message.includes("parked behind an in-flight config change"),
+		);
+		expect(parked).toBeDefined();
+		expect(parked?.[1]).toMatchObject({
+			budgetMs: RECONFIGURE_DEADLINE_MS + STOP_DEADLINE_MS,
+		});
+	});
+
+	test("a released stop disarms its deadline so a late tick cannot overwrite the answer", async () => {
+		// Given a stop parked behind a change that then applies.
+		await bringToStreaming(h);
+		const change = h.orchestrator.changeConfig({ framerate: 30 });
+		await settleMicrotasks();
+		const stop = h.orchestrator.stop();
+		await settleMicrotasks();
+		h.settleChange({ phase: "applied" });
+		await change;
+		await settleMicrotasks();
+		expect(await stop).toEqual({ result: "stopped" });
+
+		// When the parked stop's deadline would have fired.
+		expect(h.clock.fire(RECONFIGURE_DEADLINE_MS + STOP_DEADLINE_MS)).toBe(0);
+		await settleMicrotasks();
+
+		// Then nothing was reported and the honest answer stands.
+		expect(h.orchestrator.snapshot().state).toBe("idle");
+		expect(
+			errors.filter(([message]) => message.includes("parked behind")),
+		).toEqual([]);
+	});
+
+	test("a stop that misses its own deadline is logged — it used to fail in silence", async () => {
+		// Given a live stream whose runtime stop never completes.
+		const stuck = harness();
+		stuck.stopRuntimeSettles = false;
+		await bringToStreaming(stuck);
+		const stop = stuck.orchestrator.stop();
+		await settleMicrotasks();
+
+		// When the stop deadline expires.
+		expect(stuck.clock.fire(STOP_DEADLINE_MS)).toBeGreaterThan(0);
+		await settleMicrotasks();
+
+		// Then the failure is both returned AND recorded.
+		expect((await stop).result).toBe("stop_failed");
+		expect(
+			errors.some(([message]) =>
+				message.includes("stream stop did not settle within its deadline"),
+			),
+		).toBe(true);
 	});
 });
 


### PR DESCRIPTION
## What

A `streaming.stop` requested while the orchestrator is `reconfiguring` is parked behind the in-flight `change-config` transaction. That park had **no deadline and no logging** — the only branch of `stop()` whose signature is "no response, no state change, no log line". It now has both, and the ordinary stop's `stop_failed` catch logs too.

Behaviour on the healthy path is unchanged: the stop still waits for the transaction (a 12 s deadline against a 65 s worst-case change would report healthy hardware as `stop_failed`) and is answered against whatever state the transaction settled into.

## Why

A previous investigation recorded a `streaming.stop` that "never answered, logged nothing, while the event loop kept ticking", left two unproven leads, and could not place it. Lead 1 is now proven on a Rock 5B+.

`streaming.setConfig {apply_now:true, framerate:25}` on a live stream, `streaming.stop` 700 ms later, with an independent probe RPC on the same socket:

```
t=13.29  stop-fired        lifecycleNow = "reconfiguring"
t=13.29  probe getConfig   ok  2 ms   lifecycle=reconfiguring  stopWaited=5 ms
t=15.29  probe getConfig   ok  2 ms   lifecycle=reconfiguring  stopWaited=2007 ms
t=17.30  probe getConfig   ok  5 ms   lifecycle=reconfiguring  stopWaited=4013 ms
t=17.72  stop-returned     stopped                            (4432 ms)
```

The operator's Stop sat 4432 ms unanswered, `stream_lifecycle` never moved, the socket and event loop were demonstrably healthy, and `journalctl -u ceralive` for the whole window carried two unrelated lines and **nothing about the stop**. That is exactly the reported signature. It was short here only because the engine failed the transaction quickly — the branch's ceiling was 77 s + 12 s of the same silence, and a transaction that never settles at all stranded the stop forever.

**Also recorded, because it invalidates the earlier evidence:** the prior run's 1-in-5 "hang" is reproducible as the harness's own socket being pruned. `pruneStaleClients()` closes any socket with no inbound frame for 15 s; a probe that speaks only when it calls is silent for ~17 s across an 8 s stream. Same binary, same trigger: **1 apparent hang in 5** with a silent harness, **0 in 10** once it answers `ping` with `pong`. The hang moved with the harness, not the device.

## How it works

`parkStop()` bounds the wait at `RECONFIGURE_DEADLINE_MS + STOP_DEADLINE_MS` (89 s). That total is derived, not tuned: the transaction's full declared bound plus the one stop bound the released stop still gets afterwards — by construction the latest instant a healthy queued stop can answer, so it can only ever fire on a transaction that already broke its own contract.

On expiry it logs, transitions `reconfiguring → reconciling` and adopts the engine's truth (the same rule `settleConfigChangeState` applies to the transaction's own deadline — the engine's state is unknown, so ask rather than assert), and answers `stop_failed` with the distinct `reconfigure_stop_timeout`, as opposed to `stop_timeout`, which means the engine *was* asked and did not finish.

Parking is announced at `warn`, not `info`: the production console transport runs at `warn`, so an `info` line reaches the log file but never the journal the in-app Logs dialog downloads — it would have been invisible in exactly the investigation that needed it. A release disarms the deadline so a late tick cannot overwrite the honest answer.

No lifecycle-transition-table change, no schema change, no change to the queue-don't-race design.

## How to verify

Gate, from the main checkout:

- `bun tsc --noEmit` (backend) — clean
- `bun run lint` — clean
- `bun test` (backend) — **2664 pass, 0 fail**
- `bun test` (`packages/rpc`) — **282 pass, 0 fail**
- `bun run check:tech-debt`, `bun run check:rc-pins` — clean
- frontend vitest: **1495/1495 assertions pass**; 75 test *files* fail to import on a `localStorage`-less environment — byte-identical on unmodified `main`, pre-existing and untouched by this change

Red-first, by reverting ONLY the production file and keeping the tests: **3 of the 4 new tests fail** (`a transaction that never settles no longer strands the stop forever`, `parking a stop is written to the log`, `a stop that misses its own deadline is logged`). The fourth, `a released stop disarms its deadline`, passes pre-fix because pre-fix there is no deadline to fire — it guards the fix against regressing.

Board (Rock 5B+, DJI Osmo Pocket 3 on `/dev/video1`, real control plane, 23-field start payload):

- same apply-now + stop scenario now emits `stream stop parked behind an in-flight config change {attemptId, budgetMs:89000}` and still resolves honestly in 3568 ms
- `systemctl restart cerastream` → first start/stop, **6/6 clean** (12–73 ms), no socket closures
- plain start/stop, **4/4 clean** (5–44 ms)

`Board-Evidence-SHA256: 94d47c291f37ee2a357c95afa0a1ee8f8c6dcbcab5a8bc890c98a8578e98fd78`

## Risks

- The 89 s deadline is a backstop that a healthy transaction cannot reach; if it ever fires, the transaction has already violated its own published bound, and the response is to ask the engine rather than assert a state. Worst case an operator sees a truthful `stop_failed` where they previously saw nothing at all.
- Two extra log lines per apply-now stop and one per failed stop. `warn`-level, so they land in the journal by design.
- Lead 2 (stale generation bookkeeping across a restart) was chased and found nothing: 10/10 restart-then-first-stop cycles clean pre-fix once the harness answered the heartbeat.
- Separately investigated and **not reproducible**: `setConfig {asrc:"Auto"}` echoing while `config.json` keeps the old value. A full round trip lands on disk within 1.5 s in both directions (`"No audio"` → disk, `"Auto"` → disk); `asrc` is not an apply-now staged field, so nothing holds it back. Reported, not fixed.