### PR TITLE
feat(sources): one row per camera, mode selection, placeholder suppression

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -76,6 +76,8 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 | Retracting the `hdmi_error` "No HDMI signal detected" notification once the link relocks | `modules/system/hdmi-signal-notification.ts` (`clearHdmiSignalErrorOnRecovery`, hooked into `sources.ts` `commitEngineDevices`); contract below → A PERSISTENT NOTIFICATION MUST BE RETRACTABLE |
 | Scoping the `hdmi_error` "No HDMI signal detected" RAISE to a relevant selection | `modules/system/hdmi-signal-notification.ts` (`provesSelectionIsNotHdmi`) + `modules/system/sensors.ts` (`handleRk3588HdmiDmesg`); contract below → …AND ITS RAISE MUST BE SCOPED LIKE ITS RETRACTION |
 | Retracting the `cerastream` `capture_video_error` notification at a healthy session boundary | `modules/streaming/cerastream-backend.ts` (`standingEngineError`, `clearRecoveredEngineError`, `ENGINE_ERRORS_CLEARED_BY_HEALTHY_SESSION`) |
+| **One row per physical camera + per-device mode ladders (`inputModes`, `selectedInputMode`, coarse USB placeholder suppression)** | `modules/streaming/sources.ts` (`SUPPRESSED_COARSE_PIPELINE_IDS`, `buildInputModes`, `resolveSelectedInputMode`, mode-aware `deriveEngineRouting`) |
+| **Degraded-SELECTED capture snapshot (`capture_video_error` + `selected:true`)** | `modules/streaming/capture-degraded.ts`; raised/retracted in `modules/streaming/cerastream-backend.ts` (`clearRecoveredEngineError` is the ONLY clearing seam) |
 | **Device-truth save guard + persisted-mode clamp (ADR-0008 §10)** | `modules/streaming/device-mode-guard.ts` (`verifySaveDeviceMode`, `clampPersistedDeviceMode`) + `modules/streaming/persisted-mode-clamp.ts` (`reconcilePersistedDeviceMode`); the RULE itself is `@ceraui/rpc` `capabilities/device-mode-truth.ts`, shared with the frontend |
 | **Unified device-first `sources` builder + engine-device cache + `config.source` routing seam** | `modules/streaming/sources.ts` (`buildSources`, `getSourcesMessage`, `deriveEngineRouting`, `resolveSourceRouting`) |
 | **Which capture kinds release their kernel v4l2 node while the engine holds them (libuvc)** | `modules/streaming/held-devices.ts` (`releasesV4l2Node`) — CeraUI-side mirror of cerastream `engine::held_devices` |
@@ -1924,6 +1926,111 @@ table driven through the REAL procedure, the persistence-untouched guarantee, an
 the fail-open negatives) + `tests/capability-truth-clamp.test.ts` (the Osmo
 1080p60-on-H.264 migration, the one-time notification, and the never-clamp cases).
 
+## ONE ROW PER PHYSICAL CAMERA + PER-DEVICE MODE SELECTION [EXISTS]
+
+A capability source is a PIPELINE; an operator points at a DEVICE. Conflating the
+two put a permanent, unactionable row in the picker — `usb_mjpeg` rendered as
+"USB MJPEG · not connected" forever — and let ONE dual-format camera answer to
+TWO coarse rows at once.
+
+**`SUPPRESSED_COARSE_PIPELINE_IDS` (`sources.ts`) drops the USB-capture coarse
+rows in EVERY state**, not merely when a device bridges to them: `libuvch264`,
+`usb_mjpeg`, `v4l_mjpeg`, `camlink`. `v4l_mjpeg` is the starkest case — NO device
+kind bridges to it at all, so it can never be replaced by a concrete row and is a
+phantom by construction. `hdmi` / `rtmp` / `srt` / `test` are deliberately NOT in
+the set: each names a real, always-present port or capability of the board, so a
+coarse row for it is truthful with nothing plugged in. The empty state is the
+picker's single generic message, never a per-pipeline phantom. Board-proven A/B on
+a Rock 5B+: 6 rows → 5, the phantom `libuvch264` gone, the other five byte-identical.
+
+**A capture row carries every format the device advertises, each with its OWN
+ladder.** `captureDevice.modes[]` (cerastream schema `0.11.0`) is threaded verbatim
+through `fromEngineDevice` — the one engine-authored seam — and projected onto the
+row as `inputModes[]`. Three properties are load-bearing:
+
+- **A family is published only when its pipeline is OFFERED.** `buildInputModes`
+  gates on the coarse capability set, exactly the rule `buildSources` already
+  applies to a whole device. Without it a camera offers MJPEG on a board whose
+  engine never advertised `usb_mjpeg`, and the pick dies at
+  `pipeline_not_in_offered_set` AFTER the operator committed to it.
+- **The ladders are never unioned** (ADR-0008 §10). Each family projects its own
+  `caps` through the same `groupDeviceCaps` the flat list uses.
+- **Parsing is per-FAMILY, not per-device.** An engine that reports an `InputKind`
+  this build does not know drops that family; refusing the whole device would lose
+  the camera.
+
+**`config.input_mode` is a single field SCOPED to `config.source_stable_id`, not a
+map.** "Per device" is satisfied by scoping: an operator pick that lands on
+DIFFERENT hardware (compared by stable identity — node paths are recycled) CLEARS
+the mode, so a choice made for one camera can never govern another. A keyed map
+would need its own retention/eviction policy and would silently evict a stated
+intent. Absent ⇒ the engine's own precedence, which is H.264 first — byte-identical
+to every start before modes existed. Only an operator who explicitly picked a mode
+sends one.
+
+**Routing is mode-aware, because the two formats are two pipelines.** The same
+camera reaches the engine through `libuvch264` in H.264 mode and `usb_mjpeg` in
+MJPEG mode, so `deriveEngineRouting` re-answers the pipeline question against the
+selected family (`pipelineIdForInputMode`, the mode-aware sibling of
+`deviceKindToPipelineId`). A mode-only `setConfig` therefore re-routes the
+PERSISTED selection without rewriting `config.source`.
+
+**A mode switch mid-stream rides the EXISTING apply-now transaction.**
+`input_mode` is an `APPLY_NOW_FIELDS` member and a `StreamConfigChangeDelta` field;
+the engine owns the libuvc-release → re-enumeration-barrier → open transaction and
+rolls it back honestly. Do NOT build a second transaction in CeraUI.
+
+**Save-time validation intersects the SELECTED mode's ladder only.** This is ONE
+substitution, not a fork: `@ceraui/rpc` `device-mode-truth.ts` already scopes a
+ladder by "the media type the KIND names", so `device-mode-guard.ts`
+`governingKind()` hands it the selected mode instead of the device's scalar kind.
+`capabilities.ts`'s per-`media_type` split is untouched. The pick is trusted only
+while the device still ADVERTISES it. An EXPLICIT `input_mode` the device does not
+offer is REFUSED (`input_mode_unsupported`); a merely CARRIED one is silently
+dropped — a refusal answers the operator's own action, but applying it to a value
+they are not touching would let a device that stopped advertising a mode block
+every unrelated save.
+
+Coverage: `tests/one-row-per-camera.test.ts`.
+
+## THE DEGRADED-SELECTED CAPTURE SNAPSHOT [EXISTS]
+
+`capture_degraded` is NOT a wire event — `grep capture_degraded` across the
+published `@ceralive/cerastream` bindings returns nothing. cerastream reports it as
+the EXISTING `capture_video_error` runtime error additionally carrying
+`selected: true`. That pair IS the signal, and no other code may raise it.
+
+`modules/streaming/capture-degraded.ts` holds it as a persistent SNAPSHOT rather
+than a one-shot notification, because CeraUI otherwise maps engine errors only onto
+notifications and a client that connects afterwards never sees them — a backend
+restart or a frontend reconnect must not lose the state. It rides the `sources`
+payload: `degraded` on the row it is about, plus `degradedSelected` mirrored at the
+top level so the state survives the row (a device that degrades and is THEN
+unplugged has no row left to hang it on). The row is matched by stable identity
+first — the snapshot is taken at stream start and a libuvc camera renumbers on the
+very next release.
+
+**It inherits `ENGINE_ERRORS_CLEARED_BY_HEALTHY_SESSION`'s retraction and has NO
+clearing path of its own.** `clearSelectedCaptureDegraded()` is called from
+`clearRecoveredEngineError()` and nowhere else; `stop()` was added as a third call
+site of that SAME seam (it already treats a stop as a session boundary for
+`active_encode`). Three boundaries clear it: a concordant `streaming` status frame
+(rejoin), an operator stop, and a new session start.
+
+**It is dropped AHEAD of the standing-error gate, and that ordering is
+load-bearing.** `resolved.channel` is ONE notification slot shared by every
+non-srtla engine error, so `capture_video_error{selected}` → `srt_connection_lost`
+→ healthy session would return EARLY (the srt code is not in the membership table)
+and latch a capture claim the boundary disproved. The notification stays behind the
+gate, unchanged.
+
+**The re-publisher lives in `capture-degraded.ts`, not in the backend that raises
+it.** `cerastream-backend.ts` is pinned by a regression test to never name
+`./sources.ts` — the start choke point stays isolated from the source builder — and
+the import is dynamic because `sources.ts` imports this module statically.
+
+Coverage: `tests/one-row-per-camera.test.ts`.
+
 ## APPLY-NOW CONFIG CHANGE — TRANSACTION + STAGED PERSISTENCE [EXISTS]
 
 Resolution, framerate, codec and source are baked into the engine graph at build
@@ -3032,6 +3139,13 @@ config, an anchored path still held by its own device, and a live row with no
   healthy observation reset the run, and don't widen it past `physical_group_id`
   absence into re-asserting a remembered `caps`/`signal` — that is the latch
   `withKnownEngineMetadata` already refuses for good reason.
