### PR TITLE
fix(streaming): arm the crash-window config reconciler that nothing was calling

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -1967,7 +1967,56 @@ values; transitional/unreachable/neither ⇒ write NOTHING and KEEP the marker f
 the next reconnect. Guessing in either direction persists a config the operator
 never got or discards one they did.
 
-Coverage: `tests/config-change-orchestrator.test.ts` (admission, the four typed
+**AND IT IS ARMED — `config-change-reconcile-wiring.ts` is what calls it.** For
+one wave the paragraph above described behaviour that could not happen: the only
+importer of `reconcileInflightConfigChange` was its own unit test, so a marker
+left by a process that died mid transaction was never judged, the staged
+candidate was lost, and the marker file leaked. The reconciler was correct and
+simply unreachable, which is why the regression lock is on the CALL SITES.
+
+There are TWO seams, and both are needed:
+
+- **boot** (`main.ts`, immediately after `reconcileStreamSession()`) — the first
+  moment the persisted config and the engine's own session are both known; and
+- **engine reconnect** (`engine-reconnect.ts` `buildDefaultBroadcastEngineState`,
+  after the same call) — where a marker that DEFERRED at boot is re-judged.
+
+Four properties are load-bearing:
+
+- **Marker-only is enforced BY CONSTRUCTION, not by convention.** The runner
+  reads the marker FIRST and, finding none, returns `no_marker` without ever
+  asking the engine anything. That is asserted directly (`h.asked === 0`) — a
+  behavioural test, not a comment.
+- **The snapshot speaks CONFIG space.** `judgeInflightMarker` compares
+  `config.json` values with `===`, and the engine speaks PIXELS (`"3840x2160"`)
+  and exact rates (`29.97`) — the read-side twin of the apply-now dispatch bug in
+  "THE ENGINE SPEAKS PIXELS". `buildEngineEncodeSnapshot` normalizes at the one
+  seam that knows it is talking to the engine, and `judgeInflightMarker` folds
+  BOTH sides onto the rung ladder as a backstop (so a persisted `"4k"` matches a
+  reported `"3840x2160"`), literal equality first so an unplaceable token never
+  widens silently.
+- **A NON-ANSWER IS NOT "NOT STREAMING".** The lifecycle comes from the
+  orchestrator, never the bare `is_streaming` flag — that flag is false both for a
+  genuinely idle engine AND for one reconciliation has not reached yet. Only
+  `idle` is decisive; `reconciling`/`starting`/`stopping` yield `undefined`, which
+  the judge answers with `wait`. Reading the flag would retain the previous values
+  off a non-answer, discarding a change the operator DID get.
+- **Bounded, and idempotent two ways.** With a marker it polls
+  `INFLIGHT_RECONCILE_DEADLINE_MS` (15 s) at `INFLIGHT_RECONCILE_POLL_MS` (1 s),
+  because the frame evidence (`frames_emitted` / `pipeline_playing`) rides the raw
+  `active_encode` bridge, whose first status frame lands a second or two after
+  boot reaches this point. Expiry defers, which KEEPS the marker. A decisive
+  verdict retires the marker, so a repeat call is a plain no-op; and concurrent
+  callers (boot racing a heal) share ONE in-flight run rather than judging in
+  parallel. Both hooks are fire-and-forget and the runner never throws, so neither
+  boot nor the heal broadcast can be delayed or broken by it.
+
+Coverage: `tests/config-change-reconcile-wiring.test.ts` (a REAL on-disk marker
+through the REAL writer and REAL `config.json`: persist-candidate, retain-previous,
+the undecided-then-decisive re-ask, the never-decisive defer that keeps the marker,
+the no-marker zero-side-effect case, double-apply, the overlapping-run join, the
+config-space normalization table, and the two call-site locks),
+`tests/config-change-orchestrator.test.ts` (admission, the four typed
 outcomes, stop-during-applying, stop-during-rollback, the teardown_timeout →
 engine-exit escalation chain, attempt fencing, deadline reconcile, and the
 deadline-sizing assertion), `tests/config-change-staging.test.ts` (the pure
@@ -2834,6 +2883,8 @@ control, the post-save genuine-renumber control, and the F10b claimant table).
 - Don't collapse every rejected `change-config` dispatch into `rollback_failed{engine_connection_lost}` — a `CerastreamRpcError` means the transaction never began and the stream is untouched (`reverted{change_rejected}`). Keep `rollback_failed` as the DEFAULT for every other rejection, so an unrecognised failure can never claim a possibly-dead stream is fine.
 - Don't persist an apply-now candidate before the transaction says `applied`, and don't add a `reverted`-specific write — until then `config.json` still describes the session the engine is actually running.
 - Don't reconcile a params-vs-config mismatch without the in-flight marker — that mismatch is normally a legitimate "apply on next start" intent, and reconciling it overwrites the operator's choice on every boot.
+- Don't remove either `runInflightConfigChangeReconciliation()` call site (boot in `main.ts`, the heal in `engine-reconnect.ts`) — for a whole wave the crash-window reconciler existed, was correct, and was called by nothing but its own test, so a leaked marker was the observable behaviour while the docs claimed the safety net was armed. And don't hand the judge the ENGINE's own vocabulary: it compares `config.json` values, so a raw `"3840x2160"`/`29.97` reads as "neither params set" — an eternal `wait` that never retires the marker. Route it through `buildEngineEncodeSnapshot`.
+- Don't decide "the engine is not streaming" from `is_streaming` on the reconciliation path — that flag is false for an idle engine AND for one reconciliation has not reached yet, so it turns a NON-ANSWER into `retain_previous` and discards a change the operator actually got. Only a lifecycle of `idle` is decisive.
 - Don't re-add stderr regex on the cerastream path — engine errors are structured
   codes mapped via `cerastream-error-mapping.ts`.
 - Don't wire `@ceralive/cerastream` as a sibling `link:` or vendored `.tgz` — it

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -80,6 +80,7 @@ import {
 import { initAudioMeterBridge } from "./modules/streaming/audio-meter-bridge.ts";
 import { checkCamlinkUsb2 } from "./modules/streaming/camlink.ts";
 import { checkEngineCompatibilityOnStartup } from "./modules/streaming/cerastream-backend.ts";
+import { runInflightConfigChangeReconciliation } from "./modules/streaming/config-change-reconcile-wiring.ts";
 import { reconcilePersistedPipeline } from "./modules/streaming/config-migration.ts";
 import { startDeviceDiscovery } from "./modules/streaming/devices.ts";
 import { initEngineConnection } from "./modules/streaming/engine-reconnect.ts";
@@ -250,6 +251,13 @@ if (!shouldUseMocks()) {
 	await guardNonCritical("stream-session-reconcile", async () => {
 		await reconcileStreamSession();
 	});
+	// The first point at which the persisted config and the engine's own session
+	// are both known — so it is where a `config.inflight.json` left by a process
+	// that died mid transaction can finally be judged. Fire-and-forget: with a
+	// marker it polls a bounded window for the decisive engine answer (the raw
+	// active_encode bridge started further down supplies the frame evidence a
+	// second or two from now), and that must not delay the rest of boot.
+	void runInflightConfigChangeReconciliation();
 }
 
 // Resolve the runtime hardware kind (engine → device-tree → setup.hw → generic)

--- a/apps/backend/src/modules/streaming/config-change-persistence.ts
+++ b/apps/backend/src/modules/streaming/config-change-persistence.ts
@@ -60,21 +60,28 @@ export function reconcileInflightConfigChange(
 
 	const verdict = judgeInflightMarker(marker, engine);
 	if (verdict.action === "wait") {
-		logger.info("config-change marker kept — engine state not yet decisive", {
+		logger.debug("config-change marker kept — engine state not yet decisive", {
 			module: "streaming",
 			attemptId: marker.attemptId,
 		});
 		return "deferred";
 	}
 
+	// `warn`, not `info` — the SAME reason `parkStop()` uses it. The production
+	// console transport runs at `warn`, so an `info` reaches the log FILE but
+	// never the journal the in-app Logs dialog downloads. Measured on a board:
+	// the reconciliation ran correctly and left ZERO journal evidence that a
+	// crash-window marker had ever been judged. This event happens at most once
+	// per crashed transaction and is the only record that a config write was
+	// completed (or deliberately not) on the operator's behalf.
 	if (verdict.action === "persist_candidate") {
 		writeFields(marker.candidate);
-		logger.info("config-change marker resolved — candidate persisted", {
+		logger.warn("config-change marker resolved — candidate persisted", {
 			module: "streaming",
 			attemptId: marker.attemptId,
 		});
 	} else {
-		logger.info("config-change marker resolved — previous values retained", {
+		logger.warn("config-change marker resolved — previous values retained", {
 			module: "streaming",
 			attemptId: marker.attemptId,
 		});

--- a/apps/backend/src/modules/streaming/config-change-reconcile-wiring.ts
+++ b/apps/backend/src/modules/streaming/config-change-reconcile-wiring.ts
@@ -1,0 +1,286 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * Production wiring for the crash-window config-change reconciler (F11).
+ *
+ * `config-change-persistence.ts` shipped `reconcileInflightConfigChange` with the
+ * whole marker-only judgement behind it, and NOTHING in production called it —
+ * its only importer was its own unit test. `apps/backend/AGENTS.md` described
+ * marker-only crash reconciliation as live behaviour the entire time, so a
+ * `config.inflight.json` left by a process that died mid-transaction was never
+ * judged: the staged candidate was silently lost and the marker file leaked. A
+ * dead safety net the docs claimed was armed.
+ *
+ * This module is the arming. It owns two things the pure reconciler deliberately
+ * does not:
+ *
+ *   1. WHERE the engine's answer comes from (`buildEngineEncodeSnapshot`), and
+ *   2. WHEN to ask (`runInflightConfigChangeReconciliation`).
+ *
+ * THE SNAPSHOT SPEAKS CONFIG SPACE, NOT ENGINE SPACE. `judgeInflightMarker`
+ * compares the marker's fields — which are `config.json` values — against the
+ * engine's report with `===`. The engine speaks PIXELS (`"3840x2160"`) and exact
+ * rates (`29.97` from `30000/1001`), exactly as it does on the apply-now dispatch
+ * path (see config-change-bridge.ts "THE ENGINE SPEAKS PIXELS"). So the values are
+ * normalized to the rung ladder HERE, at the one seam that knows it is talking to
+ * the engine; the judge stays pure and unit-comparable.
+ *
+ * A NON-ANSWER IS NOT "NOT STREAMING". The lifecycle is read from the orchestrator
+ * rather than the bare `is_streaming` flag, because that flag is false both when
+ * the engine is genuinely idle AND while reconciliation has not yet reached it.
+ * Only `idle` is decisive evidence of an unchanged session; `reconciling` /
+ * `starting` / `stopping` yield `undefined`, which the judge answers with `wait`.
+ * Reading the flag instead would retain the previous values off a non-answer —
+ * discarding a change the operator DID get.
+ *
+ * IT IS BOUNDED AND MARKER-GATED. With no marker the runner returns immediately
+ * and never even asks the engine (proving marker-only semantics by construction,
+ * not by convention). With a marker it polls a bounded number of times, because at
+ * boot the decisive evidence arrives on someone else's schedule: the engine
+ * session is reconciled a few lines earlier, but `frames_emitted` /
+ * `pipeline_playing` ride the raw `active_encode` bridge, whose first status frame
+ * lands a second or two later. An engine that never becomes decisive within the
+ * window simply defers — which KEEPS the marker for the next reconnect, exactly as
+ * the wave3 contract requires.
+ *
+ * IT IS IDEMPOTENT, TWO WAYS. A decisive verdict retires the marker, so a repeat
+ * call is a plain `no_marker` no-op; and concurrent callers (boot racing an
+ * engine-reconnect heal) share ONE in-flight run rather than judging in parallel.
+ */
+
+import type { ActiveEncode, LifecycleState } from "@ceraui/rpc/schemas";
+import {
+	normalizeFramerateToRung,
+	normalizeResolutionToRung,
+} from "@ceraui/rpc/schemas";
+
+import { logger as defaultLogger } from "../../helpers/logger.ts";
+import { getActiveEncodeStatus } from "./active-encode-status.ts";
+import { getActiveEncodeLiveness } from "./active-passthrough.ts";
+import {
+	type InflightReconciliation,
+	reconcileInflightConfigChange,
+} from "./config-change-persistence.ts";
+import {
+	defaultStagingDeps,
+	type EngineEncodeSnapshot,
+	readInflightMarker,
+	type StagingDeps,
+} from "./config-change-staging.ts";
+import { getStreamSessionSnapshot } from "./stream-session-orchestrator.ts";
+
+/** How long to wait between re-asking an engine that has not answered yet. */
+export const INFLIGHT_RECONCILE_POLL_MS = 1_000;
+/**
+ * The whole window a boot/reconnect gets to reach a decisive engine answer.
+ * Sized to comfortably cover the raw `active_encode` bridge's connect + first
+ * status heartbeat (~2 s cadence). Expiry is not a failure — it defers, which
+ * keeps the marker for the next reconnect.
+ */
+export const INFLIGHT_RECONCILE_DEADLINE_MS = 15_000;
+
+/** Where the engine's current encode is read from. Injected so tests can pin it. */
+export interface EngineSnapshotSources {
+	readonly lifecycle: () => LifecycleState;
+	readonly activeEncode: () => ActiveEncode | null;
+	readonly liveness: () =>
+		| {
+				pipelinePlaying?: boolean | undefined;
+				framesEmitted?: number | undefined;
+		  }
+		| undefined;
+}
+
+const productionSnapshotSources: EngineSnapshotSources = {
+	lifecycle: () => getStreamSessionSnapshot().state,
+	activeEncode: () => getActiveEncodeStatus(),
+	liveness: () => getActiveEncodeLiveness(),
+};
+
+/**
+ * Build the engine's current encode in CONFIG space, or `undefined` when the
+ * engine has not actually answered.
+ *
+ * `undefined` is a first-class outcome, never a fallback: it is what the judge
+ * turns into `wait`, which writes nothing and keeps the marker. Only two states
+ * are decisive — a lifecycle of `idle` (the session really is over) and a
+ * `streaming` lifecycle for which the engine reported a resolved encode.
+ */
+export function buildEngineEncodeSnapshot(
+	sources: EngineSnapshotSources = productionSnapshotSources,
+): EngineEncodeSnapshot | undefined {
+	const lifecycle = sources.lifecycle();
+	// Decisive: the engine answered, and its answer is "no session".
+	if (lifecycle === "idle") return { streaming: false };
+	// Every other non-streaming lifecycle is an ABSENT answer, not a negative one.
+	if (lifecycle !== "streaming") return undefined;
+
+	const encode = sources.activeEncode();
+	if (encode === null) return undefined;
+
+	const resolution = normalizeResolutionToRung(encode.resolution);
+	const framerate = normalizeFramerateToRung(encode.framerate);
+	const live = sources.liveness();
+
+	return {
+		streaming: true,
+		...(resolution === undefined ? {} : { resolution }),
+		...(framerate === undefined ? {} : { framerate }),
+		codec: encode.codec,
+		...(encode.active_input === undefined
+			? {}
+			: { activeInput: encode.active_input }),
+		...(live?.pipelinePlaying === undefined
+			? {}
+			: { pipelinePlaying: live.pipelinePlaying }),
+		...(live?.framesEmitted === undefined
+			? {}
+			: { framesEmitted: live.framesEmitted }),
+	};
+}
+
+/** Minimal logger surface (winston satisfies it; tests pass a silent stub). */
+export interface InflightReconcileLogger {
+	info(message: string, meta?: Record<string, unknown>): void;
+	warn(message: string, meta?: Record<string, unknown>): void;
+}
+
+export interface InflightReconcileDeps {
+	readonly staging: StagingDeps;
+	readonly snapshot: () => EngineEncodeSnapshot | undefined;
+	readonly reconcile: (
+		engine: EngineEncodeSnapshot | undefined,
+		staging: StagingDeps,
+	) => InflightReconciliation;
+	readonly wait: (ms: number) => Promise<void>;
+	readonly logger: InflightReconcileLogger;
+	readonly pollIntervalMs: number;
+	readonly deadlineMs: number;
+}
+
+function defaultDeps(): InflightReconcileDeps {
+	return {
+		staging: defaultStagingDeps,
+		snapshot: () => buildEngineEncodeSnapshot(),
+		reconcile: (engine, staging) =>
+			reconcileInflightConfigChange(engine, staging),
+		wait: (ms) =>
+			new Promise((resolve) => {
+				setTimeout(resolve, ms);
+			}),
+		logger: defaultLogger,
+		pollIntervalMs: INFLIGHT_RECONCILE_POLL_MS,
+		deadlineMs: INFLIGHT_RECONCILE_DEADLINE_MS,
+	};
+}
+
+let inflight: Promise<InflightReconciliation> | undefined;
+
+/**
+ * Bounded by ATTEMPTS rather than a wall clock: the loop's only delay is its own
+ * `wait`, so attempts × interval IS the window, and the bound holds identically
+ * under an instant test clock. A clock compare would spin hot in tests and add a
+ * seam that proves nothing.
+ */
+async function pollUntilDecisive(
+	deps: InflightReconcileDeps,
+): Promise<InflightReconciliation> {
+	const attempts = Math.max(
+		1,
+		Math.ceil(deps.deadlineMs / Math.max(1, deps.pollIntervalMs)),
+	);
+	for (let attempt = 1; ; attempt += 1) {
+		const verdict = deps.reconcile(deps.snapshot(), deps.staging);
+		if (verdict !== "deferred") return verdict;
+		if (attempt >= attempts) return "deferred";
+		await deps.wait(deps.pollIntervalMs);
+	}
+}
+
+/**
+ * Judge a `config.inflight.json` left behind by a process that died mid
+ * transaction. Safe to call from any number of seams, at any time.
+ *
+ * Fail-soft by contract: it never throws, so a boot/reconnect hook can call it
+ * without a guard of its own.
+ */
+export function runInflightConfigChangeReconciliation(
+	overrides: Partial<InflightReconcileDeps> = {},
+): Promise<InflightReconciliation> {
+	// A run already judging this marker owns it — a second caller must join it,
+	// not race it. This is what makes a repeatedly-firing reconnect hook harmless.
+	if (inflight !== undefined) return inflight;
+
+	const deps: InflightReconcileDeps = { ...defaultDeps(), ...overrides };
+
+	// MARKER-ONLY, enforced by construction: with no marker the engine is never
+	// asked at all. A bare params-vs-config mismatch is a legitimate
+	// "apply on next start" the operator chose, and reconciling it would overwrite
+	// their intent on every single boot.
+	let marker: ReturnType<typeof readInflightMarker>;
+	try {
+		marker = readInflightMarker(deps.staging);
+	} catch {
+		return Promise.resolve("no_marker");
+	}
+	if (marker === undefined) return Promise.resolve("no_marker");
+
+	// `warn` because the production console transport is at `warn`: an `info`
+	// here lands in the log file but never in the journal (see the same note in
+	// config-change-persistence.ts). Bounded by construction — a marker exists
+	// only after a crashed transaction, and is retired by the first decisive
+	// verdict.
+	deps.logger.warn("config-change in-flight marker found — reconciling", {
+		module: "streaming",
+		attemptId: marker.attemptId,
+	});
+
+	const run = pollUntilDecisive(deps)
+		.then((verdict) => {
+			if (verdict === "deferred") {
+				deps.logger.warn(
+					"config-change marker still undecided — kept for the next reconnect",
+					{ module: "streaming", attemptId: marker?.attemptId },
+				);
+			}
+			return verdict;
+		})
+		.catch((err: unknown) => {
+			// Never let a reconciliation fault reach a boot/reconnect hook. Leaving
+			// the marker in place is the safe end state — it will be re-judged.
+			deps.logger.warn("config-change marker reconciliation failed", {
+				module: "streaming",
+				err,
+			});
+			return "deferred" as InflightReconciliation;
+		})
+		.finally(() => {
+			inflight = undefined;
+		});
+
+	inflight = run;
+	return run;
+}
+
+/**
+ * Test/teardown seam: resolve once the in-flight reconciliation has settled
+ * (mirrors `settleEngineReconnect()`). Returns immediately when idle.
+ */
+export function settleInflightConfigChangeReconciliation(): Promise<unknown> {
+	return inflight ?? Promise.resolve();
+}

--- a/apps/backend/src/modules/streaming/config-change-staging.ts
+++ b/apps/backend/src/modules/streaming/config-change-staging.ts
@@ -1,5 +1,9 @@
 import fs from "node:fs";
 
+import {
+	normalizeFramerateToRung,
+	normalizeResolutionToRung,
+} from "@ceraui/rpc/schemas";
 import { z } from "zod";
 
 import { writeFileAtomicSync } from "../../helpers/config-loader.ts";
@@ -115,6 +119,57 @@ export type ReconciliationVerdict =
 	| { readonly action: "retain_previous" }
 	| { readonly action: "wait" };
 
+const matches = (
+	candidate: string | number | undefined,
+	actual: string | number | undefined,
+): boolean => candidate === undefined || candidate === actual;
+
+/**
+ * The two axes where the marker and the engine can be RIGHT and still not be
+ * `===`. `config.json` holds ladder rungs (`"2160p"`, `30`); the engine reports
+ * pixels (`"3840x2160"`) and exact rates (`29.97` from `30000/1001`) — the same
+ * vocabulary gap that made every apply-now resolution change fail on the dispatch
+ * side (config-change-bridge.ts, "THE ENGINE SPEAKS PIXELS"). Here it would have
+ * been quieter and worse: a false mismatch reads as "neither params set", i.e. an
+ * eternal `wait` that never retires the marker.
+ *
+ * Both sides are folded onto the rung ladder, so `"4k"` vs `"3840x2160"` and
+ * `30` vs `30.0` compare equal while a genuine difference still does not. Literal
+ * equality is honoured first, so a value the ladder cannot place (an engine token
+ * this build does not know) still matches itself and never silently widens.
+ */
+const resolutionMatches = (
+	candidate: string | undefined,
+	actual: string | undefined,
+): boolean => {
+	if (matches(candidate, actual)) return true;
+	if (candidate === undefined || actual === undefined) return false;
+	const rung = normalizeResolutionToRung(candidate);
+	return rung !== undefined && rung === normalizeResolutionToRung(actual);
+};
+
+const framerateMatches = (
+	candidate: number | undefined,
+	actual: number | undefined,
+): boolean => {
+	if (matches(candidate, actual)) return true;
+	if (candidate === undefined || actual === undefined) return false;
+	const rung = normalizeFramerateToRung(candidate);
+	return rung !== undefined && rung === normalizeFramerateToRung(actual);
+};
+
+function paramsMatch(
+	fields: StagedConfigFields,
+	engine: EngineEncodeSnapshot,
+): boolean {
+	return (
+		resolutionMatches(fields.resolution, engine.resolution) &&
+		framerateMatches(fields.framerate, engine.framerate) &&
+		matches(fields.video_codec, engine.codec) &&
+		matches(fields.selected_video_input, engine.activeInput)
+	);
+}
+
 /**
  * Decide what a marker found at boot means. PURE — the caller owns the writes.
  *
@@ -134,24 +189,10 @@ export function judgeInflightMarker(
 		engine.pipelinePlaying !== false && (engine.framesEmitted ?? 0) > 0;
 	if (!gateSatisfied) return { action: "wait" };
 
-	const matches = (
-		candidate: string | number | undefined,
-		actual: string | number | undefined,
-	): boolean => candidate === undefined || candidate === actual;
-
-	const onCandidate =
-		matches(marker.candidate.resolution, engine.resolution) &&
-		matches(marker.candidate.framerate, engine.framerate) &&
-		matches(marker.candidate.video_codec, engine.codec) &&
-		matches(marker.candidate.selected_video_input, engine.activeInput);
-
+	const onCandidate = paramsMatch(marker.candidate, engine);
 	if (onCandidate) return { action: "persist_candidate" };
 
-	const onPrevious =
-		matches(marker.previous.resolution, engine.resolution) &&
-		matches(marker.previous.framerate, engine.framerate) &&
-		matches(marker.previous.video_codec, engine.codec) &&
-		matches(marker.previous.selected_video_input, engine.activeInput);
+	const onPrevious = paramsMatch(marker.previous, engine);
 
 	return onPrevious ? { action: "retain_previous" } : { action: "wait" };
 }

--- a/apps/backend/src/modules/streaming/engine-reconnect.ts
+++ b/apps/backend/src/modules/streaming/engine-reconnect.ts
@@ -64,6 +64,7 @@ import {
 	type CapabilitiesServiceDeps,
 	getLastCapabilities,
 } from "./capabilities.ts";
+import { runInflightConfigChangeReconciliation } from "./config-change-reconcile-wiring.ts";
 import { reportEngineState } from "./lifecycle-indicators.ts";
 import { getPipelinesMessage, initPipelines } from "./pipelines.ts";
 import {
@@ -162,7 +163,15 @@ function buildDefaultBroadcastEngineState(
 		await (sourcesOverride
 			? refreshAndBroadcastSources(sourcesOverride)
 			: refreshAndBroadcastSources());
-		if (sourcesOverride === undefined) await reconcileStreamSession();
+		if (sourcesOverride === undefined) {
+			await reconcileStreamSession();
+			// The engine just became reachable, which is exactly the moment a
+			// marker that DEFERRED at boot (no decisive engine answer yet) can be
+			// re-judged. Fire-and-forget: the heal broadcast above must settle on
+			// its own schedule, and the reconciliation is self-serialising, so a
+			// loop that re-fires can never double-apply.
+			void runInflightConfigChangeReconciliation();
+		}
 	};
 }
 

--- a/apps/backend/src/tests/config-change-reconcile-wiring.test.ts
+++ b/apps/backend/src/tests/config-change-reconcile-wiring.test.ts
@@ -1,0 +1,398 @@
+/*
+ * F11 — the crash-window reconciler is ARMED in production (device-platform-wave4
+ * todo 14).
+ *
+ * Wave 3 todo 12 shipped `reconcileInflightConfigChange` and nothing called it.
+ * `apps/backend/AGENTS.md` documented marker-only crash reconciliation as live
+ * behaviour while the only importer was its own unit test, so a
+ * `config.inflight.json` left by a process that died mid-transaction was never
+ * judged: the staged candidate was lost and the marker file leaked forever.
+ *
+ * These cases drive the REAL writer (`reconcileInflightConfigChange`) and the
+ * REAL `config.json` through the production wiring, against a REAL on-disk
+ * marker in a temp dir. Two properties are load-bearing and are asserted from
+ * both sides:
+ *
+ *   1. A marker present is reconciled — persist-candidate / retain-previous /
+ *      honest defer, decided by the engine's own answer.
+ *   2. NO marker means ZERO side effects. Not "writes nothing" — the engine is
+ *      never even ASKED, because a bare params-vs-config mismatch is a
+ *      legitimate apply-on-next-start the operator chose (the wave3 rule).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs, { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { getConfig } from "../modules/config.ts";
+import {
+	buildEngineEncodeSnapshot,
+	type InflightReconcileDeps,
+	runInflightConfigChangeReconciliation,
+	settleInflightConfigChangeReconciliation,
+} from "../modules/streaming/config-change-reconcile-wiring.ts";
+import type {
+	EngineEncodeSnapshot,
+	InflightConfigMarker,
+	StagingDeps,
+} from "../modules/streaming/config-change-staging.ts";
+
+let markerDir: string;
+let markerPath: string;
+
+function fileStagingDeps(): StagingDeps {
+	return {
+		markerPath,
+		readMarker: (path) => {
+			try {
+				return fs.readFileSync(path, "utf8");
+			} catch {
+				return undefined;
+			}
+		},
+		writeMarker: (path, contents) => fs.writeFileSync(path, contents),
+		removeMarker: (path) => {
+			try {
+				fs.unlinkSync(path);
+			} catch {
+				// already gone
+			}
+		},
+	};
+}
+
+function plantMarker(marker: InflightConfigMarker): void {
+	fs.writeFileSync(markerPath, JSON.stringify(marker));
+}
+
+function markerOnDisk(): boolean {
+	return fs.existsSync(markerPath);
+}
+
+const MARKER: InflightConfigMarker = {
+	attemptId: "wave4-t14",
+	startedAt: 1,
+	candidate: { resolution: "2160p", framerate: 30 },
+	previous: { resolution: "1080p", framerate: 30 },
+};
+
+/**
+ * Test harness: the production runner with a scripted engine and an instant
+ * clock, so the bounded poll is exercised without real time passing.
+ */
+function harness(
+	snapshots: ReadonlyArray<EngineEncodeSnapshot | undefined>,
+): Partial<InflightReconcileDeps> & {
+	asked: number;
+	info: string[];
+	warn: string[];
+} {
+	const box = {
+		asked: 0,
+		staging: fileStagingDeps(),
+		snapshot: (): EngineEncodeSnapshot | undefined => {
+			const next = snapshots[Math.min(box.asked, snapshots.length - 1)];
+			box.asked += 1;
+			return next;
+		},
+		wait: async (): Promise<void> => {},
+		pollIntervalMs: 1,
+		deadlineMs: 5,
+		info: [] as string[],
+		warn: [] as string[],
+		logger: {
+			info: (m: string) => {
+				box.info.push(m);
+			},
+			warn: (m: string) => {
+				box.warn.push(m);
+			},
+		},
+	};
+	return box;
+}
+
+describe("F11 — crash-window reconciliation is wired into production", () => {
+	let priorResolution: ReturnType<typeof getConfig>["resolution"];
+	let priorFramerate: ReturnType<typeof getConfig>["framerate"];
+
+	beforeEach(() => {
+		markerDir = mkdtempSync(join(tmpdir(), "ceraui-inflight-"));
+		markerPath = join(markerDir, "config.inflight.json");
+		const config = getConfig();
+		priorResolution = config.resolution;
+		priorFramerate = config.framerate;
+		config.resolution = "1080p";
+		config.framerate = 30;
+	});
+
+	afterEach(() => {
+		const config = getConfig();
+		config.resolution = priorResolution;
+		config.framerate = priorFramerate;
+		rmSync(markerDir, { recursive: true, force: true });
+	});
+
+	test("NO marker ⇒ no_marker, and the engine is never even asked", async () => {
+		// Given a device that simply booted with an apply-on-next-start intent on
+		// disk and no in-flight marker at all.
+		const h = harness([
+			{
+				streaming: true,
+				resolution: "1080p",
+				framerate: 30,
+				pipelinePlaying: true,
+				framesEmitted: 900,
+			},
+		]);
+		getConfig().resolution = "2160p";
+
+		// When the boot hook runs.
+		const verdict = await runInflightConfigChangeReconciliation(h);
+
+		// Then nothing is reconciled AND nothing was even inspected — the operator's
+		// stated intent survives every boot, untouched.
+		expect(verdict).toBe("no_marker");
+		expect(h.asked).toBe(0);
+		expect(getConfig().resolution).toBe("2160p");
+		expect(markerOnDisk()).toBe(false);
+	});
+
+	test("marker + engine live on the CANDIDATE ⇒ the lost write is completed", async () => {
+		// Given a crash between the engine's `applied` and the config write.
+		plantMarker(MARKER);
+
+		// When the engine is found live on the candidate, frames advancing.
+		const verdict = await runInflightConfigChangeReconciliation(
+			harness([
+				{
+					streaming: true,
+					resolution: "3840x2160",
+					framerate: 30,
+					pipelinePlaying: true,
+					framesEmitted: 900,
+				},
+			]),
+		);
+
+		// Then disk catches up with what the engine is actually running, and the
+		// marker is retired.
+		expect(verdict).toBe("persisted_candidate");
+		expect(getConfig().resolution).toBe("2160p");
+		expect(markerOnDisk()).toBe(false);
+	});
+
+	test("marker + engine IDLE ⇒ the old values are retained and the marker retired", async () => {
+		// Given the same crash, but the transaction never took and the engine is idle.
+		plantMarker(MARKER);
+
+		// When reconciliation runs.
+		const h = harness([{ streaming: false }]);
+		const verdict = await runInflightConfigChangeReconciliation(h);
+
+		// Then the operator's last WORKING config is what boots next time.
+		expect(verdict).toBe("retained_previous");
+		expect(getConfig().resolution).toBe("1080p");
+		expect(markerOnDisk()).toBe(false);
+
+		// …and it is announced at `warn`, because the production console transport
+		// sits at `warn`: measured on a board, an `info` reconciliation left the
+		// journal — and therefore the in-app Logs download — completely silent
+		// about a config write made on the operator's behalf.
+		expect(h.warn).toContain(
+			"config-change in-flight marker found — reconciling",
+		);
+		expect(h.info).toEqual([]);
+	});
+
+	test("an engine that is undecided AT FIRST is re-asked, then reconciled", async () => {
+		// Given a boot where the engine session has not settled yet (the raw
+		// liveness feed has delivered no frame), then settles on the candidate.
+		plantMarker(MARKER);
+
+		// When the bounded poll runs.
+		const verdict = await runInflightConfigChangeReconciliation(
+			harness([
+				undefined,
+				undefined,
+				{
+					streaming: true,
+					resolution: "3840x2160",
+					framerate: 30,
+					pipelinePlaying: true,
+					framesEmitted: 900,
+				},
+			]),
+		);
+
+		// Then the later, decisive answer is the one that counts.
+		expect(verdict).toBe("persisted_candidate");
+		expect(getConfig().resolution).toBe("2160p");
+	});
+
+	test("an engine that NEVER decides ⇒ deferred, nothing written, marker KEPT", async () => {
+		// Given an engine that stays unreachable/transitional for the whole window.
+		plantMarker(MARKER);
+
+		// When the bounded poll expires.
+		const verdict = await runInflightConfigChangeReconciliation(
+			harness([undefined]),
+		);
+
+		// Then guessing is refused — and the marker survives for the next reconnect.
+		expect(verdict).toBe("deferred");
+		expect(getConfig().resolution).toBe("1080p");
+		expect(markerOnDisk()).toBe(true);
+	});
+
+	test("running it AGAIN after a decisive verdict cannot double-apply", async () => {
+		// Given a reconciliation that already persisted the candidate.
+		plantMarker(MARKER);
+		await runInflightConfigChangeReconciliation(
+			harness([
+				{
+					streaming: true,
+					resolution: "3840x2160",
+					framerate: 30,
+					pipelinePlaying: true,
+					framesEmitted: 900,
+				},
+			]),
+		);
+		// …and an operator who has since chosen something else.
+		getConfig().resolution = "720p";
+
+		// When the engine-reconnect hook fires the SAME wiring again.
+		const h = harness([
+			{
+				streaming: true,
+				resolution: "3840x2160",
+				framerate: 30,
+				pipelinePlaying: true,
+				framesEmitted: 900,
+			},
+		]);
+		const verdict = await runInflightConfigChangeReconciliation(h);
+
+		// Then it is a no-op: the marker is gone, so nothing is re-applied.
+		expect(verdict).toBe("no_marker");
+		expect(h.asked).toBe(0);
+		expect(getConfig().resolution).toBe("720p");
+	});
+
+	test("overlapping runs (reconnect firing repeatedly) share ONE reconciliation", async () => {
+		// Given a marker and two hooks racing (boot + an engine-reconnect heal).
+		plantMarker(MARKER);
+		const first = harness([
+			undefined,
+			{
+				streaming: true,
+				resolution: "3840x2160",
+				framerate: 30,
+				pipelinePlaying: true,
+				framesEmitted: 900,
+			},
+		]);
+		const second = harness([{ streaming: false }]);
+
+		// When both are started before either settles.
+		const a = runInflightConfigChangeReconciliation(first);
+		const b = runInflightConfigChangeReconciliation(second);
+		const [verdictA, verdictB] = await Promise.all([a, b]);
+
+		// Then the second joined the first rather than judging in parallel — one
+		// verdict, one write, and the loser's engine was never consulted.
+		expect(verdictA).toBe("persisted_candidate");
+		expect(verdictB).toBe(verdictA);
+		expect(second.asked).toBe(0);
+		expect(getConfig().resolution).toBe("2160p");
+		await settleInflightConfigChangeReconciliation();
+	});
+});
+
+describe("both production seams actually call it", () => {
+	// F11 was not a logic bug — the logic was correct and simply unreachable. So
+	// the regression lock has to be on the CALL SITES, which no behavioural test
+	// of the reconciler itself can cover.
+	const readSource = (relative: string): string =>
+		fs.readFileSync(join(import.meta.dir, "..", relative), "utf8");
+
+	test("the boot path arms it once the config and engine session are consistent", () => {
+		const source = readSource("main.ts");
+		const armed = source.indexOf(
+			"void runInflightConfigChangeReconciliation()",
+		);
+		expect(armed).toBeGreaterThan(-1);
+		// It must sit AFTER the engine session is reconciled — before that, the
+		// lifecycle is `reconciling` and every judgement would defer.
+		expect(source.indexOf("await reconcileStreamSession()")).toBeLessThan(
+			armed,
+		);
+	});
+
+	test("the engine-reconnect heal re-arms it", () => {
+		const source = readSource("modules/streaming/engine-reconnect.ts");
+		expect(
+			source.includes("void runInflightConfigChangeReconciliation()"),
+		).toBe(true);
+	});
+});
+
+describe("the production engine snapshot speaks CONFIG space, not engine space", () => {
+	test("a live session is normalized out of pixels and fractional rates", () => {
+		// Given the engine reporting its own vocabulary.
+		const snapshot = buildEngineEncodeSnapshot({
+			lifecycle: () => "streaming",
+			activeEncode: () => ({
+				codec: "h265",
+				resolution: "1920x1080",
+				framerate: 29.97,
+				active_input: "/dev/video0",
+			}),
+			liveness: () => ({ pipelinePlaying: true, framesEmitted: 120 }),
+		});
+
+		// Then the judge is handed values it can compare with `config.json`.
+		expect(snapshot).toEqual({
+			streaming: true,
+			resolution: "1080p",
+			framerate: 29.97,
+			codec: "h265",
+			activeInput: "/dev/video0",
+			pipelinePlaying: true,
+			framesEmitted: 120,
+		});
+	});
+
+	test("an IDLE lifecycle is decisive; every other non-streaming state is not", () => {
+		const idle = buildEngineEncodeSnapshot({
+			lifecycle: () => "idle",
+			activeEncode: () => null,
+			liveness: () => undefined,
+		});
+		expect(idle).toEqual({ streaming: false });
+
+		// `reconciling` means the engine has NOT answered — asserting "not
+		// streaming" there would retain the old values off a non-answer.
+		for (const state of ["reconciling", "starting", "stopping"] as const) {
+			expect(
+				buildEngineEncodeSnapshot({
+					lifecycle: () => state,
+					activeEncode: () => null,
+					liveness: () => undefined,
+				}),
+			).toBeUndefined();
+		}
+	});
+
+	test("a streaming engine with no reported encode is UNDECIDED, never idle", () => {
+		expect(
+			buildEngineEncodeSnapshot({
+				lifecycle: () => "streaming",
+				activeEncode: () => null,
+				liveness: () => undefined,
+			}),
+		).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## What

The apply-now crash-window reconciler shipped one wave ago with its whole
marker-only judgement in place — and **nothing in production called it**. The only
importer of `reconcileInflightConfigChange` was its own unit test, so a
`config.inflight.json` left behind by a process that died mid transaction was
never judged: the staged candidate was lost and the marker file leaked, while
`apps/backend/AGENTS.md` described the safety net as armed.

This wires it into the two seams that can answer the question, and locks both.

## Why

The logic was correct and simply unreachable, which is the important part: no
behavioural test of the reconciler could ever have caught this, so the regression
lock is on the **call sites**.

Reproduced on the shipping fleet binary on a Rock 5B+ before any change — marker
planted, `systemctl restart ceralive`, and 25 s later the marker was still there
with not one line logged about it.

## How

**Two call sites**

- `main.ts`, immediately after `reconcileStreamSession()` — the first moment the
  persisted config and the engine's own session are both known.
- `engine-reconnect.ts`'s heal broadcast, after the same call — where a marker
  that deferred at boot is re-judged.

Both fire-and-forget; the runner never throws, so neither boot nor the heal
broadcast can be delayed or broken by it.

**`config-change-reconcile-wiring.ts` (new)** owns the two things the pure
reconciler deliberately does not — where the engine's answer comes from, and when
to ask:

- **Marker-only, by construction.** With no marker the engine is never asked at
  all, so a bare params-vs-config mismatch (a legitimate "apply on next start")
  can never be overwritten. The test asserts the engine was not consulted, not
  merely that nothing was written.
- **The snapshot speaks config space.** The judge compares `config.json` values
  with `===`, and the engine speaks pixels (`"3840x2160"`) and exact rates
  (`29.97`) — the read-side twin of the apply-now dispatch bug already recorded as
  "THE ENGINE SPEAKS PIXELS". `judgeInflightMarker` now folds both sides onto the
  rung ladder as a backstop, literal equality first so an unplaceable token never
  widens silently. A false mismatch here is quiet and worse than a loud one: it
  reads as "neither params set", i.e. an eternal `wait` that never retires the
  marker.
- **A non-answer is not "not streaming".** The lifecycle comes from the
  orchestrator, never `is_streaming` — that flag is false both for a genuinely
  idle engine and for one reconciliation has not reached yet. Only `idle` is
  decisive. Reading the flag would retain the previous values off a non-answer,
  discarding a change the operator actually got.
- **Bounded, idempotent two ways.** Polls 15 s at 1 s, because the frame evidence
  (`frames_emitted` / `pipeline_playing`) rides the raw `active_encode` bridge
  whose first status frame lands a second or two after boot reaches this point.
  Expiry defers, which keeps the marker. A decisive verdict retires it, so a
  repeat call is a no-op, and concurrent callers (boot racing a heal) share one
  run instead of judging in parallel.

**Log level.** The outcome lines moved `info` → `warn` for the same reason
`parkStop()` uses it: the production console transport sits at `warn` and the
in-app Logs dialog downloads the journal. The first board run reconciled correctly
and left **zero** operator-reachable evidence that a config write had been made on
the operator's behalf. Only a board could show that.

## How to verify

`bun test ./src/tests/config-change-reconcile-wiring.test.ts` — 12 cases driving a
**real on-disk marker** through the **real writer** and the **real `config.json`**:
persist-candidate, retain-previous, an undecided-then-decisive re-ask, a
never-decisive defer that keeps the marker, a no-marker run with zero side effects,
no double-apply on a repeat, overlapping runs joining one reconciliation, the
config-space normalization table, and the two call-site locks.

Red→green was proven in both directions. The suite was written first and failed to
resolve the module. Then, with the fix in place:

| Neuter (each reverted immediately) | Result |
|---|---|
| Delete both `void runInflightConfigChangeReconciliation()` call sites — i.e. re-create the bug exactly | `10 pass, 2 fail` |
| Drop the marker gate so the engine is asked unconditionally | `10 pass, 2 fail` |

**Board proof** (Rock 5B+, `192.168.78.131`, 12:58Z–13:05Z):

| | |
|---|---|
| Shipping binary, marker planted, restart | marker **leaked**, journal silent — the defect |
| Fixed binary, marker + idle engine | marker retired, `config.json` byte-identical, journal `warn` names the outcome |
| Fixed binary, backend killed mid transaction while a **real 720p h265 stream stayed on air** | candidate persisted from the engine's own live state — `config.json` `1080p` → `720p`; the engine's `"1280x720"` matched the `"720p"` candidate, proving the normalization on hardware |
| Fixed binary, **no marker** + a deliberate params-vs-config mismatch | `config.json` byte-identical, journal completely silent |

Board restored byte-for-byte (sha256 and mtime), no marker left, both services
active, `/` at 29 MB free at open and at close, nothing deleted.

Gate: `tsc` + spawn-policy gates PASS, root Biome PASS, `check:tech-debt` PASS,
backend suite `2680 pass / 3 fail` — the 3 are the pre-existing
`srtla ips-file writer` host limitation, verified identical on a clean stash of
`main`. Playwright/e2e cannot run on this host; the checks on this PR are the gate.

## Risks

- **Low, and bounded on every axis.** With no marker (every ordinary boot) the
  whole path is one failed file read: the engine is not asked, nothing is written,
  nothing is logged. A marker exists only after a crashed apply-now transaction.
- The bounded poll can add up to 15 s of background work on such a boot; it is
  fire-and-forget, so nothing waits on it.
- The judge's matching was **widened**, never narrowed — literal equality is still
  tried first, so no previously-matching pair can stop matching.
- The one behaviour change visible outside a crash is the log level, which makes a
  previously invisible event visible.
