### PR TITLE
fix(sources): an inference about hardware must not outrank the operator

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -2688,6 +2688,81 @@ negative controls: a selected HDMI input with no cable still raises, the EMI
 advisory still raises under the same gate, and the standing-advisory
 non-overwrite is unchanged).
 
+## AN INFERENCE MAY NOT OUTRANK THE OPERATOR, AND A SHARED NODE PATH NAMES NOBODY [EXISTS]
+
+`reconcileConfiguredSourceIdentity` self-heals a persisted `config.source` across
+a re-enumeration, and it is right to. But it is an INFERENCE about hardware
+written into the same field an operator writes their INTENT into, and it had no
+rule for what happens when the two disagree. Both failure directions were
+confirmed on a board (192.168.78.131).
+
+**A stale engine view may not overwrite a newer operator write.** The reconciler
+decides against `getSourcesMessage()`, built from the engine-device cache that
+`tryRefreshEngineDeviceCache` deliberately RETAINS across a failed fetch. During a
+~5 minute cerastream outage every `list-devices` timed out, so the cache was
+minutes old — and it still authorized a config MUTATION 7 ms after an operator
+`setConfig({source})` saved a different, correct id:
+
+```
+20:05:47.125 debug sources: engine device fetch failed; retaining last-known device cache
+20:05:47.132 info  sources: configured source re-enumerated under a new node path
+                         — migrated by stable identity {"from":"/dev/video0","to":"/dev/video3"}
+```
+
+Retain-on-failure is the right contract for a device LIST and the wrong one for a
+config write: "this device is no longer live", drawn from a view known not to have
+been refreshed, is not a verdict. The fix is a compare-and-set on a monotonic
+**selection token** (`sources.ts`, "Selection write token"):
+
+- `noteSourceSelectionWrite()` advances `sourceSelectionToken` at every site that
+  persists a STATED selection — `streaming.setConfig`, the `start` path's
+  `updateConfig` (`streaming.ts`), and the durable live `switchInput` follow. Miss
+  one and the reconciler can still overrule that selection.
+- `engineViewSelectionToken` records the token as it stood when the evidence
+  behind the current view was **REQUESTED**. It is captured inside
+  `probeEngineDevices` BEFORE the round-trip and carried on the probe to
+  `commitEngineDevices` — not sampled at commit — so a probe already in flight
+  when the operator saved cannot authorize a migration either.
+- The reconciler writes only while the two are equal.
+
+The reconciler's OWN write deliberately does not advance the token (it would
+refuse itself forever), and a failing probe commits nothing — so the stamp simply
+stops advancing and the reconciler stands down until the engine answers again.
+That IS the engine-freshness gate this defect needed, with no wall-clock bound to
+tune and no permanent suppression: the next answered probe re-authorizes it, and
+a migration still true then still fires.
+
+**A node path several devices answer to identifies none of them.**
+`findRememberingId` breaks that tie by PREFERENCE — whoever holds the path
+outright beats whoever merely retired it — which is correct for choosing a lost
+row and wrong for deciding what hardware a saved selection means. The board's own
+`last_seen_devices` had FOUR entries answering to `/dev/video3` (the HDMI-RX and
+the Osmo both remembering it as a retired alias, plus a pre-`stableId` snapshot
+holding it outright), so the preference alone decided which camera the operator
+had picked. `resolveSourceIdentity` now resolves through `unambiguousStableId`,
+which requires the claimants of a path to fold to exactly ONE identity key.
+
+- **Duplicate SNAPSHOTS are not ambiguity** — they share an identity key, so a
+  `config.json` predating the identity fold still migrates and still self-heals.
+- **It is suppression-only.** A refusal leaves the literal id standing, which the
+  engine then answers about honestly (`resolveSourceRouting` fails closed;
+  `resolvePreviewStartFrame` passes it through to the engine's typed
+  `source-unavailable`). It never adopts anything new.
+- `findRememberingId` is UNCHANGED and still owns `collectLostCandidates` — the
+  two rules answer different questions and must not be merged.
+
+Board proof (same board, same drill, before/after the fix): an ambiguous path
+(`/dev/video9`, claimed by the HDMI-RX AND the Osmo) was silently re-pointed to
+`/dev/video0` and persisted by the pre-fix binary, and left byte-identical by the
+fixed one; an UNAMBIGUOUS retired alias (`/dev/video8`, one claimant) still
+migrated to its live successor, so genuine renumber is unweakened. An operator
+save during a real engine outage then survived 45 s of reconcile ticks AND the
+engine's return with `config.json` byte-identical.
+
+Coverage: `tests/source-selection-stale-cache.test.ts` (the F10a repro driving the
+REAL `setConfig` procedure against a pre-save engine view, the re-authorization
+control, the post-save genuine-renumber control, and the F10b claimant table).
+
 ## ANTI-PATTERNS
 
 - Don't add a persistent notification without a retraction path — `duration` does
@@ -2786,6 +2861,8 @@ non-overwrite is unchanged).
 - Don't key a REMEMBERED device (`last_seen_devices`, the session-seen snapshot map) on its node path — a libuvc camera renumbers on every open/close cycle, so that appends a new entry per cycle and renders one camera as N rows with N `lost` candidates. Route through `identityKey()`. And when folding, don't drop the retired paths: `resolveSourceIdentity` resolves a stale `config.source` THROUGH `last_seen_devices`, so a fold that forgets them strands the operator's selection — that is what `previousIds` is for.
 - Don't record a device's `stable_id` into `liveStableIds` before the bridge check in `buildSources` — an unbridged device renders no row, so letting it suppress the remembered `lost` row erases the device from the list entirely.
 - Don't leave a re-enumerated `config.source`/`config.asrc` unrepaired, and don't repair either by name, slot, or "whichever id resolves" — migration is by STABLE IDENTITY only (`reconcileConfiguredSourceIdentity` / `reconcileConfiguredAudioIdentity`), and the retired id must be published as `previousIds` so consumers can tell MOVED from GONE.
