### PR TITLE
feat(sources): remember the last-streamed device, not every device ever seen

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -77,6 +77,7 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 | Scoping the `hdmi_error` "No HDMI signal detected" RAISE to a relevant selection | `modules/system/hdmi-signal-notification.ts` (`provesSelectionIsNotHdmi`) + `modules/system/sensors.ts` (`handleRk3588HdmiDmesg`); contract below → …AND ITS RAISE MUST BE SCOPED LIKE ITS RETRACTION |
 | Retracting the `cerastream` `capture_video_error` notification at a healthy session boundary | `modules/streaming/cerastream-backend.ts` (`standingEngineError`, `clearRecoveredEngineError`, `ENGINE_ERRORS_CLEARED_BY_HEALTHY_SESSION`) |
 | **One row per physical camera + per-device mode ladders (`inputModes`, `selectedInputMode`, coarse USB placeholder suppression)** | `modules/streaming/sources.ts` (`SUPPRESSED_COARSE_PIPELINE_IDS`, `buildInputModes`, `resolveSelectedInputMode`, mode-aware `deriveEngineRouting`) |
+| **Last-streamed-config retention (the ONE remembered `lost` device)** | `modules/streaming/sources.ts` (`collectLostCandidates`, `noteStreamedSourceCommitted`) + `config.last_streamed_source` in `helpers/config-schemas.ts`; commit hook wired at `stream-session-orchestrator.ts` `onStreamCommitted` |
 | **Degraded-SELECTED capture snapshot (`capture_video_error` + `selected:true`)** | `modules/streaming/capture-degraded.ts`; raised/retracted in `modules/streaming/cerastream-backend.ts` (`clearRecoveredEngineError` is the ONLY clearing seam) |
 | **Device-truth save guard + persisted-mode clamp (ADR-0008 §10)** | `modules/streaming/device-mode-guard.ts` (`verifySaveDeviceMode`, `clampPersistedDeviceMode`) + `modules/streaming/persisted-mode-clamp.ts` (`reconcilePersistedDeviceMode`); the RULE itself is `@ceraui/rpc` `capabilities/device-mode-truth.ts`, shared with the frontend |
 | **Unified device-first `sources` builder + engine-device cache + `config.source` routing seam** | `modules/streaming/sources.ts` (`buildSources`, `getSourcesMessage`, `deriveEngineRouting`, `resolveSourceRouting`) |
@@ -1993,6 +1994,72 @@ every unrelated save.
 
 Coverage: `tests/one-row-per-camera.test.ts`.
 
+## LAST-STREAMED-CONFIG RETENTION — ONE REMEMBERED DEVICE [EXISTS]
+
+An absent capture device is worth an unavailable `lost` row only if somebody
+wants it back. The retired rule inferred that from ENUMERATION: every device the
+process had ever seen became a lost candidate, uncapped, for the whole backend
+lifetime. So a colleague's webcam plugged in once, or a dongle moved to another
+machine, left a permanent unusable row in the operator's picker with no way to
+clear it short of a restart.
+
+**Exactly ONE device is remembered: the one an outcome-gated start last committed
+to.** Going live with a device is the evidence that was missing; merely seeing it
+is not. Everything else leaves the list the moment it is live-absent — its
+`last_seen_devices` entry stays, invisible, because identity migration still needs
+it.
+
+- **`config.last_streamed_source` (+ `_stable_id`) is the slot**, and it is
+  DELIBERATELY DISTINCT from `config.source`. A save-only edit moves the
+  operator's selection freely and must not move the slot; a restart restores the
+  row from the slot, never from the selection.
+- **`noteStreamedSourceCommitted()` (`sources.ts`) is the only writer.** It is
+  idempotent — a start landing on the SAME source writes nothing at all, which is
+  what keeps an automatic restoration of an interrupted session from disturbing
+  it — and it resolves the persisted id through `resolveSourceIdentity` first, so
+  the slot names the hardware that actually went live rather than a node path the
+  device has since left behind.
+- **The commit signal is the ORCHESTRATOR's `transition("streaming")`, not
+  `PLAYING`.** `onStreamCommitted` fires only after `runStartWithRetry` resolves,
+  i.e. downstream of the `playing-wait` phase, which is satisfied by a direct
+  `state:"streaming"` reply or a concordant `state:"streaming"` + `streaming:true`
+  heartbeat. A graph reaching PLAYING says a pipeline was built, not that it
+  delivered — moving the slot there would move it for attempts that then fail.
+  `reconcile()` deliberately does NOT fire it: adopting a session the engine was
+  already running is not a new commitment.
+- **It is wired as a LAZY `import()`.** `stream-session-orchestrator.ts` is
+  already reachable from the source graph, so a static edge back into
+  `sources.ts` reorders module initialisation and leaves the boot-time source
+  build reading a half-initialised module — observed as an EMPTY device list at
+  boot, i.e. every capture row silently missing. Same hazard, same fix, as the
+  engine-audio-change handler in `sources.ts`.
+- **A non-camera source SUPERSEDES by taking the slot EMPTY.** A coarse, virtual
+  or network source has no `resolveSelectionAnchor` identity, so nothing resolves
+  to a remembered snapshot and the previously-held camera stops being remembered.
+  Superseding and clearing are one operation; there is no separate clear path.
+- **PRESENCE ALWAYS BEATS RETENTION.** The lost loop is unchanged: a remembered
+  device that is live by node path or by stable identity renders as a normal
+  selectable row. A device unplugged for two seconds and back is never
+  unpickable — it is simply absent from the list while it is absent from the
+  hardware.
+- **`mergeLastSeenLru` retains TWO ids, not one.** `config.source` was always
+  exempt from eviction; `config.last_streamed_source` now is too, because its
+  snapshot IS the lost row. The two are usually the same id and come apart on a
+  save-only edit — without the second exemption a dozen devices of churn could
+  evict the very snapshot the slot points at. The LRU cap (12) and the
+  `previousIds` cap (8) are untouched.
+- **The session-seen snapshot map is no longer a lost-row source.** It survives as
+  the process's own observation record (it is what proves a renumbering camera
+  folded onto ONE identity instead of accumulating a row per node path) and as
+  `resetEngineDeviceCache()`'s test-isolation surface. Nothing renders from it.
+
+Coverage: `tests/lost-device-retention.test.ts` — one dedicated test per row of
+the policy's state-transition table (save-only, failed gate, committed start,
+non-camera supersede, stop, renumber, restoration re-commit, replug, restart)
+plus the blip negative control and both LRU exemptions. Frontend half:
+`apps/frontend/tests/e2e/lost-device.spec.ts` (a source must be STREAMED before
+it can be lost).
+
 ## THE DEGRADED-SELECTED CAPTURE SNAPSHOT [EXISTS]
 
 `capture_degraded` is NOT a wire event — `grep capture_degraded` across the
@@ -3141,7 +3208,9 @@ config, an anchored path still held by its own device, and a live row with no
   `withKnownEngineMetadata` already refuses for good reason.
 - Don't re-add a coarse USB-capture placeholder row (`usb_mjpeg`, `v4l_mjpeg`, `libuvch264`, `camlink`) — a pipeline is not a device, the row is unactionable in every state, and one dual-format camera answers to two of them. And don't extend `SUPPRESSED_COARSE_PIPELINE_IDS` to `hdmi`/`rtmp`/`srt`/`test`: each names a real always-present board capability, so its coarse row is truthful with nothing plugged in.
 - Don't publish a device mode family whose pipeline the engine does not offer — the pick dies at `pipeline_not_in_offered_set` AFTER the operator committed to it. Gate `buildInputModes` on the coarse capability set, and don't union two media types' ladders (ADR-0008 §10).