+- Don't re-add a coarse USB-capture placeholder row (`usb_mjpeg`, `v4l_mjpeg`, `libuvch264`, `camlink`) — a pipeline is not a device, the row is unactionable in every state, and one dual-format camera answers to two of them. And don't extend `SUPPRESSED_COARSE_PIPELINE_IDS` to `hdmi`/`rtmp`/`srt`/`test`: each names a real always-present board capability, so its coarse row is truthful with nothing plugged in.
+- Don't publish a device mode family whose pipeline the engine does not offer — the pick dies at `pipeline_not_in_offered_set` AFTER the operator committed to it. Gate `buildInputModes` on the coarse capability set, and don't union two media types' ladders (ADR-0008 §10).
+- Don't key `config.input_mode` per device in a map, and don't let it survive a move to different hardware — it is a single field SCOPED to `config.source_stable_id`, cleared when the stable identity changes. A map needs a retention policy (todo 22's territory) and silently evicts a stated operator intent.
+- Don't send `input_mode` when the operator never chose one — absent hands the format choice back to the engine's own precedence (H.264 first), which is the unchanged behaviour for every device and every existing caller.
+- Don't route a mode pick down the scalar kind's pipeline — the same camera is `libuvch264` in H.264 mode and `usb_mjpeg` in MJPEG mode. Use `pipelineIdForInputMode`.
+- Don't fork a mode-aware copy of the device-mode rule — `device-mode-truth.ts` already scopes by "the media type the KIND names", so pointing it at the SELECTED mode is the entire change (`governingKind`). And don't turn the carried-mode drop into a refusal: only an EXPLICIT pick the device does not advertise may be refused.
+- Don't handle a `capture_degraded` event — there is no such event. Key on `capture_video_error` + `selected === true`. Don't give the snapshot a clearing path of its own (it inherits `clearRecoveredEngineError`), and don't move its clear BEHIND the standing-error gate: the `cerastream` notification slot is shared, so a later unrelated error would latch a capture claim the boundary disproved.
 - Don't import from `@ceralive/srtla` — that package is retired from CeraUI. Use `@ceralive/srtla-send` (the `srtla-send-rs` binding, registry dep). Check `../../../srtla-send-rs/AGENTS.md` before touching call sites.
 - Don't add HTTP REST endpoints — all device control goes through oRPC over WebSocket.
 - Don't re-serialise the DNS health check ahead of the caller's query in `dnsCacheResolve`, and don't share one `Resolver` between them — the check only GATES the answer, and a shared c-ares channel's `cancel()` would abort the sibling leg. Both legs sit inside the per-attempt launch deadline (see DNS ON THE STREAM-START CRITICAL PATH).

--- a/apps/backend/src/helpers/config-schemas.ts
+++ b/apps/backend/src/helpers/config-schemas.ts
@@ -47,6 +47,7 @@ import {
 	type DetectionMethod,
 	detectionMethodSchema,
 	deviceKindSchema,
+	inputModeSchema,
 	isNamespacedRelayId,
 	kioskDisplaySchema,
 	kioskPerformanceSchema,
@@ -256,6 +257,13 @@ export const runtimeConfigSchema = z.object({
 	// one the operator meant. Additive-optional — absent means a legacy/anchorless
 	// selection, which resolves exactly as it did before this field existed.
 	source_stable_id: z.string().optional(),
+	// Which capture format the selected device is opened under, for a device that
+	// exposes more than one. Scoped to `source_stable_id`: an operator pick that
+	// moves to DIFFERENT hardware clears it, so a mode chosen for one camera can
+	// never govern another. Additive-optional — absent hands the choice back to
+	// the engine's own precedence (H.264 first), which is what every device did
+	// before this field existed.
+	input_mode: inputModeSchema.optional(),
 	// Operator-ordered video-source preference (input_id list, most-preferred
 	// first). Persisted so a device-first reorder survives reload; setConfig
 	// writes it, getConfig echoes it. Additive-optional.

--- a/apps/backend/src/modules/streaming/capture-degraded.ts
+++ b/apps/backend/src/modules/streaming/capture-degraded.ts
@@ -1,0 +1,113 @@
+/*
+    CeraUI - web UI for the CERALIVE project
+    Copyright (C) 2024-2025 CeraLive project
+
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * The degraded-SELECTED capture snapshot (wave-4 todo 21d).
+ *
+ * cerastream's capture-resilience layer reports that the operator's OWN selected
+ * capture leg came up degraded. It is NOT a distinct wire event — `grep
+ * capture_degraded` across the published `@ceralive/cerastream` bindings returns
+ * nothing, because the engine emits it as the EXISTING `capture_video_error`
+ * runtime error additionally carrying `selected: true`.
+ *
+ * That matters for how it is retracted. `capture_video_error` already has an
+ * engine-authored recovery signal and a single clearing seam in
+ * `cerastream-backend.ts` (`ENGINE_ERRORS_CLEARED_BY_HEALTHY_SESSION` +
+ * `clearRecoveredEngineError`). This snapshot INHERITS that seam verbatim and
+ * deliberately grows no clearing path of its own — a second, independently-timed
+ * retraction is precisely how the two halves of a raise/clear pair drift apart.
+ *
+ * It is a persistent SNAPSHOT rather than a one-shot notification because a
+ * backend restart or a frontend reconnect must not lose the state: CeraUI today
+ * maps engine errors only onto notifications, which a client that connects
+ * afterwards never sees. It rides the `sources` payload so the state arrives
+ * with the row it is about.
+ */
+
+import type { SourceDegraded } from "@ceraui/rpc/schemas";
+
+import { logger } from "../../helpers/logger.ts";
+
+/** The standing snapshot: WHICH device, and WHAT the engine said about it. */
+export interface CaptureDegradedSnapshot {
+	/** The engine `input_id` the selection resolved to when the report arrived. */
+	sourceId: string | undefined;
+	/** Its stable hardware identity, so a renumber does not strand the snapshot. */
+	stableId: string | undefined;
+	state: SourceDegraded;
+}
+
+let snapshot: CaptureDegradedSnapshot | undefined;
+
+/**
+ * Re-publish `sources` after the snapshot moved.
+ *
+ * Owned HERE rather than by the engine backend that raises it, because
+ * `cerastream-backend.ts` is pinned by a regression test to never name
+ * `./sources.ts` at all — the start choke point must stay isolated from the
+ * source builder. The import is dynamic for the mirror-image reason
+ * `sources.ts` uses for `audio.ts`: `sources.ts` imports THIS module
+ * statically, so a static import back would cycle.
+ */
+type CaptureDegradedPublisher = () => void;
+
+const defaultPublisher: CaptureDegradedPublisher = () => {
+	void import("./sources.ts")
+		.then(({ broadcastSources }) => {
+			broadcastSources();
+		})
+		.catch((err: unknown) => {
+			logger.debug("capture-degraded: sources re-publish failed", { err });
+		});
+};
+
+let publisher: CaptureDegradedPublisher = defaultPublisher;
+
+/** Test seam: swap the re-publisher (`undefined` restores the default). */
+export function setCaptureDegradedPublisherForTest(
+	fn: CaptureDegradedPublisher | undefined,
+): void {
+	publisher = fn ?? defaultPublisher;
+}
+
+/**
+ * Record that the SELECTED capture leg is degraded.
+ *
+ * The engine names no device — `selected: true` means "the one you chose" — so
+ * the identity is bound here, from the selection as it stands at report time.
+ */
+export function noteSelectedCaptureDegraded(
+	report: CaptureDegradedSnapshot,
+): void {
+	snapshot = report;
+	publisher();
+}
+
+/** Retract the snapshot. Returns whether anything was actually standing. */
+export function clearSelectedCaptureDegraded(): boolean {
+	if (snapshot === undefined) return false;
+	snapshot = undefined;
+	publisher();
+	return true;
+}
+
+export function getSelectedCaptureDegraded():
+	| CaptureDegradedSnapshot
+	| undefined {
+	return snapshot;
+}

--- a/apps/backend/src/modules/streaming/cerastream-backend.ts
+++ b/apps/backend/src/modules/streaming/cerastream-backend.ts
@@ -118,6 +118,10 @@ import {
 	notificationRemove,
 } from "../ui/notifications.ts";
 import { type AudioMode, resolveAudioMode } from "./audio.ts";
+import {
+	clearSelectedCaptureDegraded,
+	noteSelectedCaptureDegraded,
+} from "./capture-degraded.ts";
 import type { ResolvedCerastreamError } from "./cerastream-error-mapping.ts";
 import { resolveCerastreamError } from "./cerastream-error-mapping.ts";
 import { SRTLA_LISTEN_PORT } from "./constants.ts";
@@ -753,6 +757,11 @@ export class CerastreamBackend implements StreamingBackend {
 		// A crashed or already-gone engine sends no final idle status, so the
 		// stop itself has to be the clearing signal.
 		this.clearSessionScopedTelemetry();
+		// Same rule, same reason: a `capture_video_error` is a claim about ONE
+		// session, and this ends it. Routed through the one clearing seam so the
+		// snapshot and the notification can never disagree about whether the
+		// session's failure is still current.
+		this.clearRecoveredEngineError();
 		const client = this.client;
 		const subscription = this.subscription;
 		const operation = (async () => {
@@ -1107,6 +1116,7 @@ export class CerastreamBackend implements StreamingBackend {
 	}
 
 	private handleErrorEvent(event: RuntimeErrorEvent): void {
+		this.noteDegradedSelectedCapture(event);
 		const resolved = resolveCerastreamError(
 			event.code,
 			event.source,
@@ -1145,11 +1155,42 @@ export class CerastreamBackend implements StreamingBackend {
 	 * established are deliberately absent from the table and stay latched.
 	 */
 	private clearRecoveredEngineError(): void {
+		// The degraded-selected snapshot describes the SAME session this boundary
+		// falsifies, so it retracts HERE and nowhere else — it deliberately has no
+		// clearing path of its own to drift from this one. It is dropped ahead of
+		// the standing-error gate rather than behind it because the `cerastream`
+		// notification slot is SHARED: a later unrelated error occupying it would
+		// otherwise return early and latch a capture claim the boundary disproved.
+		clearSelectedCaptureDegraded();
 		const standing = this.standingEngineError;
 		if (standing === undefined) return;
 		if (!ENGINE_ERRORS_CLEARED_BY_HEALTHY_SESSION.has(standing.code)) return;
 		this.standingEngineError = undefined;
 		this.deps.bridge.removeNotification(standing.channel);
+	}
+
+	/**
+	 * Record that the OPERATOR'S OWN selected capture leg came up degraded.
+	 *
+	 * `capture_degraded` is not a wire event: cerastream reports this as the
+	 * EXISTING `capture_video_error` additionally carrying `selected: true`, so
+	 * that pair is the whole signal and no other code may raise it. Scoping it to
+	 * the one code in {@link ENGINE_ERRORS_CLEARED_BY_HEALTHY_SESSION} is what
+	 * makes the retraction above sufficient — a code with no established recovery
+	 * signal would latch forever.
+	 */
+	private noteDegradedSelectedCapture(event: RuntimeErrorEvent): void {
+		if (event.code !== PROCESS_ERROR_CODES.CAPTURE_VIDEO_ERROR) return;
+		if (event.selected !== true) return;
+		const config = this.deps.getConfig();
+		noteSelectedCaptureDegraded({
+			sourceId: config.selected_video_input ?? config.source,
+			stableId: config.source_stable_id,
+			state: {
+				code: event.code,
+				...(event.reason === undefined ? {} : { reason: event.reason }),
+			},
+		});
 	}
 
 	private enqueue(op: () => Promise<void>, label: string): Promise<void> {
@@ -1285,6 +1326,12 @@ export class CerastreamBackend implements StreamingBackend {
 				: {}),
 			...(config.framerate !== undefined
 				? { framerate: config.framerate }
+				: {}),
+			// Absent hands the format choice back to the engine's own precedence,
+			// which is H.264 first — byte-identical to every start before modes
+			// existed. Only an operator who explicitly picked a mode sends one.
+			...(config.input_mode !== undefined
+				? { input_mode: config.input_mode }
 				: {}),
 			...(Object.keys(audio).length > 0 ? { audio } : {}),
 		};

--- a/apps/backend/src/modules/streaming/config-change-bridge.ts
+++ b/apps/backend/src/modules/streaming/config-change-bridge.ts
@@ -28,6 +28,7 @@ type ChangeConfigCapableBackend = {
 		codec?: string;
 		input_id?: string;
 		pipeline?: string;
+		input_mode?: string;
 	}) => Promise<{
 		attempt_id: string;
 		phase: ConfigChangePhase;
@@ -81,6 +82,7 @@ export async function changeEngineRuntimeConfig(
 		...(delta.video_codec === undefined ? {} : { codec: delta.video_codec }),
 		...(delta.input_id === undefined ? {} : { input_id: delta.input_id }),
 		...(delta.pipeline === undefined ? {} : { pipeline: delta.pipeline }),
+		...(delta.input_mode === undefined ? {} : { input_mode: delta.input_mode }),
 	});
 
 	logger.info("config change transaction settled", {

--- a/apps/backend/src/modules/streaming/config-change-staging.ts
+++ b/apps/backend/src/modules/streaming/config-change-staging.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 
 import {
+	inputModeSchema,
 	normalizeFramerateToRung,
 	normalizeResolutionToRung,
 } from "@ceraui/rpc/schemas";
@@ -18,6 +19,9 @@ const stagedFieldsSchema = z.object({
 	resolution: z.string().optional(),
 	framerate: z.number().optional(),
 	video_codec: z.string().optional(),
+	// Switching a dual-format camera between H.264 and MJPEG rebuilds the capture
+	// leg, so it is a transaction like the axes above — never a live reload.
+	input_mode: inputModeSchema.optional(),
 });
 export type StagedConfigFields = z.infer<typeof stagedFieldsSchema>;
 

--- a/apps/backend/src/modules/streaming/device-mode-guard.ts
+++ b/apps/backend/src/modules/streaming/device-mode-guard.ts
@@ -30,6 +30,7 @@ import {
 	type DeviceModeVerdict,
 	evaluateDeviceMode,
 	type Framerate,
+	type InputMode,
 	nearestDeliverableMode,
 	type Resolution,
 	type SourceModeCeiling,
@@ -61,6 +62,7 @@ function governingLadder(
 	sourceId: string | undefined,
 	sources: readonly StreamSource[],
 	lastSeenDevices: readonly LastSeenDevice[] | undefined,
+	inputMode: InputMode | undefined,
 ): GoverningLadder | undefined {
 	if (sourceId === undefined) return undefined;
 	const effectiveId = resolveSourceIdentity(sourceId, sources, lastSeenDevices);
@@ -68,8 +70,37 @@ function governingLadder(
 	if (source === undefined || source.modes.length === 0) return undefined;
 	return {
 		modes: source.modes,
-		kind: source.origin === "capture" ? source.kind : undefined,
+		// The shared rule scopes a ladder by the media type the KIND names, so
+		// handing it the SELECTED mode instead of the device's scalar kind is the
+		// whole of mode-awareness: the same evaluator, pointed at the ladder the
+		// leg will actually negotiate. Validating a dual-format camera against its
+		// H.264 ladder while MJPEG is selected refuses a mode the device can
+		// deliver, and permits one it cannot — the union lie in both directions.
+		kind: governingKind(source, inputMode),
 	};
+}
+
+/**
+ * The kind whose media type governs, honouring the operator's mode pick.
+ *
+ * The pick is only trusted while the device still ADVERTISES it: a mode carried
+ * over from other hardware must not narrow a ladder it has nothing to do with.
+ * A non-capture source has no mode to speak of, so it keeps answering
+ * `undefined` and nothing narrows — the unchanged none-cap policy.
+ */
+function governingKind(
+	source: StreamSource,
+	inputMode: InputMode | undefined,
+): string | undefined {
+	if (source.origin !== "capture") return undefined;
+	const selected = inputMode ?? source.selectedInputMode;
+	if (
+		selected !== undefined &&
+		source.inputModes?.some((mode) => mode.inputMode === selected) === true
+	) {
+		return selected;
+	}
+	return source.kind;
 }
 
 /** The encode target being checked, as the caller knows it. */
@@ -78,6 +109,8 @@ export interface DeviceModeTarget {
 	sourceId: string | undefined;
 	resolution: Resolution | undefined;
 	framerate: Framerate | undefined;
+	/** The mode being saved. Absent → the source's own selected/scalar mode. */
+	inputMode?: InputMode | undefined;
 }
 
 /** Injected state, so the load-time clamp can be driven without the singletons. */
@@ -110,7 +143,12 @@ export function verifySaveDeviceMode(
 	deps?: DeviceModeGuardDeps,
 ): DeviceModeVerdict {
 	const { sources, lastSeenDevices } = resolveDeps(deps);
-	const ladder = governingLadder(target.sourceId, sources, lastSeenDevices);
+	const ladder = governingLadder(
+		target.sourceId,
+		sources,
+		lastSeenDevices,
+		target.inputMode,
+	);
 	if (ladder === undefined) return { supported: true };
 	return evaluateDeviceMode({
 		modes: ladder.modes,
@@ -131,7 +169,12 @@ export function clampPersistedDeviceMode(
 	deps?: DeviceModeGuardDeps,
 ): SourceModeCeiling | undefined {
 	const { sources, lastSeenDevices } = resolveDeps(deps);
-	const ladder = governingLadder(target.sourceId, sources, lastSeenDevices);
+	const ladder = governingLadder(
+		target.sourceId,
+		sources,
+		lastSeenDevices,
+		target.inputMode,
+	);
 	if (ladder === undefined) return undefined;
 	const query = {
 		modes: ladder.modes,

--- a/apps/backend/src/modules/streaming/devices.ts
+++ b/apps/backend/src/modules/streaming/devices.ts
@@ -30,6 +30,8 @@ import { readdir } from "node:fs/promises";
 import {
 	type CaptureCap,
 	type CaptureDevice,
+	type CaptureMode,
+	captureModeSchema,
 	type DeviceKind,
 	type DeviceMediaClass,
 	type DevicesMessage,
@@ -175,6 +177,10 @@ export interface EngineCaptureDevice {
 	media_class: DeviceMediaClass;
 	kind?: string | undefined;
 	caps?: CaptureCap[] | undefined;
+	// Per-mode-family ladders (cerastream schema 0.11.0). Typed loosely so an
+	// engine that reports a family this build does not know about is dropped by
+	// the parse below rather than rejecting the whole device.
+	modes?: readonly unknown[] | undefined;
 	// Reboot-stable hardware identity (cerastream Todo 20 `stable_id`). Carried
 	// verbatim so sources reconciliation can migrate a re-enumerated device by
 	// stable identity rather than node path (Todo 34).
@@ -204,6 +210,7 @@ export function fromEngineDevice(device: EngineCaptureDevice): CaptureDevice {
 		media_class: device.media_class,
 		kind: mapEngineDeviceKind(device.kind, device.display_name),
 		...(device.caps !== undefined ? { caps: device.caps } : {}),
+		...(engineModes(device.modes) ?? {}),
 		...(device.stable_id !== undefined ? { stable_id: device.stable_id } : {}),
 		...(device.physical_group_id !== undefined
 			? { physical_group_id: device.physical_group_id }
@@ -228,6 +235,26 @@ export function fromEngineDevice(device: EngineCaptureDevice): CaptureDevice {
  */
 function engineSignal(device: EngineCaptureDevice): SourceSignal {
 	return (device.caps?.length ?? 0) > 0 ? "present" : "absent";
+}
+
+/**
+ * The mode families this build can actually route, parsed one at a time.
+ *
+ * Per-family rather than per-device on purpose: cerastream may add an
+ * `InputKind` before CeraUI knows it, and refusing the whole device over one
+ * unrecognised family would lose the camera entirely — the none-cap policy the
+ * capability layer already follows. An entirely absent or entirely unparseable
+ * list omits the field, which reads as "no split reported".
+ */
+function engineModes(
+	modes: readonly unknown[] | undefined,
+): { modes: CaptureMode[] } | undefined {
+	if (modes === undefined) return undefined;
+	const parsed = modes
+		.map((mode) => captureModeSchema.safeParse(mode))
+		.filter((result) => result.success)
+		.map((result) => result.data);
+	return parsed.length > 0 ? { modes: parsed } : undefined;
 }
 
 /** Pure: collapse a v4l2 scan + audio map into the deduped device list. */
@@ -295,6 +322,7 @@ async function defaultGetEngineDevices(): Promise<CaptureDevice[] | null> {
 				media_class: d.media_class,
 				kind: d.kind,
 				caps: d.caps,
+				modes: d.modes,
 				stable_id: d.stable_id,
 			}),
 		);

--- a/apps/backend/src/modules/streaming/sources.ts
+++ b/apps/backend/src/modules/streaming/sources.ts
@@ -47,21 +47,28 @@ import type {
 	GetCapabilitiesResult,
 	ListDevicesResult,
 } from "@ceralive/cerastream";
-import { deviceKindToPipelineId } from "@ceraui/rpc";
+import { deviceKindToPipelineId, pipelineIdForInputMode } from "@ceraui/rpc";
 import type {
 	CaptureDevice,
+	CaptureInputMode,
 	DevicesMessage,
 	Framerate,
+	InputMode,
 	NetworkIngest,
 	PipelineAudioKind,
 	RequiresGateway,
 	Resolution,
+	SourceDegraded,
 	SourcesMessage,
 	SourcesVisibility,
 	StreamSource,
 	StreamSourceBase,
 } from "@ceraui/rpc/schemas";
-import { framerateSchema, resolutionSchema } from "@ceraui/rpc/schemas";
+import {
+	framerateSchema,
+	inputModeSchema,
+	resolutionSchema,
+} from "@ceraui/rpc/schemas";
 import type { LastSeenDevice } from "../../helpers/config-schemas.ts";
 import { logger } from "../../helpers/logger.ts";
 import { broadcastMsg } from "../../rpc/compat.ts";
@@ -74,6 +81,10 @@ import {
 	getLastCapabilities,
 	groupDeviceCaps,
 } from "./capabilities.ts";
+import {
+	type CaptureDegradedSnapshot,
+	getSelectedCaptureDegraded,
+} from "./capture-degraded.ts";
 import { fromEngineDevice } from "./devices.ts";
 import { releasesV4l2Node } from "./held-devices.ts";
 import { applyOnboardVideoDisplayRule } from "./onboard-display-names.ts";
@@ -92,6 +103,36 @@ const NETWORK_SOURCE_IDS: Record<string, RequiresGateway> = {
 
 /** The single virtual source id (the test pattern). */
 const VIRTUAL_SOURCE_ID = "test";
+
+/**
+ * The coarse capability sources that describe a USB CAPTURE PIPELINE rather than
+ * a port an operator can point at.
+ *
+ * These rows are phantoms and always were: `usb_mjpeg` renders permanently as
+ * "USB MJPEG · not connected" whether or not any camera is attached, because a
+ * pipeline is not a device. Worse, one physical dual-format camera answers to
+ * TWO of them, so the coarse layer alone could show a single Osmo Pocket 3 as
+ * two selectable rows. The device-first model already publishes exactly one
+ * concrete row per physical camera, with its formats carried as `inputModes`,
+ * so the coarse row adds nothing an operator can act on.
+ *
+ * They are suppressed in EVERY state, not merely when a device bridges to them —
+ * a permanent phantom is exactly what the locked one-row-per-camera decision
+ * removes. The no-devices empty state is the picker's single generic message.
+ *
+ * `v4l_mjpeg` is the starkest case: NO device kind bridges to it at all, so it
+ * can never be replaced by a concrete row and is a phantom by construction.
+ *
+ * HDMI, network ingest and the test pattern are deliberately NOT here: each
+ * names a real, always-present port or capability of the board itself, so a
+ * coarse row for it is truthful even with nothing plugged in.
+ */
+const SUPPRESSED_COARSE_PIPELINE_IDS: ReadonlySet<string> = new Set([
+	"libuvch264",
+	"usb_mjpeg",
+	"v4l_mjpeg",
+	"camlink",
+]);
 
 /**
  * CeraUI-side fallback that keeps the virtual test-pattern source audio-
@@ -244,16 +285,114 @@ function buildBaseEntry(
 	return { ...base, origin: "coarse", labelKey: sourceLabelKey(cap.id) };
 }
 
+/** Everything a capture row needs beyond the device itself and its coarse slot. */
+interface CaptureEntryContext {
+	/** Pipeline ids the engine currently advertises as coarse capability sources. */
+	offeredPipelineIds: ReadonlySet<string>;
+	/** The operator's persisted `config.input_mode`, if any. */
+	persistedInputMode: InputMode | undefined;
+	/** The standing degraded-selected snapshot, if any. */
+	degraded: CaptureDegradedSnapshot | undefined;
+}
+
+/**
+ * Stamp the degraded snapshot onto the ONE row it is about.
+ *
+ * Matched by stable identity first: the snapshot is taken at stream start and a
+ * libuvc camera renumbers on the very next release, so a node-path-only match
+ * would lose the row it describes. The node path is the fallback for a device
+ * the engine gives no stable identity for.
+ */
+function degradedFor(
+	device: CaptureDevice,
+	snapshot: CaptureDegradedSnapshot | undefined,
+): { degraded: SourceDegraded } | undefined {
+	if (snapshot === undefined) return undefined;
+	const matchesIdentity =
+		snapshot.stableId !== undefined &&
+		snapshot.stableId !== "" &&
+		snapshot.stableId === device.stable_id;
+	if (!matchesIdentity && snapshot.sourceId !== device.input_id)
+		return undefined;
+	return { degraded: snapshot.state };
+}
+
+/**
+ * The mode families this device exposes that the board can ACTUALLY open.
+ *
+ * A family is published only when its `pipeline_kind` bridges to a pipeline the
+ * engine currently advertises as a coarse capability source — exactly the rule
+ * `buildSources` already applies to a whole device. Without it a camera could
+ * offer the operator an MJPEG mode on a board whose engine never offered
+ * `usb_mjpeg`, and the pick would die at `pipeline_not_in_offered_set` after
+ * they had already committed to it.
+ *
+ * Each family carries its OWN ladder, projected through the same `groupDeviceCaps`
+ * the flat list uses, so the two can never disagree about a rung.
+ */
+function buildInputModes(
+	device: CaptureDevice,
+	offeredPipelineIds: ReadonlySet<string>,
+): CaptureInputMode[] {
+	const out: CaptureInputMode[] = [];
+	for (const mode of device.modes ?? []) {
+		const pipelineId = pipelineIdForInputMode(mode.pipeline_kind);
+		if (pipelineId === undefined || !offeredPipelineIds.has(pipelineId))
+			continue;
+		out.push({
+			inputMode: mode.pipeline_kind,
+			mediaType: mode.media_type,
+			pipelineId,
+			modes: groupDeviceCaps(mode.caps),
+		});
+	}
+	return out;
+}
+
+/**
+ * The format this device's leg will be opened under.
+ *
+ * The operator's persisted pick wins only while this device still advertises it
+ * — a mode that disappeared (a different camera, a firmware change) must not
+ * keep governing. Otherwise the answer is the engine's own scalar `kind`, which
+ * IS its highest-precedence mode, so an operator who never chose gets H.264 on a
+ * dual-format camera exactly as they did before modes existed.
+ */
+function resolveSelectedInputMode(
+	device: CaptureDevice,
+	inputModes: readonly CaptureInputMode[],
+	persisted: InputMode | undefined,
+): InputMode | undefined {
+	if (
+		persisted !== undefined &&
+		inputModes.some((mode) => mode.inputMode === persisted)
+	) {
+		return persisted;
+	}
+	const parsed = inputModeSchema.safeParse(device.kind);
+	return parsed.success ? parsed.data : undefined;
+}
+
 /** Build one concrete `capture` entry, inheriting facets from its coarse entry. */
 function buildCaptureEntry(
 	device: CaptureDevice,
 	pipelineId: string,
 	coarse: StreamSource,
+	context: CaptureEntryContext,
 ): StreamSource {
+	const inputModes = buildInputModes(device, context.offeredPipelineIds);
+	const selectedInputMode = resolveSelectedInputMode(
+		device,
+		inputModes,
+		context.persistedInputMode,
+	);
 	return {
 		id: device.input_id,
 		pipelineId,
 		modes: device.caps !== undefined ? groupDeviceCaps(device.caps) : [],
+		...(inputModes.length > 0 ? { inputModes } : {}),
+		...(selectedInputMode !== undefined ? { selectedInputMode } : {}),
+		...(degradedFor(device, context.degraded) ?? {}),
 		// Stamped by `fromEngineDevice` (the only seam that knows the engine
 		// authored the row); anything else is honestly `unknown`.
 		signal: device.signal ?? "unknown",
@@ -337,6 +476,10 @@ export interface BuildSourcesInput {
 	/** In-memory session snapshots; the metadata source for in-session lost rows
 	 *  (uncapped, so LRU churn never orphans a session-seen id). */
 	sessionSnapshots?: ReadonlyMap<string, LastSeenDevice>;
+	/** The operator's persisted `config.input_mode`. Absent → engine precedence. */
+	inputMode?: InputMode;
+	/** The standing degraded-selected snapshot. Absent → no row is degraded. */
+	degraded?: CaptureDegradedSnapshot;
 }
 
 /**
@@ -490,6 +633,14 @@ export function buildSources(input: BuildSourcesInput): StreamSource[] {
 		if (entry.origin === "coarse")
 			coarseByPipeline.set(entry.pipelineId, entry);
 	}
+	// Built from the COARSE set, before any suppression: a suppressed placeholder
+	// still proves the engine offers that pipeline, which is exactly the question
+	// a mode family has to answer to be publishable.
+	const captureContext: CaptureEntryContext = {
+		offeredPipelineIds: new Set(coarseByPipeline.keys()),
+		persistedInputMode: input.inputMode,
+		degraded: input.degraded,
+	};
 
 	const capturesByPipeline = new Map<string, StreamSource[]>();
 	// Live capture rows indexed by stable identity, so a remembered id the loop
@@ -517,7 +668,7 @@ export function buildSources(input: BuildSourcesInput): StreamSource[] {
 		if (bridged === undefined) continue;
 		const coarse = coarseByPipeline.get(bridged);
 		if (coarse === undefined) continue;
-		const entry = buildCaptureEntry(device, bridged, coarse);
+		const entry = buildCaptureEntry(device, bridged, coarse, captureContext);
 		if (device.stable_id !== undefined && device.stable_id !== "") {
 			liveStableIds.add(device.stable_id);
 			const byIdentity = capturesByStableId.get(device.stable_id) ?? [];
@@ -575,6 +726,10 @@ export function buildSources(input: BuildSourcesInput): StreamSource[] {
 				out.push(...captures, ...lost);
 				continue;
 			}
+			// The bridged-device case above already replaced this slot; what is left
+			// is the placeholder, and for a USB capture pipeline that placeholder is
+			// a phantom in every state (see SUPPRESSED_COARSE_PIPELINE_IDS).
+			if (SUPPRESSED_COARSE_PIPELINE_IDS.has(entry.pipelineId)) continue;
 		}
 		out.push(entry);
 	}
@@ -599,11 +754,23 @@ export interface EngineRouting {
 export function deriveEngineRouting(
 	sourceId: string,
 	sources: readonly StreamSource[],
+	inputMode?: InputMode,
 ): EngineRouting | undefined {
 	const source = sources.find((s) => s.id === sourceId);
 	if (source === undefined) return undefined;
 	if (source.origin === "capture") {
-		return { pipeline: source.pipelineId, selected_video_input: source.id };
+		// A dual-format camera does not reach the engine through ONE pipeline: the
+		// same hardware is `libuvch264` in H.264 mode and `usb_mjpeg` in MJPEG mode.
+		// The row's own `pipelineId` is bridged from the device's SCALAR kind, so a
+		// selected mode has to re-answer the question — and only against a family
+		// this device actually publishes, which `buildInputModes` has already proven
+		// is offered. An unrecognised mode falls back and never redirects.
+		const selected = inputMode ?? source.selectedInputMode;
+		const family = source.inputModes?.find((m) => m.inputMode === selected);
+		return {
+			pipeline: family?.pipelineId ?? source.pipelineId,
+			selected_video_input: source.id,
+		};
 	}
 	return { pipeline: source.pipelineId, selected_video_input: undefined };
 }
@@ -743,6 +910,7 @@ export function resolveSourceRouting(
 	sources: readonly StreamSource[],
 	lastSeenDevices?: readonly LastSeenDevice[],
 	anchorStableId?: string,
+	inputMode?: InputMode,
 ): ResolveSourceRoutingResult {
 	const resolution = resolveSourceIdentityDetailed(
 		sourceId,
@@ -764,7 +932,7 @@ export function resolveSourceRouting(
 	if (source.origin === "network" && source.available === false) {
 		return { ok: false, error: SOURCE_UNAVAILABLE_ERROR };
 	}
-	const routing = deriveEngineRouting(effectiveId, sources);
+	const routing = deriveEngineRouting(effectiveId, sources, inputMode);
 	if (routing === undefined) {
 		return { ok: false, error: UNKNOWN_SOURCE_ERROR };
 	}
@@ -1355,6 +1523,7 @@ export function getSourcesMessage(): SourcesMessage {
 	const caps = getLastCapabilities();
 	const config = getConfig();
 	const sourcesVisibility = config.sources_visibility;
+	const degraded = getSelectedCaptureDegraded();
 	const sources = buildSources({
 		sources: caps?.sources ?? [],
 		devices: getEngineDeviceCache(),
@@ -1363,8 +1532,16 @@ export function getSourcesMessage(): SourcesMessage {
 		...(config.source !== undefined ? { configSource: config.source } : {}),
 		lastSeenDevices: config.last_seen_devices ?? [],
 		sessionSnapshots: sessionSeenDeviceSnapshots,
+		...(config.input_mode !== undefined
+			? { inputMode: config.input_mode }
+			: {}),
+		...(degraded !== undefined ? { degraded } : {}),
 	});
-	return { hardware: getEffectiveHardware(), sources };
+	return {
+		hardware: getEffectiveHardware(),
+		sources,
+		...(degraded !== undefined ? { degradedSelected: degraded.state } : {}),
+	};
 }
 
 /**

--- a/apps/backend/src/modules/streaming/stream-session-orchestrator.ts
+++ b/apps/backend/src/modules/streaming/stream-session-orchestrator.ts
@@ -2,6 +2,7 @@ import {
 	CONFIG_CHANGE_REASON_DEADLINE,
 	type ConfigChangePhase,
 	type ConfigChangeResult,
+	type InputMode,
 	isLegalLifecycleTransition,
 	isTerminalConfigChangePhase,
 	type LifecycleState,
@@ -77,6 +78,11 @@ export type StreamConfigChangeDelta = {
 	readonly video_codec?: string;
 	readonly input_id?: string;
 	readonly pipeline?: string;
+	// The ENGINE owns the libuvc-release → re-enumeration-barrier → open
+	// transaction a live mode switch needs, and rolls it back honestly. This
+	// field is only how the operator's choice reaches it — never a second
+	// transaction of CeraUI's own.
+	readonly input_mode?: InputMode;
 };
 
 export type EngineConfigChangeOutcome = {

--- a/apps/backend/src/rpc/procedures/streaming.procedure.ts
+++ b/apps/backend/src/rpc/procedures/streaming.procedure.ts
@@ -15,6 +15,7 @@ import {
 	GATEWAY_INACTIVE_ERROR,
 	getEngineOutputSchema,
 	getMockHardwareOutputSchema,
+	type InputMode,
 	listDevicesOutputSchema,
 	pipelinesMessageSchema,
 	reloadAudioDelayInputSchema,
@@ -24,6 +25,7 @@ import {
 	type StartResult,
 	type StreamingConfigInput,
 	type StreamingSetConfigInput,
+	type StreamSource,
 	SWITCH_AUDIO_ERRORS,
 	type SwitchInputOutput,
 	setMockDeviceAttachedInputSchema,
@@ -105,6 +107,8 @@ import {
 	getSourcesMessage,
 	noteSourceSelectionWrite,
 	type ResolveSourceRoutingResult,
+	resolveSelectionAnchor,
+	resolveSourceIdentity,
 	resolveSourceRouting,
 } from "../../modules/streaming/sources.ts";
 import {
@@ -503,6 +507,7 @@ const APPLY_NOW_FIELDS = [
 	"resolution",
 	"framerate",
 	"video_codec",
+	"input_mode",
 ] as const;
 
 /**
@@ -530,6 +535,7 @@ function stageApplyNowFields(
 		...(input.video_codec === undefined
 			? {}
 			: { video_codec: input.video_codec }),
+		...(input.input_mode === undefined ? {} : { input_mode: input.input_mode }),
 		...(sourceRouting?.pipeline === undefined
 			? {}
 			: { pipeline: sourceRouting.pipeline }),
@@ -546,6 +552,9 @@ function stageApplyNowFields(
 		...(config.video_codec === undefined
 			? {}
 			: { video_codec: config.video_codec }),
+		...(config.input_mode === undefined
+			? {}
+			: { input_mode: config.input_mode }),
 		...(config.pipeline === undefined ? {} : { pipeline: config.pipeline }),
 		...(config.selected_video_input === undefined
 			? {}
@@ -565,6 +574,87 @@ function stageApplyNowFields(
 	return candidate;
 }
 
+/**
+ * The typed refusal for an `input_mode` the selected device does not advertise.
+ * A stable wire value — the picker keys its honest rejection copy on it.
+ */
+export const INPUT_MODE_UNSUPPORTED_ERROR = "input_mode_unsupported";
+
+type InputModeChoice =
+	| { ok: true; inputMode: InputMode | undefined }
+	| { ok: false; error: typeof INPUT_MODE_UNSUPPORTED_ERROR };
+
+/**
+ * Which capture format this save lands on, and whether the device can honour it.
+ *
+ * Two asymmetries are load-bearing.
+ *
+ * A mode is scoped to the HARDWARE it was chosen for, decided by stable identity
+ * rather than node path — the kernel recycles `/dev/videoN`, so a path match
+ * proves nothing about which camera is being pointed at. Selecting a different
+ * device therefore DROPS the mode instead of carrying it over; falling back to
+ * the engine's own precedence (H.264 first) is always safe, whereas inheriting
+ * MJPEG onto a camera that only does H.264 is not.
+ *
+ * And an EXPLICIT pick the device does not advertise is REFUSED, while a merely
+ * CARRIED one is silently dropped. A refusal answers the operator's own action
+ * honestly; applying the same refusal to a value they are not touching would let
+ * a device that stopped advertising a mode block every unrelated save.
+ */
+function resolveInputModeChoice(
+	input: StreamingSetConfigInput,
+	config: RuntimeConfig,
+	sources: readonly StreamSource[],
+): InputModeChoice {
+	const sourceId = input.source ?? config.source;
+	const source =
+		sourceId === undefined
+			? undefined
+			: sources.find(
+					(entry) =>
+						entry.id ===
+						resolveSourceIdentity(
+							sourceId,
+							sources,
+							config.last_seen_devices,
+							input.source === undefined
+								? configuredSelectionAnchor(sourceId)
+								: undefined,
+						),
+				);
+
+	const carried = staysOnTheSameDevice(input, config, sources)
+		? config.input_mode
+		: undefined;
+	const requested = input.input_mode ?? carried;
+	if (requested === undefined) return { ok: true, inputMode: undefined };
+
+	const offered = source?.origin === "capture" ? source.inputModes : undefined;
+	// No advertised split is an ABSENCE of truth, not evidence against the pick —
+	// the same none-cap policy the device-mode rule follows.
+	if (offered === undefined || offered.length === 0) {
+		return { ok: true, inputMode: requested };
+	}
+	if (offered.some((mode) => mode.inputMode === requested)) {
+		return { ok: true, inputMode: requested };
+	}
+	if (input.input_mode !== undefined) {
+		return { ok: false, error: INPUT_MODE_UNSUPPORTED_ERROR };
+	}
+	return { ok: true, inputMode: undefined };
+}
+
+/** Whether this save keeps pointing at the SAME physical device as the last one. */
+function staysOnTheSameDevice(
+	input: StreamingSetConfigInput,
+	config: RuntimeConfig,
+	sources: readonly StreamSource[],
+): boolean {
+	if (input.source === undefined) return true;
+	const anchor = resolveSelectionAnchor(input.source, sources);
+	return anchor !== undefined && anchor === config.source_stable_id;
+}
+
 export const setConfigProcedure = authedProcedure
 	.input(streamingSetConfigInputSchema)
 	.output(streamingSetConfigOutputSchema)
@@ -576,19 +666,59 @@ export const setConfigProcedure = authedProcedure
 		// its derived pipeline into `input` so the override-validation + merge below
 		// see it. selected_video_input is recomputed on EVERY source write (persisted
 		// further down) — the capture input_id, or cleared for a non-capture source.
+		const sourcesSnapshot = getSourcesMessage().sources;
+
+		// A mode belongs to ONE device, so it is resolved BEFORE routing: the mode
+		// decides which pipeline the device is opened through, and a pick carried
+		// over from different hardware must be dropped rather than applied to a
+		// camera that never advertised it.
+		const modeChoice = resolveInputModeChoice(input, config, sourcesSnapshot);
+		if (!modeChoice.ok) {
+			logger.warn("setConfig: the device does not offer the requested mode", {
+				module: "streaming",
+				source: input.source ?? config.source,
+				input_mode: input.input_mode,
+			});
+			return { success: false, error: modeChoice.error, applied: {} };
+		}
+		const effectiveInputMode = modeChoice.inputMode;
+
 		let sourceRouting:
 			| Extract<ResolveSourceRoutingResult, { ok: true }>
 			| undefined;
 		if (input.source !== undefined) {
 			const routed = resolveSourceRouting(
 				input.source,
-				getSourcesMessage().sources,
-				getConfig().last_seen_devices,
+				sourcesSnapshot,
+				config.last_seen_devices,
+				undefined,
+				effectiveInputMode,
 			);
 			if (!routed.ok) {
 				return { success: false, error: routed.error, applied: {} };
 			}
 			sourceRouting = routed;
+			input.pipeline = routed.pipeline;
+		} else if (
+			effectiveInputMode !== config.input_mode &&
+			config.source !== undefined
+		) {
+			// A mode-only save still moves the pipeline — a dual-format camera is
+			// `libuvch264` in H.264 mode and `usb_mjpeg` in MJPEG mode — so the
+			// PERSISTED selection is re-routed under the new mode. It resolves
+			// through the persisted anchor, exactly as the start path does, and
+			// deliberately does NOT set `sourceRouting`: nothing about the operator's
+			// source SELECTION changed, so `config.source` must not be rewritten.
+			const routed = resolveSourceRouting(
+				config.source,
+				sourcesSnapshot,
+				config.last_seen_devices,
+				configuredSelectionAnchor(config.source),
+				effectiveInputMode,
+			);
+			if (!routed.ok) {
+				return { success: false, error: routed.error, applied: {} };
+			}
 			input.pipeline = routed.pipeline;
 		}
 
@@ -630,14 +760,22 @@ export const setConfigProcedure = authedProcedure
 		// half-save is still a full pairing against the hardware. And the source is
 		// the one being SAVED: checking the persisted one waves through exactly the
 		// ladder switch that makes the combo illegal.
-		if (input.resolution !== undefined || input.framerate !== undefined) {
+		if (
+			input.resolution !== undefined ||
+			input.framerate !== undefined ||
+			effectiveInputMode !== config.input_mode
+		) {
 			const verdict = verifySaveDeviceMode(
 				{
 					sourceId: input.source ?? config.source,
 					resolution: input.resolution ?? config.resolution,
 					framerate: input.framerate ?? config.framerate,
+					// A mode SWITCH re-validates the persisted axes against the ladder
+					// they will now be negotiated on: the very point of the per-media_type
+					// split is that 1080p60 on H.264 says nothing about MJPEG.
+					inputMode: effectiveInputMode,
 				},
-				{ lastSeenDevices: config.last_seen_devices },
+				{ sources: sourcesSnapshot, lastSeenDevices: config.last_seen_devices },
 			);
 			if (!verdict.supported) {
 				logger.warn("setConfig: device cannot deliver the requested mode", {
@@ -688,6 +826,9 @@ export const setConfigProcedure = authedProcedure
 			config.selected_video_input = sourceRouting.selected_video_input;
 			noteSourceSelectionWrite(input.source);
 		}
+		// Written even when it resolves to `undefined`: that is the CLEAR, and it is
+		// what stops a mode chosen for one camera governing the next one.
+		config.input_mode = effectiveInputMode;
 		if (input.bitrate_overlay !== undefined)
 			config.bitrate_overlay = input.bitrate_overlay;
 
@@ -770,6 +911,10 @@ export const setConfigProcedure = authedProcedure
 			applied.pipeline = config.pipeline;
 			applied.selected_video_input = config.selected_video_input;
 		}
+		if (input.input_mode !== undefined) {
+			applied.input_mode = config.input_mode;
+			applied.pipeline = config.pipeline;
+		}
 
 		if (shouldUseMocks()) {
 			setMockEncoderConfig({
@@ -818,6 +963,9 @@ export const setConfigProcedure = authedProcedure
 				? {}
 				: { input_id: staged.selected_video_input }),
 			...(staged.pipeline === undefined ? {} : { pipeline: staged.pipeline }),
+			...(staged.input_mode === undefined
+				? {}
+				: { input_mode: staged.input_mode }),
 		});
 
 		if (outcome.result !== "applied") {

--- a/apps/backend/src/tests/capability-truth-save.test.ts
+++ b/apps/backend/src/tests/capability-truth-save.test.ts
@@ -201,6 +201,7 @@ describe("streaming.setConfig — device-truth validation (todo 11a)", () => {
 		config.resolution = undefined;
 		config.framerate = undefined;
 		config.selected_video_input = undefined;
+		config.input_mode = undefined;
 	});
 	afterEach(() => {
 		const config = getConfig();

--- a/apps/backend/src/tests/lost-device-retention.test.ts
+++ b/apps/backend/src/tests/lost-device-retention.test.ts
@@ -166,10 +166,11 @@ describe("buildSources — lost-device synthesis (pure)", () => {
 		expect(sources.some((s) => s.origin === "coarse" && s.id === "hdmi")).toBe(
 			false,
 		);
-		// the other coarse entries are untouched.
+		// the USB-capture placeholders that used to sit beside it are suppressed
+		// in every state now (todo 21a), so no coarse row survives this build.
 		expect(
 			sources.filter((s) => s.origin === "coarse").map((s) => s.id),
-		).toEqual(["usb_mjpeg", "v4l_mjpeg", "camlink", "libuvch264"]);
+		).toEqual([]);
 	});
 
 	it("(2) replug → the lost row is replaced by the live row in one rebuild", () => {
@@ -257,7 +258,9 @@ describe("buildSources — lost-device synthesis (pure)", () => {
 			sessionSnapshots: sessionMap(snapshot),
 		});
 		expect(sources.some((s) => s.id === "video0")).toBe(false);
-		expect(sources.map((s) => s.id)).toEqual(["usb_mjpeg", "test"]);
+		// `usb_mjpeg` is a suppressed USB-capture placeholder, so only the virtual
+		// test-pattern row remains (todo 21a).
+		expect(sources.map((s) => s.id)).toEqual(["test"]);
 	});
 
 	it("(QA) device absent AND not configured AND not session-seen → NO lost row (no zombie)", () => {

--- a/apps/backend/src/tests/one-row-per-camera.test.ts
+++ b/apps/backend/src/tests/one-row-per-camera.test.ts
@@ -1,0 +1,868 @@
+/*
+ * One row per physical camera + per-device mode selection (wave-4 todo 21).
+ *
+ * Four contracts, all of which were reachable defects before this todo:
+ *
+ *   (a) the coarse USB-capture placeholder rows ("USB MJPEG" and friends) are a
+ *       pipeline, not a device — they render permanently, they cannot be acted
+ *       on, and ONE dual-format camera answers to TWO of them. They are gone in
+ *       every state; HDMI / network ingest / test pattern are untouched.
+ *   (b) the concrete row carries every format the device advertises, and the
+ *       operator's pick persists per DEVICE and reaches the engine.
+ *   (c) save-time validation intersects the SELECTED mode's ladder only.
+ *   (d) a degraded SELECTED capture leg is a persistent snapshot on the source
+ *       surface, cleared by the ONE existing recovery seam.
+ */
+
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from "bun:test";
+import type { RuntimeErrorEvent } from "@ceralive/cerastream";
+import {
+	type GetCapabilitiesResult,
+	SCHEMA_VERSION,
+} from "@ceralive/cerastream";
+import type {
+	CaptureCap,
+	CaptureDevice,
+	CaptureMode,
+	DeviceKind,
+	NetworkIngest,
+	StreamSource,
+} from "@ceraui/rpc/schemas";
+import { call } from "@orpc/server";
+
+import type { RuntimeConfig } from "../helpers/config-schemas.ts";
+import {
+	initMockService,
+	resetMockState,
+	setStreamingState,
+	stopMockService,
+} from "../mocks/mock-service.ts";
+import { getConfig } from "../modules/config.ts";
+import {
+	clearSelectedCaptureDegraded,
+	getSelectedCaptureDegraded,
+	noteSelectedCaptureDegraded,
+	setCaptureDegradedPublisherForTest,
+} from "../modules/streaming/capture-degraded.ts";
+import {
+	CerastreamBackend,
+	type CerastreamBackendDeps,
+} from "../modules/streaming/cerastream-backend.ts";
+import { fromEngineDevice } from "../modules/streaming/devices.ts";
+import {
+	initPipelines,
+	setMockHardware,
+} from "../modules/streaming/pipelines.ts";
+import {
+	applyObservedEngineDevices,
+	buildSources,
+	deriveEngineRouting,
+	getSourcesMessage,
+	resetEngineDeviceCache,
+} from "../modules/streaming/sources.ts";
+import { updateStatus } from "../modules/streaming/streaming.ts";
+import { setConfigProcedure } from "../rpc/procedures/streaming.procedure.ts";
+import type { AppWebSocket, RPCContext } from "../rpc/types.ts";
+
+type SourceCap = GetCapabilitiesResult["sources"][number];
+
+function source(id: string, overrides: Partial<SourceCap> = {}): SourceCap {
+	return {
+		id,
+		supports_audio: true,
+		supports_resolution_override: true,
+		supports_framerate_override: true,
+		default_resolution: "1080p",
+		default_framerate: 30,
+		...overrides,
+	};
+}
+
+// Both USB pipelines are offered by the engine, which is what makes the MJPEG
+// mode routable at all — and what makes the suppression a real assertion rather
+// than an artefact of a capability set that never carried the row.
+const CAPS: GetCapabilitiesResult = {
+	platform: {
+		supports_h265: true,
+		hardware_accelerated: true,
+		max_resolution: "2160p",
+	},
+	encoder: {
+		codecs: ["h264", "h265"],
+		bitrate_range: { min: 500, max: 50000, unit: "kbps" },
+	},
+	sources: [
+		source("hdmi"),
+		source("libuvch264"),
+		source("usb_mjpeg"),
+		source("rtmp"),
+		source("test"),
+	],
+};
+
+const CAP_SOURCES: SourceCap[] = CAPS.sources;
+
+function provide() {
+	return {
+		fetchEngineCapabilities: async () => ({
+			caps: CAPS,
+			schemaVersion: SCHEMA_VERSION,
+		}),
+		fetchEngineDevices: async () => ({ devices: [] }),
+	};
+}
+
+const NO_INGEST: NetworkIngest = { rtmp: null, srt: null };
+
+function cap(
+	width: number,
+	height: number,
+	framerate: string,
+	media_type: string,
+): CaptureCap {
+	return { width, height, framerate, media_type };
+}
+
+const H264 = "video/x-h264";
+const MJPEG = "image/jpeg";
+
+/**
+ * The board's running example: a DJI Osmo Pocket 3. Its H.264 ladder tops out at
+ * 1080p30 while its MJPEG ladder reaches 1080p60 and 2160p30 — so the two
+ * genuinely disagree and a union is observably wrong in both directions.
+ */
+const OSMO_MODES: CaptureMode[] = [
+	{
+		media_type: H264,
+		pipeline_kind: "uvc_h264",
+		caps: [
+			cap(1920, 1080, "30/1", H264),
+			cap(1280, 720, "60/1", H264),
+			cap(1280, 720, "30/1", H264),
+		],
+	},
+	{
+		media_type: MJPEG,
+		pipeline_kind: "mjpeg",
+		caps: [
+			cap(1920, 1080, "60/1", MJPEG),
+			cap(1920, 1080, "30/1", MJPEG),
+			cap(3840, 2160, "30/1", MJPEG),
+		],
+	},
+];
+
+/** The RØDE HDMI-to-USB-C: H.264 only. The negative control throughout. */
+const RODE_MODES: CaptureMode[] = [
+	{
+		media_type: H264,
+		pipeline_kind: "uvc_h264",
+		caps: [cap(1920, 1080, "30/1", H264), cap(1280, 720, "60/1", H264)],
+	},
+];
+
+function engineDevice(
+	input_id: string,
+	kind: DeviceKind,
+	modes: CaptureMode[],
+	displayName: string,
+	stableId: string,
+): CaptureDevice {
+	return fromEngineDevice({
+		input_id,
+		device_path: `/dev/${input_id}`,
+		display_name: displayName,
+		media_class: "video",
+		kind,
+		caps: modes.flatMap((mode) => mode.caps),
+		modes,
+		stable_id: stableId,
+	});
+}
+
+const OSMO_STABLE = "usb:2ca3:0023:OSMO";
+const RODE_STABLE = "usb:19f7:0003:RODE";
+
+function osmo(inputId = "video1"): CaptureDevice {
+	return engineDevice(
+		inputId,
+		"uvc_h264",
+		OSMO_MODES,
+		"DJIPocket3: OsmoPocket3",
+		OSMO_STABLE,
+	);
+}
+
+function rode(inputId = "video2"): CaptureDevice {
+	return engineDevice(
+		inputId,
+		"uvc_h264",
+		RODE_MODES,
+		"RØDE HDMI to USB-C",
+		RODE_STABLE,
+	);
+}
+
+function build(devices: CaptureDevice[]): StreamSource[] {
+	return buildSources({
+		sources: CAP_SOURCES,
+		devices,
+		networkIngest: NO_INGEST,
+	});
+}
+
+function captureRows(sources: StreamSource[]): StreamSource[] {
+	return sources.filter((s) => s.origin === "capture");
+}
+
+function makeContext(): RPCContext {
+	const ws = {
+		send: () => {},
+		data: { isAuthenticated: true, lastActive: Date.now() },
+	} as unknown as AppWebSocket;
+	return {
+		ws,
+		isAuthenticated: () => true,
+		authenticate: () => {},
+		deauthenticate: () => {},
+		markActive: () => {},
+		getLastActive: () => 0,
+		setSenderId: () => {},
+		getSenderId: () => undefined,
+		clearSenderId: () => {},
+	};
+}
+
+// ── (a) ONE ROW PER PHYSICAL CAMERA ─────────────────────────────────────────
+
+describe("(a) the coarse USB-capture placeholder is gone in every state", () => {
+	test("a dual-mode camera produces EXACTLY one row, and no 'USB MJPEG' placeholder", () => {
+		const sources = build([osmo()]);
+
+		expect(captureRows(sources).map((s) => s.id)).toEqual(["video1"]);
+		expect(sources.some((s) => s.id === "usb_mjpeg")).toBe(false);
+		expect(sources.some((s) => s.id === "libuvch264")).toBe(false);
+	});
+
+	test("with NO devices at all the placeholders are still absent", () => {
+		const sources = build([]);
+		expect(sources.map((s) => s.id)).toEqual(["hdmi", "rtmp", "test"]);
+	});
+
+	test("a second H.264-only camera adds exactly one more row (RØDE negative control)", () => {
+		const sources = build([osmo(), rode()]);
+		expect(captureRows(sources).map((s) => s.id)).toEqual(["video1", "video2"]);
+		expect(sources.some((s) => s.id === "usb_mjpeg")).toBe(false);
+	});
+
+	test("HDMI, network ingest and the test pattern keep their coarse behaviour", () => {
+		const sources = build([]);
+		const byId = new Map(sources.map((s) => [s.id, s]));
+		expect(byId.get("hdmi")?.origin).toBe("coarse");
+		expect(byId.get("rtmp")?.origin).toBe("network");
+		expect(byId.get("test")?.origin).toBe("virtual");
+	});
+
+	test("the HDMI coarse row still survives beside a live USB camera", () => {
+		const sources = build([osmo()]);
+		expect(sources.some((s) => s.origin === "coarse" && s.id === "hdmi")).toBe(
+			true,
+		);
+	});
+});
+
+// ── (b) MODES ON THE ROW + ROUTING ──────────────────────────────────────────
+
+describe("(b) the concrete row carries the device's own mode ladders", () => {
+	test("a dual-mode camera publishes BOTH families, each with its own ladder", () => {
+		const row = captureRows(build([osmo()]))[0];
+		if (row?.origin !== "capture") throw new Error("expected a capture row");
+
+		expect(row.inputModes?.map((m) => m.inputMode)).toEqual([
+			"uvc_h264",
+			"mjpeg",
+		]);
+
+		const h264 = row.inputModes?.find((m) => m.inputMode === "uvc_h264");
+		const mjpeg = row.inputModes?.find((m) => m.inputMode === "mjpeg");
+		// 1080p60 is real under MJPEG and NOT under H.264 — the ladders are split,
+		// never unioned.
+		expect(h264?.modes.find((m) => m.width === 1920)?.framerates).not.toContain(
+			60,
+		);
+		expect(mjpeg?.modes.find((m) => m.width === 1920)?.framerates).toContain(
+			60,
+		);
+		expect(mjpeg?.modes.some((m) => m.width === 3840)).toBe(true);
+	});
+
+	test("the default selected mode is the engine's scalar kind — H.264", () => {
+		const row = captureRows(build([osmo()]))[0];
+		if (row?.origin !== "capture") throw new Error("expected a capture row");
+		expect(row.selectedInputMode).toBe("uvc_h264");
+	});
+
+	test("an H.264-only camera publishes ONE family (no mode-selector clutter)", () => {
+		const row = captureRows(build([rode()]))[0];
+		if (row?.origin !== "capture") throw new Error("expected a capture row");
+		expect(row.inputModes?.map((m) => m.inputMode)).toEqual(["uvc_h264"]);
+		expect(row.selectedInputMode).toBe("uvc_h264");
+	});
+
+	test("a mode whose pipeline the engine does not offer is never published", () => {
+		const sources = buildSources({
+			// `usb_mjpeg` withdrawn from the capability set.
+			sources: CAP_SOURCES.filter((s) => s.id !== "usb_mjpeg"),
+			devices: [osmo()],
+			networkIngest: NO_INGEST,
+		});
+		const row = captureRows(sources)[0];
+		if (row?.origin !== "capture") throw new Error("expected a capture row");
+		expect(row.inputModes?.map((m) => m.inputMode)).toEqual(["uvc_h264"]);
+	});
+
+	test("a pre-0.11.0 engine (no modes) publishes no ladder split at all", () => {
+		const legacy = fromEngineDevice({
+			input_id: "video1",
+			device_path: "/dev/video1",
+			display_name: "DJIPocket3: OsmoPocket3",
+			media_class: "video",
+			kind: "uvc_h264",
+			caps: [cap(1920, 1080, "30/1", H264)],
+		});
+		const row = captureRows(build([legacy]))[0];
+		if (row?.origin !== "capture") throw new Error("expected a capture row");
+		expect(row.inputModes).toBeUndefined();
+		expect(row.modes.length).toBeGreaterThan(0);
+	});
+
+	test("routing follows the SELECTED mode's pipeline, not the scalar kind's", () => {
+		const sources = build([osmo()]);
+		expect(deriveEngineRouting("video1", sources)?.pipeline).toBe("libuvch264");
+		expect(deriveEngineRouting("video1", sources, "mjpeg")?.pipeline).toBe(
+			"usb_mjpeg",
+		);
+		// The input_id is the same physical device either way.
+		expect(
+			deriveEngineRouting("video1", sources, "mjpeg")?.selected_video_input,
+		).toBe("video1");
+	});
+
+	test("an H.264-only camera keeps routing to libuvch264 under any mode", () => {
+		const sources = build([rode()]);
+		expect(deriveEngineRouting("video2", sources, "mjpeg")?.pipeline).toBe(
+			"libuvch264",
+		);
+	});
+});
+
+// ── (c) + (b) PERSISTENCE THROUGH THE REAL RPC ──────────────────────────────
+
+describe("input_mode persistence + mode-aware validation (real setConfig)", () => {
+	const savedMockMode = process.env.MOCK_MODE;
+	const savedNodeEnv = process.env.NODE_ENV;
+	let prior: ReturnType<typeof getConfig>;
+
+	beforeAll(async () => {
+		process.env.MOCK_MODE = "true";
+		initMockService("caps-full");
+		setMockHardware("rk3588");
+		await initPipelines(provide());
+	});
+	beforeEach(() => {
+		const config = getConfig();
+		prior = { ...config };
+		resetEngineDeviceCache();
+		clearSelectedCaptureDegraded();
+		config.source = undefined;
+		config.source_stable_id = undefined;
+		config.input_mode = undefined;
+		config.pipeline = undefined;
+		config.resolution = undefined;
+		config.framerate = undefined;
+		config.selected_video_input = undefined;
+		config.last_seen_devices = undefined;
+	});
+	afterEach(() => {
+		const config = getConfig();
+		Object.assign(config, prior);
+		// `{...config}` cannot carry a key that was ABSENT when it was captured, so
+		// a field this suite INTRODUCED must be cleared by name — `bun test` shares
+		// one config singleton across every file in the process.
+		config.input_mode = prior.input_mode;
+		config.source_stable_id = prior.source_stable_id;
+		resetEngineDeviceCache();
+		clearSelectedCaptureDegraded();
+		setStreamingState(false);
+		updateStatus(false);
+		resetMockState();
+	});
+	afterAll(async () => {
+		stopMockService();
+		setMockHardware("rk3588");
+		await initPipelines();
+		if (savedMockMode === undefined) delete process.env.MOCK_MODE;
+		else process.env.MOCK_MODE = savedMockMode;
+		if (savedNodeEnv === undefined) delete process.env.NODE_ENV;
+		else process.env.NODE_ENV = savedNodeEnv;
+	});
+
+	async function save(input: Record<string, unknown>) {
+		return call(setConfigProcedure, input, { context: makeContext() });
+	}
+
+	test("an unset mode persists nothing — the engine keeps its own precedence", async () => {
+		applyObservedEngineDevices([osmo()]);
+		const result = await save({ source: "video1" });
+		expect(result.success).toBe(true);
+		expect(getConfig().input_mode).toBeUndefined();
+		expect(getConfig().pipeline).toBe("libuvch264");
+	});
+
+	test("a chosen mode persists AND moves the pipeline (round-trip)", async () => {
+		applyObservedEngineDevices([osmo()]);
+		await save({ source: "video1" });
+
+		const result = await save({ input_mode: "mjpeg" });
+		expect(result.success).toBe(true);
+		expect(result.applied.input_mode).toBe("mjpeg");
+		expect(getConfig().input_mode).toBe("mjpeg");
+		expect(getConfig().pipeline).toBe("usb_mjpeg");
+
+		// It survives a rebuild of the source list, and the row reports it.
+		const row = getSourcesMessage().sources.find((s) => s.id === "video1");
+		if (row?.origin !== "capture") throw new Error("expected a capture row");
+		expect(row.selectedInputMode).toBe("mjpeg");
+	});
+
+	test("a mode the device does not advertise is REFUSED, disk untouched", async () => {
+		applyObservedEngineDevices([rode()]);
+		await save({ source: "video2" });
+
+		const result = await save({ input_mode: "mjpeg" });
+		expect(result.success).toBe(false);
+		expect(result.error).toBe("input_mode_unsupported");
+		expect(getConfig().input_mode).toBeUndefined();
+		expect(getConfig().pipeline).toBe("libuvch264");
+	});
+
+	test("selecting DIFFERENT hardware clears the mode instead of inheriting it", async () => {
+		applyObservedEngineDevices([osmo(), rode()]);
+		await save({ source: "video1" });
+		await save({ input_mode: "mjpeg" });
+		expect(getConfig().input_mode).toBe("mjpeg");
+
+		await save({ source: "video2" });
+		expect(getConfig().input_mode).toBeUndefined();
+		expect(getConfig().pipeline).toBe("libuvch264");
+	});
+
+	test("re-selecting the SAME hardware keeps the mode", async () => {
+		applyObservedEngineDevices([osmo()]);
+		await save({ source: "video1" });
+		await save({ input_mode: "mjpeg" });
+
+		await save({ source: "video1" });
+		expect(getConfig().input_mode).toBe("mjpeg");
+	});
+
+	// ── (c) the validation table, per SELECTED mode ─────────────────────────
+
+	test("1080p60 is REFUSED while H.264 is the selected mode", async () => {
+		applyObservedEngineDevices([osmo()]);
+		await save({ source: "video1" });
+		const result = await save({ resolution: "1080p", framerate: 60 });
+		expect(result.success).toBe(false);
+		expect(result.error).toBe("device_mode_unsupported");
+	});
+
+	test("the SAME 1080p60 is ACCEPTED once MJPEG is the selected mode", async () => {
+		applyObservedEngineDevices([osmo()]);
+		await save({ source: "video1" });
+		await save({ input_mode: "mjpeg" });
+
+		const result = await save({ resolution: "1080p", framerate: 60 });
+		expect(result.success).toBe(true);
+		expect(getConfig().resolution).toBe("1080p");
+		expect(getConfig().framerate).toBe(60);
+	});
+
+	test("2160p30 is MJPEG-only — refused under H.264, accepted under MJPEG", async () => {
+		applyObservedEngineDevices([osmo()]);
+		await save({ source: "video1" });
+		expect((await save({ resolution: "2160p", framerate: 30 })).success).toBe(
+			false,
+		);
+
+		await save({ input_mode: "mjpeg" });
+		expect((await save({ resolution: "2160p", framerate: 30 })).success).toBe(
+			true,
+		);
+	});
+
+	test("switching INTO a mode that cannot deliver the persisted axes is refused", async () => {
+		applyObservedEngineDevices([osmo()]);
+		await save({ source: "video1" });
+		await save({ input_mode: "mjpeg" });
+		await save({ resolution: "2160p", framerate: 30 });
+
+		// H.264 tops out at 1080p30, so the pending 2160p30 has nowhere to land.
+		const result = await save({ input_mode: "uvc_h264" });
+		expect(result.success).toBe(false);
+		expect(result.error).toBe("device_mode_unsupported");
+		expect(getConfig().input_mode).toBe("mjpeg");
+	});
+
+	test("the H.264-only camera's validation is unchanged (negative control)", async () => {
+		applyObservedEngineDevices([rode()]);
+		await save({ source: "video2" });
+		expect((await save({ resolution: "1080p", framerate: 30 })).success).toBe(
+			true,
+		);
+		expect((await save({ resolution: "1080p", framerate: 60 })).success).toBe(
+			false,
+		);
+	});
+});
+
+// ── (d) THE DEGRADED-SELECTED SNAPSHOT ──────────────────────────────────────
+
+describe("(d) the degraded-selected snapshot rides the sources payload", () => {
+	beforeEach(() => {
+		setCaptureDegradedPublisherForTest(() => {});
+		clearSelectedCaptureDegraded();
+	});
+	afterEach(() => {
+		clearSelectedCaptureDegraded();
+		setCaptureDegradedPublisherForTest(undefined);
+	});
+
+	function degradedBuild(devices: CaptureDevice[]): StreamSource[] {
+		return buildSources({
+			sources: CAP_SOURCES,
+			devices,
+			networkIngest: NO_INGEST,
+			...(getSelectedCaptureDegraded() !== undefined
+				? { degraded: getSelectedCaptureDegraded() }
+				: {}),
+		});
+	}
+
+	test("it lands on the SELECTED row and nowhere else", () => {
+		noteSelectedCaptureDegraded({
+			sourceId: "video1",
+			stableId: OSMO_STABLE,
+			state: { code: "capture_video_error", reason: "no_frames" },
+		});
+
+		const rows = captureRows(degradedBuild([osmo(), rode()]));
+		const [selected, other] = rows;
+		if (selected?.origin !== "capture" || other?.origin !== "capture") {
+			throw new Error("expected two capture rows");
+		}
+		expect(selected.degraded).toEqual({
+			code: "capture_video_error",
+			reason: "no_frames",
+		});
+		expect(other.degraded).toBeUndefined();
+	});
+
+	test("it follows the device across a renumber (stable identity, not node path)", () => {
+		noteSelectedCaptureDegraded({
+			sourceId: "video1",
+			stableId: OSMO_STABLE,
+			state: { code: "capture_video_error" },
+		});
+		// A libuvc camera renumbers on the very next release.
+		const rows = captureRows(degradedBuild([osmo("video7")]));
+		const row = rows[0];
+		if (row?.origin !== "capture") throw new Error("expected a capture row");
+		expect(row.degraded?.code).toBe("capture_video_error");
+	});
+
+	test("a device with no snapshot carries no degraded state", () => {
+		const rows = captureRows(degradedBuild([osmo()]));
+		const row = rows[0];
+		if (row?.origin !== "capture") throw new Error("expected a capture row");
+		expect(row.degraded).toBeUndefined();
+	});
+
+	test("clearing retracts it and reports whether anything was standing", () => {
+		expect(clearSelectedCaptureDegraded()).toBe(false);
+		noteSelectedCaptureDegraded({
+			sourceId: "video1",
+			stableId: OSMO_STABLE,
+			state: { code: "capture_video_error" },
+		});
+		expect(clearSelectedCaptureDegraded()).toBe(true);
+		expect(getSelectedCaptureDegraded()).toBeUndefined();
+	});
+
+	test("raising and retracting each re-publish the sources payload", () => {
+		let published = 0;
+		setCaptureDegradedPublisherForTest(() => {
+			published += 1;
+		});
+		noteSelectedCaptureDegraded({
+			sourceId: "video1",
+			stableId: OSMO_STABLE,
+			state: { code: "capture_video_error" },
+		});
+		expect(published).toBe(1);
+		clearSelectedCaptureDegraded();
+		expect(published).toBe(2);
+		// A clear with nothing standing publishes nothing.
+		clearSelectedCaptureDegraded();
+		expect(published).toBe(2);
+	});
+});
+
+// ── (d) THE BACKEND BRIDGE: raise + the ONE inherited clearing seam ──────────
+
+const silentLogger: CerastreamBackendDeps["logger"] = {
+	debug() {},
+	info() {},
+	warn() {},
+	error() {},
+};
+
+/**
+ * A control client just complete enough for `start()` to reach a confirmed
+ * `streaming` session, so `stop()` acts on a REAL active session rather than
+ * short-circuiting on `!this.active`. Only the surface `start`/`stop` touch is
+ * implemented.
+ */
+function makeFakeClient() {
+	return {
+		hello: { schema_version: SCHEMA_VERSION },
+		start: async () => ({ session_id: "s1", state: "streaming" }),
+		stop: async () => ({ state: "idle" }),
+		subscribeEvents: async () => ({
+			result: { subscribed: ["status", "error"] },
+			close: () => {},
+		}),
+		close: async () => {},
+		rawRequest: async () => ({ session_id: "s1", state: "streaming" }),
+	} as unknown as Awaited<ReturnType<CerastreamBackendDeps["connect"]>>;
+}
+
+function makeEngineHarness(opts: { live?: boolean } = {}): {
+	backend: CerastreamBackend;
+	removed: string[];
+} {
+	const removed: string[] = [];
+	const client = makeFakeClient();
+	const backend = new CerastreamBackend({
+		connect:
+			opts.live === true
+				? async () => client
+				: async () => {
+						throw new Error("connect is unused on the event path");
+					},
+		connectOptions: {},
+		getConfig: () =>
+			({
+				source: "video1",
+				selected_video_input: "video1",
+				source_stable_id: OSMO_STABLE,
+			}) as RuntimeConfig,
+		saveConfig: () => {},
+		bridge: {
+			notify: () => {},
+			notificationExists: () => false,
+			removeNotification: (name: string) => {
+				removed.push(name);
+			},
+			broadcastStatus: () => {},
+			broadcastBuffering: () => {},
+		},
+		execPath: "cerastream",
+		configPath: "/tmp/cerastream-capture-degraded.json",
+		logger: silentLogger,
+	});
+	return { backend, removed };
+}
+
+function engineError(
+	code: string,
+	extra: Record<string, unknown> = {},
+): RuntimeErrorEvent {
+	return {
+		type: "error",
+		seq: 0,
+		code,
+		source: "engine",
+		...extra,
+	} as unknown as RuntimeErrorEvent;
+}
+
+function statusEvent(
+	state: string,
+	streaming: boolean,
+): Parameters<CerastreamBackend["handleEvent"]>[0] {
+	return {
+		type: "status",
+		seq: 1,
+		state,
+		streaming,
+	} as Parameters<CerastreamBackend["handleEvent"]>[0];
+}
+
+describe("(d) capture_video_error + selected:true is the degraded-selected signal", () => {
+	beforeEach(() => {
+		setCaptureDegradedPublisherForTest(() => {});
+		clearSelectedCaptureDegraded();
+	});
+	afterEach(() => {
+		clearSelectedCaptureDegraded();
+		setCaptureDegradedPublisherForTest(undefined);
+	});
+
+	test("it raises a snapshot bound to the operator's own selection", () => {
+		const { backend } = makeEngineHarness();
+		backend.handleEvent(
+			engineError("capture_video_error", {
+				selected: true,
+				reason: "no_frames",
+			}),
+		);
+
+		expect(getSelectedCaptureDegraded()).toEqual({
+			sourceId: "video1",
+			stableId: OSMO_STABLE,
+			state: { code: "capture_video_error", reason: "no_frames" },
+		});
+	});
+
+	test("the SAME code WITHOUT selected:true raises no snapshot", () => {
+		const { backend } = makeEngineHarness();
+		backend.handleEvent(engineError("capture_video_error"));
+		expect(getSelectedCaptureDegraded()).toBeUndefined();
+		backend.handleEvent(
+			engineError("capture_video_error", { selected: false }),
+		);
+		expect(getSelectedCaptureDegraded()).toBeUndefined();
+	});
+
+	test("another selected-flagged code raises no snapshot — the pair is the signal", () => {
+		const { backend } = makeEngineHarness();
+		for (const code of [
+			"capture_audio_error",
+			"pipeline_stall",
+			"capture_unrecoverable",
+		]) {
+			backend.handleEvent(engineError(code, { selected: true }));
+			expect(getSelectedCaptureDegraded()).toBeUndefined();
+		}
+	});
+
+	// ── the three clearing paths, all through the ONE inherited seam ─────────
+
+	test("CLEAR 1 — rejoin: a concordant streaming status frame retracts it", () => {
+		const { backend, removed } = makeEngineHarness();
+		backend.handleEvent(engineError("capture_video_error", { selected: true }));
+		expect(getSelectedCaptureDegraded()).toBeDefined();
+
+		backend.handleEvent(statusEvent("streaming", true));
+
+		expect(getSelectedCaptureDegraded()).toBeUndefined();
+		// the SAME seam retracted the notification — one path, not two.
+		expect(removed).toEqual(["cerastream"]);
+	});
+
+	test("CLEAR 2 — stop: ending a LIVE session retracts it", async () => {
+		const { backend } = makeEngineHarness({ live: true });
+		await backend.start(
+			{ pipeline: "libuvch264" } as RuntimeConfig,
+			{
+				host: "127.0.0.1",
+				port: 9000,
+				pipeline: "libuvch264",
+			} as never,
+		);
+		// Raised AFTER the start, so the start's own clear cannot be what passes.
+		backend.handleEvent(engineError("capture_video_error", { selected: true }));
+		expect(getSelectedCaptureDegraded()).toBeDefined();
+
+		expect(backend.stop(() => {})).toBe(true);
+
+		expect(getSelectedCaptureDegraded()).toBeUndefined();
+	});
+
+	test("CLEAR 3 — new session: a start never inherits the previous failure", async () => {
+		const { backend } = makeEngineHarness();
+		backend.handleEvent(engineError("capture_video_error", { selected: true }));
+		expect(getSelectedCaptureDegraded()).toBeDefined();
+
+		await backend
+			.start({} as RuntimeConfig, {} as never)
+			.catch(() => undefined);
+
+		expect(getSelectedCaptureDegraded()).toBeUndefined();
+	});
+
+	test("an IDLE status frame is not proof — the snapshot stands", () => {
+		const { backend } = makeEngineHarness();
+		backend.handleEvent(engineError("capture_video_error", { selected: true }));
+
+		backend.handleEvent(statusEvent("idle", false));
+		backend.handleEvent(statusEvent("starting", false));
+
+		expect(getSelectedCaptureDegraded()).toBeDefined();
+	});
+
+	test("a later error taking the SHARED notification slot cannot latch the snapshot", () => {
+		const { backend, removed } = makeEngineHarness();
+		backend.handleEvent(engineError("capture_video_error", { selected: true }));
+		// `srt_connection_lost` now occupies the shared `cerastream` slot, so the
+		// notification correctly stays; the capture claim must NOT ride along.
+		backend.handleEvent(engineError("srt_connection_lost"));
+
+		backend.handleEvent(statusEvent("streaming", true));
+
+		expect(removed).toEqual([]);
+		expect(getSelectedCaptureDegraded()).toBeUndefined();
+	});
+
+	test("the snapshot reaches the sources payload's top level too", () => {
+		const { backend } = makeEngineHarness();
+		backend.handleEvent(
+			engineError("capture_video_error", {
+				selected: true,
+				reason: "no_frames",
+			}),
+		);
+		const snapshot = getSelectedCaptureDegraded();
+		const message = {
+			...buildSourcesMessageFor([osmo()], snapshot),
+		};
+		expect(message.degradedSelected).toEqual({
+			code: "capture_video_error",
+			reason: "no_frames",
+		});
+	});
+});
+
+function buildSourcesMessageFor(
+	devices: CaptureDevice[],
+	degraded: ReturnType<typeof getSelectedCaptureDegraded>,
+): { sources: StreamSource[]; degradedSelected?: unknown } {
+	const sources = buildSources({
+		sources: CAP_SOURCES,
+		devices,
+		networkIngest: NO_INGEST,
+		...(degraded !== undefined ? { degraded } : {}),
+	});
+	return {
+		sources,
+		...(degraded !== undefined ? { degradedSelected: degraded.state } : {}),
+	};
+}

--- a/apps/backend/src/tests/sources.test.ts
+++ b/apps/backend/src/tests/sources.test.ts
@@ -86,22 +86,18 @@ function activeIngest(): NetworkIngest {
 }
 
 describe("buildSources — caps-first base + device overlay", () => {
-	it("emits a coarse entry per non-device capability source with ids identical to the pipeline registry (golden fixture)", () => {
+	it("emits a coarse entry per non-device capability source, USB-capture placeholders excluded (golden fixture)", () => {
 		const sources = buildSources({
 			sources: goldenCapSources(),
 			devices: [],
 			networkIngest: activeIngest(),
 		});
 
-		// ids identical to today's pipeline registry, same order.
-		expect(sources.map((s) => s.id)).toEqual([...GOLDEN_SOURCE_IDS]);
+		// Registry order preserved, minus the USB-capture placeholders (todo 21a).
+		expect(sources.map((s) => s.id)).toEqual(["hdmi", "rtmp", "srt", "test"]);
 
 		const byId = new Map(sources.map((s) => [s.id, s]));
 		expect(byId.get("hdmi")?.origin).toBe("coarse");
-		expect(byId.get("usb_mjpeg")?.origin).toBe("coarse");
-		expect(byId.get("v4l_mjpeg")?.origin).toBe("coarse");
-		expect(byId.get("camlink")?.origin).toBe("coarse");
-		expect(byId.get("libuvch264")?.origin).toBe("coarse");
 		expect(byId.get("rtmp")?.origin).toBe("network");
 		expect(byId.get("srt")?.origin).toBe("network");
 		expect(byId.get("test")?.origin).toBe("virtual");
@@ -112,7 +108,7 @@ describe("buildSources — caps-first base + device overlay", () => {
 		}
 	});
 
-	it("legacy engine (no devices) yields exactly today's coarse pipeline ids", () => {
+	it("legacy engine (no devices) yields only the coarse rows that name a real port", () => {
 		const sources = buildSources({
 			sources: goldenCapSources(),
 			devices: [],
@@ -121,13 +117,7 @@ describe("buildSources — caps-first base + device overlay", () => {
 		const coarseIds = sources
 			.filter((s) => s.origin === "coarse")
 			.map((s) => s.id);
-		expect(coarseIds).toEqual([
-			"hdmi",
-			"usb_mjpeg",
-			"v4l_mjpeg",
-			"camlink",
-			"libuvch264",
-		]);
+		expect(coarseIds).toEqual(["hdmi"]);
 	});
 
 	it("replaces the hdmi coarse entry with two capture entries for two same-kind HDMI dongles", () => {
@@ -167,10 +157,11 @@ describe("buildSources — caps-first base + device overlay", () => {
 			(s) => s.origin === "coarse" && s.id === "hdmi",
 		);
 		expect(hdmiCoarse).toBeUndefined();
-		// no other coarse entry was lost.
+		// no other coarse entry was lost — and the USB-capture placeholders that
+		// used to sit beside it are gone in this state too (todo 21a).
 		expect(
 			sources.filter((s) => s.origin === "coarse").map((s) => s.id),
-		).toEqual(["usb_mjpeg", "v4l_mjpeg", "camlink", "libuvch264"]);
+		).toEqual([]);
 	});
 
 	it("inherits facet flags from the replaced coarse entry onto capture entries", () => {
@@ -211,10 +202,10 @@ describe("buildSources — caps-first base + device overlay", () => {
 
 		// no capture entry was produced for the unbridged usb device.
 		expect(sources.some((s) => s.origin === "capture")).toBe(false);
-		// every coarse entry survives, including hdmi.
+		// hdmi survives; the USB-capture placeholders do not, in this state either.
 		expect(
 			sources.filter((s) => s.origin === "coarse").map((s) => s.id),
-		).toEqual(["hdmi", "usb_mjpeg", "v4l_mjpeg", "camlink", "libuvch264"]);
+		).toEqual(["hdmi"]);
 	});
 
 	it("ignores audio-class devices in the overlay", () => {

--- a/packages/rpc/src/capabilities/intersect-caps.ts
+++ b/packages/rpc/src/capabilities/intersect-caps.ts
@@ -165,6 +165,24 @@ export function deviceKindToPipelineId(kind: string | undefined): string | undef
 }
 
 /**
+ * The pipeline ONE mode family of a device is opened through — the mode-aware
+ * sibling of {@link deviceKindToPipelineId}.
+ *
+ * That function bridges a device's SCALAR kind, i.e. its highest-precedence mode
+ * alone. A dual-format camera has more than one, and they do NOT share a
+ * pipeline: the same physical camera reaches the engine through `libuvch264` in
+ * H.264 mode and through `usb_mjpeg` in MJPEG mode. Routing an operator's MJPEG
+ * pick down the H.264 pipeline would hand the engine a graph built for the
+ * format it was told not to use.
+ *
+ * `undefined` for a mode that names no direct video pipeline, so a caller can
+ * DROP a family it could not route rather than offering one it cannot honour.
+ */
+export function pipelineIdForInputMode(inputMode: string | undefined): string | undefined {
+	return deviceKindToPipelineId(inputMode);
+}
+
+/**
  * Resolve a concrete capture format to the `Resolution` rung it advertises.
  *
  * None-cap (permissive) policy: when `width` or `height` is absent the format

--- a/packages/rpc/src/schemas/sources.schema.ts
+++ b/packages/rpc/src/schemas/sources.schema.ts
@@ -35,11 +35,46 @@ import {
 	deviceModeSchema,
 	framerateSchema,
 	hardwareTypeSchema,
+	inputModeSchema,
 	pipelineAudioKindSchema,
 	requiresGatewaySchema,
 	resolutionSchema,
 	sourceSignalSchema,
 } from './streaming.schema';
+
+/**
+ * ONE capture format a device advertises, carrying the ladder that belongs to
+ * THAT format alone (cerastream ADR-0008 §10 — per-`media_type` ladders are the
+ * only truth and may never be unioned).
+ *
+ * `pipelineId` is the coarse capability source this mode family routes through,
+ * resolved at build time and PROVEN to be offered: a mode whose pipeline the
+ * engine does not advertise is never published, exactly as an unbridged device
+ * is never published. So a consumer can route any listed mode without asking a
+ * second question.
+ */
+export const captureInputModeSchema = z.object({
+	inputMode: inputModeSchema,
+	mediaType: z.string(),
+	pipelineId: z.string(),
+	modes: z.array(deviceModeSchema),
+});
+export type CaptureInputMode = z.infer<typeof captureInputModeSchema>;
+
+/**
+ * A degraded SELECTED capture leg, as a persistent SNAPSHOT rather than a
+ * one-shot event — a backend or frontend reconnect must not lose the state.
+ *
+ * It is not its own wire event: the engine reports it as the EXISTING
+ * `capture_video_error` runtime error additionally carrying `selected: true`.
+ * It therefore inherits that code's recovery signal verbatim and has no
+ * clearing path of its own.
+ */
+export const sourceDegradedSchema = z.object({
+	code: z.string(),
+	reason: z.string().optional(),
+});
+export type SourceDegraded = z.infer<typeof sourceDegradedSchema>;
 
 /** The four StreamSource origins (the discriminated-union discriminator). */
 export const sourceOriginSchema = z.enum(['capture', 'coarse', 'virtual', 'network']);
@@ -95,6 +130,16 @@ export const captureSourceSchema = streamSourceBase.extend({
 	// these as aliases, or a device that merely moved reads as one that vanished.
 	// The backend publishes it only on a proven migration — never as a guess.
 	previousIds: z.array(z.string()).optional(),
+	// Every capture format this ONE physical device advertises, each with its own
+	// ladder. ADDITIVE-OPTIONAL: absent on a pre-0.11.0 engine, which a consumer
+	// must read as "no ladder split was reported", never as "no modes".
+	inputModes: z.array(captureInputModeSchema).optional(),
+	// The format the leg will actually be opened under: the operator's persisted
+	// pick when this device still advertises it, else the engine's own scalar
+	// `kind`, which IS its highest-precedence mode.
+	selectedInputMode: inputModeSchema.optional(),
+	// Present only while the engine reports THIS row's capture leg degraded.
+	degraded: sourceDegradedSchema.optional(),
 });
 export type CaptureStreamSource = z.infer<typeof captureSourceSchema>;
 
@@ -134,5 +179,10 @@ export type StreamSource = z.infer<typeof streamSourceSchema>;
 export const sourcesMessageSchema = z.object({
 	hardware: hardwareTypeSchema,
 	sources: z.array(streamSourceSchema),
+	// The same standing snapshot the selected row carries, mirrored at the top
+	// level so it survives the row: a device that degrades and is then unplugged
+	// has no row left to hang the state on, and a client that reconnects in that
+	// window would otherwise be told nothing is wrong. Additive-optional.
+	degradedSelected: sourceDegradedSchema.optional(),
 });
 export type SourcesMessage = z.infer<typeof sourcesMessageSchema>;

--- a/packages/rpc/src/schemas/streaming.schema.ts
+++ b/packages/rpc/src/schemas/streaming.schema.ts
@@ -50,6 +50,24 @@ export const PORT_MAX = 65535;
 export const audioCodecSchema = z.enum(['opus', 'aac']);
 export type AudioCodec = z.infer<typeof audioCodecSchema>;
 
+// WHICH capture format a device's leg negotiates (cerastream schema 0.11.0
+// `input_mode`). Deliberately NOT `deviceKindSchema`: that enum also carries
+// CeraUI's own coarse `usb`/`other` guesses from the v4l2 display-name
+// heuristic, which name no engine `InputKind` and would be refused as invalid
+// params. Typed against exactly what the engine accepts. Declared this early
+// because `streamingConfigInputSchema` references it.
+export const inputModeSchema = z.enum([
+	'audio',
+	'hdmi',
+	'uvc_h264',
+	'uvc_h265',
+	'mjpeg',
+	'camlink',
+	'test',
+	'network',
+]);
+export type InputMode = z.infer<typeof inputModeSchema>;
+
 // Alias for frontend compatibility
 export type AudioCodecs = 'aac' | 'opus';
 
@@ -248,6 +266,11 @@ export const streamingConfigInputSchema = z.object({
 	// (bandwidth-saver) receiver listener. Both additive-optional.
 	fec_enabled: z.boolean().optional(),
 	recovery_mode: streamRecoveryPreferenceSchema.optional(),
+	// Which capture format the SELECTED device's leg is opened under, for a
+	// device that exposes more than one (see `inputModeSchema`). Additive-optional;
+	// absent hands the choice back to the engine's own precedence, which is H.264
+	// first — the unchanged behaviour for every device and every existing caller.
+	input_mode: inputModeSchema.optional(),
 });
 export type StreamingConfigInput = z.infer<typeof streamingConfigInputSchema>;
 
@@ -759,6 +782,9 @@ export const configMessageSchema = z.object({
 	// Device-first operator source selection, echoed back so the UI reflects the
 	// saved source on reload (T3/T13). Additive-optional.
 	source: z.string().optional(),
+	// The capture format the selected device is opened under, echoed so the
+	// picker reflects the saved mode on reload. Additive-optional.
+	input_mode: inputModeSchema.optional(),
 	// SRT receive-profile tuning, echoed back so the card reflects the saved
 	// values on reload (Tasks 18/19).
 	fec_enabled: z.boolean().optional(),
@@ -937,6 +963,17 @@ export type CaptureCap = z.infer<typeof captureCapSchema>;
 export const sourceSignalSchema = z.enum(['present', 'absent', 'unknown']);
 export type SourceSignal = z.infer<typeof sourceSignalSchema>;
 
+// One mode FAMILY a capture device exposes, mirroring cerastream's
+// `captureModeSchema`. Each family carries its OWN `caps` ladder: a resolution
+// offered under `video/x-h264` says nothing about what `image/jpeg` offers on
+// the same device, so the two are never unioned (ADR-0008 §10).
+export const captureModeSchema = z.object({
+	media_type: z.string(),
+	pipeline_kind: inputModeSchema,
+	caps: z.array(captureCapSchema),
+});
+export type CaptureMode = z.infer<typeof captureModeSchema>;
+
 // Mirrors the cerastream `captureDeviceSchema` plus three CeraUI-owned UI facets:
 // `kind` for grouping, `lost` for the unplugged-during-session grace state, and
 // `signal` for the present-but-nothing-arriving state.
@@ -947,6 +984,10 @@ export const captureDeviceSchema = z.object({
 	media_class: deviceMediaClassSchema,
 	kind: deviceKindSchema,
 	caps: z.array(captureCapSchema).optional(),
+	// Every mode family this ONE device exposes, each with its own ladder
+	// (cerastream schema 0.11.0). ADDITIVE-OPTIONAL: absent on an older engine,
+	// which reads as "no ladder split reported" — never as "no modes".
+	modes: z.array(captureModeSchema).optional(),
 	// Reboot-stable hardware identity (cerastream Todo 20 `stable_id`). Additive +
 	// optional. Sources reconciliation keys a re-enumerated device (node path
 	// changed, video1→video2) on this, not `input_id`, so a rename migrates the


### PR DESCRIPTION
**Affected repo & language:** CeraUI — TypeScript (backend + `@ceraui/rpc`). No frontend files touched.

## What

A capability source is a *pipeline*; an operator points at a *device*. Conflating the two put a permanent, unactionable row in the Live source picker — "USB MJPEG · not connected" whether or not anything was plugged in — and let a single dual-format camera answer to two coarse rows at once.

Four changes, all additive on the wire:

**(a) One row per physical camera.** The coarse USB-capture placeholders (`libuvch264`, `usb_mjpeg`, `v4l_mjpeg`, `camlink`) are no longer emitted in any state. `v4l_mjpeg` is the starkest case: no device kind bridges to it, so it can never be replaced by a concrete row and is a phantom by construction. `hdmi` / `rtmp` / `srt` / `test` are deliberately untouched — each names a real, always-present capability of the board, so its coarse row is truthful with nothing connected.

**(b) Per-device mode selection.** A capture row now carries every capture format the device advertises (`inputModes[]`), each with its own ladder, threaded from the engine's `modes[]` (cerastream schema 0.11.0). `config.input_mode` persists the operator's pick and reaches the engine's `start` and its existing `change-config` transaction.

**(c) Mode-aware save validation.** Save-time validation intersects the *selected* mode's ladder rather than a union across modes.

**(d) Degraded-selected backend bridge.** A degraded selected capture leg becomes a persistent status snapshot on the source surface instead of a one-shot notification, so a backend restart or a frontend reconnect no longer loses it.

## Why

The picker was showing rows an operator could not act on, and hiding the one choice they might actually want to make on a dual-format camera. Three details are worth a reviewer's attention because they are not obvious:

- **`capture_degraded` is not a wire event.** `grep -rn capture_degraded node_modules/@ceralive/cerastream/dist/` returns nothing. cerastream reports it as the *existing* `capture_video_error` runtime error additionally carrying `selected: true`. The snapshot therefore keys on exactly that pair and **inherits that code's existing retraction** (`ENGINE_ERRORS_CLEARED_BY_HEALTHY_SESSION` → `clearRecoveredEngineError`) rather than growing a second, independently-timed clearing path. `stop()` was added as a third call site of that same seam; it already treats a stop as a session boundary for `active_encode`.
- **The snapshot is dropped *ahead* of the standing-error gate.** `resolved.channel` is one notification slot shared by every non-srtla engine error, so `capture_video_error{selected}` → `srt_connection_lost` → healthy session would return early (the srt code is not in the membership table) and latch a capture claim the boundary had already disproved.
- **`config.input_mode` is a single field scoped to `config.source_stable_id`, not a map.** "Per device" is satisfied by scoping: a pick that lands on different hardware (compared by *stable identity* — node paths are recycled) clears the mode. A keyed map would need its own retention/eviction policy and would silently evict a stated operator intent.

Mode-awareness in (c) is one substitution, not a fork — `@ceraui/rpc` `device-mode-truth.ts` already scopes a ladder by "the media type the KIND names", so it is handed the selected mode instead of the device's scalar kind. The per-`media_type` split in `capabilities.ts` is unchanged.

## How to verify

```
bun install
bun run lint                       # exit 0
cd apps/backend && bun run check   # tsc clean
cd apps/backend && bun test        # 2751 pass, 0 fail
```

The new suite is `apps/backend/src/tests/one-row-per-camera.test.ts` (36 cases). Red-first was proven by neutering each behaviour and re-running: suppression off reddens 9 tests, an unpersisted mode 6, mode-blind routing 2, mode-blind validation 3, an unraised snapshot 6, and the two subtle properties (stop clears; the clear sits ahead of the shared-slot gate) redden exactly one test each.

Six existing assertions in `sources.test.ts` and `lost-device-retention.test.ts` asserted the coarse USB rows *exist*. That is the expectation this change reverses by design, so they were rewritten to the new policy with the reason named inline — nothing deleted, skipped or loosened, and each still asserts an exact row list.

**On real hardware** (Rock 5B+, DJI Osmo Pocket 3 + RØDE HDMI-to-USB-C), A/B'd against the pre-fix binary on the same board minutes apart:

- 6 rows before (including the phantom `libuvch264`) → 5 rows after, every other row byte-identical.
- Both cameras expose two kernel nodes each and render exactly one row.
- The Osmo accepts 2160p30 and refuses 1080p60 against its own ladder; the H.264-only RØDE's validation answers are byte-identical before and after.
- Selecting different hardware clears the persisted mode.

## Risks

**Low, with one honest caveat.**

A persisted `config.source` naming a now-suppressed coarse pipeline resolves to `unknown_source`. In practice that state was already broken: whenever such a device is present the coarse row is replaced by the concrete one, and when it is absent the start fails at the engine anyway.

The board's engine is `cerastream 2026.7.2` (schema 0.10.0), which emits no `modes[]` and consumes no `input_mode`, so **end-to-end mode selection could not be proven on hardware** — what was proven there is the fail-open path against that engine (no `inputModes` published, default falls back to the engine's own H.264-first precedence, validation and routing unchanged). Exercising a real MJPEG↔H.264 switch needs a 0.11.0 engine `.deb` installed on the board; that is a packaging gap, not an implementation gap, and it is what the wave's board-acceptance task exists to close.

Rollback is a revert — every field is additive and optional, and an engine that reports no modes behaves exactly as it did before this change.

---

**Checklist**

- [x] Docs updated if behavior or structure changed (Rule A: `apps/backend/AGENTS.md` — two new contract sections, the WHERE-TO-LOOK table, and seven anti-patterns)
- [x] Started from updated main; branch rebased on latest canonical branch (Rule B)
- [x] Rule D local-scratch reference check passes for tracked files
- [x] Tests pass; QA evidence attached or linked
