### PR TITLE
chore(deps): pin @ceralive/cerastream 2026.7.5 — schema 0.11.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ setup.json are coerced to `"cerastream"` at parse time with a warning).
 The backend resolves both streaming deps as public-npm registry packages — no sibling checkout, no vendored tarball:
 
 ```
-"@ceralive/cerastream":  "2026.7.4"   (public npm, @ceralive scope)
+"@ceralive/cerastream":  "2026.7.5"   (public npm, @ceralive scope)
 "@ceralive/srtla-send":  "2026.6.2"   (public npm, @ceralive scope)
 ```
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -9,7 +9,7 @@
 		"bun": ">=1.3.0"
 	},
 	"dependencies": {
-		"@ceralive/cerastream": "2026.7.4",
+		"@ceralive/cerastream": "2026.7.5",
 		"@ceralive/control-protocol": "2026.7.0",
 		"@ceralive/srtla-send": "2026.6.2",
 		"@ceraui/rpc": "workspace:*",

--- a/apps/backend/src/mocks/providers/streaming.ts
+++ b/apps/backend/src/mocks/providers/streaming.ts
@@ -691,6 +691,7 @@ const TIER2_ERROR_SOURCE: Record<ProcessErrorCode, ProcessErrorSource> = {
 	srtla_no_connections: "srtla",
 	capture_audio_error: "engine",
 	capture_video_error: "engine",
+	capture_unrecoverable: "engine",
 	pipeline_stall: "engine",
 	srt_connect_failed: "engine",
 	srt_connection_lost: "engine",

--- a/apps/backend/src/modules/streaming/streamloop/process-error-patterns.ts
+++ b/apps/backend/src/modules/streaming/streamloop/process-error-patterns.ts
@@ -36,6 +36,7 @@ export const PROCESS_ERROR_CODES = {
 	PIPELINE_STALL: "pipeline_stall",
 	SRT_CONNECT_FAILED: "srt_connect_failed",
 	SRT_CONNECTION_LOST: "srt_connection_lost",
+	CAPTURE_UNRECOVERABLE: "capture_unrecoverable",
 } as const;
 
 export type ProcessErrorCode =
@@ -92,6 +93,11 @@ export const PROCESS_ERROR_MESSAGES: Record<
 	[PROCESS_ERROR_CODES.SRT_CONNECTION_LOST]: {
 		message: "The SRT connection failed. No automatic reconnect is scheduled.",
 		suppressIfSrtlaNotified: true,
+	},
+	[PROCESS_ERROR_CODES.CAPTURE_UNRECOVERABLE]: {
+		message:
+			"The capture device stopped responding and could not be recovered. Reconnect it, then start the stream again.",
+		suppressIfSrtlaNotified: false,
 	},
 };
 

--- a/apps/backend/src/tests/cerastream-bindings-skew.test.ts
+++ b/apps/backend/src/tests/cerastream-bindings-skew.test.ts
@@ -122,16 +122,18 @@ describe("cerastream bindings version-skew guard", () => {
 		);
 		// Tier 2 must map 1:1 onto CeraUI's PROCESS_ERROR_CODES (the table swap).
 		expect(processErrorCodeSchema.options).toContain("srt_connection_lost");
-		expect(processErrorCodeSchema.options.length).toBe(7);
+		expect(processErrorCodeSchema.options).toContain("capture_unrecoverable");
+		expect(processErrorCodeSchema.options.length).toBe(8);
 	});
 