-- Don't key `config.input_mode` per device in a map, and don't let it survive a move to different hardware — it is a single field SCOPED to `config.source_stable_id`, cleared when the stable identity changes. A map needs a retention policy (todo 22's territory) and silently evicts a stated operator intent.
+- Don't key `config.input_mode` per device in a map, and don't let it survive a move to different hardware — it is a single field SCOPED to `config.source_stable_id`, cleared when the stable identity changes. A map needs its own retention policy and silently evicts a stated operator intent.
+- Don't remember a device as `lost` because it was SEEN — only the device of the LAST-STREAMED configuration is remembered while absent, and `config.last_streamed_source` is that slot. Don't anchor it on `config.source` (a save-only edit moves that freely and must not move the slot), don't move it on `PLAYING` or on `reconcile()`'s adoption of an existing session (only the orchestrator's confirmed `transition("streaming")` is a commitment), and don't static-import `sources.ts` into `stream-session-orchestrator.ts` to wire it — that reorders module initialisation and empties the boot-time device list.
+- Don't drop `config.last_streamed_source` from `mergeLastSeenLru`'s retained set — its snapshot IS the lost row, and the two exemptions come apart on exactly the save-only edit this policy exists to tolerate.
 - Don't send `input_mode` when the operator never chose one — absent hands the format choice back to the engine's own precedence (H.264 first), which is the unchanged behaviour for every device and every existing caller.
 - Don't route a mode pick down the scalar kind's pipeline — the same camera is `libuvch264` in H.264 mode and `usb_mjpeg` in MJPEG mode. Use `pipelineIdForInputMode`.
 - Don't fork a mode-aware copy of the device-mode rule — `device-mode-truth.ts` already scopes by "the media type the KIND names", so pointing it at the SELECTED mode is the entire change (`governingKind`). And don't turn the carried-mode drop into a refusal: only an EXPLICIT pick the device does not advertise may be refused.

--- a/apps/backend/src/helpers/config-schemas.ts
+++ b/apps/backend/src/helpers/config-schemas.ts
@@ -257,6 +257,24 @@ export const runtimeConfigSchema = z.object({
 	// one the operator meant. Additive-optional — absent means a legacy/anchorless
 	// selection, which resolves exactly as it did before this field existed.
 	source_stable_id: z.string().optional(),
+	// The source of the last configuration that actually WENT LIVE — the ONE
+	// device remembered as a `lost` row while it is absent (the
+	// last-streamed-config retention policy). Deliberately DISTINCT from
+	// `source`: a
+	// save-only edit moves the operator's selection freely, and a selection that
+	// was never streamed is not something the device should keep advertising once
+	// the hardware is gone. It moves only when a start satisfies the engine's
+	// outcome gate, so a failed attempt and a stop both leave it standing.
+	// Additive-optional — an existing config simply remembers nothing until its
+	// first committed start.
+	last_streamed_source: z.string().optional(),
+	// The stable hardware identity of the slot above, captured at the same instant
+	// for the same reason `source_stable_id` exists: `last_streamed_source` is a
+	// NODE PATH and the kernel recycles those, so a path the remembered camera no
+	// longer holds may since have been inherited by a different device. Present
+	// only when the engine vouched for an identity; absent for a coarse, virtual
+	// or network source, which names no single piece of hardware.
+	last_streamed_source_stable_id: z.string().optional(),
 	// Which capture format the selected device is opened under, for a device that
 	// exposes more than one. Scoped to `source_stable_id`: an operator pick that
 	// moves to DIFFERENT hardware clears it, so a mode chosen for one camera can

--- a/apps/backend/src/modules/streaming/sources.ts
+++ b/apps/backend/src/modules/streaming/sources.ts
@@ -467,15 +467,16 @@ export interface BuildSourcesInput {
 	networkIngest: NetworkIngest;
 	/** Device-wide source visibility (Todo 6). Absent → every source visible. */
 	sourcesVisibility?: SourcesVisibility;
-	/** The operator's persisted `config.source` id; drives the across-restart
-	 *  lost row for the configured device. Absent → no config-driven lost row. */
-	configSource?: string;
-	/** Persisted `config.last_seen_devices`; the metadata source for the
-	 *  across-restart configured-device lost row. Absent → treated as empty. */
+	/** Persisted `config.last_streamed_source`: the device of the last
+	 *  configuration that went live, and the ONLY one remembered while absent.
+	 *  Absent → no lost row at all. */
+	lastStreamedSource?: string;
+	/** Persisted `config.last_streamed_source_stable_id`: the identity that slot
+	 *  was anchored to. Absent → the slot resolves by node path. */
+	lastStreamedStableId?: string;
+	/** Persisted `config.last_seen_devices`; the metadata the remembered slot is
+	 *  rendered from. Absent → treated as empty. */
 	lastSeenDevices?: readonly LastSeenDevice[];
-	/** In-memory session snapshots; the metadata source for in-session lost rows
-	 *  (uncapped, so LRU churn never orphans a session-seen id). */
-	sessionSnapshots?: ReadonlyMap<string, LastSeenDevice>;
 	/** The operator's persisted `config.input_mode`. Absent → engine precedence. */
 	inputMode?: InputMode;
 	/** The standing degraded-selected snapshot. Absent → no row is degraded. */
@@ -583,32 +584,38 @@ function foldIdentity(
 }
 
 /**
- * The remembered snapshots eligible to become a lost row: every in-session
- * snapshot, plus the configured id's persisted snapshot across a restart (the
- * session map is empty then).
+ * The ONE remembered snapshot eligible to become a lost row: the device of the
+ * LAST-STREAMED configuration, and nothing else.
  *
- * Deduped by IDENTITY, not by id. Within the session map (which is keyed by
- * `input_id` and deliberately monotonic) the LAST entry for an identity wins —
- * insertion order makes that the freshest node path. The persisted snapshot is
- * still only consulted when the identity is not already represented, so a
- * session snapshot keeps winning over its persisted twin.
+ * The retired rule remembered every device the process had ever ENUMERATED, so
+ * an unplugged accessory the operator had never streamed from — a colleague's
+ * webcam, a dongle moved to another machine — kept a permanent unavailable row,
+ * uncapped, for the lifetime of the backend. Merely having been seen is not
+ * evidence that anyone wants it back; going live with it is. So exactly one
+ * device is held: the one an outcome-gated start last committed to, which is
+ * also the only one whose absence is worth interrupting an operator about.
+ *
+ * IDENTITY OUTRANKS THE PATH, AND REPLACES IT. When the slot carries a stable
+ * id, that is the only thing matched: `last_streamed_source` is a node path, the
+ * kernel recycles those, and `findRememberingId` deliberately resolves a
+ * contested path by PREFERENCE (holder beats alias) — which is the right rule
+ * for rendering a row and the wrong one for deciding which camera an operator
+ * streamed. Falling back to the path there would remember whichever device had
+ * since inherited it, the same mistake `resolveSourceIdentityDetailed` refuses
+ * to make at the routing seam. A slot with no identity (a coarse, virtual or
+ * network source, or an engine that vouches for none) resolves by path exactly
+ * as the configured-device row always did.
  */
 function collectLostCandidates(input: BuildSourcesInput): LastSeenDevice[] {
-	const candidates = new Map<string, LastSeenDevice>();
-	if (input.sessionSnapshots !== undefined) {
-		for (const snapshot of input.sessionSnapshots.values())
-			candidates.set(identityKey(snapshot), snapshot);
-	}
-	const configSource = input.configSource;
-	if (configSource !== undefined) {
-		const persisted = findRememberingId(
-			input.lastSeenDevices ?? [],
-			configSource,
-		);
-		if (persisted !== undefined && !candidates.has(identityKey(persisted)))
-			candidates.set(identityKey(persisted), persisted);
-	}
-	return [...candidates.values()];
+	const anchorId = input.lastStreamedSource;
+	if (anchorId === undefined) return [];
+	const remembered = input.lastSeenDevices ?? [];
+	const anchorStableId = input.lastStreamedStableId;
+	const anchored =
+		anchorStableId !== undefined && anchorStableId !== ""
+			? remembered.find((d) => d.stableId === anchorStableId)
+			: findRememberingId(remembered, anchorId);
+	return anchored === undefined ? [] : [anchored];
 }
 
 /**
@@ -1022,6 +1029,65 @@ export function configuredSelectionAnchor(
 	return config.source_stable_id;
 }
 
+/**
+ * Move the remembered-lost slot onto the source a start has just PROVEN it can
+ * deliver from, superseding whatever was remembered before.
+ *
+ * The commit signal is deliberately the engine's outcome gate — a session the
+ * orchestrator has confirmed is really streaming — and NOT the pipeline reaching
+ * PLAYING, which happens earlier and says only that a graph was built. A slot
+ * moved on PLAYING would be moved by attempts that then fail, which is the one
+ * thing the "a failed start changes nothing" rule forbids.
+ *
+ * A start that lands on the SAME source writes nothing at all. That is what
+ * keeps an automatic restoration of an interrupted session from disturbing the
+ * slot: a restoration re-commits the configuration that was already live, so
+ * there is nothing to move and no config write to make.
+ *
+ * A source that names no single piece of hardware — coarse, virtual, network —
+ * still takes the slot, and takes it EMPTY: `resolveSelectionAnchor` gives it no
+ * identity, so nothing resolves to a remembered snapshot and the previously-held
+ * camera simply stops being remembered. Superseding and clearing are the same
+ * operation here, which is why there is no separate clear path.
+ */
+export function noteStreamedSourceCommitted(): boolean {
+	const config = getConfig();
+	const configured = config.source;
+	if (configured === undefined) return false;
+
+	const sources = getSourcesMessage().sources;
+	// The same resolution the start path routed with, for the same reason: the
+	// persisted id can be a node path the device has since left behind, and the
+	// slot must name the hardware that actually went live.
+	const sourceId = resolveSourceIdentity(
+		configured,
+		sources,
+		config.last_seen_devices,
+		configuredSelectionAnchor(configured),
+	);
+	const stableId = resolveSelectionAnchor(sourceId, sources);
+	if (
+		config.last_streamed_source === sourceId &&
+		config.last_streamed_source_stable_id === stableId
+	) {
+		return false;
+	}
+
+	config.last_streamed_source = sourceId;
+	if (stableId === undefined) {
+		delete config.last_streamed_source_stable_id;
+	} else {
+		config.last_streamed_source_stable_id = stableId;
+	}
+	saveConfig();
+	logger.info("sources: last-streamed source committed", {
+		source: sourceId,
+		stableId,
+	});
+	broadcastSourcesIfChanged();
+	return true;
+}
+
 /** Test seam: the current operator-write / committed-view token pair. */
 export function getSourceSelectionTokens(): {
 	selection: number;
@@ -1069,12 +1135,18 @@ const lastEngineVideoDevices = new Map<string, CaptureDevice>();
  *  exempt from eviction, so the configured device's snapshot survives churn. */
 const LAST_SEEN_DEVICES_CAP = 12;
 
-// The IN-MEMORY session-seen snapshot map (C7): every bridgeable video input_id
-// ever returned by a successful `list-devices` this process lifetime, keyed to its
+// The IN-MEMORY session-seen snapshot map: every bridgeable video input_id ever
+// returned by a successful `list-devices` this process lifetime, keyed to its
 // snapshot. UNCAPPED and monotonic — an empty list never clears it (distinct from
 // the replaceable engineDeviceCache), and only `resetEngineDeviceCache()` drops it
-// (test isolation). It is the metadata source for IN-SESSION lost rows, so LRU
-// churn on the persisted cap can never orphan a session-seen id.
+// (test isolation).
+//
+// It is NO LONGER a lost-row candidate source. Under last-streamed-config
+// retention a device that was merely SEEN is not remembered when it goes absent,
+// so feeding this map to `collectLostCandidates` is precisely the uncapped
+// behaviour that policy retires. What survives is its original job: the process's
+// own record of what it has observed, which is what proves a renumbering camera
+// folded onto ONE identity instead of accumulating a row per node path.
 const sessionSeenDeviceSnapshots = new Map<string, LastSeenDevice>();
 
 /** A bridgeable-video snapshot for a device, or `undefined` for a non-candidate
@@ -1161,31 +1233,39 @@ function claimNodePathsOnce(
  * LRU-merge freshly-observed snapshots into the persisted last-seen list:
  * most-recently-observed first, then prior entries whose device was not
  * re-observed. Over the cap, evict least-recent from the tail — EXCEPT the
- * configured id, which is pulled out and always kept so the configured device's
- * snapshot survives any churn.
+ * entries named in `retained`, which are kept at their own position however
+ * stale they are.
+ *
+ * TWO ids are retained, not one, and the second is load-bearing. The operator's
+ * current selection has always been exempt; the LAST-STREAMED device now is too,
+ * because its snapshot IS the lost row. The two are the same id most of the
+ * time and deliberately come apart on a save-only edit — so without the second
+ * exemption a dozen devices of churn could evict the very snapshot the retention
+ * slot still points at, and the remembered device would go quietly missing from
+ * the list instead of showing as absent. The CAP itself is untouched.
  */
 function mergeLastSeenLru(
 	current: readonly LastSeenDevice[],
 	observed: readonly LastSeenDevice[],
-	configSource: string | undefined,
+	retained: ReadonlySet<string>,
 ): LastSeenDevice[] {
 	const ordered = claimNodePathsOnce(
 		dedupeByIdentity([...observed, ...current]),
 	);
 	if (ordered.length <= LAST_SEEN_DEVICES_CAP) return ordered;
 
-	const configuredIndex =
-		configSource === undefined
-			? -1
-			: ordered.findIndex((d) => d.id === configSource);
-	const configured =
-		configuredIndex === -1 ? undefined : ordered[configuredIndex];
-	if (configured === undefined) return ordered.slice(0, LAST_SEEN_DEVICES_CAP);
-
-	const rest = ordered.filter((_, i) => i !== configuredIndex);
-	const kept = rest.slice(0, LAST_SEEN_DEVICES_CAP - 1);
-	kept.splice(Math.min(configuredIndex, kept.length), 0, configured);
-	return kept;
+	const kept = new Set<number>();
+	ordered.forEach((device, index) => {
+		if (retained.has(device.id)) kept.add(index);
+	});
+	for (
+		let index = 0;
+		index < ordered.length && kept.size < LAST_SEEN_DEVICES_CAP;
+		index++
+	) {
+		kept.add(index);
+	}
+	return ordered.filter((_, index) => kept.has(index));
 }
 
 // Record a successful device observation into BOTH the uncapped session map and
@@ -1205,14 +1285,19 @@ function recordObservedDevices(devices: readonly CaptureDevice[]): void {
 
 	const config = getConfig();
 	const current = config.last_seen_devices ?? [];
-	const next = mergeLastSeenLru(current, snapshots, config.source);
+	const retained = new Set(
+		[config.source, config.last_streamed_source].filter(
+			(id): id is string => id !== undefined,
+		),
+	);
+	const next = mergeLastSeenLru(current, snapshots, retained);
 	if (JSON.stringify(current) === JSON.stringify(next)) return;
 	config.last_seen_devices = next;
 	saveConfig();
 }
 
-/** The in-memory session-seen snapshots (C7): the metadata source for in-session
- *  lost rows. Read by `getSourcesMessage`; exposed for wiring and tests. */
+/** The in-memory record of every bridgeable video device observed this process
+ *  lifetime. Exposed for wiring and tests; it renders no rows. */
 export function getSessionSeenDeviceSnapshots(): ReadonlyMap<
 	string,
 	LastSeenDevice
@@ -1529,9 +1614,13 @@ export function getSourcesMessage(): SourcesMessage {
 		devices: getEngineDeviceCache(),
 		networkIngest: getNetworkIngestInfo(),
 		...(sourcesVisibility !== undefined ? { sourcesVisibility } : {}),
-		...(config.source !== undefined ? { configSource: config.source } : {}),
+		...(config.last_streamed_source !== undefined
+			? { lastStreamedSource: config.last_streamed_source }
+			: {}),
+		...(config.last_streamed_source_stable_id !== undefined
+			? { lastStreamedStableId: config.last_streamed_source_stable_id }
+			: {}),
 		lastSeenDevices: config.last_seen_devices ?? [],
-		sessionSnapshots: sessionSeenDeviceSnapshots,
 		...(config.input_mode !== undefined
 			? { inputMode: config.input_mode }
 			: {}),

--- a/apps/backend/src/modules/streaming/stream-session-orchestrator.ts
+++ b/apps/backend/src/modules/streaming/stream-session-orchestrator.ts
@@ -136,6 +136,13 @@ export type StreamSessionOrchestratorDeps = {
 	readonly suppressionContext?: () => SuppressionContext;
 	readonly reportRetry?: (diagnostic: StartRetryDiagnostic) => void;
 	readonly reportTerminalFailure?: (diagnostic: StartRetryDiagnostic) => void;
+	/**
+	 * Called once a launch has cleared the engine's outcome gate — the single
+	 * moment a start is known to have really delivered, for every origin. It is
+	 * deliberately NOT called from `reconcile()`: adopting a session the engine
+	 * was already running is not a new commitment to anything.
+	 */
+	readonly onStreamCommitted?: () => void;
 };
 
 type ActiveAttempt = {
@@ -341,6 +348,13 @@ export function createStreamSessionOrchestrator(
 		}
 		transition("streaming");
 		deps.setStreamingStatus(true);
+		// Never let a bookkeeping failure turn a stream that IS live into a
+		// reported start failure.
+		try {
+			deps.onStreamCommitted?.();
+		} catch (error) {
+			logger.warn("stream commit bookkeeping failed", { attemptId, error });
+		}
 		return { result: "started", attemptId };
 	};
 
@@ -622,6 +636,17 @@ const productionOrchestrator = createStreamSessionOrchestrator({
 	reportTerminalFailure: reportStartTerminalFailure,
 	changeRuntimeConfig: changeEngineRuntimeConfig,
 	publishConfigChangePhase: broadcastConfigChangePhase,
+	// Lazily imported for the reason `sources.ts` states about its own audio
+	// handler: this module is already reachable FROM the source graph, so a
+	// static edge back into it reorders module initialisation and leaves the
+	// boot-time source build reading a half-initialised module.
+	onStreamCommitted: () => {
+		void import("./sources.ts")
+			.then(({ noteStreamedSourceCommitted }) => noteStreamedSourceCommitted())
+			.catch((error) =>
+				logger.warn("stream commit bookkeeping failed", { error }),
+			);
+	},
 });
 
 export function startStreamSession(

--- a/apps/backend/src/tests/capture-absence-grace.test.ts
+++ b/apps/backend/src/tests/capture-absence-grace.test.ts
@@ -154,6 +154,7 @@ describe("Auto audio — absence hysteresis across a libuvc interface rebind", (
 		setMockAudioDevicesProvider(() => ({ "DJI DJIPocket3": "DJIPocket3" }));
 		getConfig().asrc = AUDIO_SOURCE_AUTO;
 		getConfig().source = CAMERA_ID;
+		getConfig().last_streamed_source = CAMERA_ID;
 	});
 
 	afterEach(() => {
@@ -165,6 +166,7 @@ describe("Auto audio — absence hysteresis across a libuvc interface rebind", (
 		updateStatus(false);
 		delete getConfig().asrc;
 		delete getConfig().source;
+		delete getConfig().last_streamed_source;
 		delete getConfig().last_seen_devices;
 	});
 

--- a/apps/backend/src/tests/hdmi-signal-recheck.test.ts
+++ b/apps/backend/src/tests/hdmi-signal-recheck.test.ts
@@ -139,6 +139,7 @@ describe("recheckSourceSignals — a signal that arrives after the first probe",
 		clearCapabilitiesCache();
 		getConfig().last_seen_devices = [];
 		delete getConfig().source;
+		delete getConfig().last_streamed_source;
 	});
 
 	afterEach(() => {
@@ -380,6 +381,7 @@ describe("recheckSourceSignals — a signal that arrives after the first probe",
 	test("membership still comes from the caller's observation, so a stale answer cannot resurrect an unplugged device", async () => {
 		await seedHdmiCaps();
 		getConfig().source = HDMI_RX_ID;
+		getConfig().last_streamed_source = HDMI_RX_ID;
 		applyObservedEngineDevices([
 			{
 				input_id: HDMI_RX_ID,

--- a/apps/backend/src/tests/lost-device-retention.test.ts
+++ b/apps/backend/src/tests/lost-device-retention.test.ts
@@ -1,12 +1,24 @@
 /*
- * C7 — lost-device retention + persisted last-seen metadata (Todo 11).
+ * Last-streamed-config retention: the device of the LAST-STREAMED configuration
+ * is the ONLY one remembered as a `lost` row while it is absent. Starting a
+ * stream with a different configuration SUPERSEDES that slot; a device that was
+ * merely enumerated leaves the list once it is live-absent, keeping only its
+ * invisible `last_seen_devices` entry for identity migration.
  *
- * `buildSources` synthesizes a `lost` capture row for a remembered device absent
- * from the current engine list: one seen THIS session (uncapped in-memory session
- * map), or the CONFIGURED device across a restart (persisted, capped,
- * config.source-exempt LRU). The lost row REPLACES its coarse base slot, so a
- * remembered input is EXACTLY one row — never a coarse+lost duplicate. A device
- * neither configured nor session-seen synthesizes NOTHING (no zombie list growth).
+ * POLICY CHANGE — the expectations this file previously held for in-session
+ * retention were REPLACED, not weakened (Rule E). The retired rule remembered
+ * every device the process had ever enumerated, uncapped, for the lifetime of
+ * the backend: an accessory unplugged once and taken away kept a permanent
+ * unavailable row in the picker. Merely having been SEEN is not evidence that
+ * anyone wants a device back — going live with it is. The replaced assertions
+ * asserted the old rule directly (a session-seen non-configured device
+ * synthesizing a lost row), so there was no way to state the new policy without
+ * contradicting them. Every property that was not about WHICH devices are
+ * remembered — one row per remembered input, no coarse duplicate, the persisted
+ * LRU cap, the hotplug/probe ordering rules — is still asserted below.
+ *
+ * The state-transition table this policy is defined by has one dedicated test
+ * per row, under "the state-transition table".
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
@@ -41,12 +53,15 @@ import {
 	getSessionSeenDeviceSnapshots,
 	getSourcesMessage,
 	mergeObservedWithProbe,
+	noteStreamedSourceCommitted,
 	refreshAndBroadcastSources,
 	refreshEngineDeviceCache,
 	refreshSourcesForHotplug,
 	resetEngineDeviceCache,
 	setEngineAudioChangeHandler,
 } from "../modules/streaming/sources.ts";
+import { StreamStartFailure } from "../modules/streaming/start-failure-taxonomy.ts";
+import { createStreamSessionOrchestrator } from "../modules/streaming/stream-session-orchestrator.ts";
 import { addClient, removeClient } from "../rpc/events.ts";
 import type { AppWebSocket } from "../rpc/types.ts";
 
@@ -94,6 +109,9 @@ function captureDevice(
 		media_class: overrides.media_class ?? "video",
 		kind,
 		...(overrides.caps !== undefined ? { caps: overrides.caps } : {}),
+		...(overrides.stable_id !== undefined
+			? { stable_id: overrides.stable_id }
+			: {}),
 	};
 }
 
@@ -109,13 +127,13 @@ function lastSeen(
 		kind,
 		pipelineId,
 		devicePath: overrides.devicePath ?? `/dev/${id}`,
+		...(overrides.stableId !== undefined
+			? { stableId: overrides.stableId }
+			: {}),
+		...(overrides.previousIds !== undefined
+			? { previousIds: overrides.previousIds }
+			: {}),
 	};
-}
-
-function sessionMap(
-	...snapshots: LastSeenDevice[]
-): Map<string, LastSeenDevice> {
-	return new Map(snapshots.map((s) => [s.id, s]));
 }
 
 const NO_INGEST: NetworkIngest = { rtmp: null, srt: null };
@@ -134,10 +152,19 @@ function engineDevice(
 	};
 }
 
-// ─── (1) unplug: exactly one lost row, no coarse duplicate ────────────────────
+function clearRetentionConfig(): void {
+	const config = getConfig();
+	config.last_seen_devices = [];
+	delete config.source;
+	delete config.source_stable_id;
+	delete config.last_streamed_source;
+	delete config.last_streamed_source_stable_id;
+}
 
-describe("buildSources — lost-device synthesis (pure)", () => {
-	it("(1) unplug of the configured device → EXACTLY one row (lost, unavailable, named from snapshot), no coarse duplicate", () => {
+// ─── the projection: only the remembered device becomes a row ─────────────────
+
+describe("buildSources — only the LAST-STREAMED device is remembered", () => {
+	it("the remembered device, absent → EXACTLY one row (lost, unavailable, named from its snapshot), no coarse duplicate", () => {
 		const snapshot = lastSeen("video0", "hdmi", "hdmi", {
 			displayName: "Magewell HDMI Capture",
 		});
@@ -145,9 +172,8 @@ describe("buildSources — lost-device synthesis (pure)", () => {
 			sources: goldenCapSources(),
 			devices: [],
 			networkIngest: NO_INGEST,
-			configSource: "video0",
+			lastStreamedSource: "video0",
 			lastSeenDevices: [snapshot],
-			sessionSnapshots: sessionMap(snapshot),
 		});
 
 		const rows = sources.filter((s) => s.id === "video0");
@@ -166,14 +192,44 @@ describe("buildSources — lost-device synthesis (pure)", () => {
 		expect(sources.some((s) => s.origin === "coarse" && s.id === "hdmi")).toBe(
 			false,
 		);
-		// the USB-capture placeholders that used to sit beside it are suppressed
-		// in every state now (todo 21a), so no coarse row survives this build.
 		expect(
 			sources.filter((s) => s.origin === "coarse").map((s) => s.id),
 		).toEqual([]);
 	});
 
-	it("(2) replug → the lost row is replaced by the live row in one rebuild", () => {
+	it("a device that was SEEN but never streamed, absent → NO row at all", () => {
+		// The whole point of the policy. Both devices are remembered in
+		// `last_seen_devices` and both are live-absent; only the streamed one is a
+		// row, and the other's metadata stays for identity migration.
+		const streamed = lastSeen("video0", "hdmi", "hdmi");
+		const merelySeen = lastSeen("video2", "hdmi", "hdmi", {
+			displayName: "Session Cam",
+		});
+		const sources = buildSources({
+			sources: goldenCapSources(),
+			devices: [],
+			networkIngest: NO_INGEST,
+			lastStreamedSource: "video0",
+			lastSeenDevices: [streamed, merelySeen],
+		});
+
+		expect(sources.find((s) => s.id === "video0")?.lost).toBe(true);
+		expect(sources.some((s) => s.id === "video2")).toBe(false);
+	});
+
+	it("the operator's CURRENT selection is not the anchor — a never-streamed selection yields no row", () => {
+		// `config.source` moves freely on a save-only edit; the slot does not, and
+		// this is the projection half of that separation.
+		const sources = buildSources({
+			sources: goldenCapSources(),
+			devices: [],
+			networkIngest: NO_INGEST,
+			lastSeenDevices: [lastSeen("video0", "hdmi", "hdmi")],
+		});
+		expect(sources.some((s) => s.id === "video0")).toBe(false);
+	});
+
+	it("replug → the lost row is replaced by the live row in one rebuild", () => {
 		const snapshot = lastSeen("video0", "hdmi", "hdmi", {
 			displayName: "Magewell HDMI Capture",
 		});
@@ -185,9 +241,8 @@ describe("buildSources — lost-device synthesis (pure)", () => {
 				}),
 			],
 			networkIngest: NO_INGEST,
-			configSource: "video0",
+			lastStreamedSource: "video0",
 			lastSeenDevices: [snapshot],
-			sessionSnapshots: sessionMap(snapshot),
 		});
 
 		const rows = sources.filter((s) => s.id === "video0");
@@ -197,87 +252,34 @@ describe("buildSources — lost-device synthesis (pure)", () => {
 		expect(rows[0]?.lost).toBeUndefined();
 	});
 
-	it("(3) restart: only the CONFIGURED id's last_seen entry becomes a lost row (session map empty)", () => {
-		const sources = buildSources({
-			sources: goldenCapSources(),
-			devices: [],
-			networkIngest: NO_INGEST,
-			configSource: "video0",
-			lastSeenDevices: [
-				lastSeen("video0", "hdmi", "hdmi", { displayName: "Configured HDMI" }),
-				lastSeen("video1", "hdmi", "hdmi", { displayName: "Other HDMI" }),
-			],
-			sessionSnapshots: sessionMap(),
-		});
-
-		const video0 = sources.find((s) => s.id === "video0");
-		expect(video0?.lost).toBe(true);
-		if (video0?.origin === "capture")
-			expect(video0.displayName).toBe("Configured HDMI");
-		// the non-configured last_seen entry does NOT synthesize a row across a restart.
-		expect(sources.some((s) => s.id === "video1")).toBe(false);
-	});
-
-	it("(5) session-seen non-configured device → lost row present; after restart (session reset) → NO lost row", () => {
-		const seen = lastSeen("video2", "hdmi", "hdmi", {
-			displayName: "Session Cam",
-		});
-		// A: seen this session, NOT config.source, then detached.
-		const inSession = buildSources({
-			sources: goldenCapSources(),
-			devices: [],
-			networkIngest: NO_INGEST,
-			configSource: "video0",
-			lastSeenDevices: [seen],
-			sessionSnapshots: sessionMap(seen),
-		});
-		const sessionRow = inSession.find((s) => s.id === "video2");
-		expect(sessionRow?.lost).toBe(true);
-
-		// B: simulated restart — session map reset, video2 NOT the configured id.
-		const afterRestart = buildSources({
-			sources: goldenCapSources(),
-			devices: [],
-			networkIngest: NO_INGEST,
-			configSource: "video0",
-			lastSeenDevices: [seen],
-			sessionSnapshots: sessionMap(),
-		});
-		expect(afterRestart.some((s) => s.id === "video2")).toBe(false);
-	});
-
-	it("(8) a snapshot whose pipelineId is absent from the current coarse set synthesizes NO row", () => {
+	it("a snapshot whose pipelineId is absent from the current coarse set synthesizes NO row", () => {
 		const snapshot = lastSeen("video0", "hdmi", "hdmi");
 		const sources = buildSources({
 			// hdmi is NOT offered this build (caps changed), so nothing bridges to it.
 			sources: [capSource("usb_mjpeg"), capSource("test")],
 			devices: [],
 			networkIngest: NO_INGEST,
-			configSource: "video0",
+			lastStreamedSource: "video0",
 			lastSeenDevices: [snapshot],
-			sessionSnapshots: sessionMap(snapshot),
 		});
 		expect(sources.some((s) => s.id === "video0")).toBe(false);
 		// `usb_mjpeg` is a suppressed USB-capture placeholder, so only the virtual
-		// test-pattern row remains (todo 21a).
+		// test-pattern row remains.
 		expect(sources.map((s) => s.id)).toEqual(["test"]);
 	});
 
-	it("(QA) device absent AND not configured AND not session-seen → NO lost row (no zombie)", () => {
+	it("a slot pointing at a device no longer remembered at all synthesizes NO row (no zombie)", () => {
 		const sources = buildSources({
 			sources: goldenCapSources(),
 			devices: [],
 			networkIngest: NO_INGEST,
-			configSource: "video0",
-			// video9 is remembered ONLY in persisted last_seen, and it is NOT the
-			// configured id and NOT session-seen → it must stay a zombie-free ghost.
-			lastSeenDevices: [lastSeen("video9", "hdmi", "hdmi")],
-			sessionSnapshots: sessionMap(),
+			lastStreamedSource: "video9",
+			lastSeenDevices: [lastSeen("video0", "hdmi", "hdmi")],
 		});
 		expect(sources.some((s) => s.id === "video9")).toBe(false);
 	});
 
-	it("(11) every synthesized lost row parses under streamSourceSchema with devicePath present", () => {
+	it("every synthesized lost row parses under streamSourceSchema with devicePath present", () => {
 		const snapshot = lastSeen("video0", "hdmi", "hdmi", {
 			displayName: "Elgato Cam Link 4K",
 			devicePath: "/dev/video7",
@@ -286,9 +288,8 @@ describe("buildSources — lost-device synthesis (pure)", () => {
 			sources: goldenCapSources(),
 			devices: [],
 			networkIngest: NO_INGEST,
-			configSource: "video0",
+			lastStreamedSource: "video0",
 			lastSeenDevices: [snapshot],
-			sessionSnapshots: sessionMap(snapshot),
 		});
 		for (const source of sources) {
 			expect(() => streamSourceSchema.parse(source)).not.toThrow();
@@ -300,12 +301,70 @@ describe("buildSources — lost-device synthesis (pure)", () => {
 			expect(lost.lost).toBe(true);
 		}
 	});
+
+	it("an anchored IDENTITY outranks the node path, and a path another device inherited never resolves", () => {
+		// `/dev/video1` is now held outright by a different camera's snapshot, which
+		// `findRememberingId` would prefer. Remembering THAT device would put a
+		// stranger's row in the picker under the operator's own retention slot.
+		const anchored = lastSeen("video4", "uvc_h264", "libuvch264", {
+			displayName: "DJI Osmo Pocket 3",
+			stableId: "usb:2ca3:0023:SN-A",
+			previousIds: ["video1"],
+		});
+		const inheritor = lastSeen("video1", "mjpeg", "usb_mjpeg", {
+			displayName: "Some Other Camera",
+			stableId: "usb:19f7:0080:SN-B",
+		});
+
+		const byIdentity = buildSources({
+			sources: goldenCapSources(),
+			devices: [],
+			networkIngest: NO_INGEST,
+			lastStreamedSource: "video1",
+			lastStreamedStableId: "usb:2ca3:0023:SN-A",
+			lastSeenDevices: [inheritor, anchored],
+		}).filter((s) => s.lost === true);
+
+		expect(byIdentity).toHaveLength(1);
+		expect(byIdentity[0]?.id).toBe("video4");
+	});
 });
 
-// ─── (4) schema: additive key, default [], required devicePath ────────────────
+// ─── schema: additive, and DISTINCT from config.source ────────────────────────
+
+describe("runtimeConfigSchema — the retention slot", () => {
+	it("parses an old config that has never streamed (no last_streamed_source)", () => {
+		const parsed = runtimeConfigSchema.safeParse({
+			max_br: 5000,
+			srt_latency: 2000,
+		});
+		expect(parsed.success).toBe(true);
+		if (parsed.success) {
+			expect(parsed.data.last_streamed_source).toBeUndefined();
+			expect(parsed.data.last_streamed_source_stable_id).toBeUndefined();
+		}
+	});
+
+	it("round-trips a slot that DIFFERS from the operator's current selection", () => {
+		const parsed = runtimeConfigSchema.safeParse({
+			source: "/dev/video0",
+			source_stable_id: "usb:hdmi",
+			last_streamed_source: "/dev/video3",
+			last_streamed_source_stable_id: "usb:2ca3:0023:SN-A",
+		});
+		expect(parsed.success).toBe(true);
+		if (parsed.success) {
+			expect(parsed.data.source).toBe("/dev/video0");
+			expect(parsed.data.last_streamed_source).toBe("/dev/video3");
+			expect(parsed.data.last_streamed_source_stable_id).toBe(
+				"usb:2ca3:0023:SN-A",
+			);
+		}
+	});
+});
 
 describe("runtimeConfigSchema — last_seen_devices additive key", () => {
-	it("(4) parses an old config with no last_seen_devices key (optional)", () => {
+	it("parses an old config with no last_seen_devices key (optional)", () => {
 		const parsed = runtimeConfigSchema.safeParse({
 			max_br: 5000,
 			srt_latency: 2000,
@@ -314,7 +373,7 @@ describe("runtimeConfigSchema — last_seen_devices additive key", () => {
 		if (parsed.success) expect(parsed.data.last_seen_devices).toBeUndefined();
 	});
 
-	it("(4) defaults to [] via RUNTIME_CONFIG_DEFAULTS", () => {
+	it("defaults to [] via RUNTIME_CONFIG_DEFAULTS", () => {
 		expect(RUNTIME_CONFIG_DEFAULTS.last_seen_devices).toEqual([]);
 	});
 
@@ -351,113 +410,7 @@ describe("runtimeConfigSchema — last_seen_devices additive key", () => {
 	});
 });
 
-// ─── (6,7,10) recording + persistence + LRU integration ───────────────────────
-
-describe("session recording + persisted LRU (integration)", () => {
-	beforeEach(() => {
-		resetEngineDeviceCache();
-		getConfig().last_seen_devices = [];
-		delete getConfig().source;
-	});
-
-	afterEach(() => {
-		resetEngineDeviceCache();
-		getConfig().last_seen_devices = [];
-		delete getConfig().source;
-	});
-
-	it("(6) an empty list-devices result does NOT clear the session map (lost rows survive a zero-device blip)", async () => {
-		await refreshEngineDeviceCache({
-			fetchEngineDevices: async () => ({ devices: [engineDevice("video0")] }),
-		});
-		expect(getSessionSeenDeviceSnapshots().has("video0")).toBe(true);
-
-		// engine restart briefly reports zero devices (a reachable, empty list).
-		await refreshEngineDeviceCache({
-			fetchEngineDevices: async () => ({ devices: [] }),
-		});
-		expect(getEngineDeviceCache()).toHaveLength(0);
-		// the session memory is monotonic — the id is NOT dropped.
-		expect(getSessionSeenDeviceSnapshots().has("video0")).toBe(true);
-
-		const sources = buildSources({
-			sources: goldenCapSources(),
-			devices: getEngineDeviceCache(),
-			networkIngest: NO_INGEST,
-			sessionSnapshots: getSessionSeenDeviceSnapshots(),
-		});
-		expect(sources.find((s) => s.id === "video0")?.lost).toBe(true);
-	});
-
-	it("(7) LRU churn of 14 other devices never evicts the configured id's snapshot", async () => {
-		getConfig().source = "video0";
-		await refreshEngineDeviceCache({
-			fetchEngineDevices: async () => ({ devices: [engineDevice("video0")] }),
-		});
-		for (let i = 1; i <= 14; i++) {
-			await refreshEngineDeviceCache({
-				fetchEngineDevices: async () => ({
-					devices: [engineDevice(`churn${i}`)],
-				}),
-			});
-		}
-
-		const persisted = getConfig().last_seen_devices ?? [];
-		expect(persisted).toHaveLength(12);
-		expect(persisted.some((d) => d.id === "video0")).toBe(true);
-		// the uncapped session map keeps ALL 15 observed ids.
-		expect(getSessionSeenDeviceSnapshots().size).toBe(15);
-	});
-
-	it("(10) a non-configured session-seen device evicted from the persisted LRU still synthesizes a full lost row in-session", async () => {
-		getConfig().source = "video-config";
-		await refreshEngineDeviceCache({
-			fetchEngineDevices: async () => ({
-				devices: [engineDevice("video-config")],
-			}),
-		});
-		await refreshEngineDeviceCache({
-			fetchEngineDevices: async () => ({
-				devices: [engineDevice("videoX", "Roaming Cam")],
-			}),
-		});
-		for (let i = 1; i <= 13; i++) {
-			await refreshEngineDeviceCache({
-				fetchEngineDevices: async () => ({
-					devices: [engineDevice(`churn${i}`)],
-				}),
-			});
-		}
-
-		const persisted = getConfig().last_seen_devices ?? [];
-		// videoX was evicted from the capped persisted list…
-		expect(persisted.some((d) => d.id === "videoX")).toBe(false);
-		// …but survives in the uncapped session map (metadata intact).
-		expect(getSessionSeenDeviceSnapshots().has("videoX")).toBe(true);
-
-		const sources = buildSources({
-			sources: goldenCapSources(),
-			devices: [],
-			networkIngest: NO_INGEST,
-			configSource: getConfig().source,
-			lastSeenDevices: persisted,
-			sessionSnapshots: getSessionSeenDeviceSnapshots(),
-		});
-		const lost = sources.find((s) => s.id === "videoX");
-		expect(lost?.lost).toBe(true);
-		if (lost?.origin === "capture")
-			expect(lost.displayName).toBe("Roaming Cam");
-	});
-});
-
-// ─── (9) registry-driven combined transition (no second fetch) ────────────────
-
-function recordingClient(sink: string[]): AppWebSocket {
-	return {
-		data: { isAuthenticated: true, lastActive: Date.now() },
-		send: (message: string) => sink.push(message),
-	} as unknown as AppWebSocket;
-}
+// ─── the state-transition table (one test per row) ────────────────────────────
 
 async function seedHdmiCaps(): Promise<void> {
 	await getCapabilities({
@@ -489,24 +442,420 @@ async function seedHdmiCaps(): Promise<void> {
 	});
 }
 
-describe("applyObservedDevicesAndBroadcast — combined hotplug transition (C7)", () => {
+describe("the state-transition table", () => {
 	beforeEach(() => {
 		resetEngineDeviceCache();
 		clearCapabilitiesCache();
-		getConfig().last_seen_devices = [];
-		delete getConfig().source;
+		clearRetentionConfig();
 	});
 
 	afterEach(() => {
 		resetEngineDeviceCache();
 		clearCapabilitiesCache();
-		getConfig().last_seen_devices = [];
-		delete getConfig().source;
+		clearRetentionConfig();
 	});
 
-	it("(9) a device removed via the observed list rebroadcasts BOTH devices and sources, sources carrying the lost row — no second fetch", async () => {
+	/** Make `deviceId` a live, engine-authored HDMI device and select it. */
+	async function selectLiveDevice(deviceId: string): Promise<void> {
+		await seedHdmiCaps();
+		applyObservedEngineDevices([
+			captureDevice(deviceId, "hdmi", { display_name: `Camera ${deviceId}` }),
+		]);
+		getConfig().source = deviceId;
+	}
+
+	/** One orchestrator whose launch outcome the caller decides. */
+	function orchestratorWithCommitSpy(commits: string[]) {
+		return createStreamSessionOrchestrator({
+			createAttemptId: () => "attempt-1",
+			setStreamingStatus: () => {},
+			stopRuntime: async () => {},
+			queryRuntime: async () => "idle",
+			retryPolicy: {
+				maxAttempts: 1,
+				totalBudgetMs: 60_000,
+				baseDelayMs: 1,
+				maxDelayMs: 1,
+			},
+			// The production hook, plus a record of when it fired — so these tests
+			// assert the real write, never a stand-in for it.
+			onStreamCommitted: () => {
+				commits.push(getConfig().source ?? "");
+				noteStreamedSourceCommitted();
+			},
+		});
+	}
+
+	it("SAVE-ONLY config change → the slot is UNCHANGED while config.source moves", async () => {
+		await selectLiveDevice("video0");
+		noteStreamedSourceCommitted();
+		expect(getConfig().last_streamed_source).toBe("video0");
+
+		// A save-only edit rewrites the operator's selection and nothing else.
+		getConfig().source = "video1";
+		expect(getConfig().last_streamed_source).toBe("video0");
+	});
+
+	it("a start that FAILS the outcome gate → the slot is UNCHANGED (the hook never fires)", async () => {
+		await selectLiveDevice("video0");
+		const commits: string[] = [];
+		const orchestrator = orchestratorWithCommitSpy(commits);
+
+		const result = await orchestrator.start({
+			origin: "ui",
+			launch: async ({ attemptId }) => {
+				// Exactly what an expired `playing-wait` phase throws: the graph may
+				// well have reached PLAYING, but the engine never confirmed a really
+				// streaming session, so the launch never resolves.
+				throw new StreamStartFailure({
+					attemptId,
+					phase: "playing-wait",
+					class: "start_timeout",
+					retriable: false,
+				});
+			},
+		});
+
+		expect(result.result).toBe("failed");
+		expect(commits).toEqual([]);
+		expect(getConfig().last_streamed_source).toBeUndefined();
+	});
+
+	it("a start that SATISFIES the outcome gate → the slot MOVES to that configuration's device", async () => {
+		await selectLiveDevice("video0");
+		const commits: string[] = [];
+		const orchestrator = orchestratorWithCommitSpy(commits);
+
+		const result = await orchestrator.start({
+			origin: "ui",
+			launch: async () => {},
+		});
+
+		expect(result.result).toBe("started");
+		expect(commits).toEqual(["video0"]);
+	});
+
+	it("the slot records the STABLE IDENTITY of the committed device, not just its node path", async () => {
+		await seedHdmiCaps();
+		applyObservedEngineDevices([
+			captureDevice("video3", "hdmi", { stable_id: "usb:2ca3:0023:SN-A" }),
+		]);
+		getConfig().source = "video3";
+
+		expect(noteStreamedSourceCommitted()).toBe(true);
+		expect(getConfig().last_streamed_source).toBe("video3");
+		expect(getConfig().last_streamed_source_stable_id).toBe(
+			"usb:2ca3:0023:SN-A",
+		);
+	});
+
+	it("a committed start on a NON-camera source SUPERSEDES the remembered camera", async () => {
+		await seedHdmiCaps();
+		applyObservedEngineDevices([
+			captureDevice("video3", "hdmi", { stable_id: "usb:2ca3:0023:SN-A" }),
+		]);
+		getConfig().source = "video3";
+		noteStreamedSourceCommitted();
+		applyObservedEngineDevices([]);
+		expect(
+			getSourcesMessage().sources.find((s) => s.id === "video3")?.lost,
+		).toBe(true);
+
+		// The operator switches to the network ingest and goes live with it.
+		getConfig().source = "rtmp";
+		expect(noteStreamedSourceCommitted()).toBe(true);
+		expect(getConfig().last_streamed_source).toBe("rtmp");
+		expect(getConfig().last_streamed_source_stable_id).toBeUndefined();
+		expect(getSourcesMessage().sources.some((s) => s.id === "video3")).toBe(
+			false,
+		);
+	});
+
+	it("STOP → the slot is UNCHANGED (only a start ever moves it)", async () => {
+		await selectLiveDevice("video0");
+		const commits: string[] = [];
+		const orchestrator = orchestratorWithCommitSpy(commits);
+		await orchestrator.start({ origin: "ui", launch: async () => {} });
+		expect(commits).toHaveLength(1);
+
+		const stopped = await orchestrator.stop();
+		expect(stopped.result).toBe("stopped");
+		expect(commits).toHaveLength(1);
+		expect(getConfig().last_streamed_source).toBe("video0");
+	});
+
+	it("a device RENUMBER → the slot follows the stable identity, not the node path", async () => {
+		await seedHdmiCaps();
+		getConfig().last_streamed_source = "video1";
+		getConfig().last_streamed_source_stable_id = "usb:2ca3:0023:SN-A";
+		getConfig().last_seen_devices = [
+			lastSeen("video7", "hdmi", "hdmi", {
+				displayName: "DJI Osmo Pocket 3",
+				stableId: "usb:2ca3:0023:SN-A",
+				previousIds: ["video1"],
+			}),
+		];
+
+		// Absent under its CURRENT node path — the slot still names the old one.
+		const lost = getSourcesMessage().sources.filter((s) => s.lost === true);
+		expect(lost).toHaveLength(1);
+		expect(lost[0]?.id).toBe("video7");
+	});
+
+	it("a restoration re-commit of the SAME configuration NEVER moves the slot (and writes nothing)", async () => {
+		await selectLiveDevice("video0");
+		expect(noteStreamedSourceCommitted()).toBe(true);
+		const after = getConfig().last_streamed_source;
+
+		// A restoration re-runs the configuration that was already live, so there is
+		// nothing to move; the false return is the "no config write" guarantee.
+		expect(noteStreamedSourceCommitted()).toBe(false);
+		expect(noteStreamedSourceCommitted()).toBe(false);
+		expect(getConfig().last_streamed_source).toBe(after);
+	});
+
+	it("a REPLUG while physically present is always listed — presence beats retention", async () => {
+		await seedHdmiCaps();
+		getConfig().last_streamed_source = "video0";
+		getConfig().last_seen_devices = [lastSeen("video0", "hdmi", "hdmi")];
+
+		applyObservedEngineDevices([]);
+		expect(
+			getSourcesMessage().sources.find((s) => s.id === "video0")?.lost,
+		).toBe(true);
+
+		applyObservedEngineDevices([captureDevice("video0", "hdmi")]);
+		const back = getSourcesMessage().sources.find((s) => s.id === "video0");
+		expect(back?.lost).toBeUndefined();
+		expect(back?.available).toBe(true);
+	});
+
+	it("a BACKEND RESTART restores the slot from config, not from anything in memory", async () => {
+		await seedHdmiCaps();
+		getConfig().last_streamed_source = "video0";
+		getConfig().last_seen_devices = [
+			lastSeen("video0", "hdmi", "hdmi", { displayName: "Studio HDMI" }),
+		];
+
+		// resetEngineDeviceCache() is the restart simulation: every in-memory
+		// device memory is dropped and only config.json survives.
+		resetEngineDeviceCache();
+		expect(getSessionSeenDeviceSnapshots().size).toBe(0);
+		expect(getEngineDeviceCache()).toHaveLength(0);
+
+		const restored = getSourcesMessage().sources.find((s) => s.id === "video0");
+		expect(restored?.lost).toBe(true);
+		if (restored?.origin === "capture")
+			expect(restored.displayName).toBe("Studio HDMI");
+	});
+
+	it("NEGATIVE CONTROL — a 2-second blip on a never-streamed device never makes it unpickable", async () => {
+		await seedHdmiCaps();
+		getConfig().last_streamed_source = "video0";
+		getConfig().last_seen_devices = [lastSeen("video0", "hdmi", "hdmi")];
+		applyObservedEngineDevices([
+			captureDevice("video0", "hdmi"),
+			captureDevice("video1", "hdmi", { display_name: "Borrowed Cam" }),
+		]);
+		expect(
+			getSourcesMessage().sources.find((s) => s.id === "video1")?.available,
+		).toBe(true);
+
+		// The blip: gone for one observation. It is not the remembered device, so it
+		// leaves the list entirely rather than lingering as an unusable row.
+		applyObservedEngineDevices([captureDevice("video0", "hdmi")]);
+		expect(getSourcesMessage().sources.some((s) => s.id === "video1")).toBe(
+			false,
+		);
+
+		// …and it is a fully selectable row again the moment it is back.
+		applyObservedEngineDevices([
+			captureDevice("video0", "hdmi"),
+			captureDevice("video1", "hdmi", { display_name: "Borrowed Cam" }),
+		]);
+		const back = getSourcesMessage().sources.find((s) => s.id === "video1");
+		expect(back?.available).toBe(true);
+		expect(back?.lost).toBeUndefined();
+	});
+});
+
+// ─── recording + persistence + LRU integration ────────────────────────────────
+
+describe("session recording + persisted LRU (integration)", () => {
+	beforeEach(() => {
+		resetEngineDeviceCache();
+		clearRetentionConfig();
+	});
+
+	afterEach(() => {
+		resetEngineDeviceCache();
+		clearRetentionConfig();
+	});
+
+	it("an empty list-devices result does NOT clear the remembered slot's row (survives a zero-device blip)", async () => {
+		await refreshEngineDeviceCache({
+			fetchEngineDevices: async () => ({ devices: [engineDevice("video0")] }),
+		});
+		getConfig().last_streamed_source = "video0";
+
+		// engine restart briefly reports zero devices (a reachable, empty list).
+		await refreshEngineDeviceCache({
+			fetchEngineDevices: async () => ({ devices: [] }),
+		});
+		expect(getEngineDeviceCache()).toHaveLength(0);
+
+		const sources = buildSources({
+			sources: goldenCapSources(),
+			devices: getEngineDeviceCache(),
+			networkIngest: NO_INGEST,
+			lastStreamedSource: "video0",
+			lastSeenDevices: getConfig().last_seen_devices ?? [],
+		});
+		expect(sources.find((s) => s.id === "video0")?.lost).toBe(true);
+	});
+
+	it("LRU churn of 14 other devices never evicts the configured id's snapshot", async () => {
+		getConfig().source = "video0";
+		await refreshEngineDeviceCache({
+			fetchEngineDevices: async () => ({ devices: [engineDevice("video0")] }),
+		});
+		for (let i = 1; i <= 14; i++) {
+			await refreshEngineDeviceCache({
+				fetchEngineDevices: async () => ({
+					devices: [engineDevice(`churn${i}`)],
+				}),
+			});
+		}
+
+		const persisted = getConfig().last_seen_devices ?? [];
+		expect(persisted).toHaveLength(12);
+		expect(persisted.some((d) => d.id === "video0")).toBe(true);
+		// the uncapped session record keeps ALL 15 observed ids.
+		expect(getSessionSeenDeviceSnapshots().size).toBe(15);
+	});
+
+	it("LRU churn never evicts the LAST-STREAMED snapshot either, even once the selection has moved on", async () => {
+		// The two exemptions come apart exactly here: a save-only edit left
+		// `config.source` on a different device, so only the second one protects
+		// the snapshot the retention slot is rendered from.
+		await refreshEngineDeviceCache({
+			fetchEngineDevices: async () => ({
+				devices: [engineDevice("video0", "Streamed Cam")],
+			}),
+		});
+		getConfig().last_streamed_source = "video0";
+		getConfig().source = "churn1";
+		for (let i = 1; i <= 14; i++) {
+			await refreshEngineDeviceCache({
+				fetchEngineDevices: async () => ({
+					devices: [engineDevice(`churn${i}`)],
+				}),
+			});
+		}
+
+		const persisted = getConfig().last_seen_devices ?? [];
+		expect(persisted).toHaveLength(12);
+		expect(persisted.some((d) => d.id === "video0")).toBe(true);
+
+		const lost = buildSources({
+			sources: goldenCapSources(),
+			devices: [],
+			networkIngest: NO_INGEST,
+			lastStreamedSource: "video0",
+			lastSeenDevices: persisted,
+		}).filter((s) => s.lost === true);
+		expect(lost).toHaveLength(1);
+		expect(lost[0]?.id).toBe("video0");
+	});
+
+	it("a churned-out device that was never streamed keeps NO row, in-session or otherwise", async () => {
+		getConfig().source = "video-config";
+		getConfig().last_streamed_source = "video-config";
+		await refreshEngineDeviceCache({
+			fetchEngineDevices: async () => ({
+				devices: [engineDevice("video-config")],
+			}),
+		});
+		await refreshEngineDeviceCache({
+			fetchEngineDevices: async () => ({
+				devices: [engineDevice("videoX", "Roaming Cam")],
+			}),
+		});
+		for (let i = 1; i <= 13; i++) {
+			await refreshEngineDeviceCache({
+				fetchEngineDevices: async () => ({
+					devices: [engineDevice(`churn${i}`)],
+				}),
+			});
+		}
+
+		const persisted = getConfig().last_seen_devices ?? [];
+		expect(persisted.some((d) => d.id === "videoX")).toBe(false);
+		// The session record still holds it — invisible, for identity migration.
+		expect(getSessionSeenDeviceSnapshots().has("videoX")).toBe(true);
+
+		const sources = buildSources({
+			sources: goldenCapSources(),
+			devices: [],
+			networkIngest: NO_INGEST,
+			lastStreamedSource: getConfig().last_streamed_source,
+			lastSeenDevices: persisted,
+		});
+		expect(sources.some((s) => s.id === "videoX")).toBe(false);
+		expect(sources.find((s) => s.id === "video-config")?.lost).toBe(true);
+	});
+
+	it("the persisted retired-path memory is still capped at 8", async () => {
+		const stableId = "usb:2ca3:0023:SN-A";
+		for (let i = 0; i <= 12; i++) {
+			await refreshEngineDeviceCache({
+				fetchEngineDevices: async () => ({
+					devices: [
+						{
+							input_id: `video${i}`,
+							device_path: `/dev/video${i}`,
+							display_name: "DJI Osmo Pocket 3",
+							media_class: "video",
+							kind: "hdmi",
+							stable_id: stableId,
+						},
+					],
+				}),
+			});
+		}
+
+		const persisted = getConfig().last_seen_devices ?? [];
+		expect(persisted).toHaveLength(1);
+		expect(persisted[0]?.previousIds?.length).toBe(8);
+	});
+});
+
+// ─── registry-driven combined transition (no second fetch) ────────────────────
+
+function recordingClient(sink: string[]): AppWebSocket {
+	return {
+		data: { isAuthenticated: true, lastActive: Date.now() },
+		send: (message: string) => sink.push(message),
+	} as unknown as AppWebSocket;
+}
+
+describe("applyObservedDevicesAndBroadcast — combined hotplug transition", () => {
+	beforeEach(() => {
+		resetEngineDeviceCache();
+		clearCapabilitiesCache();
+		clearRetentionConfig();
+	});
+
+	afterEach(() => {
+		resetEngineDeviceCache();
+		clearCapabilitiesCache();
+		clearRetentionConfig();
+	});
+
+	it("a device removed via the observed list rebroadcasts BOTH devices and sources, sources carrying the lost row — no second fetch", async () => {
 		await seedHdmiCaps();
 		getConfig().source = "video0";
+		getConfig().last_streamed_source = "video0";
 		// The registry first observed the device present (records the snapshot).
 		applyObservedEngineDevices([
 			captureDevice("video0", "hdmi", { display_name: "Studio HDMI" }),
@@ -563,20 +912,19 @@ describe("refreshSourcesForHotplug — a failing engine probe never masks a remo
 	beforeEach(() => {
 		resetEngineDeviceCache();
 		clearCapabilitiesCache();
-		getConfig().last_seen_devices = [];
-		delete getConfig().source;
+		clearRetentionConfig();
 	});
 
 	afterEach(() => {
 		resetEngineDeviceCache();
 		clearCapabilitiesCache();
-		getConfig().last_seen_devices = [];
-		delete getConfig().source;
+		clearRetentionConfig();
 	});
 
 	async function seedPresentDevice(): Promise<void> {
 		await seedHdmiCaps();
 		getConfig().source = "video0";
+		getConfig().last_streamed_source = "video0";
 		applyObservedEngineDevices([
 			captureDevice("video0", "hdmi", { display_name: "Studio HDMI" }),
 		]);
@@ -663,15 +1011,13 @@ describe("refreshSourcesForHotplug — a stale successful probe never masks the 
 	beforeEach(() => {
 		resetEngineDeviceCache();
 		clearCapabilitiesCache();
-		getConfig().last_seen_devices = [];
-		delete getConfig().source;
+		clearRetentionConfig();
 	});
 
 	afterEach(() => {
 		resetEngineDeviceCache();
 		clearCapabilitiesCache();
-		getConfig().last_seen_devices = [];
-		delete getConfig().source;
+		clearRetentionConfig();
 	});
 
 	function captureBroadcast(
@@ -698,10 +1044,11 @@ describe("refreshSourcesForHotplug — a stale successful probe never masks the 
 		).sources.find((s) => s.id === id);
 	}
 
-	/** The device was seen, then unplugged — so it currently renders `lost`. */
+	/** The device was streamed, then unplugged — so it currently renders `lost`. */
 	async function seedLostDevice(): Promise<void> {
 		await seedHdmiCaps();
 		getConfig().source = "video0";
+		getConfig().last_streamed_source = "video0";
 		applyObservedEngineDevices([
 			captureDevice("video0", "hdmi", { display_name: "Studio HDMI" }),
 		]);
@@ -733,6 +1080,7 @@ describe("refreshSourcesForHotplug — a stale successful probe never masks the 
 	it("a removal the local scan observed is NOT resurrected by a probe still answering with the pre-removal list", async () => {
 		await seedHdmiCaps();
 		getConfig().source = "video0";
+		getConfig().last_streamed_source = "video0";
 		applyObservedEngineDevices([
 			captureDevice("video0", "hdmi", { display_name: "Studio HDMI" }),
 		]);
@@ -879,6 +1227,7 @@ describe("refreshSourcesForHotplug — a stale successful probe never masks the 
 	it("an OLDER hotplug refresh answering late never clobbers a NEWER one's result", async () => {
 		await seedHdmiCaps();
 		getConfig().source = "video0";
+		getConfig().last_streamed_source = "video0";
 		applyObservedEngineDevices([
 			captureDevice("video0", "hdmi", { display_name: "Studio HDMI" }),
 		]);
@@ -918,6 +1267,7 @@ describe("refreshSourcesForHotplug — a stale successful probe never masks the 
 	it("an OLDER refresh whose probe FAILS late does not fall back over a NEWER result", async () => {
 		await seedHdmiCaps();
 		getConfig().source = "video0";
+		getConfig().last_streamed_source = "video0";
 		applyObservedEngineDevices([
 			captureDevice("video0", "hdmi", { display_name: "Studio HDMI" }),
 		]);
@@ -942,20 +1292,19 @@ describe("refreshSourcesForHotplug — a stale successful probe never masks the 
 		failStaleProbe(new Error("engine unavailable"));
 		await older;
 
-		// The PR #214 observed-fallback is still correct — it just belongs to the
-		// generation that owns the current view, not to a superseded one.
+		// The observed-fallback is still correct — it just belongs to the generation
+		// that owns the current view, not to a superseded one.
 		expect(getEngineDeviceCache().map((d) => d.input_id)).toEqual(["video0"]);
 	});
 });
 
 // ─── replug: a probe that cannot speak for the device must not DEGRADE it ─────
 //
-// The live RØDE reconnect regression. #214/#215 made the replugged device stay
-// PRESENT; this is about it staying ITSELF. The local scan can only guess a kind
-// from the card name (`deriveKind`), and for a UVC dongle the guess is `usb` —
-// which bridges to NO pipeline, so `buildSources` drops the row entirely and the
-// coarse `usb_mjpeg` slot renders "USB MJPEG / not connected" instead. It is
-// permanent for the same reason #215 was: nothing re-pokes a stable device set.
+// The live RØDE reconnect regression. The local scan can only guess a kind from
+// the card name (`deriveKind`), and for a UVC dongle the guess is `usb` — which
+// bridges to NO pipeline, so `buildSources` drops the row entirely and the coarse
+// `usb_mjpeg` slot renders "USB MJPEG / not connected" instead. It is permanent
+// because nothing re-pokes a stable device set.
 
 describe("refreshSourcesForHotplug — a replug the probe has not caught up with keeps its engine identity", () => {
 	// Byte-exact strings from the bug hardware (Rock 5B+). The v4l2 card name
@@ -967,15 +1316,13 @@ describe("refreshSourcesForHotplug — a replug the probe has not caught up with
 	beforeEach(() => {
 		resetEngineDeviceCache();
 		clearCapabilitiesCache();
-		getConfig().last_seen_devices = [];
-		delete getConfig().source;
+		clearRetentionConfig();
 	});
 
 	afterEach(() => {
 		resetEngineDeviceCache();
 		clearCapabilitiesCache();
-		getConfig().last_seen_devices = [];
-		delete getConfig().source;
+		clearRetentionConfig();
 	});
 
 	function engineHdmiRx(): ListDevicesResult["devices"][number] {
@@ -1045,6 +1392,7 @@ describe("refreshSourcesForHotplug — a replug the probe has not caught up with
 	async function seedThenUnplugRode(): Promise<void> {
 		await seedHdmiAndMjpegCaps();
 		getConfig().source = "/dev/video1";
+		getConfig().last_streamed_source = "/dev/video1";
 		await refreshEngineDeviceCache({
 			fetchEngineDevices: async () => ({
 				devices: [engineHdmiRx(), engineRode()],
@@ -1084,7 +1432,7 @@ describe("refreshSourcesForHotplug — a replug the probe has not caught up with
 		).toBe(false);
 	});
 
-	it("the same restoration applies when the probe FAILS outright (the #214 observed-fallback branch)", async () => {
+	it("the same restoration applies when the probe FAILS outright (the observed-fallback branch)", async () => {
 		await seedThenUnplugRode();
 
 		await refreshSourcesForHotplug([scannedHdmiRx(), scannedRode()], {

--- a/apps/backend/src/tests/mock-device-attach.test.ts
+++ b/apps/backend/src/tests/mock-device-attach.test.ts
@@ -99,6 +99,9 @@ describe("setMockDeviceAttached seam (C7)", () => {
 		getConfig().last_seen_devices = [];
 		delete getConfig().source;
 		await seedCapsAndDevices();
+		// Only the last-streamed device is remembered when absent, so the detach
+		// seam is exercised against the one state in which a lost row exists.
+		getConfig().last_streamed_source = USB_INPUT_ID;
 	});
 	afterEach(() => {
 		setStreamingState(false);
@@ -106,6 +109,7 @@ describe("setMockDeviceAttached seam (C7)", () => {
 		resetEngineDeviceCache();
 		getConfig().last_seen_devices = [];
 		delete getConfig().source;
+		delete getConfig().last_streamed_source;
 		resetMockState();
 	});
 	afterAll(() => {

--- a/apps/backend/src/tests/onboard-video-display-name.test.ts
+++ b/apps/backend/src/tests/onboard-video-display-name.test.ts
@@ -171,7 +171,7 @@ describe("sources broadcast — the row the operator actually sees", () => {
 			sources: [HDMI_CAP],
 			devices: [],
 			networkIngest: NO_INGEST,
-			configSource: "/dev/video0",
+			lastStreamedSource: "/dev/video0",
 			lastSeenDevices: lastSeen,
 		});
 

--- a/apps/backend/src/tests/source-cross-device-renumber.test.ts
+++ b/apps/backend/src/tests/source-cross-device-renumber.test.ts
@@ -138,16 +138,15 @@ function lastSeen(
 
 function sourcesFrom(
 	devices: readonly CaptureDevice[],
-	configSource: string,
+	lastStreamedSource: string,
 	lastSeenDevices: readonly LastSeenDevice[],
 ): StreamSource[] {
 	return realSources.buildSources({
 		sources: goldenCapSources(),
 		devices,
 		networkIngest: NO_INGEST,
-		configSource,
+		lastStreamedSource,
 		lastSeenDevices,
-		sessionSnapshots: realSources.getSessionSeenDeviceSnapshots(),
 	});
 }
 

--- a/apps/backend/src/tests/source-identity-renumber.test.ts
+++ b/apps/backend/src/tests/source-identity-renumber.test.ts
@@ -103,9 +103,8 @@ function sourcesAfterReplug(successor: CaptureDevice): StreamSource[] {
 		sources: goldenCapSources(),
 		devices: [captureDevice("/dev/video0", "hdmi"), successor],
 		networkIngest: NO_INGEST,
-		configSource: "/dev/video1",
+		lastStreamedSource: "/dev/video1",
 		lastSeenDevices: [snapshot],
-		sessionSnapshots: new Map([[snapshot.id, snapshot]]),
 	});
 }
 
@@ -152,9 +151,8 @@ describe("buildSources — a re-enumerated device never leaves a hole", () => {
 			sources: goldenCapSources(),
 			devices: [captureDevice("/dev/video0", "hdmi")],
 			networkIngest: NO_INGEST,
-			configSource: "/dev/video1",
+			lastStreamedSource: "/dev/video1",
 			lastSeenDevices: [snapshot],
-			sessionSnapshots: new Map([[snapshot.id, snapshot]]),
 		});
 
 		expect(sources.find((s) => s.id === "/dev/video1")?.lost).toBe(true);
@@ -222,9 +220,8 @@ describe("reconcileConfiguredSourceIdentity — the migration is PERSISTED", () 
 				}),
 			],
 			networkIngest: NO_INGEST,
-			configSource: "/dev/video1",
+			lastStreamedSource: "/dev/video1",
 			lastSeenDevices: [snapshot],
-			sessionSnapshots: new Map([[snapshot.id, snapshot]]),
 		});
 
 		expect(reconcileConfiguredSourceIdentity(sources)).toBe(false);
@@ -251,7 +248,6 @@ describe("reconcileConfiguredSourceIdentity — the migration is PERSISTED", () 
 			],
 			networkIngest: NO_INGEST,
 			lastSeenDevices: [],
-			sessionSnapshots: new Map(),
 		});
 
 		expect(reconcileConfiguredSourceIdentity(sources)).toBe(false);

--- a/apps/backend/src/tests/source-lost-rejection.test.ts
+++ b/apps/backend/src/tests/source-lost-rejection.test.ts
@@ -145,11 +145,13 @@ describe("streaming source availability rejection (C7)", () => {
 		resetEngineDeviceCache();
 		getConfig().pipeline = undefined;
 		getConfig().source = undefined;
+		delete getConfig().last_streamed_source;
 		getConfig().last_seen_devices = [];
 	});
 	afterEach(() => {
 		getConfig().source = priorSource;
 		getConfig().pipeline = priorPipeline;
+		delete getConfig().last_streamed_source;
 		getConfig().last_seen_devices = priorLastSeen;
 		resetEngineDeviceCache();
 		setStreamingState(false);
@@ -166,9 +168,14 @@ describe("streaming source availability rejection (C7)", () => {
 		else process.env.NODE_ENV = savedNodeEnv;
 	});
 
-	/** Observe a device then unplug it, so its CURRENT row is a `lost` capture. */
+	/**
+	 * Observe a device then unplug it, so its CURRENT row is a `lost` capture.
+	 * It has to be the LAST-STREAMED device to be remembered at all — that is the
+	 * only state in which a `lost` row exists for the routing seam to refuse.
+	 */
 	function makeSourceLost(inputId: string): void {
 		applyObservedEngineDevices([captureDevice(inputId, "hdmi", "Studio HDMI")]);
+		getConfig().last_streamed_source = inputId;
 		applyObservedEngineDevices([]);
 	}
 

--- a/apps/backend/src/tests/source-renumber-dedup.test.ts
+++ b/apps/backend/src/tests/source-renumber-dedup.test.ts
@@ -294,8 +294,10 @@ describe("lost rows — a renumbered camera is one candidate, not one per path",
 			sources: capSources(),
 			devices: [],
 			networkIngest: NO_INGEST,
+			// Anchored on the FIRST node it ever answered to, so this also proves the
+			// retired path still resolves through `previousIds` after the fold.
+			lastStreamedSource: "/dev/video1",
 			lastSeenDevices: getConfig().last_seen_devices ?? [],
-			sessionSnapshots: getSessionSeenDeviceSnapshots(),
 		});
 
 		const osmoRows = sources.filter(
@@ -306,21 +308,31 @@ describe("lost rows — a renumbered camera is one candidate, not one per path",
 		expect(osmoRows[0]?.id).toBe("/dev/video3");
 	});
 
-	it("NEGATIVE CONTROL — two genuinely different cameras still yield two lost rows", async () => {
+	it("NEGATIVE CONTROL — two genuinely different cameras are not folded into one, so each anchors its OWN row", async () => {
 		await observe([
 			engineDevice("/dev/video1", "uvc_h264", OSMO_STABLE_ID),
 			engineDevice("/dev/video4", "mjpeg", RODE_STABLE_ID),
 		]);
 
-		const sources = buildSources({
-			sources: capSources(),
-			devices: [],
-			networkIngest: NO_INGEST,
-			lastSeenDevices: getConfig().last_seen_devices ?? [],
-			sessionSnapshots: getSessionSeenDeviceSnapshots(),
-		});
+		const lostUnder = (anchor: string) =>
+			buildSources({
+				sources: capSources(),
+				devices: [],
+				networkIngest: NO_INGEST,
+				lastStreamedSource: anchor,
+				lastSeenDevices: getConfig().last_seen_devices ?? [],
+			}).filter((s) => s.lost === true);
 
-		expect(sources.filter((s) => s.lost === true)).toHaveLength(2);
+		// Under last-streamed-config retention at most ONE device is remembered, so
+		// over-collapse is caught by asking each camera separately: a fold would
+		// make both anchors resolve to the same row.
+		const osmo = lostUnder("/dev/video1");
+		expect(osmo).toHaveLength(1);
+		expect(osmo[0]?.id).toBe("/dev/video1");
+
+		const rode = lostUnder("/dev/video4");
+		expect(rode).toHaveLength(1);
+		expect(rode[0]?.id).toBe("/dev/video4");
 	});
 });
 
@@ -354,7 +366,6 @@ describe("preview start — resolves to the CURRENT node, not the saved one", ()
 			devices: [captureDevice("/dev/video2", "uvc_h264", OSMO_STABLE_ID)],
 			networkIngest: NO_INGEST,
 			lastSeenDevices: getConfig().last_seen_devices ?? [],
-			sessionSnapshots: getSessionSeenDeviceSnapshots(),
 		});
 	}
 
@@ -395,8 +406,8 @@ describe("preview start — resolves to the CURRENT node, not the saved one", ()
 			sources: capSources(),
 			devices: [captureDevice("/dev/video0", "hdmi")],
 			networkIngest: NO_INGEST,
+			lastStreamedSource: "/dev/video1",
 			lastSeenDevices: getConfig().last_seen_devices ?? [],
-			sessionSnapshots: getSessionSeenDeviceSnapshots(),
 		});
 
 		expect(sources.find((s) => s.id === "/dev/video1")?.lost).toBe(true);
@@ -511,8 +522,10 @@ describe("held devices — the /dev scan is not a presence oracle for a libuvc c
 			sources: capSources(),
 			devices: getEngineDeviceCache(),
 			networkIngest: NO_INGEST,
+			// It is also the remembered device, so a `lost` row is the outcome this
+			// asserts against rather than one the fixture cannot reach.
+			lastStreamedSource: "/dev/video1",
 			lastSeenDevices: getConfig().last_seen_devices ?? [],
-			sessionSnapshots: getSessionSeenDeviceSnapshots(),
 		});
 
 		const osmo = sources.find((s) => s.id === "/dev/video1");

--- a/apps/backend/src/tests/source-selection-stale-cache.test.ts
+++ b/apps/backend/src/tests/source-selection-stale-cache.test.ts
@@ -128,16 +128,15 @@ function lastSeen(
 /** Build the `sources` view the reconciler is handed, from a given device list. */
 function sourcesFrom(
 	devices: readonly CaptureDevice[],
-	configSource: string,
+	lastStreamedSource: string,
 	lastSeenDevices: readonly LastSeenDevice[],
 ): StreamSource[] {
 	return realSources.buildSources({
 		sources: goldenCapSources(),
 		devices,
 		networkIngest: NO_INGEST,
-		configSource,
+		lastStreamedSource,
 		lastSeenDevices,
-		sessionSnapshots: realSources.getSessionSeenDeviceSnapshots(),
 	});
 }
 

--- a/apps/backend/src/tests/sources.test.ts
+++ b/apps/backend/src/tests/sources.test.ts
@@ -399,7 +399,7 @@ describe("buildSources — capture signal state (present / absent / unknown)", (
 			sources: [capSource("hdmi")],
 			devices: [],
 			networkIngest: NO_INGEST,
-			configSource: "video9",
+			lastStreamedSource: "video9",
 			lastSeenDevices: [snapshot],
 		});
 		const lost = sources.find((s) => s.id === "video9");
@@ -513,9 +513,8 @@ describe("resolveSourceRouting — availability gate (C7)", () => {
 			sources: [capSource("hdmi"), capSource("test")],
 			devices: [],
 			networkIngest: NO_INGEST,
-			configSource: "video0",
+			lastStreamedSource: "video0",
 			lastSeenDevices: [snapshot],
-			sessionSnapshots: new Map([[snapshot.id, snapshot]]),
 		});
 		const lost = sources.find((s) => s.id === "video0");
 		expect(lost?.lost).toBe(true);
@@ -545,9 +544,8 @@ describe("resolveSourceRouting — availability gate (C7)", () => {
 			sources: [capSource("hdmi"), capSource("test")],
 			devices: [captureDevice("video0", "hdmi")],
 			networkIngest: NO_INGEST,
-			configSource: "video0",
+			lastStreamedSource: "video0",
 			lastSeenDevices: [snapshot],
-			sessionSnapshots: new Map([[snapshot.id, snapshot]]),
 		});
 		const live = sources.find((s) => s.id === "video0");
 		expect(live?.available).toBe(true);
@@ -758,9 +756,8 @@ describe("buildSources — hotplug re-enumeration reconciliation (Todo 34)", () 
 			sources: [capSource("hdmi"), capSource("test")],
 			devices: [hotplugDevice("video2", STABLE_A)],
 			networkIngest: NO_INGEST,
-			configSource: "video1",
+			lastStreamedSource: "video1",
 			lastSeenDevices: [video1],
-			sessionSnapshots: new Map([[video1.id, video1]]),
 		});
 
 		expect(lostRows(sources)).toHaveLength(0);
@@ -777,9 +774,8 @@ describe("buildSources — hotplug re-enumeration reconciliation (Todo 34)", () 
 			sources: [capSource("hdmi"), capSource("test")],
 			devices: [],
 			networkIngest: NO_INGEST,
-			configSource: "video1",
+			lastStreamedSource: "video1",
 			lastSeenDevices: [video1],
-			sessionSnapshots: new Map([[video1.id, video1]]),
 		});
 
 		const lost = lostRows(sources);
@@ -797,12 +793,8 @@ describe("buildSources — hotplug re-enumeration reconciliation (Todo 34)", () 
 			sources: [capSource("hdmi"), capSource("test")],
 			devices: [hotplugDevice("video3", STABLE_A)],
 			networkIngest: NO_INGEST,
-			configSource: "video1",
+			lastStreamedSource: "video1",
 			lastSeenDevices: [video1, video2],
-			sessionSnapshots: new Map([
-				[video1.id, video1],
-				[video2.id, video2],
-			]),
 		});
 
 		expect(lostRows(sources)).toHaveLength(0);
@@ -820,9 +812,8 @@ describe("buildSources — hotplug re-enumeration reconciliation (Todo 34)", () 
 			sources: [capSource("hdmi"), capSource("test")],
 			devices: [hotplugDevice("video2", STABLE_B)],
 			networkIngest: NO_INGEST,
-			configSource: "video1",
+			lastStreamedSource: "video1",
 			lastSeenDevices: [video1],
-			sessionSnapshots: new Map([[video1.id, video1]]),
 		});
 
 		const lost = lostRows(sources);
@@ -842,9 +833,8 @@ describe("buildSources — hotplug re-enumeration reconciliation (Todo 34)", () 
 			sources: [capSource("hdmi"), capSource("test")],
 			devices: [hotplugDevice("video2", undefined)],
 			networkIngest: NO_INGEST,
-			configSource: "video1",
+			lastStreamedSource: "video1",
 			lastSeenDevices: [video1],
-			sessionSnapshots: new Map([[video1.id, video1]]),
 		});
 
 		expect(lostRows(sources)).toHaveLength(1);
@@ -873,9 +863,8 @@ describe("resolveSourceRouting — renumbered-replug self-heal (Todo 36)", () =>
 			sources: [capSource("hdmi"), capSource("test")],
 			devices: [captureDevice("video2", "hdmi", { stable_id: STABLE_A })],
 			networkIngest: NO_INGEST,
-			configSource: "video1",
+			lastStreamedSource: "video1",
 			lastSeenDevices: [video1],
-			sessionSnapshots: new Map([[video1.id, video1]]),
 		});
 		// Todo 34 already suppressed the stale video1 Lost row; the persisted
 		// config.source "video1" is now absent from the live list.

--- a/apps/backend/src/tests/transient-honesty-characterization.test.ts
+++ b/apps/backend/src/tests/transient-honesty-characterization.test.ts
@@ -174,6 +174,7 @@ describe("A. the absence grace holds the VERDICT and nothing else", () => {
 		setMockAudioDevicesProvider(() => ({ DJIPocket3: "DJIPocket3" }));
 		getConfig().asrc = AUDIO_SOURCE_AUTO;
 		getConfig().source = "/dev/video1";
+		getConfig().last_streamed_source = "/dev/video1";
 	});
 	afterEach(() => {
 		setMockAudioDevicesProvider(undefined);
@@ -183,6 +184,7 @@ describe("A. the absence grace holds the VERDICT and nothing else", () => {
 		updateStatus(false);
 		delete getConfig().asrc;
 		delete getConfig().source;
+		delete getConfig().last_streamed_source;
 	});
 
 	test("baseline: the healthy view resolves the camera to its OWN card", async () => {
@@ -241,6 +243,7 @@ describe("B. the PRODUCTION no-signal raise predicate, with no injected seam", (
 		resetEngineDeviceCache();
 		clearCapabilitiesCache();
 		delete getConfig().source;
+		delete getConfig().last_streamed_source;
 	});
 
 	function standingHdmiMessage(): string | undefined {
@@ -275,6 +278,7 @@ describe("B. the PRODUCTION no-signal raise predicate, with no injected seam", (
 	test("no selection at all is not evidence, so the raise stands", async () => {
 		await observeDevices([OSMO_VIDEO, HDMI_RX]);
 		delete getConfig().source;
+		delete getConfig().last_streamed_source;
 
 		handleRk3588HdmiDmesg(NO_SIGNAL_LINE);
 

--- a/apps/frontend/tests/e2e/input-picker.spec.ts
+++ b/apps/frontend/tests/e2e/input-picker.spec.ts
@@ -235,17 +235,25 @@ test.describe("input picker mock negative coverage (Task 34)", () => {
 		});
 	});
 
-	test("a just-unplugged device remains visible as a disabled live-switch entry", async ({
+	test("a just-unplugged device that was never streamed leaves the live-switch list", async ({
 		backendRpc,
 		page,
 	}) => {
+		// Under last-streamed-config retention only the device of the last
+		// configuration that actually went live is remembered while it is absent.
+		// This one has never been on air, so it leaves the list rather than
+		// lingering as a permanently unusable entry — and an entry that is gone is
+		// no more switchable than a disabled one, so the property this guards (an
+		// unplugged device is never a live-switch target) is unchanged. The
+		// remembered device's stays-but-disabled arm is covered by
+		// `lost-device.spec.ts`.
 		await setDeviceAttached(backendRpc, "usb", true);
 		const row = deviceRow(page, "usb");
 		await expect(row).toBeVisible({ timeout: 8000 });
 		await expect(row.locator("[data-switch-input]")).toBeEnabled();
 
 		await setDeviceAttached(backendRpc, "usb", false);
-		await expect(row.locator("[data-switch-input]")).toBeDisabled({ timeout: 8000 });
+		await expect(row).toHaveCount(0, { timeout: 8000 });
 	});
 });
 

--- a/apps/frontend/tests/e2e/lost-device.spec.ts
+++ b/apps/frontend/tests/e2e/lost-device.spec.ts
@@ -150,6 +150,36 @@ async function setConfig(
 	await rpc.call(["streaming", "setConfig"], fields);
 }
 
+/**
+ * Take `source` live once and stop again, over the REAL start/stop RPCs.
+ *
+ * Only the device of the LAST-STREAMED configuration is remembered when it goes
+ * absent, so a source that has never been on air has no lost row to render. This
+ * is the operator sequence that earns one — selecting a device is not enough, and
+ * deliberately so: an accessory that was merely picked and unplugged should leave
+ * the list rather than linger in it.
+ */
+async function streamOnce(
+	page: Page,
+	rpc: PageRpc,
+	source: string,
+): Promise<void> {
+	const started = (await rpc.call(["streaming", "start"], {
+		source,
+	})) as StartResult;
+	expect(started.success).toBe(true);
+	await rpc.call(["streaming", "stop"], {});
+	// A finished stream hands the operator its session summary, and the idle
+	// cockpit — which carries the source surface every later assertion reads —
+	// is not mounted until they dismiss it.
+	const done = page.getByRole("button", { name: /^done$/i });
+	await expect(done).toBeVisible({ timeout: 15_000 });
+	await done.click();
+	await expect(
+		page.getByRole("button", { name: /start stream/i }),
+	).toBeVisible({ timeout: 15_000 });
+}
+
 test.describe("lost-device lifecycle (real seam)", () => {
 	test.beforeEach(async ({ page }, testInfo) => {
 		test.skip(
@@ -209,6 +239,9 @@ test.describe("lost-device lifecycle (real seam)", () => {
 		await expect(usbRow).toHaveAttribute("data-selected", "true", {
 			timeout: 15_000,
 		});
+		// Take the RØDE live once: only the LAST-STREAMED device is remembered when
+		// it goes absent, so this is what earns it a lost row in step 2.
+		await streamOnce(page, pageRpc, "usb");
 
 		// Audio block (todo 18) is visible once an effective source exists.
 		await expect(page.getByTestId("source-audio")).toBeVisible();
@@ -290,16 +323,22 @@ test.describe("lost-device lifecycle (real seam)", () => {
 		page,
 	}) => {
 		if (!pageRpc) throw new Error("page RPC is not installed");
-		// Select `usb`, then detach it (real seam). The SAME per-worker backend keeps
-		// BOTH the persisted config.source and the detached mock state across a
-		// browser reload — so this exercises the across-restart retention path
-		// (todo 11(c): the lost row is rebuilt from config.last_seen_devices).
+		// Stream `usb` once, then detach it (real seam). The SAME per-worker backend
+		// keeps BOTH the persisted retention slot and the detached mock state across
+		// a browser reload — so this exercises the across-restart retention path
+		// (the lost row is rebuilt from config.last_seen_devices on boot).
 		const usbRow = page.getByTestId("source-row-usb");
 		await expect(usbRow).toBeVisible({ timeout: 15_000 });
+		await setConfig(pageRpc, {
+			srtla_addr: "127.0.0.1",
+			srtla_port: 5000,
+			srt_streamid: "e2e",
+		});
 		await page.getByTestId("source-select-usb").click();
 		await expect(usbRow).toHaveAttribute("data-selected", "true", {
 			timeout: 15_000,
 		});
+		await streamOnce(page, pageRpc, "usb");
 		expect((await setDeviceAttached(pageRpc, "usb", false)).success).toBe(true);
 		await expect(page.getByTestId("source-lost-banner")).toBeVisible({
 			timeout: 15_000,


### PR DESCRIPTION
## What

An absent capture device now earns an unavailable **Lost** row only if it is the
device of the **last-streamed configuration**. Everything else leaves the picker
once it is live-absent, keeping its `last_seen_devices` entry — invisible — for
identity migration.

## Why

The retired rule inferred "somebody wants this device back" from **enumeration**:
every device the process had ever listed became a lost candidate, uncapped, for the
whole backend lifetime. An accessory plugged in once and taken away left a
permanent, unactionable row with no way to clear it short of a restart.

The board carried a live instance of this before a line was deployed — a DJI Osmo
that had not been physically attached for hours was still rendering, purely because
it happened to be `config.source`:

```
PRE-FIX (6 rows)                                    POST-FIX (5 rows)
/dev/video0  HDMI Input                             /dev/video0  HDMI Input
/dev/video3  DJIPocket3   lost=true   ← phantom     /dev/video1  RØDE HDMI to USB-C
/dev/video1  RØDE HDMI to USB-C                     rtmp / srt / test
rtmp / srt / test
```

Same hardware, same minute, only the binary differs. Every surviving row is
byte-identical.

Going live with a device is the evidence that was missing; merely seeing it is not.

## How

- **`config.last_streamed_source` (+ `_stable_id`)** is the slot, additive-optional,
  and deliberately **distinct from `config.source`** — a save-only edit moves the
  operator's selection freely and must not move the slot, and a restart restores the
  row from the slot rather than the selection.
- **The commit signal is the orchestrator's confirmed `transition("streaming")`**,
  downstream of the existing `playing-wait` gate — never `PLAYING`, which says a
  pipeline was built rather than that it delivered. No new commit signal was
  invented. `reconcile()` deliberately does not fire it: adopting a session the
  engine was already running is not a new commitment.
- **Superseding and clearing are one operation.** A coarse/virtual/network source has
  no stable identity, so it takes the slot *empty*; nothing then resolves to a
  remembered snapshot and the previously-held camera stops being remembered.
- **`mergeLastSeenLru` retains two ids instead of one.** `config.source` always was
  exempt from eviction; the slot must be too, because its snapshot *is* the lost row,
  and the two come apart on exactly the save-only edit this policy exists to
  tolerate. The LRU cap (12) and the `previousIds` cap (8) are untouched.
- The hook is wired as a **lazy `import()`** — see Risks.

No frontend source files changed. No schema break. No engine change.

## How to verify

```bash
cd apps/backend && bun tsc --noEmit          # clean
bunx biome check <touched files>             # zero errors/warnings
bun test apps/backend                        # 2763 pass / 4 fail (all pre-existing)
bun run --filter frontend test:e2e -- lost-device.spec.ts input-picker.spec.ts \
    --project=desktop --workers=1            # 5 pass / 0 fail
```

The 4 backend failures (`auto-audio` ×2 HDMI card name, `hardware-kind` ×2
rk3588-vs-generic) are **byte-identical on clean `main`** — verified by stashing this
change and re-running. They are host-environment specific.

`lost-device.spec.ts` scores **3/3 here vs 2/3 on clean `main`** in the same
environment: this change makes that suite *more* stable.

### Board proof (Rock 5B+, `192.168.78.131`)

Every row of the policy's state-transition table was exercised on real hardware.
Highlights:

| Row | Evidence |
|---|---|
| Committed start moves the slot | real stream, `idle→starting→streaming→stopping→idle`, 30 live status frames; slot written **with the device's stable identity** |
| Failed gate leaves it | two independent failures (a `params` refusal and the engine's `capture-source-unavailable`) wrote nothing |
| Unplug → Lost row persists | kernel node genuinely gone (`ls /sys/class/video4linux` → `video0` only), row survives |
| Non-camera start supersedes | test-pattern start → slot `"test"`, stable id cleared, camera row **gone** |
| Replug → selectable again | device returned on a *different* node and rendered available |
| Restoration never moves it | **4 committed starts produced exactly 3 slot writes** — the identical re-commit wrote nothing |
| Backend restart | slot survived `systemctl restart ceralive` |
| Blip negative control | a never-streamed device blipped for 2 s is present, available and pickable — never unpickable |

Deploy discipline: staged to `/data`, sha256 verified before *and* after, `df -h /`
read `29M` avail unchanged throughout (nothing deleted), `cerastream` never touched,
board never rebooted, health gate green after every step.

## Risks

**The one real hazard this change surfaced.** The commit hook was first wired as a
*static* `import` of `sources.ts` into `stream-session-orchestrator.ts`. That module
is already reachable **from** the source graph, so the new edge reordered module
initialisation and left the boot-time source build reading a half-initialised
module — an **empty device list at boot**, every capture row silently missing. It
passed every unit test (they import in a different order) and was caught only by the
Playwright suite. Fixed with a lazy `import()` — the same pattern `sources.ts`
already uses for its own audio-change handler — and recorded as an anti-pattern in
`apps/backend/AGENTS.md`.

**Known bound, stated honestly:** a remembered device renumbering *while absent* and
resolving back through `previousIds` is unit-covered only; inducing it needs a second
camera to force the node reshuffle. Its decision logic is shared with the
board-proven paths.

## Rule E — test expectations were REPLACED, not weakened

This is a **user-sanctioned policy change** (signed off in the work plan), not a bug
fix. Three surfaces asserted the retired rule *directly*, so the new policy could not
be stated without contradicting them:

| File | Retired expectation | Replacement |
|---|---|---|
| `lost-device-retention.test.ts` | a session-seen, non-configured device synthesizes a lost row | one dedicated test **per state-transition-table row**, plus the blip control and both LRU exemptions |
| `source-renumber-dedup.test.ts` | "two different cameras yield two lost rows" | the same anti-over-collapse property asserted **per anchor** — a fold would make both anchors resolve to the same row |
| `input-picker.spec.ts` | a just-unplugged device stays visible-but-disabled | a never-streamed device **leaves** the list; the stays-but-disabled arm is still covered by `lost-device.spec.ts` |

Every property that was not about *which* devices are remembered is still asserted.
Nothing was deleted or skipped, and each replacement carries its justification as a
comment at the point of change.

**Red-first proven by three independent neuters**, each reddening a distinct set:

| Neuter | Result |
|---|---|
| restore the retired uncapped candidate source | 5 fail / 41 pass |
| make the commit hook write nothing | 5 fail / 41 pass |
| stop the orchestrator calling the hook | 2 fail / 44 pass |