+- Don't let that repair write from an engine view older than the operator's own last word, and don't add a `config.source` write site without `noteSourceSelectionWrite()` — the retained-on-failure device cache is minutes old during an outage and will overwrite a just-saved selection (see AN INFERENCE MAY NOT OUTRANK THE OPERATOR). Sample the token BEFORE the probe's round-trip, not at commit, or a probe already in flight still wins; and never advance it from the reconciler's own write, which would make the gate refuse itself forever.
+- Don't resolve a persisted selection through a node path more than one remembered device answers to — `findRememberingId`'s holder-beats-alias preference picks a camera rather than proving one. Use `unambiguousStableId`, keep the refusal suppression-only (the literal id must still reach the engine), and don't "unify" it with `findRememberingId`, which correctly keeps that preference for `collectLostCandidates`.
 - Don't let the v4l2 scan's `deriveKind()` guess overwrite a kind the engine has already reported for that device, and don't clear `lastEngineVideoDevices` when a device leaves the list — a `usb` guess bridges to no pipeline, so the row is dropped and its coarse slot renders "not connected" for a device that is physically present. Don't relax the display-name gate on the restore to an `input_id`-only lookup either: node paths are recycled, and a fabricated identity is worse than a coarse one. And don't widen that restore past IDENTITY (`kind`/`stable_id`) back onto the remembered `caps`/`signal` — re-asserting a past probe's verdict is how a device that loses its signal keeps claiming it has one, forever.
 - Don't let the periodic signal recheck start a second probe while its own is still out (`signalRecheckInFlight`) — a fixed-interval loop whose probe outlives its interval supersedes ITSELF on every tick and publishes nothing at all, and a link-losing receiver is exactly what makes an enumeration slow.
 - Don't assert a GLOBAL call count on a process-wide seam like `helpers/run.ts` — `bun test` loads every file into ONE process, and background work started by an earlier file keeps issuing OS commands. `wifiUpdateDevices()` is the known offender: while any Wi-Fi adapter reads unavailable it re-arms itself every 3 s for a five-minute budget (`modules/wifi/wifi-interfaces.ts`), firing several `run("nmcli", …)` calls per pass. Filter the spy's calls to the binary under test instead (`logs-injection.test.ts`), which asserts the same property and cannot be flipped by a foreign command.

--- a/apps/backend/src/modules/streaming/sources.ts
+++ b/apps/backend/src/modules/streaming/sources.ts
@@ -376,6 +376,39 @@ function findRememberingId(
 	);
 }
 
+function remembersNodePath(device: LastSeenDevice, id: string): boolean {
+	return device.id === id || device.previousIds?.includes(id) === true;
+}
+
+/**
+ * The ONE stable hardware identity a node path names, or `undefined` when the
+ * path cannot be pinned to a single physical device.
+ *
+ * `/dev/videoN` is recycled, so several remembered devices can legitimately
+ * answer to the same path — one holding it outright, another remembering it as a
+ * retired alias. `findRememberingId` breaks that tie by PREFERENCE (holder wins),
+ * which is the right rule for rendering a lost row and the wrong one for deciding
+ * what hardware an operator's saved selection means: the board's own
+ * `last_seen_devices` carried the HDMI-RX and a DJI Osmo Pocket 3 both answering
+ * to `/dev/video3`, and the preference silently handed the Osmo's selection to
+ * the HDMI-RX. A migration that re-points a selection at a different camera is
+ * strictly worse than one that does not fire, so ambiguity refuses.
+ *
+ * Duplicate SNAPSHOTS of one device are not ambiguity — they fold to a single
+ * identity key, so a `config.json` predating the identity fold still migrates
+ * (and still self-heals on the next observation).
+ */
+function unambiguousStableId(
+	devices: readonly LastSeenDevice[],
+	id: string,
+): string | undefined {
+	const claimants = devices.filter((d) => remembersNodePath(d, id));
+	const identities = new Set(claimants.map(identityKey));
+	if (identities.size !== 1) return undefined;
+	const stableId = claimants[0]?.stableId;
+	return stableId === undefined || stableId === "" ? undefined : stableId;
+}
+
 /**
  * How many retired node paths one remembered device carries. A libuvc camera
  * renumbers on every open/close cycle, so this is unbounded churn without a cap;
@@ -618,14 +651,19 @@ export type ResolveSourceRoutingResult =
 // return the id unchanged (no over-matching: a genuinely different device is
 // never silently adopted). Mirrors the audio `resolveAudioSelection` stable-id
 // join, adapted to the id→stableId indirection video persists.
+//
+// The identity must be UNAMBIGUOUS, which is stricter than "remembered". Node
+// paths are recycled, so a path several devices answer to identifies none of
+// them, and resolving it by preference re-points the selection at whichever
+// hardware the tie-break happened to reach — see `unambiguousStableId`.
 export function resolveSourceIdentity(
 	sourceId: string,
 	sources: readonly StreamSource[],
 	lastSeenDevices?: readonly LastSeenDevice[],
 ): string {
 	if (sources.some((s) => s.id === sourceId)) return sourceId;
-	const stableId = findRememberingId(lastSeenDevices ?? [], sourceId)?.stableId;
-	if (stableId === undefined || stableId === "") return sourceId;
+	const stableId = unambiguousStableId(lastSeenDevices ?? [], sourceId);
+	if (stableId === undefined) return sourceId;
 	const successor = sources.find(
 		(s) => s.origin === "capture" && s.stableId === stableId,
 	);
@@ -656,6 +694,56 @@ export function resolveSourceRouting(
 		ok: true,
 		pipeline: routing.pipeline,
 		selected_video_input: routing.selected_video_input,
+	};
+}
+
+// ─── Selection write token (F10a) ───────────────────────────────────────────
+//
+// A monotonic stamp on the operator's stated intent, so a cache-driven
+// reconciliation can never overwrite a selection that is NEWER than the evidence
+// it is reasoning from.
+//
+// The reconciler decides against the engine-device cache, and that cache is
+// deliberately RETAINED across a failed `list-devices` — the right contract for
+// a device LIST (a transient outage must not erase the world), and the wrong one
+// for authorizing a config MUTATION. Confirmed on a board during a ~5 minute
+// cerastream outage: the cache was minutes old, and it overwrote an operator
+// `setConfig({source})` 7 ms after it landed. "Device is no longer live", drawn
+// from a view known not to have been refreshed, is not a verdict.
+//
+// `sourceSelectionToken` advances on every OPERATOR write of `config.source`
+// (never on the reconciler's own write — that would make the mechanism refuse
+// itself forever). `engineViewSelectionToken` records the token that was current
+// when the evidence behind the CURRENT view was REQUESTED — captured before the
+// probe's round-trip, not after it, so a probe that was already in flight when
+// the operator saved cannot authorize a migration either. The compare-and-set is
+// therefore exact: equal means nothing the operator did is newer than what the
+// engine was asked.
+//
+// A failing probe commits nothing, so the stamp simply stops advancing and the
+// reconciler stands down until the engine answers again — which is the
+// engine-freshness gate this defect needed, without a wall-clock bound to tune.
+let sourceSelectionToken = 0;
+let engineViewSelectionToken = 0;
+
+/**
+ * Record that the OPERATOR has just written `config.source`. Every call site
+ * that persists a stated selection — `streaming.setConfig`, the `start` path's
+ * `updateConfig`, and the durable live `switchInput` follow — must call this, or
+ * the reconciler may still overrule that selection from a stale view.
+ */
+export function noteSourceSelectionWrite(): void {
+	sourceSelectionToken += 1;
+}
+
+/** Test seam: the current operator-write / committed-view token pair. */
+export function getSourceSelectionTokens(): {
+	selection: number;
+	engineView: number;
+} {
+	return {
+		selection: sourceSelectionToken,
+		engineView: engineViewSelectionToken,
 	};
 }
 