-	test("SCHEMA_VERSION is pinned to 0.10.0", () => {
-		// device-quality-wave3 Todo 10: the 2026.7.4 pin ships schema 0.10.0 (the
-		// additive ADR-0008 identity + Todo 9 config-change batch), superseding the
-		// 0.8.0 the prior pin shipped. This value must equal what the on-device
-		// engine reports in `hello` — capabilities.ts raises the advisory
-		// `schemaVersionMismatch` banner off exactly that comparison.
-		expect(SCHEMA_VERSION).toBe("0.10.0");
+	test("SCHEMA_VERSION is pinned to 0.11.0", () => {
+		// device-platform-wave4 Todo 20: the 2026.7.5 pin ships schema 0.11.0 (the
+		// per-device `modes[]`/`input_mode` ladder, `capture_degraded.selected`, and
+		// the new terminal `capture_unrecoverable` error), superseding the 0.10.0 the
+		// prior pin shipped. This value must equal what the on-device engine reports
+		// in `hello` — capabilities.ts raises the advisory `schemaVersionMismatch`
+		// banner off exactly that comparison.
+		expect(SCHEMA_VERSION).toBe("0.11.0");
 	});
 
 	test("audio-level topic + connect-error codes are on the surface (Todo 22)", () => {

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -19,7 +19,7 @@ Svelte 5 PWA for CeraUI — the on-device control plane for CeraLive streaming h
 The `backend` app consumes both streaming bindings as pinned public npm packages:
 
 ```
-"@ceralive/cerastream": "2026.7.4"   (public npm, @ceralive scope)
+"@ceralive/cerastream": "2026.7.5"   (public npm, @ceralive scope)
 "@ceralive/srtla-send": "2026.6.2"   (public npm, @ceralive scope)
 ```
 

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
       "name": "backend",
       "version": "2026.6.2",
       "dependencies": {
-        "@ceralive/cerastream": "2026.7.4",
+        "@ceralive/cerastream": "2026.7.5",
         "@ceralive/control-protocol": "2026.7.0",
         "@ceralive/srtla-send": "2026.6.2",
         "@ceraui/rpc": "workspace:*",
@@ -342,7 +342,7 @@
 
     "@ceralive/biome-config": ["@ceralive/biome-config@2026.6.2", "", {}, "sha512-LqDaJufxLOC3Rm38u/ocpUro/ub8llv1q9pcS3W/Ys7gBy+wLjS2TmcyhMjNMRg9c7pCQlPMI6eS8JkhpN+ecw=="],
 
-    "@ceralive/cerastream": ["@ceralive/cerastream@2026.7.4", "", { "dependencies": { "zod": "^4.3.5" } }, "sha512-eZl24rtImGCtuAxtl+E0LVm5AZ3l4eFhxQT7pW77lyP5WbfayGR7dRqdbLtxdBr315yTO03MBXUJhPMJLf7JGA=="],
+    "@ceralive/cerastream": ["@ceralive/cerastream@2026.7.5", "", { "dependencies": { "zod": "^4.3.5" } }, "sha512-hYBiBHteHOrOfXlAUWRE0azlOt5WAUlZBH8mSq6RDLHRd7cQmumE6+5PHggdoEVkUC2U5EMqfwiV9pia5aiG0Q=="],
 
     "@ceralive/control-protocol": ["@ceralive/control-protocol@2026.7.0", "", { "dependencies": { "zod": "^4.3.5" } }, "sha512-/pLQpo3bTUzzxaQJK0zta4XKS6EJWr26p5jj2YST69ejxafQiCCjXKgdOkMWU9VjKm0XeMNQehxXOb6ylMGGHg=="],
 


### PR DESCRIPTION
**Affected repo & language:** CeraUI — TypeScript (backend)

## What

Bumps `@ceralive/cerastream` from `2026.7.4` to `2026.7.5` (engine schema `0.10.0` → `0.11.0`) and adopts the one new Tier-2 error code that comes with it.

The pin is two files (`apps/backend/package.json` + `bun.lock`). The other five exist because CeraUI has guards that deliberately refuse a silent adoption:

- `PROCESS_ERROR_CODES` derives the `ProcessErrorCode` type, which in turn types an exhaustive `Record` in the mock provider and the user-message catalog beside it — so the new `capture_unrecoverable` is a **compile error** until it is answered for in all three places.
- The version-skew test pins `SCHEMA_VERSION`, which `capabilities.ts` compares against the device's `hello` frame to raise the advisory mismatch banner.
- Two docs carry a literal mirror of the pin, and `test:release-package-contracts` machine-enforces that they match `package.json`.

Both guards are **re-pinned, not relaxed**. The Tier-2 assertion additionally now names the code (`toContain("capture_unrecoverable")`) instead of only counting members, so it asserts the thing it means rather than passing on any 8th code.

This is adoption only — nothing yet branches on the new `modes[]`, `input_mode`, or the degraded notice's `selected` flag. That surfacing is separate work.

## Why

`2026.7.5` is the engine release carrying the per-device capture-mode ladder (`modes[]` / `input_mode`), the `selected` flag on the capture-degraded notice, and the new terminal `capture_unrecoverable` error. CeraUI has to be pinned to it before any of that can be used.

Leaving `SCHEMA_VERSION` at `0.10.0` would not be cosmetic: it would raise a false version-mismatch banner on every real `0.11.0` engine.

`capture_unrecoverable` is **terminal** — the engine is not going to recover the capture leg — so its operator message says to reconnect the device and start again, rather than implying a reconnect that is not coming. It is not suppressed behind an srtla error it has nothing to do with.

## How to verify

```sh
bun install
cd apps/backend && bun tsc --noEmit && bun test      # 2715 pass / 0 fail
cd ../.. && bun run lint                              # exit 0
bun run --filter @ceraui/rpc test                     # 282 pass / 0 fail
bun run test:release-package-contracts                # exit 0 (doc-pin contract)
bun run check:rc-pins && bun run check:tech-debt      # exit 0
```

The lockfile entry can be checked against the registry directly — it should equal the published integrity digest, and nothing else should have moved:

```sh
npm view @ceralive/cerastream@2026.7.5 dist.integrity
git diff main -- bun.lock        # 2 hunks, both the @ceralive/cerastream entry
```

To confirm the new types actually resolve (rather than just that the tree compiles), parse them against the pinned schemas — including the forward-compat case where a `0.10.0`-shaped error with no `selected` key must still parse:

```ts
import { SCHEMA_VERSION, captureDeviceSchema, cerastreamConfigSchema,
         processErrorCodeSchema, runtimeErrorEventSchema } from "@ceralive/cerastream";

SCHEMA_VERSION === "0.11.0";
processErrorCodeSchema.options.includes("capture_unrecoverable");     // true, 8 members
cerastreamConfigSchema.shape.input_mode.safeParse("not_a_kind").success; // false
runtimeErrorEventSchema.parse({ type: "error", seq: 1, code: "capture_video_error",
                                source: "engine" }).selected;          // undefined
```

> **Local-run note:** on Node ≥ 25 the frontend unit suite fails ~76 files at import time (`localStorage` undefined via `$persist`) — this is the pre-existing trap documented in `apps/frontend/AGENTS.md`, not a regression. Run it as `NODE_OPTIONS="--localstorage-file=/tmp/ls.json" bunx vitest run` and it is **196/196 files, 2083/2083 tests green**. CI runs Node 24 and is unaffected.

## Risks

Low, and mostly bounded by the guards above rather than by review.

- The runtime behaviour change is one new entry in the error-code → message table. Nothing dispatches `capture_unrecoverable` inside CeraUI; it can only arrive from the engine, and before this change it would have arrived as an unmapped code.
- If the engine on a device is still `0.10.0`, `capabilities.ts` raises the existing advisory schema-mismatch banner. That is the intended signal, and it is advisory — it does not block streaming.
- Rollback is reverting this commit; the lockfile change is a single package with no transitive movement.
- E2E was not run to completion locally (`playwright install-deps` is Debian-only and this host is Arch). The 12 e2e failures observed locally reproduce **identically on clean `main` @ `2026.7.4`**, so they are environmental. CI runs the real e2e lanes.

---

**Checklist**

- [x] Docs updated if behavior or structure changed (Rule A: AGENTS.md, README, docs/, ARCHITECTURE.md, versions.yaml)
- [x] Started from updated main; branch rebased on latest canonical branch (Rule B)
- [x] Rule D local-scratch reference check passes for tracked files
- [x] Tests pass; QA evidence attached or linked