@@ -869,6 +957,10 @@ export function getEngineAudioDevices(): EngineAudioDevice[] {
 interface EngineDeviceProbe {
 	devices: CaptureDevice[];
 	audio: EngineAudioDevice[];
+	// The operator-write token as it stood when this probe was DISPATCHED, so a
+	// round-trip that was already in flight when a selection was saved commits a
+	// view that is correctly marked older than that selection.
+	selectionToken: number;
 }
 
 /**
@@ -881,6 +973,7 @@ interface EngineDeviceProbe {
 async function probeEngineDevices(
 	deps: EngineDeviceCacheDeps,
 ): Promise<EngineDeviceProbe | undefined> {
+	const selectionToken = sourceSelectionToken;
 	try {
 		const result = await deps.fetchEngineDevices();
 		const devices = result.devices.map((d) =>
@@ -898,6 +991,7 @@ async function probeEngineDevices(
 		rememberEngineVideoDevices(devices);
 		return {
 			devices,
+			selectionToken,
 			// Parallel AUDIO cache (T4): an EXPLICIT field copy of the audio entries
 			// that PRESERVES the `alsa_card_id` join key verbatim. It is read
 			// defensively (the pre-T18 binding schema strips it → `undefined`; the
@@ -1042,8 +1136,10 @@ export function setEngineAudioChangeHandler(
 function commitEngineDevices(
 	devices: readonly CaptureDevice[],
 	audio?: readonly EngineAudioDevice[],
+	viewSelectionToken: number = sourceSelectionToken,
 ): void {
 	engineDeviceCache = [...devices];
+	engineViewSelectionToken = viewSelectionToken;
 	let audioChanged = false;
 	if (audio !== undefined) {
 		const next = JSON.stringify(audio);
@@ -1071,7 +1167,7 @@ export async function tryRefreshEngineDeviceCache(
 ): Promise<boolean> {
 	const probe = await probeEngineDevices(deps);
 	if (probe === undefined) return false;
-	commitEngineDevices(probe.devices, probe.audio);
+	commitEngineDevices(probe.devices, probe.audio, probe.selectionToken);
 	return true;
 }
 
@@ -1096,6 +1192,8 @@ export function resetEngineDeviceCache(): void {
 	sessionSeenDeviceSnapshots.clear();
 	lastEngineVideoDevices.clear();
 	lastBroadcastSources = undefined;
+	sourceSelectionToken = 0;
+	engineViewSelectionToken = 0;
 }
 
 /**
@@ -1168,6 +1266,13 @@ export function getSourcesMessage(): SourcesMessage {
  * Only a STABLE-IDENTITY match migrates (never a name or a slot guess), so a
  * genuinely different device is never adopted, and a real unplug keeps its
  * `lost` row and is left untouched. Returns whether the config changed.
+ *
+ * And only an engine view at least as new as the operator's own last word may
+ * decide it. This is an INFERENCE about hardware; a saved selection is a stated
+ * intent, and an inference drawn from evidence the operator has already
+ * superseded must lose (F10a — see "Selection write token"). The refusal is not
+ * terminal: the next answered probe re-stamps the view, and a migration that is
+ * still true then still fires.
  */
 export function reconcileConfiguredSourceIdentity(
 	sources: readonly StreamSource[],
@@ -1181,6 +1286,13 @@ export function reconcileConfiguredSourceIdentity(
 		config.last_seen_devices,
 	);
 	if (successor === configured) return false;
+	if (engineViewSelectionToken !== sourceSelectionToken) {
+		logger.debug(
+			"sources: declining to migrate the configured source — the engine view predates the operator's selection",
+			{ configured, successor },
+		);
+		return false;
+	}
 
 	config.source = successor;
 	if (config.selected_video_input === configured) {
@@ -1355,6 +1467,7 @@ export async function refreshSourcesForHotplug(
 	commitEngineDevices(
 		mergeObservedWithProbe(observed, probe.devices),
 		probe.audio,
+		probe.selectionToken,
 	);
 	broadcastSources();
 }
@@ -1418,6 +1531,7 @@ async function runSignalRecheck(
 	commitEngineDevices(
 		mergeObservedWithProbe(observed, probe.devices),
 		probe.audio,
+		probe.selectionToken,
 	);
 	broadcastSourcesIfChanged();
 }

--- a/apps/backend/src/modules/streaming/streaming.ts
+++ b/apps/backend/src/modules/streaming/streaming.ts
@@ -48,6 +48,7 @@ import { getSupportedTransports } from "./capabilities.ts";
 import { validateBitrate } from "./encoder.ts";
 import { AUDIO_CODECS } from "./pipeline-sources.ts";
 import { searchPipelines, validatePipelineOverrides } from "./pipelines.ts";
+import { noteSourceSelectionWrite } from "./sources.ts";
 import { resolveSrtla } from "./srtla.ts";
 import { resolveStreamEndpoint } from "./transport/resolve-endpoint.ts";
 
@@ -243,6 +244,7 @@ export async function updateConfig(_conn: WebSocket, params: ConfigParameters) {
 	if (params.source !== undefined) {
 		config.source = params.source;
 		config.selected_video_input = params.selected_video_input;
+		noteSourceSelectionWrite();
 	}
 
 	if (pipeline.supportsAudio && params.acodec) {

--- a/apps/backend/src/rpc/procedures/streaming.procedure.ts
+++ b/apps/backend/src/rpc/procedures/streaming.procedure.ts
@@ -102,6 +102,7 @@ import {
 import {
 	broadcastSources,
 	getSourcesMessage,
+	noteSourceSelectionWrite,
 	type ResolveSourceRoutingResult,
 	resolveSourceRouting,
 } from "../../modules/streaming/sources.ts";
@@ -681,6 +682,7 @@ export const setConfigProcedure = authedProcedure
 		if (sourceRouting !== undefined) {
 			config.source = input.source;
 			config.selected_video_input = sourceRouting.selected_video_input;
+			noteSourceSelectionWrite();
 		}
 		if (input.bitrate_overlay !== undefined)
 			config.bitrate_overlay = input.bitrate_overlay;
@@ -994,6 +996,7 @@ export function applySwitchInputFollow(
 	config.source = inputId;
 	config.pipeline = routed.pipeline;
 	config.selected_video_input = routed.selected_video_input;
+	noteSourceSelectionWrite();
 	saveConfig();
 	broadcastMsg("config", config);
 

--- a/apps/backend/src/tests/source-selection-stale-cache.test.ts
+++ b/apps/backend/src/tests/source-selection-stale-cache.test.ts
@@ -1,0 +1,512 @@
+/*
+ * F10 — the reconciler must never overrule the operator, and must never
+ * re-point a selection at a DIFFERENT physical device.
+ *
+ * Both halves were confirmed on hardware (192.168.78.131) during the wave-3
+ * device-quality QA and recorded in that effort's issue register. Neither was
+ * covered by `source-identity-renumber.test.ts` / `source-renumber-dedup.test.ts`,
+ * because both of those drive the SUCCESSFUL-probe case and the whole defect
+ * lives in what happens when the probe is NOT succeeding — or when the remembered
+ * evidence is ambiguous.
+ *
+ * F10a — stale-cache-after-save. `reconcileConfiguredSourceIdentity` decides
+ * against `getSourcesMessage()`, which is built from the engine-device cache that
+ * `tryRefreshEngineDeviceCache` deliberately RETAINS across a failed fetch. During
+ * a ~5 minute cerastream outage every `list-devices` timed out, so that cache was
+ * minutes old — and it still authorized a config MUTATION 7 ms after an operator
+ * `setConfig({source})` had saved a different, CORRECT id:
+ *
+ *   20:05:47.125 debug sources: engine device fetch failed; retaining last-known device cache
+ *   20:05:47.132 info  sources: configured source re-enumerated under a new node path
+ *                            — migrated by stable identity {"from":"/dev/video0","to":"/dev/video3"}
+ *
+ * F10b — renumber-to-different-device. The migration resolves the persisted id
+ * through `last_seen_devices`, and `/dev/videoN` is recycled: the board's own
+ * snapshot list carried TWO different physical devices answering to
+ * `/dev/video3` (the HDMI-RX holding it outright, the Osmo remembering it as a
+ * retired alias). Whichever one the lookup happened to reach decided which
+ * hardware the operator's selection now named.
+ */
+
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	test,
+} from "bun:test";
+import type {
+	CaptureDevice,
+	DeviceKind,
+	NetworkIngest,
+	StreamSource,
+} from "@ceraui/rpc/schemas";
+import { call } from "@orpc/server";
+
+import type { LastSeenDevice } from "../helpers/config-schemas.ts";
+import { getConfig } from "../modules/config.ts";
+import * as configMigration from "../modules/streaming/config-migration.ts";
+import * as sourcesModule from "../modules/streaming/sources.ts";
+import type { AppWebSocket, RPCContext } from "../rpc/types.ts";
+
+// Snapshot the REAL modules at load time — `mock.module` mutates the namespace in
+// place, so the restore in afterAll must come from here (same rule as
+// `config-source-migration.test.ts`).
+const realSources = { ...sourcesModule };
+const realConfigMigration = { ...configMigration };
+
+const SOURCES_PATH = "../modules/streaming/sources.ts";
+const CONFIG_MIGRATION_PATH = "../modules/streaming/config-migration.ts";
+
+const NO_INGEST: NetworkIngest = { rtmp: null, srt: null };
+
+const HDMI_NAME = "HDMI Input";
+const HDMI_STABLE = "port:fdee0000.hdmirx-controller";
+const OSMO_NAME = "DJIPocket3: OsmoPocket3";
+const OSMO_STABLE = "usb:2ca3:0023:DJI_DJIPocket3_123456789ABCDEF";
+const RODE_NAME = "RØDE HDMI to USB-C: RØDE HDMI";
+const RODE_STABLE = "usb:19f7:0037";
+
+function capSource(id: string) {
+	return {
+		id,
+		supports_audio: false,
+		supports_resolution_override: true,
+		supports_framerate_override: true,
+		default_resolution: "1080p",
+		default_framerate: 30,
+	};
+}
+
+function goldenCapSources() {
+	return ["hdmi", "usb_mjpeg", "v4l_mjpeg", "camlink", "libuvch264"].map(
+		capSource,
+	);
+}
+
+function captureDevice(
+	input_id: string,
+	kind: DeviceKind,
+	overrides: Partial<CaptureDevice> = {},
+): CaptureDevice {
+	return {
+		input_id,
+		device_path: overrides.device_path ?? input_id,
+		display_name: overrides.display_name ?? input_id,
+		media_class: "video",
+		kind,
+		...(overrides.stable_id !== undefined
+			? { stable_id: overrides.stable_id }
+			: {}),
+	};
+}
+
+function lastSeen(
+	id: string,
+	kind: DeviceKind,
+	pipelineId: string,
+	overrides: Partial<LastSeenDevice> = {},
+): LastSeenDevice {
+	return {
+		id,
+		displayName: overrides.displayName ?? id,
+		kind,
+		pipelineId,
+		devicePath: overrides.devicePath ?? id,
+		...(overrides.stableId !== undefined
+			? { stableId: overrides.stableId }
+			: {}),
+		...(overrides.previousIds !== undefined
+			? { previousIds: overrides.previousIds }
+			: {}),
+	};
+}
+
+/** Build the `sources` view the reconciler is handed, from a given device list. */
+function sourcesFrom(
+	devices: readonly CaptureDevice[],
+	configSource: string,
+	lastSeenDevices: readonly LastSeenDevice[],
+): StreamSource[] {
+	return realSources.buildSources({
+		sources: goldenCapSources(),
+		devices,
+		networkIngest: NO_INGEST,
+		configSource,
+		lastSeenDevices,
+		sessionSnapshots: realSources.getSessionSeenDeviceSnapshots(),
+	});
+}
+
+function makeContext(): RPCContext {
+	const ws = {
+		send: () => {},
+		data: { isAuthenticated: true, lastActive: Date.now() },
+	} as unknown as AppWebSocket;
+	return {
+		ws,
+		isAuthenticated: () => true,
+		authenticate: () => {},
+		deauthenticate: () => {},
+		markActive: () => {},
+		getLastActive: () => 0,
+		setSenderId: () => {},
+		getSenderId: () => undefined,
+		clearSenderId: () => {},
+	};
+}
+
+/**
+ * The list the OPERATOR's UI (and therefore the `setConfig` procedure) is looking
+ * at: the board AFTER the renumber, with the HDMI-RX on `/dev/video0`. This is
+ * deliberately NOT the list the reconciler sees — the whole defect is that the
+ * two disagree because the engine-device cache could not be refreshed.
+ */
+const OPERATOR_VIEW: StreamSource[] = [
+	{
+		origin: "capture",
+		id: "/dev/video0",
+		pipelineId: "hdmi",
+		kind: "hdmi",
+		displayName: HDMI_NAME,
+		devicePath: "/dev/video0",
+		stableId: HDMI_STABLE,
+		modes: [],
+		supportsAudio: true,
+		supportsResolutionOverride: true,
+		supportsFramerateOverride: true,
+		audioKind: "selectable",
+		available: true,
+	},
+	{
+		origin: "capture",
+		id: "/dev/video1",
+		pipelineId: "usb_mjpeg",
+		kind: "mjpeg",
+		displayName: RODE_NAME,
+		devicePath: "/dev/video1",
+		stableId: RODE_STABLE,
+		modes: [],
+		supportsAudio: true,
+		supportsResolutionOverride: true,
+		supportsFramerateOverride: true,
+		audioKind: "selectable",
+		available: true,
+	},
+];
+
+// ---------------------------------------------------------------------------
+// F10a — a stale engine view may not overwrite a NEWER operator save
+// ---------------------------------------------------------------------------
+
+describe("F10a — stale-cache-after-save", () => {
+	const savedMockMode = process.env.MOCK_MODE;
+	const savedNodeEnv = process.env.NODE_ENV;
+
+	let setConfigProcedure: Awaited<
+		typeof import("../rpc/procedures/streaming.procedure.ts")
+	>["setConfigProcedure"];
+
+	beforeAll(async () => {
+		delete process.env.MOCK_MODE;
+		process.env.NODE_ENV = "test";
+
+		// The operator's own view — fresh, and NOT what the reconciler is handed.
+		mock.module(SOURCES_PATH, () => ({
+			...realSources,
+			getSourcesMessage: () => ({
+				hardware: "rk3588" as const,
+				sources: OPERATOR_VIEW,
+			}),
+		}));
+		mock.module(CONFIG_MIGRATION_PATH, () => ({
+			...realConfigMigration,
+			validatePersistedPipeline: () => ({ valid: true }),
+		}));
+
+		const proc = await import("../rpc/procedures/streaming.procedure.ts");
+		setConfigProcedure = proc.setConfigProcedure;
+	});
+
+	afterAll(() => {
+		mock.module(SOURCES_PATH, () => ({ ...realSources }));
+		mock.module(CONFIG_MIGRATION_PATH, () => ({ ...realConfigMigration }));
+		if (savedMockMode === undefined) delete process.env.MOCK_MODE;
+		else process.env.MOCK_MODE = savedMockMode;
+		if (savedNodeEnv === undefined) delete process.env.NODE_ENV;
+		else process.env.NODE_ENV = savedNodeEnv;
+	});
+
+	beforeEach(() => {
+		realSources.resetEngineDeviceCache();
+		const config = getConfig();
+		config.source = undefined;
+		config.selected_video_input = undefined;
+		config.last_seen_devices = [];
+	});
+
+	afterEach(() => {
+		realSources.resetEngineDeviceCache();
+		const config = getConfig();
+		config.source = undefined;
+		config.selected_video_input = undefined;
+		config.last_seen_devices = [];
+	});
+
+	/**
+	 * The board's persisted memory of the HDMI-RX AFTER the renumber: it holds
+	 * `/dev/video0` now and remembers `/dev/video3` as a retired alias. Exactly
+	 * one remembered device answers to `/dev/video0`, so F10b's ambiguity rule is
+	 * NOT what is under test here — only the freshness of the engine view is.
+	 */
+	function hdmiSnapshot(): LastSeenDevice {
+		return lastSeen("/dev/video0", "hdmi", "hdmi", {
+			displayName: HDMI_NAME,
+			devicePath: "/dev/video0",
+			stableId: HDMI_STABLE,
+			previousIds: ["/dev/video3"],
+		});
+	}
+
+	/** The engine view as it was BEFORE the outage: HDMI-RX still on video3. */
+	function preOutageDevices(): CaptureDevice[] {
+		return [
+			captureDevice("/dev/video3", "hdmi", {
+				display_name: HDMI_NAME,
+				stable_id: HDMI_STABLE,
+			}),
+		];
+	}
+
+	test("a reconciliation drawn from a PRE-SAVE engine view leaves the operator's selection alone", async () => {
+		// (1) The engine answers once, and that answer becomes the current view.
+		realSources.applyObservedEngineDevices(preOutageDevices());
+
+		// (2) The board renumbers and cerastream goes unreachable — every
+		//     `list-devices` throws, so the cache is RETAINED and never re-committed.
+		//     The operator, looking at the fresh list, saves the CORRECT id.
+		const saved = await call(
+			setConfigProcedure,
+			{ source: "/dev/video0" },
+			{ context: makeContext() },
+		);
+		expect(saved.success).toBe(true);
+		expect(getConfig().source).toBe("/dev/video0");
+
+		getConfig().last_seen_devices = [hdmiSnapshot()];
+
+		// (3) A `sources` broadcast runs the reconciler against that stale view.
+		const stale = sourcesFrom(
+			realSources.getEngineDeviceCache(),
+			"/dev/video0",
+			[hdmiSnapshot()],
+		);
+		// The stale view genuinely still shows the device on its old node path —
+		// this is the evidence the reconciler used to migrate.
+		expect(stale.some((s) => s.id === "/dev/video3")).toBe(true);
+
+		const changed = realSources.reconcileConfiguredSourceIdentity(stale);
+
+		expect(changed).toBe(false);
+		expect(getConfig().source).toBe("/dev/video0");
+	});
+
+	test("the SAME view authorizes the migration once the engine has answered again", async () => {
+		realSources.applyObservedEngineDevices(preOutageDevices());
+
+		const saved = await call(
+			setConfigProcedure,
+			{ source: "/dev/video0" },
+			{ context: makeContext() },
+		);
+		expect(saved.success).toBe(true);
+		getConfig().last_seen_devices = [hdmiSnapshot()];
+
+		// The engine comes back and re-commits the very same view. The reconciler
+		// is no longer reasoning from evidence older than the operator's intent, so
+		// it is authorized again — and this time it is a genuine renumber.
+		realSources.applyObservedEngineDevices(preOutageDevices());
+
+		const view = sourcesFrom(
+			realSources.getEngineDeviceCache(),
+			"/dev/video0",
+			[hdmiSnapshot()],
+		);
+		expect(realSources.reconcileConfiguredSourceIdentity(view)).toBe(true);
+		expect(getConfig().source).toBe("/dev/video3");
+	});
+
+	test("a genuine mid-stream renumber still migrates after an operator save", async () => {
+		// The regression this must not cause: refusing every migration that follows
+		// a save. A save, then a FRESH engine answer showing the replugged RØDE on
+		// a new node, must still self-heal.
+		realSources.applyObservedEngineDevices([
+			captureDevice("/dev/video1", "mjpeg", {
+				display_name: RODE_NAME,
+				stable_id: RODE_STABLE,
+			}),
+		]);
+
+		const saved = await call(
+			setConfigProcedure,
+			{ source: "/dev/video1" },
+			{ context: makeContext() },
+		);
+		expect(saved.success).toBe(true);
+
+		const rodeSnapshot = lastSeen("/dev/video1", "mjpeg", "usb_mjpeg", {
+			displayName: RODE_NAME,
+			devicePath: "/dev/video1",
+			stableId: RODE_STABLE,
+		});
+		getConfig().last_seen_devices = [rodeSnapshot];
+
+		realSources.applyObservedEngineDevices([
+			captureDevice("/dev/video2", "mjpeg", {
+				display_name: RODE_NAME,
+				stable_id: RODE_STABLE,
+			}),
+		]);
+
+		const view = sourcesFrom(
+			realSources.getEngineDeviceCache(),
+			"/dev/video1",
+			[rodeSnapshot],
+		);
+		expect(realSources.reconcileConfiguredSourceIdentity(view)).toBe(true);
+		expect(getConfig().source).toBe("/dev/video2");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// F10b — a node path claimed by two devices names neither of them
+// ---------------------------------------------------------------------------
+
+describe("F10b — renumber-to-different-device", () => {
+	beforeEach(() => {
+		realSources.resetEngineDeviceCache();
+		const config = getConfig();
+		config.source = undefined;
+		config.selected_video_input = undefined;
+		config.last_seen_devices = [];
+	});
+
+	afterEach(() => {
+		realSources.resetEngineDeviceCache();
+		const config = getConfig();
+		config.source = undefined;
+		config.selected_video_input = undefined;
+		config.last_seen_devices = [];
+	});
+
+	/** The Osmo, which held `/dev/video3` when the operator picked it and has
+	 *  since renumbered to `/dev/video5` (libuvc renumbers on every cycle). */
+	function osmoSnapshot(): LastSeenDevice {
+		return lastSeen("/dev/video5", "uvc_h264", "libuvch264", {
+			displayName: OSMO_NAME,
+			devicePath: "/dev/video5",
+			stableId: OSMO_STABLE,
+			previousIds: ["/dev/video3"],
+		});
+	}
+
+	/** The HDMI-RX, which took `/dev/video3` after the Osmo vacated it. */
+	function hdmiOnVideo3(): LastSeenDevice {
+		return lastSeen("/dev/video3", "hdmi", "hdmi", {
+			displayName: HDMI_NAME,
+			devicePath: "/dev/video3",
+			stableId: HDMI_STABLE,
+		});
+	}
+
+	/** The live board: HDMI-RX on video0, Osmo unplugged. */
+	function liveDevices(): CaptureDevice[] {
+		return [
+			captureDevice("/dev/video0", "hdmi", {
+				display_name: HDMI_NAME,
+				stable_id: HDMI_STABLE,
+			}),
+		];
+	}
+
+	test("refuses to migrate a node path TWO remembered devices answer to", () => {
+		const remembered = [osmoSnapshot(), hdmiOnVideo3()];
+		const config = getConfig();
+		config.source = "/dev/video3";
+		config.last_seen_devices = remembered;
+
+		realSources.applyObservedEngineDevices(liveDevices());
+		const view = sourcesFrom(liveDevices(), "/dev/video3", remembered);
+
+		const changed = realSources.reconcileConfiguredSourceIdentity(view);
+
+		// Migrating here would silently re-point the operator's Osmo selection at
+		// the HDMI-RX — a DIFFERENT physical device — and survive a reboot.
+		expect(changed).toBe(false);
+		expect(getConfig().source).toBe("/dev/video3");
+	});
+
+	test("resolveSourceIdentity leaves an ambiguous node path untouched", () => {
+		const remembered = [osmoSnapshot(), hdmiOnVideo3()];
+		const view = sourcesFrom(liveDevices(), "/dev/video3", remembered);
+
+		expect(
+			realSources.resolveSourceIdentity("/dev/video3", view, remembered),
+		).toBe("/dev/video3");
+	});
+
+	test("an UNAMBIGUOUS retired alias still migrates (renumber unweakened)", () => {
+		// The same shape with the second claimant removed: exactly one remembered
+		// device answers to `/dev/video3`, and it IS the live HDMI-RX.
+		const remembered = [
+			lastSeen("/dev/video0", "hdmi", "hdmi", {
+				displayName: HDMI_NAME,
+				devicePath: "/dev/video0",
+				stableId: HDMI_STABLE,
+				previousIds: ["/dev/video3"],
+			}),
+		];
+		const config = getConfig();
+		config.source = "/dev/video3";
+		config.selected_video_input = "/dev/video3";
+		config.last_seen_devices = remembered;
+
+		realSources.applyObservedEngineDevices(liveDevices());
+		const view = sourcesFrom(liveDevices(), "/dev/video3", remembered);
+
+		expect(realSources.reconcileConfiguredSourceIdentity(view)).toBe(true);
+		expect(getConfig().source).toBe("/dev/video0");
+		expect(getConfig().selected_video_input).toBe("/dev/video0");
+	});
+
+	test("two SNAPSHOTS of the same device are not ambiguous (dedupe self-heal)", () => {
+		// A `config.json` written before the identity fold carries duplicate rows
+		// for ONE camera. They share a stable identity, so the path has one owner
+		// and the migration must still fire.
+		const remembered = [
+			lastSeen("/dev/video0", "hdmi", "hdmi", {
+				displayName: HDMI_NAME,
+				devicePath: "/dev/video0",
+				stableId: HDMI_STABLE,
+				previousIds: ["/dev/video3"],
+			}),
+			lastSeen("/dev/video3", "hdmi", "hdmi", {
+				displayName: HDMI_NAME,
+				devicePath: "/dev/video3",
+				stableId: HDMI_STABLE,
+			}),
+		];
+		const config = getConfig();
+		config.source = "/dev/video3";
+		config.last_seen_devices = remembered;
+
+		realSources.applyObservedEngineDevices(liveDevices());
+		const view = sourcesFrom(liveDevices(), "/dev/video3", remembered);
+
+		expect(realSources.reconcileConfiguredSourceIdentity(view)).toBe(true);
+		expect(getConfig().source).toBe("/dev/video0");
+	});
+});


### PR DESCRIPTION
## What

`reconcileConfiguredSourceIdentity` self-heals a persisted `config.source` across a device
re-enumeration. It writes into the same field an operator writes their intent into, and it had
no rule for what happens when the two disagree. This adds one.

- **A stale engine view can no longer overwrite a newer operator save.** Selection writes carry a
  monotonic token; the reconciler compare-and-sets on it and may write only while the engine view
  is at least as new as the operator's last word.
- **Migration no longer re-points a selection onto a different physical device.** A node path that
  several remembered devices answer to now blocks the migration instead of being resolved by
  preference.

## Why

Both halves were confirmed on hardware (192.168.78.131) and recorded in the wave-3 register.

The reconciler decides against the engine-device cache, which `tryRefreshEngineDeviceCache`
deliberately RETAINS across a failed `list-devices`. That is the right contract for a device LIST —
a transient outage must not erase the world — and the wrong one for authorizing a config MUTATION.
During a ~5 minute cerastream outage every probe timed out, so the cache was minutes old, and it
still migrated `config.source` 7 ms after an operator `setConfig({source})` had saved the correct id:

```
20:05:47.125 debug sources: engine device fetch failed; retaining last-known device cache
20:05:47.132 info  sources: configured source re-enumerated under a new node path
                         — migrated by stable identity {"from":"/dev/video0","to":"/dev/video3"}
```

Separately, `/dev/videoN` is recycled, so several remembered devices legitimately answer to one
path. The lookup broke that tie by preference (whoever holds the path outright beats whoever
retired it) — which *picks* a camera rather than *proving* one. This is not hypothetical: the
board's own `last_seen_devices` has **four** distinct devices claiming `/dev/video3`, and its live
`config.source` (`/dev/video1`) is claimed by two.

## How

- `sources.ts` — `sourceSelectionToken` advances on every operator write; `engineViewSelectionToken`
  records the token as it stood when the evidence behind the current view was *requested*. The stamp
  is captured inside `probeEngineDevices` **before** the round-trip and carried on the probe into
  `commitEngineDevices`, so a probe already in flight when the operator saved cannot authorize a
  migration either. The reconciler's own write never advances the token (it would refuse itself
  forever), and a failing probe commits nothing — so the reconciler simply stands down until the
  engine answers again, with no wall-clock bound to tune and no permanent suppression.
- `sources.ts` — `unambiguousStableId()` requires the claimants of a node path to fold to exactly
  one identity key. Duplicate *snapshots* of one device share a key, so a pre-fold `config.json`
  still migrates and still self-heals. The refusal is suppression-only: the literal id stands and
  still reaches the engine. `findRememberingId` is unchanged and still owns `collectLostCandidates`
  — the two answer different questions and must not be merged.
- `streaming.procedure.ts` / `streaming.ts` — `noteSourceSelectionWrite()` at all three sites that
  persist a stated selection: `setConfig`, the durable live `switchInput` follow, and `start`.
- `apps/backend/AGENTS.md` — the contract, plus two ANTI-PATTERNS entries.

## How to verify

```bash
cd apps/backend
bun test src/tests/source-selection-stale-cache.test.ts   # 7 pass here, 3 fail on the parent commit
bun test src/tests/source-identity-renumber.test.ts \
         src/tests/source-renumber-dedup.test.ts \
         src/tests/config-source-migration.test.ts \
         src/tests/sources.test.ts                        # 99 pass, untouched
```

The F10a fixture drives the **real** `streaming.setConfig` procedure against a genuinely stale
engine-cache-derived view. The four controls in the new file are green on both trees: the
re-authorization once the engine answers again, a genuine renumber *after* a save, an unambiguous
retired alias, and the duplicate-snapshot self-heal.

Board proof (same board, same drill, before vs after):

| | pre-fix binary | fixed binary |
|---|---|---|
| `/dev/video9` — claimed by the HDMI-RX **and** the Osmo | silently re-pointed to `/dev/video0`, persisted | byte-identical, selection stands |
| `/dev/video8` — one claimant (genuine renumber) | — | migrates to `/dev/video0` |
| operator save during a real `cerastream` outage | — | survives 45 s of reconcile ticks **and** the engine's return; `config.json` mtime frozen at the save instant |

Health gate after the drill: both units active, `readiness.degraded = false`, rootfs capacity
unchanged, board config restored byte-exact.

## Risks

- **Could this stop a legitimate renumber from healing?** Only until the engine next answers. The
  gate keys on the engine view being older than the operator's last word, and every successful
  probe re-stamps it — so the worst case is one `recheckSourceSignals` interval (5 s) of delay, and
  the hardware control above shows the migration still firing after a save.
- **Could the ambiguity rule refuse a device it should have migrated?** Only when two *different*
  stable identities claim the same node path, which is precisely the case where the correct answer
  is unknowable. Duplicate rows for one device are unaffected (covered by a test and by the
  hardware control).
- A missed `noteSourceSelectionWrite()` on a future `config.source` write site would silently
  reopen the first defect. That is called out in ANTI-PATTERNS; all three current sites are wired.

Backend-only; no schema change, no wire change, no new user-facing strings (so no i18n work).
