### PR TITLE
feat(orchestrator): boot-scoped one-shot stream restoration with terminal marker states

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ CeraUI/
 | Validation constraints (FE adapter) | `apps/frontend/src/lib/components/streaming/ValidationAdapter.ts` |
 | **Apply-now vs apply-on-next-start choice (encoder dialog)** | `apps/frontend/src/main/dialogs/EncoderDialog.svelte` + `apps/frontend/src/lib/streaming/appliesNextStart.ts` (`restartChoiceRequired`) |
 | **Config-change phase fencing + operator copy (frontend)** | `apps/frontend/src/lib/streaming/configChangePhase.ts` + `configChangeCopy.ts` |
+| **One-shot, boot-scoped stream restoration after an engine death (armed marker, adopt-before-restore, explicit stop causes)** | `apps/backend/src/modules/streaming/armed-stream-marker.ts` + `stream-restoration.ts`; contract in [`apps/backend/AGENTS.md`](apps/backend/AGENTS.md) → ONE-SHOT STREAM RESTORATION AFTER ENGINE DEATH |
 | Validation constants (source of truth) | `packages/rpc/src/schemas/` |
 | Custom UI components | `apps/frontend/src/lib/components/custom/` |
 | shadcn-svelte primitives (bits-ui v2) | `apps/frontend/src/lib/components/ui/` |

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -29,12 +29,14 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 | Authoritative stream-session lifecycle (UI/autostart/remote arbitration, cancellation generations, boot adoption) | `modules/streaming/stream-session-orchestrator.ts` |
 | **Apply-now config change (transaction seam, `reconfiguring` state, queued stop)** | `modules/streaming/stream-session-orchestrator.ts` (`changeConfig`, `noteConfigChangePhase`) + `modules/streaming/config-change-bridge.ts` |
 | **Apply-now staged persistence + marker-only crash reconciliation** | `modules/streaming/config-change-staging.ts` (pure) + `modules/streaming/config-change-persistence.ts` (writes) |
+| **One-shot stream restoration after engine death (armed marker + boot-scoped gate table)** | `modules/streaming/armed-stream-marker.ts` (pure gate + persistence + `StreamStopCause`) + `modules/streaming/stream-restoration.ts` (`armStreamRestoration`, `runStreamRestoration`) |
 | **Derived `reconfiguring` deadline (65 000 engine bound + 12 000 stop bound)** | `modules/streaming/start-lifecycle-timing.ts` (`RECONFIGURE_DEADLINE_MS`) ← `@ceraui/rpc` `config-change.schema.ts` |
 | Transactional launch cleanup + phase/stop deadlines | `modules/streaming/launch-transaction.ts`, `start-lifecycle-timing.ts`, `streamloop/start-stream.ts`; contract in `../../docs/START-LIFECYCLE.md` |
 | Bounded start retry + suppression + diagnostics | `modules/streaming/stream-start-retry.ts`, `stream-start-retry-reporting.ts` |
 | Pre-engine gate deadline deferral (`pendingGateRemainingMs` ← `asrcProbeRemainingMs`) | `modules/streaming/stream-start-retry.ts` + `modules/streaming/audio.ts`; contract in `../../AGENTS.md` → STREAMING BACKEND QUALITY |
 | Raw `active_encode` bridge (passthrough + frame-liveness the typed client strips) | `modules/streaming/active-passthrough.ts`; cache-lifetime contract below → RAW `active_encode` BRIDGE |
 | Engine restarted mid-session (session control connection dropped → retire the session so the next start works) | `modules/streaming/cerastream-backend.ts` (`noteConnectionLoss`, `withSessionClient`, `onSessionConnectionLost`); contract below → SESSION CONTROL CONNECTION |
+| …and then RESTORE that stream, once, within the same boot | `modules/streaming/stream-restoration.ts` (`runStreamRestoration`); contract below → ONE-SHOT STREAM RESTORATION AFTER ENGINE DEATH |
 | Stream health rollup (`frames.advancing` freshness window, idle/dead/degraded/healthy) | `modules/streaming/health.ts` (`collectRealLiveness`, `deriveFramesAdvancing`, `FRAMES_FRESHNESS_MS`) |
 | WebSocket server wiring | `modules/ui/websocket-server.ts` + `rpc/server.ts` |
 | Auth token logic | `modules/ui/auth.ts` + `rpc/middleware/auth.middleware.ts` |
@@ -2286,6 +2288,129 @@ marker/judgement table), `tests/config-change-persistence.test.ts` (the REAL
 procedure: applied-writes vs reverted/rollback_failed-don't, the delta contents,
 both apply-now fallbacks, and marker-present vs marker-absent reconciliation).
 
+## ONE-SHOT STREAM RESTORATION AFTER ENGINE DEATH [EXISTS]
+
+`noteConnectionLoss` retires a session whose control connection died (see SESSION
+CONTROL CONNECTION above) and, until now, that was the end of it: systemd
+restarted `cerastream`, nothing tried again, and wave3 measured **0/6**
+stream-level resumptions after a SIGKILL. `modules/streaming/armed-stream-marker.ts`
+(the durable state + the PURE gate table) and `modules/streaming/stream-restoration.ts`
+(the wiring + the runner) close that, with a deliberately narrow guarantee:
+**exactly one restart attempt, scoped to the current boot.**
+
+**The ARMED-STREAM MARKER is `stream.armed.json`**, written at the orchestrator's
+`transition("streaming")` outcome gate — the SAME commit point todo 22's
+`noteStreamedSourceCommitted` hooks, through a second dep (`onStreamArmed`)
+rather than more work inside the first, because the two answer different
+questions and each has to be provable alone. It carries the stream-defining
+config snapshot plus the current `boot_id`, and nothing else that matters.
+
+- **The snapshot is the RUNNING config, not `config.json`.** A save with no
+  `apply_now` persists a restart-requiring field while the live session keeps
+  encoding the previous one, so restoring from disk would apply an edit the
+  operator explicitly deferred to their next start. `startStream` therefore takes
+  an optional `configOverride` (absent for every other caller — byte-identical
+  behaviour) and restoration passes the snapshot.
+- **It is schema-parsed on WRITE, not only on read.** The snapshot is built by
+  copying from the runtime config, which also holds `password_hash`, `ssh_pass`
+  and `remote_key`; Zod strips everything outside the declared shape so a future
+  copy-loop mistake cannot put a credential on disk. Do NOT "simplify" the
+  write-path `parse()` away — it is the credential barrier, and a test asserts it.
+- **The engine session id is DIAGNOSTIC ONLY and can never be a gate.** Four
+  facts, each re-verified against current code rather than inherited: the
+  adoption seam answers `"streaming" | "idle" | "unknown"` and nothing else
+  (`streaming-backend.ts` `EngineRuntimeState`); `CerastreamBackend.start()`
+  parses the engine's `StartResult` for its `state` alone and drops the
+  `session_id` it really does carry (`grep session_id` across the backend hits
+  test fixtures only); the engine's `Event::Status` carries no session identity
+  (only the unrelated `Event::Preview` does); and the engine's ids are
+  process-local counters (`format!("cs-{}", inner.counter)`), so a restarted
+  engine re-issues `cs-1` for a DIFFERENT session — comparing them would be worse
+  than not comparing them.
+
+**ADOPTION WINS, UNCONDITIONALLY AND FIRST.** The runtime-state check runs ahead
+of every marker gate and short-circuits: if the engine reports ANY streaming
+session it is adopted via the existing `reconcile()` path and restoration does
+not happen. This is what makes a backend-only restart safe — a marker survives a
+backend restart exactly as it survives an engine death, and only the engine can
+say which occurred. Asking about the marker first is how a device ends up with
+two sessions.
+
+**Restoration fires only when ALL of these hold**, and each is independently
+blocking (one test per condition, each proven load-bearing by neutering it):
+marker present ∧ engine authoritatively IDLE ∧ `marker.bootId === current boot_id`
+∧ not cleared by an operator stop ∧ no planned-shutdown stamp ∧ no prior attempt.
+
+**STOP-CAUSE PLUMBING.** The engine-loss path calls the SAME
+`stopStreamSession()` as an operator Stop, so the stop now carries an explicit
+`StreamStopCause` and the orchestrator reports it from the INTENT, ahead of the
+outcome (an operator who pressed Stop meant it whether or not the engine
+answered, and a stop parked behind a config-change transaction must not leave the
+marker armed for the minute it waits). `operator` CLEARS the marker;
+`engine_loss` and `reconfigure` PRESERVE it. A parked stop replays its own
+recorded cause on release.
+
+**`boot_id` fails CLOSED.** An unreadable `/proc/sys/kernel/random/boot_id` is
+treated exactly like a mismatch, and a start that cannot read one arms nothing at
+all. Failing closed costs a restoration; failing open auto-restarts a stream
+across a power cycle, which is a separate product decision and out of scope.
+
+**The planned-shutdown flag is stamped ONTO the marker**, not kept as a
+standalone file, so it can never outlive what it suppresses: no armed stream
+means nothing to write, and the next armed stream starts from a clean marker. A
+separate flag needs its own clearing rule, and getting that wrong disables
+restoration permanently and silently. Written by `startSoftwareUpdate()` and the
+`system.reboot`/`system.poweroff` procedures. The update case is the real one: an
+apt update restarts `ceralive` WITHOUT changing the boot id, so a stream armed
+before an engine crash earlier in the same boot would otherwise be restored by
+the post-update backend.
+
+**`unknown` triggers NEITHER, with a declared sub-deadline.** The engine answers
+`unknown` both while it is down and while a probe is transitional, so the runner
+polls at `RESTORATION_POLL_MS` (1 s) for up to `RESTORATION_UNKNOWN_DEADLINE_MS`
+(10 s). Resolving to `idle` proceeds to eligibility, resolving to `streaming`
+adopts, and expiry writes a terminal `stream_recovery_failed{runtime_state_unknown}`
+that does NOT re-arm on a later restart. A busy LIFECYCLE (a config-change
+transaction settling, a stop finishing) waits the same way rather than racing it.
+
+**ONE-SHOT IS THE FEATURE.** Both outcomes write a terminal attempted-state onto
+the marker, so the answer to "what happens on the next backend restart" is always
+"nothing". There is no retry and no backoff; a device that cannot restore lands in
+an honest `idle` with a published reason. Typed events:
+`stream_recovered` / `stream_recovery_failed` (keyed operator copy in all 10
+locales; the machine-readable `reason` rides `params` and is never interpolated
+into operator text).
+
+**DECLARED RESTORATION BOUND: 30 s** (`RESTORATION_BOUND_MS`) from the reconnect
+event, RECORDED per attempt (`elapsedMs` + `withinBound`) rather than enforced as
+a second deadline — the launch already owns its own bounded retry machinery, and
+racing a competing timer against it would report a healthy-but-slow start as a
+failure.
+
+**THREE TRIGGERS, ONE SELF-SERIALISING RUN**: the engine-loss retirement
+(`cerastream-backend.ts` — the only seam that sees a SIGKILLed engine come back,
+because `engine-reconnect.ts` settles at boot and never re-arms), backend boot
+(`main.ts`, immediately AFTER `reconcileStreamSession()` so adoption has already
+happened), and the engine-reconnect heal. A second caller JOINS the in-flight run.
+
+**It does NOT move todo 22's `last_streamed_source` slot.** Restoration re-runs
+the configuration that was already live, and `noteStreamedSourceCommitted` is
+idempotent on the same source — so the slot is untouched by construction rather
+than by a special case. Restoration deliberately goes through the ordinary commit
+hook so that stays true.
+
+**The two markers coexist and neither reads the other.** `config.inflight.json`
+(apply-now transaction) and `stream.armed.json` (a stream was live) are different
+files with different lifetimes; an engine that died mid-transaction legitimately
+leaves both, and each is judged on its own.
+
+Coverage: `tests/stream-restoration.test.ts` — the pure gate table with one case
+per independently-blocking condition, the adopt/restore/neither discrimination
+table driven through the REAL runner against REAL on-disk markers, the stop-cause
+table, one-attempt-only in both outcome directions, planned-shutdown suppression,
+boot_id mismatch, the credential-barrier assertion, the two-marker coexistence
+pair, and the orchestrator commit/stop seams.
+
 ## DEVICE-FIRST SOURCE MODEL [EXISTS]
 
 `modules/streaming/sources.ts` is the single builder behind the `sources`
@@ -3255,6 +3380,16 @@ config, an anchored path still held by its own device, and a live row with no
 - Don't collapse every rejected `change-config` dispatch into `rollback_failed{engine_connection_lost}` — a `CerastreamRpcError` means the transaction never began and the stream is untouched (`reverted{change_rejected}`). Keep `rollback_failed` as the DEFAULT for every other rejection, so an unrecognised failure can never claim a possibly-dead stream is fine.
 - Don't persist an apply-now candidate before the transaction says `applied`, and don't add a `reverted`-specific write — until then `config.json` still describes the session the engine is actually running.
 - Don't reconcile a params-vs-config mismatch without the in-flight marker — that mismatch is normally a legitimate "apply on next start" intent, and reconciling it overwrites the operator's choice on every boot.
+- Don't ask the armed-stream marker anything before asking the ENGINE whether it is streaming — a marker survives a backend restart exactly as it survives an engine death, and only the engine can tell the two apart. Adoption short-circuits ahead of every marker gate; invert that order and a backend-only restart launches a SECOND session.
+- Don't gate restoration on an engine session id, and don't "upgrade" `diagnostics.engineSessionId` into one — the adoption seam never carries it, `start()` drops the one the engine does return, status events have none, and the engine's ids are process-local counters that collide across restarts (a restarted engine re-issues `cs-1`).
+- Don't call `stopStreamSession()` without stating a cause, and don't default it — the engine-loss path and an operator Stop reach the identical function, so an implicit cause either forgets every crash or restarts a stream the operator deliberately ended. `operator` clears the marker; `engine_loss`/`reconfigure` preserve it.
+- Don't restore across a `boot_id` mismatch, and don't treat an UNREADABLE boot id as a match — both fail closed on purpose. A device reboot never auto-restarts a stream; that is a separate product decision, not an oversight.
+- Don't turn the one-shot into a retry loop. BOTH outcomes write a terminal attempted-state before anything else, and that is the whole guarantee — an attempted marker is never attempted again, in either direction.
+- Don't move the planned-shutdown suppression into its own flag file — stamped onto the marker it dies with the thing it suppresses; as a standalone file it needs a clearing rule whose failure mode is restoration silently dead forever.
+- Don't drop the write-path `armedStreamMarkerSchema.parse()` as redundant with the read-path one — the snapshot is copied out of the runtime config, which also holds `password_hash`/`ssh_pass`/`remote_key`, so that parse is the credential barrier.
+- Don't let a restoration launch read `getConfig()` — pass the marker's snapshot through `startStream`'s `configOverride`, or a deferred (non-`apply_now`) edit gets applied by a restart the operator never asked for.
+- Don't give restoration a private commit path around `onStreamCommitted` — routing it through the ordinary idempotent hook is exactly what keeps todo 22's `last_streamed_source` slot from moving.
+- Don't add a second deadline racing the launch's own retry machinery for the 30 s restoration bound — it is RECORDED per attempt (`elapsedMs`/`withinBound`), not enforced, so a healthy-but-slow start is never reported as a failure.
 - Don't remove either `runInflightConfigChangeReconciliation()` call site (boot in `main.ts`, the heal in `engine-reconnect.ts`) — for a whole wave the crash-window reconciler existed, was correct, and was called by nothing but its own test, so a leaked marker was the observable behaviour while the docs claimed the safety net was armed. And don't hand the judge the ENGINE's own vocabulary: it compares `config.json` values, so a raw `"3840x2160"`/`29.97` reads as "neither params set" — an eternal `wait` that never retires the marker. Route it through `buildEngineEncodeSnapshot`.
 - Don't decide "the engine is not streaming" from `is_streaming` on the reconciliation path — that flag is false for an idle engine AND for one reconciliation has not reached yet, so it turns a NON-ANSWER into `retain_previous` and discards a change the operator actually got. Only a lifecycle of `idle` is decisive.
 - Don't re-add stderr regex on the cerastream path — engine errors are structured

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -92,6 +92,7 @@ import {
 } from "./modules/streaming/link-telemetry.ts";
 import { getPipelineList } from "./modules/streaming/pipelines.ts";
 import { refreshAndBroadcastSources } from "./modules/streaming/sources.ts";
+import { runStreamRestoration } from "./modules/streaming/stream-restoration.ts";
 import { reconcileStreamSession } from "./modules/streaming/stream-session-orchestrator.ts";
 import {
 	getStreamingProcesses,
@@ -258,6 +259,11 @@ if (!shouldUseMocks()) {
 	// active_encode bridge started further down supplies the frame evidence a
 	// second or two from now), and that must not delay the rest of boot.
 	void runInflightConfigChangeReconciliation();
+	// The backend-restart half of restoration. `reconcileStreamSession()` above
+	// has already adopted an engine session that outlived this process, so the
+	// run sees `streaming` and correctly declines — a backend-only restart can
+	// never produce a second session.
+	void runStreamRestoration();
 }
 
 // Resolve the runtime hardware kind (engine → device-tree → setup.hw → generic)

--- a/apps/backend/src/modules/remote-control/set-profile-wiring.ts
+++ b/apps/backend/src/modules/remote-control/set-profile-wiring.ts
@@ -63,7 +63,10 @@ function projectCaps(): SetProfileCaps {
 
 async function reconnect(): Promise<void> {
 	if (!getIsStreaming()) return;
-	const stopped = await stopStreamSession();
+	// `reconfigure`, not `operator`: this stop is the first half of a restart the
+	// platform asked for, so the armed-stream marker must survive it. Clearing it
+	// here would silently disarm restoration for the rest of the session.
+	const stopped = await stopStreamSession("reconfigure");
 	if (stopped.result !== "stopped") {
 		logger.warn(
 			"set-profile: stream stop failed; persisted config applies on next start",

--- a/apps/backend/src/modules/streaming/armed-stream-marker.ts
+++ b/apps/backend/src/modules/streaming/armed-stream-marker.ts
@@ -1,0 +1,421 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * The ARMED-STREAM MARKER and the PURE gate table that reads it.
+ *
+ * A stream that was live when the engine was SIGKILLed used to end there:
+ * `noteConnectionLoss` retires the session, systemd restarts cerastream, and
+ * nobody ever tries again. Wave3 measured that at 0/6 stream-level resumptions.
+ * This module holds the one piece of durable state that makes a single,
+ * boot-scoped, one-shot restoration possible — and, more importantly, the gate
+ * table that decides when it must NOT happen.
+ *
+ * It is deliberately dependency-light (fs + zod + the logger) so it can be
+ * imported from anywhere in the streaming graph without reordering module
+ * initialisation. The wiring that reads `config.json`, drives the engine and
+ * publishes events lives in `stream-restoration.ts`.
+ *
+ * THE ENGINE SESSION ID IS DIAGNOSTIC ONLY, AND THAT IS NOT A STYLE CHOICE.
+ * Four independent facts make it unusable as a gate, each verified against the
+ * current code rather than inherited from the plan text:
+ *
+ *   1. the adoption seam answers `"streaming" | "idle" | "unknown"` and nothing
+ *      else (`streaming-backend.ts` `EngineRuntimeState`, consumed by
+ *      `reconcileRuntimeState()`), so a session identity never reaches CeraUI
+ *      through the one call that could act on it;
+ *   2. `CerastreamBackend.start()` parses the engine's start reply for its
+ *      `state` alone and drops the rest — no `session_id` is retained anywhere;
+ *   3. the engine's `status` events carry no session identity either, so the
+ *      long-lived subscription cannot supply one; and
+ *   4. the engine's own ids are process-local counters, so a restarted engine
+ *      re-issues the SAME id for a DIFFERENT session — comparing them would be
+ *      worse than not comparing them.
+ *
+ * So `diagnostics.engineSessionId` is written when we happen to know it and is
+ * never read by `decideStreamRestoration`. Do not promote it to a gate.
+ *
+ * TWO MARKERS COEXIST HERE. `config.inflight.json` (todo 14) records an
+ * apply-now config transaction; `stream.armed.json` records that a stream was
+ * live. They are different files, different schemas and different lifetimes,
+ * and neither reads the other — a device can legitimately hold both at once
+ * (an engine that died mid apply-now), and each must be judged on its own.
+ */
+
+import fs from "node:fs";
+
+import {
+	audioCodecSchema,
+	inputModeSchema,
+	type LifecycleState,
+} from "@ceraui/rpc/schemas";
+import { z } from "zod";
+
+import { writeFileAtomicSync } from "../../helpers/config-loader.ts";
+import {
+	framerateSchema,
+	relayProtocolSchema,
+	resolutionSchema,
+	videoCodecSchema,
+	videoPassthroughSchema,
+} from "../../helpers/config-schemas.ts";
+import { logger } from "../../helpers/logger.ts";
+import type { EngineRuntimeState } from "./streaming-backend.ts";
+
+export const ARMED_STREAM_MARKER_FILE = "stream.armed.json";
+
+/**
+ * Where the kernel publishes the identity of the current boot. It changes on
+ * every power cycle and reboot and on nothing else, which is exactly the
+ * question the marker has to answer: "is this the same boot the stream was
+ * live in?".
+ */
+export const BOOT_ID_PATH = "/proc/sys/kernel/random/boot_id";
+
+/**
+ * The stream-defining slice of the runtime config — everything a launch reads,
+ * and NOTHING else. Credentials (`password_hash`, `ssh_pass`, `remote_key`, the
+ * pairing seed) are deliberately absent: this file exists to restart a stream,
+ * not to become a second copy of the secret store.
+ */
+const armedStreamConfigSchema = z.object({
+	delay: z.number().optional(),
+	srt_latency: z.number().optional(),
+	pipeline: z.string().optional(),
+	acodec: audioCodecSchema.optional(),
+	asrc: z.string().optional(),
+	relay_server: z.string().optional(),
+	relay_account: z.string().optional(),
+	relay_streamid_override: z.string().optional(),
+	relay_protocol: relayProtocolSchema.optional(),
+	srtla_addr: z.string().optional(),
+	srtla_port: z.number().optional(),
+	srt_streamid: z.string().optional(),
+	selected_ingest_endpoint: z.string().optional(),
+	max_br: z.number().optional(),
+	resolution: resolutionSchema.optional(),
+	framerate: framerateSchema.optional(),
+	video_codec: videoCodecSchema.optional(),
+	video_passthrough: videoPassthroughSchema.optional(),
+	source: z.string().optional(),
+	source_stable_id: z.string().optional(),
+	selected_video_input: z.string().optional(),
+	input_mode: inputModeSchema.optional(),
+});
+export type ArmedStreamConfig = z.infer<typeof armedStreamConfigSchema>;
+
+/** Why a stop was issued. `operator` is the ONLY cause that clears the marker. */
+export const STREAM_STOP_CAUSES = [
+	"operator",
+	"engine_loss",
+	"reconfigure",
+] as const;
+export type StreamStopCause = (typeof STREAM_STOP_CAUSES)[number];
+
+/** Why a restoration could not be attempted, or attempted and did not land. */
+export const RECOVERY_FAILURE_REASONS = [
+	"runtime_state_unknown",
+	"lifecycle_busy",
+	"config_invalid",
+	"start_failed",
+	"start_busy",
+	"start_cancelled",
+] as const;
+export type RecoveryFailureReason = (typeof RECOVERY_FAILURE_REASONS)[number];
+
+const recoveryFailureReasonSchema = z.enum(RECOVERY_FAILURE_REASONS);
+
+/**
+ * The terminal attempted-state. Its PRESENCE — not its outcome — is the
+ * one-shot guarantee: a marker that carries an attempt can never be attempted
+ * again, so no number of backend restarts turns this into a retry loop.
+ */
+const restorationAttemptSchema = z.object({
+	outcome: z.enum(["recovered", "failed"]),
+	reason: recoveryFailureReasonSchema.optional(),
+	at: z.number(),
+	/**
+	 * Milliseconds from the reconnect event that triggered the run to the
+	 * outcome, recorded against the DECLARED 30 s restoration bound. Recorded
+	 * on every attempt, in both directions, so the bound is judged from
+	 * evidence rather than asserted.
+	 */
+	elapsedMs: z.number(),
+	withinBound: z.boolean(),
+});
+export type RestorationAttempt = z.infer<typeof restorationAttemptSchema>;
+
+const armedStreamMarkerSchema = z.object({
+	armedAt: z.number(),
+	bootId: z.string().min(1),
+	config: armedStreamConfigSchema,
+	/**
+	 * Recorded because it is useful in a journal, and read by NOTHING. See the
+	 * module header for why the engine session id cannot gate anything.
+	 */
+	diagnostics: z
+		.object({
+			attemptId: z.string().optional(),
+			origin: z.string().optional(),
+			engineSessionId: z.string().optional(),
+		})
+		.optional(),
+	/** Set by an OTA/update/shutdown path; suppresses restoration outright. */
+	plannedShutdown: z.object({ reason: z.string(), at: z.number() }).optional(),
+	attempt: restorationAttemptSchema.optional(),
+});
+export type ArmedStreamMarker = z.infer<typeof armedStreamMarkerSchema>;
+
+/** File I/O seam — mirrors `config-change-staging.ts` `StagingDeps`. */
+export type ArmedStreamMarkerDeps = {
+	readonly markerPath: string;
+	readonly readMarker: (path: string) => string | undefined;
+	readonly writeMarker: (path: string, contents: string) => void;
+	readonly removeMarker: (path: string) => void;
+	readonly readBootId: () => string | undefined;
+};
+
+export function readSystemBootId(
+	path: string = BOOT_ID_PATH,
+): string | undefined {
+	try {
+		const raw = fs.readFileSync(path, "utf8").trim();
+		return raw.length > 0 ? raw : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export const defaultArmedStreamMarkerDeps: ArmedStreamMarkerDeps = {
+	markerPath: ARMED_STREAM_MARKER_FILE,
+	readMarker: (path) => {
+		try {
+			return fs.readFileSync(path, "utf8");
+		} catch {
+			return undefined;
+		}
+	},
+	writeMarker: writeFileAtomicSync,
+	removeMarker: (path) => {
+		try {
+			fs.unlinkSync(path);
+		} catch {
+			// Already gone — clearing an absent marker is the desired end state.
+		}
+	},
+	readBootId: () => readSystemBootId(),
+};
+
+export function readArmedStreamMarker(
+	deps: ArmedStreamMarkerDeps = defaultArmedStreamMarkerDeps,
+): ArmedStreamMarker | undefined {
+	const raw = deps.readMarker(deps.markerPath);
+	if (raw === undefined) return undefined;
+	try {
+		return armedStreamMarkerSchema.parse(JSON.parse(raw));
+	} catch (err) {
+		logger.warn("discarding an unreadable armed-stream marker", { err });
+		deps.removeMarker(deps.markerPath);
+		return undefined;
+	}
+}
+
+export function writeArmedStreamMarker(
+	marker: ArmedStreamMarker,
+	deps: ArmedStreamMarkerDeps = defaultArmedStreamMarkerDeps,
+): void {
+	try {
+		// Parsed on WRITE, not just on read: the snapshot is built by copying from
+		// the runtime config, and that config also holds `password_hash`,
+		// `ssh_pass` and `remote_key`. Zod strips everything outside the declared
+		// shape, so a future copy-loop mistake cannot put a credential on disk.
+		deps.writeMarker(
+			deps.markerPath,
+			JSON.stringify(armedStreamMarkerSchema.parse(marker)),
+		);
+	} catch (err) {
+		// A stream that is live must never fail because its recovery hint could
+		// not be written. The worst case is the pre-existing behaviour: an engine
+		// death ends the session and nothing restores it.
+		logger.warn("could not write the armed-stream marker", { err });
+	}
+}
+
+export function clearArmedStreamMarker(
+	deps: ArmedStreamMarkerDeps = defaultArmedStreamMarkerDeps,
+): void {
+	deps.removeMarker(deps.markerPath);
+}
+
+/**
+ * Apply a stop's CAUSE to the marker. Only an operator Stop clears it — an
+ * engine loss and a reconfigure restart both leave a live stream's intent
+ * standing, which is exactly what makes them recoverable.
+ */
+export function noteStreamStopped(
+	cause: StreamStopCause,
+	deps: ArmedStreamMarkerDeps = defaultArmedStreamMarkerDeps,
+): void {
+	if (cause !== "operator") return;
+	clearArmedStreamMarker(deps);
+}
+
+/**
+ * Suppress restoration for a shutdown the device is performing on purpose.
+ *
+ * It is stamped ONTO the marker rather than kept as a standalone flag file so it
+ * can never outlive the thing it suppresses: no armed stream means nothing to
+ * write, and the next armed stream starts from a clean marker. A separate flag
+ * would need its own clearing rule, and getting that wrong disables restoration
+ * permanently and silently.
+ */
+export function notePlannedShutdown(
+	reason: string,
+	options: {
+		readonly marker?: ArmedStreamMarkerDeps;
+		readonly now?: () => number;
+	} = {},
+): boolean {
+	const deps = options.marker ?? defaultArmedStreamMarkerDeps;
+	const marker = readArmedStreamMarker(deps);
+	if (marker === undefined) return false;
+	if (marker.plannedShutdown !== undefined) return true;
+	writeArmedStreamMarker(
+		{ ...marker, plannedShutdown: { reason, at: (options.now ?? Date.now)() } },
+		deps,
+	);
+	logger.warn("stream restoration suppressed by a planned shutdown", {
+		module: "streaming",
+		reason,
+	});
+	return true;
+}
+
+/** Every reason the gate refuses to restore WITHOUT having tried. */
+export const RESTORATION_BLOCKED_REASONS = [
+	"no_marker",
+	"already_attempted",
+	"planned_shutdown",
+	"boot_id_mismatch",
+] as const;
+export type RestorationBlockedReason =
+	(typeof RESTORATION_BLOCKED_REASONS)[number];
+
+export type RestorationDecision =
+	/** The engine is running a session — adopt it, and never restore. */
+	| { readonly action: "adopt" }
+	/** Every gate holds; launch exactly one attempt. */
+	| { readonly action: "restore" }
+	/** Not yet decidable; poll again inside the sub-deadline. */
+	| { readonly action: "wait"; readonly reason: RecoveryFailureReason }
+	/** Decidably ineligible; nothing is written, nothing is attempted. */
+	| { readonly action: "blocked"; readonly reason: RestorationBlockedReason }
+	/** The sub-deadline expired without a decisive answer — terminal. */
+	| { readonly action: "give_up"; readonly reason: RecoveryFailureReason };
+
+/**
+ * How long an UNDECIDED runtime state may be polled before the attempt is
+ * written off. The engine answers `unknown` both while it is down and while a
+ * probe is transitional, so this is the window a systemd-restarted cerastream
+ * has to come back and say something authoritative.
+ */
+export const RESTORATION_UNKNOWN_DEADLINE_MS = 10_000;
+/** Poll cadence inside that window — the orchestrator's own reconcile cadence. */
+export const RESTORATION_POLL_MS = 1_000;
+/**
+ * The DECLARED restoration bound: outcome-gated advancing frames within 30 s of
+ * the reconnect event that triggered the run. It is RECORDED per attempt rather
+ * than enforced as a second deadline — the launch already owns its own bounded
+ * retry machinery, and racing a competing timer against it would report a
+ * healthy-but-slow start as a failure.
+ */
+export const RESTORATION_BOUND_MS = 30_000;
+
+/**
+ * The whole gate table, PURE, so every condition can be flipped on its own.
+ *
+ * Ordering carries the two safety properties:
+ *
+ * ADOPTION WINS, UNCONDITIONALLY AND FIRST. A backend-only restart leaves the
+ * engine streaming; asking about the marker before asking about the engine is
+ * how a device ends up with two sessions. The runtime-state check therefore
+ * runs ahead of every marker gate and short-circuits.
+ *
+ * A DECIDABLE REFUSAL OUTRANKS AN UNDECIDED STATE. `already_attempted`,
+ * `planned_shutdown` and `boot_id_mismatch` are permanent facts, so they are
+ * settled before the loop is allowed to spend its sub-deadline polling a state
+ * whose answer could not change the outcome anyway.
+ */
+export function decideStreamRestoration(input: {
+	readonly marker: ArmedStreamMarker | undefined;
+	readonly runtimeState: EngineRuntimeState;
+	readonly lifecycleState: LifecycleState;
+	readonly currentBootId: string | undefined;
+	readonly elapsedMs: number;
+	readonly unknownDeadlineMs?: number;
+}): RestorationDecision {
+	if (input.runtimeState === "streaming") return { action: "adopt" };
+
+	const marker = input.marker;
+	if (marker === undefined) return { action: "blocked", reason: "no_marker" };
+	if (marker.attempt !== undefined)
+		return { action: "blocked", reason: "already_attempted" };
+	if (marker.plannedShutdown !== undefined)
+		return { action: "blocked", reason: "planned_shutdown" };
+	// An absent boot id is treated exactly like a mismatched one: we cannot
+	// PROVE this is the same boot, and "never auto-restart across a reboot" is
+	// only a guarantee if the unprovable case fails closed.
+	if (
+		input.currentBootId === undefined ||
+		marker.bootId !== input.currentBootId
+	)
+		return { action: "blocked", reason: "boot_id_mismatch" };
+
+	const deadline = input.unknownDeadlineMs ?? RESTORATION_UNKNOWN_DEADLINE_MS;
+	const expired = input.elapsedMs >= deadline;
+
+	if (input.runtimeState === "unknown")
+		return expired
+			? { action: "give_up", reason: "runtime_state_unknown" }
+			: { action: "wait", reason: "runtime_state_unknown" };
+
+	// The engine is authoritatively idle, but our own lifecycle may still own the
+	// slot — a config-change transaction settling, a stop finishing, a reconcile
+	// in flight. Restoration waits behind it rather than racing it.
+	if (input.lifecycleState !== "idle")
+		return expired
+			? { action: "give_up", reason: "lifecycle_busy" }
+			: { action: "wait", reason: "lifecycle_busy" };
+
+	return { action: "restore" };
+}
+
+/** Fold an outcome into the terminal attempted-state written onto the marker. */
+export function buildRestorationAttempt(input: {
+	readonly outcome: "recovered" | "failed";
+	readonly reason?: RecoveryFailureReason;
+	readonly at: number;
+	readonly elapsedMs: number;
+}): RestorationAttempt {
+	return {
+		outcome: input.outcome,
+		...(input.reason === undefined ? {} : { reason: input.reason }),
+		at: input.at,
+		elapsedMs: input.elapsedMs,
+		withinBound: input.elapsedMs <= RESTORATION_BOUND_MS,
+	};
+}

--- a/apps/backend/src/modules/streaming/cerastream-backend.ts
+++ b/apps/backend/src/modules/streaming/cerastream-backend.ts
@@ -468,11 +468,21 @@ function defaultOnSessionConnectionLost(site: string): void {
 					import("./streaming.ts"),
 				]);
 			reportEngineState({ isStreaming: getIsStreaming(), reachable: false });
-			const stopped = await stopStreamSession();
+			// `engine_loss` is what keeps this path distinguishable from an operator
+			// Stop, which reaches the very same `stopStreamSession`. The cause is
+			// the ONLY thing that tells the armed-stream marker to survive.
+			const stopped = await stopStreamSession("engine_loss");
 			defaultLogger.warn(
 				"cerastream: engine session retired after a control-connection loss",
 				{ site, stop: stopped.result },
 			);
+			// The engine-loss retirement IS the reconnect event for a SIGKILLed
+			// engine: the reconnect loop settled at boot and never re-arms, so
+			// nothing else notices systemd bringing cerastream back. The run polls
+			// for an authoritative runtime state and is self-serialising, so a
+			// second loss cannot start a second one.
+			const { runStreamRestoration } = await import("./stream-restoration.ts");
+			void runStreamRestoration();
 		} catch (err) {
 			defaultLogger.error(
 				"cerastream: could not retire the session after a control-connection loss",

--- a/apps/backend/src/modules/streaming/engine-reconnect.ts
+++ b/apps/backend/src/modules/streaming/engine-reconnect.ts
@@ -71,6 +71,7 @@ import {
 	type EngineDeviceCacheDeps,
 	refreshAndBroadcastSources,
 } from "./sources.ts";
+import { runStreamRestoration } from "./stream-restoration.ts";
 import { reconcileStreamSession } from "./stream-session-orchestrator.ts";
 import { getIsStreaming } from "./streaming.ts";
 
@@ -171,6 +172,10 @@ function buildDefaultBroadcastEngineState(
 			// its own schedule, and the reconciliation is self-serialising, so a
 			// loop that re-fires can never double-apply.
 			void runInflightConfigChangeReconciliation();
+			// The boot-race half of restoration: an engine that was still down when
+			// this process started could not be asked anything at boot. Same
+			// fire-and-forget, self-serialising posture as the line above.
+			void runStreamRestoration();
 		}
 	};
 }

--- a/apps/backend/src/modules/streaming/stream-restoration.ts
+++ b/apps/backend/src/modules/streaming/stream-restoration.ts
@@ -1,0 +1,476 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+ * ONE-SHOT STREAM RESTORATION — the production wiring around the pure gate table
+ * in `armed-stream-marker.ts`.
+ *
+ * It owns four things the gate deliberately does not: WHERE the marker's config
+ * snapshot comes from, WHEN a run is triggered, HOW the single restart attempt
+ * is launched, and WHAT the operator is told about it.
+ *
+ * ONE-SHOT IS THE FEATURE, NOT A LIMITATION. Both outcomes — recovered and
+ * failed — write a terminal attempted-state onto the marker before anything
+ * else, so the answer to "what happens if the backend restarts again" is always
+ * "nothing". There is no retry, no backoff, and no second chance; a device that
+ * cannot restore its stream lands in an honest `idle` with a published reason
+ * rather than in a loop nobody asked for.
+ *
+ * ADOPTION ALWAYS BEATS RESTORATION. The runtime-state check runs first and
+ * short-circuits, so a backend-only restart against a still-streaming engine
+ * adopts that session and never launches a second one. That is the whole reason
+ * the check is not "did we leave a marker behind" — a marker survives a backend
+ * restart exactly as it survives an engine death, and only the engine can say
+ * which of the two happened.
+ *
+ * THE RUN IS SELF-SERIALISING. Three seams trigger it — the engine-loss
+ * retirement, backend boot, and the engine-reconnect heal — and they overlap in
+ * practice. A second caller JOINS the in-flight run instead of racing it, which
+ * is what makes a repeatedly-firing reconnect hook harmless.
+ */
+
+import type { LifecycleState } from "@ceraui/rpc/schemas";
+
+import { logger as defaultLogger } from "../../helpers/logger.ts";
+import { getConfig } from "../config.ts";
+import { notificationBroadcast } from "../ui/notifications.ts";
+import {
+	type ArmedStreamConfig,
+	type ArmedStreamMarker,
+	type ArmedStreamMarkerDeps,
+	buildRestorationAttempt,
+	clearArmedStreamMarker,
+	decideStreamRestoration,
+	defaultArmedStreamMarkerDeps,
+	RESTORATION_BOUND_MS,
+	RESTORATION_POLL_MS,
+	RESTORATION_UNKNOWN_DEADLINE_MS,
+	type RecoveryFailureReason,
+	readArmedStreamMarker,
+	writeArmedStreamMarker,
+} from "./armed-stream-marker.ts";
+import { queryEngineRuntimeStreaming } from "./engine-runtime-state.ts";
+import { getStreamSessionSnapshot } from "./stream-session-orchestrator.ts";
+import type { EngineRuntimeState } from "./streaming-backend.ts";
+
+/**
+ * The stream-defining slice of the live config, captured verbatim.
+ *
+ * It is the RUNNING configuration, which is not the same thing as `config.json`:
+ * a save with no `apply_now` writes a restart-requiring field to disk while the
+ * engine keeps encoding the previous one. Restoring from disk would therefore
+ * apply an edit the operator explicitly deferred to their next start. The
+ * snapshot is what makes restoration restore the stream that was interrupted.
+ */
+export function captureArmedStreamConfig(): ArmedStreamConfig {
+	const config = getConfig();
+	const snapshot: Record<string, unknown> = {};
+	const copy = (key: keyof ArmedStreamConfig): void => {
+		const value = (config as unknown as Record<string, unknown>)[key];
+		if (value !== undefined) snapshot[key] = value;
+	};
+	copy("delay");
+	copy("srt_latency");
+	copy("pipeline");
+	copy("acodec");
+	copy("asrc");
+	copy("relay_server");
+	copy("relay_account");
+	copy("relay_streamid_override");
+	copy("relay_protocol");
+	copy("srtla_addr");
+	copy("srtla_port");
+	copy("srt_streamid");
+	copy("selected_ingest_endpoint");
+	copy("max_br");
+	copy("resolution");
+	copy("framerate");
+	copy("video_codec");
+	copy("video_passthrough");
+	copy("source");
+	copy("source_stable_id");
+	copy("selected_video_input");
+	copy("input_mode");
+	return snapshot as ArmedStreamConfig;
+}
+
+export type ArmRestorationOptions = {
+	readonly marker?: ArmedStreamMarkerDeps;
+	readonly captureConfig?: () => ArmedStreamConfig;
+	readonly now?: () => number;
+	readonly diagnostics?: ArmedStreamMarker["diagnostics"];
+};
+
+/**
+ * Arm the marker at the engine's own outcome gate. Called from the orchestrator's
+ * `transition("streaming")` commit point — the single moment a start is known to
+ * have really delivered — and from nowhere else.
+ *
+ * A boot id we cannot read means we could not later PROVE the device had not
+ * rebooted, so nothing is armed at all. Failing closed here costs a restoration;
+ * failing open would auto-restart a stream across a power cycle.
+ */
+export function armStreamRestoration(
+	options: ArmRestorationOptions = {},
+): boolean {
+	const deps = options.marker ?? defaultArmedStreamMarkerDeps;
+	const bootId = deps.readBootId();
+	if (bootId === undefined) {
+		defaultLogger.warn(
+			"stream restoration: no boot id available; the session is not armed",
+		);
+		return false;
+	}
+	const capture = options.captureConfig ?? captureArmedStreamConfig;
+	const now = options.now ?? Date.now;
+	writeArmedStreamMarker(
+		{
+			armedAt: now(),
+			bootId,
+			config: capture(),
+			...(options.diagnostics === undefined
+				? {}
+				: { diagnostics: options.diagnostics }),
+		},
+		deps,
+	);
+	return true;
+}
+
+export type RestorationLaunchOutcome =
+	| { readonly ok: true }
+	| { readonly ok: false; readonly reason: RecoveryFailureReason };
+
+export type RestorationRunOutcome =
+	| { readonly result: "adopted" }
+	| { readonly result: "blocked"; readonly reason: string }
+	| { readonly result: "recovered"; readonly elapsedMs: number }
+	| {
+			readonly result: "failed";
+			readonly reason: RecoveryFailureReason;
+			readonly elapsedMs: number;
+	  };
+
+export interface RestorationLogger {
+	info(message: string, meta?: Record<string, unknown>): void;
+	warn(message: string, meta?: Record<string, unknown>): void;
+}
+
+export interface StreamRestorationDeps {
+	readonly marker: ArmedStreamMarkerDeps;
+	readonly runtimeState: () => Promise<EngineRuntimeState>;
+	readonly lifecycleState: () => LifecycleState;
+	readonly launch: (
+		config: ArmedStreamConfig,
+	) => Promise<RestorationLaunchOutcome>;
+	readonly publish: (outcome: RestorationRunOutcome) => void;
+	readonly wait: (ms: number) => Promise<void>;
+	readonly now: () => number;
+	readonly logger: RestorationLogger;
+	readonly pollIntervalMs: number;
+	readonly unknownDeadlineMs: number;
+}
+
+/**
+ * Launch the single restart attempt with the marker's snapshot.
+ *
+ * Every collaborator is imported lazily for the module-ordering reason the rest
+ * of this graph documents: the launch path reaches `sources.ts`, which is
+ * upstream of the orchestrator that imports this module.
+ */
+async function defaultLaunch(
+	config: ArmedStreamConfig,
+): Promise<RestorationLaunchOutcome> {
+	const [
+		{ validateConfig },
+		{ resolveSrtla },
+		{ prepareSrtlaIpAddresses },
+		{ startStream },
+		{ startStreamSession },
+		{ StreamStartFailure, classifyStartFailure, typedStartFailure },
+	] = await Promise.all([
+		import("./streaming.ts"),
+		import("./srtla.ts"),
+		import("./streamloop/session.ts"),
+		import("./streamloop/start-stream.ts"),
+		import("./stream-session-orchestrator.ts"),
+		import("./start-failure-taxonomy.ts"),
+	]);
+
+	let resolved: Awaited<ReturnType<typeof validateConfig>>;
+	try {
+		resolved = await validateConfig({ ...config });
+		await prepareSrtlaIpAddresses(resolved.srtlaAddr);
+	} catch (error) {
+		defaultLogger.warn("stream restoration: the saved config is not usable", {
+			error,
+		});
+		return { ok: false, reason: "config_invalid" };
+	}
+
+	const result = await startStreamSession({
+		origin: "restoration",
+		launch: async ({ attemptId }) => {
+			const srtlaAddr = await resolveSrtla(resolved.srtlaAddr);
+			const launched = await startStream(
+				resolved.pipeline,
+				srtlaAddr,
+				resolved.srtlaPort,
+				resolved.streamid,
+				{},
+				attemptId,
+				config,
+			);
+			if (!launched.success) {
+				throw new StreamStartFailure(
+					launched.failureClass !== undefined
+						? typedStartFailure(
+								attemptId,
+								launched.phase,
+								launched.failureClass,
+								launched.error,
+							)
+						: classifyStartFailure(launched.phase, launched.error, attemptId),
+				);
+			}
+		},
+	});
+
+	if (result.result === "started") return { ok: true };
+	if (result.result === "busy") return { ok: false, reason: "start_busy" };
+	if (result.result === "cancelled")
+		return { ok: false, reason: "start_cancelled" };
+	return { ok: false, reason: "start_failed" };
+}
+
+function defaultPublish(outcome: RestorationRunOutcome): void {
+	if (outcome.result === "recovered") {
+		notificationBroadcast(
+			"stream_recovered",
+			"success",
+			"The stream was restored after the streaming engine restarted.",
+			10,
+			false,
+			true,
+			true,
+			"notifications.streamRecovered",
+			{ elapsedMs: outcome.elapsedMs },
+		);
+		return;
+	}
+	if (outcome.result !== "failed") return;
+	notificationBroadcast(
+		"stream_recovery_failed",
+		"error",
+		"The stream could not be restored after the streaming engine restarted. Open Settings → System Logs for details.",
+		0,
+		true,
+		true,
+		true,
+		"notifications.streamRecoveryFailed",
+		{ reason: outcome.reason },
+	);
+}
+
+function defaultDeps(): StreamRestorationDeps {
+	return {
+		marker: defaultArmedStreamMarkerDeps,
+		runtimeState: queryEngineRuntimeStreaming,
+		lifecycleState: () => getStreamSessionSnapshot().state,
+		launch: defaultLaunch,
+		publish: defaultPublish,
+		wait: (ms) =>
+			new Promise((resolve) => {
+				setTimeout(resolve, ms);
+			}),
+		now: Date.now,
+		logger: defaultLogger,
+		pollIntervalMs: RESTORATION_POLL_MS,
+		unknownDeadlineMs: RESTORATION_UNKNOWN_DEADLINE_MS,
+	};
+}
+
+/**
+ * Retire the marker we JUDGED — and only that one.
+ *
+ * A successful restoration commits a new session, and that commit arms a FRESH
+ * marker through the ordinary outcome gate. Stamping the terminal attempt on top
+ * of it would retire a marker describing a stream that is live right now, so the
+ * NEXT engine death would find an already-attempted marker and give up. Measured
+ * on a board: SIGKILL #1 restored in 11.5 s, #2 and #3 did nothing at all.
+ *
+ * `armedAt` is the compare-and-set token — same shape as the source-selection
+ * write token. A failed attempt commits nothing, so nothing re-arms, so the
+ * terminal state lands exactly as before.
+ */
+function recordAttempt(
+	deps: StreamRestorationDeps,
+	judged: ArmedStreamMarker,
+	outcome: "recovered" | "failed",
+	elapsedMs: number,
+	reason?: RecoveryFailureReason,
+): void {
+	const current = readArmedStreamMarker(deps.marker);
+	if (current === undefined || current.armedAt !== judged.armedAt) return;
+	writeArmedStreamMarker(
+		{
+			...current,
+			attempt: buildRestorationAttempt({
+				outcome,
+				...(reason === undefined ? {} : { reason }),
+				at: deps.now(),
+				elapsedMs,
+			}),
+		},
+		deps.marker,
+	);
+}
+
+let inflight: Promise<RestorationRunOutcome> | undefined;
+
+async function runOnce(
+	deps: StreamRestorationDeps,
+): Promise<RestorationRunOutcome> {
+	const startedAt = deps.now();
+	for (;;) {
+		const marker = readArmedStreamMarker(deps.marker);
+		const decision = decideStreamRestoration({
+			marker,
+			runtimeState: await deps.runtimeState(),
+			lifecycleState: deps.lifecycleState(),
+			currentBootId: deps.marker.readBootId(),
+			elapsedMs: deps.now() - startedAt,
+			unknownDeadlineMs: deps.unknownDeadlineMs,
+		});
+
+		if (decision.action === "adopt") {
+			deps.logger.info(
+				"stream restoration: the engine is already streaming — adopted, not restored",
+			);
+			return { result: "adopted" };
+		}
+
+		if (decision.action === "blocked") {
+			// A marker from a previous boot can never become eligible again, so it
+			// is retired rather than left to be re-judged on every reconnect.
+			if (decision.reason === "boot_id_mismatch") {
+				clearArmedStreamMarker(deps.marker);
+			}
+			if (decision.reason !== "no_marker") {
+				deps.logger.warn("stream restoration blocked", {
+					module: "streaming",
+					reason: decision.reason,
+				});
+			}
+			return { result: "blocked", reason: decision.reason };
+		}
+
+		if (decision.action === "wait") {
+			await deps.wait(deps.pollIntervalMs);
+			continue;
+		}
+
+		const elapsedMs = deps.now() - startedAt;
+		if (decision.action === "give_up") {
+			if (marker !== undefined)
+				recordAttempt(deps, marker, "failed", elapsedMs, decision.reason);
+			deps.logger.warn("stream restoration gave up", {
+				module: "streaming",
+				reason: decision.reason,
+				elapsedMs,
+			});
+			const outcome = {
+				result: "failed",
+				reason: decision.reason,
+				elapsedMs,
+			} as const;
+			deps.publish(outcome);
+			return outcome;
+		}
+
+		if (marker === undefined) return { result: "blocked", reason: "no_marker" };
+
+		const launched = await deps.launch(marker.config);
+		const attemptElapsedMs = deps.now() - startedAt;
+		if (launched.ok) {
+			recordAttempt(deps, marker, "recovered", attemptElapsedMs);
+			deps.logger.warn("stream restored after an engine restart", {
+				module: "streaming",
+				elapsedMs: attemptElapsedMs,
+				boundMs: RESTORATION_BOUND_MS,
+				withinBound: attemptElapsedMs <= RESTORATION_BOUND_MS,
+			});
+			const outcome = {
+				result: "recovered",
+				elapsedMs: attemptElapsedMs,
+			} as const;
+			deps.publish(outcome);
+			return outcome;
+		}
+
+		recordAttempt(deps, marker, "failed", attemptElapsedMs, launched.reason);
+		deps.logger.warn("stream restoration attempt failed", {
+			module: "streaming",
+			reason: launched.reason,
+			elapsedMs: attemptElapsedMs,
+		});
+		const outcome = {
+			result: "failed",
+			reason: launched.reason,
+			elapsedMs: attemptElapsedMs,
+		} as const;
+		deps.publish(outcome);
+		return outcome;
+	}
+}
+
+/**
+ * Judge an armed-stream marker against the engine's current truth and, when
+ * every gate holds, launch exactly one restart.
+ *
+ * Fail-soft by contract: it never throws, so a boot/reconnect/engine-loss hook
+ * can call it without a guard of its own.
+ */
+export function runStreamRestoration(
+	overrides: Partial<StreamRestorationDeps> = {},
+): Promise<RestorationRunOutcome> {
+	if (inflight !== undefined) return inflight;
+	const deps: StreamRestorationDeps = { ...defaultDeps(), ...overrides };
+
+	const run = runOnce(deps)
+		.catch((err: unknown): RestorationRunOutcome => {
+			// Leaving the marker untouched is the safe end state: an un-judged
+			// marker is re-judged on the next reconnect, whereas a half-written
+			// terminal state would silently forfeit the one attempt.
+			deps.logger.warn("stream restoration run failed", {
+				module: "streaming",
+				err,
+			});
+			return { result: "blocked", reason: "run_failed" };
+		})
+		.finally(() => {
+			inflight = undefined;
+		});
+
+	inflight = run;
+	return run;
+}
+
+/** Test/teardown seam: resolve once the in-flight run has settled. */
+export function settleStreamRestoration(): Promise<unknown> {
+	return inflight ?? Promise.resolve();
+}

--- a/apps/backend/src/modules/streaming/stream-session-orchestrator.ts
+++ b/apps/backend/src/modules/streaming/stream-session-orchestrator.ts
@@ -12,6 +12,10 @@ import {
 
 import { logger } from "../../helpers/logger.ts";
 import { notificationBroadcast } from "../ui/notifications.ts";
+import {
+	noteStreamStopped,
+	type StreamStopCause,
+} from "./armed-stream-marker.ts";
 import { asrcProbeRemainingMs } from "./audio.ts";
 import {
 	broadcastConfigChangePhase,
@@ -48,6 +52,9 @@ export const STREAM_LAUNCH_ORIGINS = [
 	"autostart",
 	"set-profile",
 	"remote-control",
+	// Its own origin so the one-shot engine-death restoration is admitted through
+	// the SAME mutex every other origin uses, never a private path around it.
+	"restoration",
 ] as const;
 export type StreamLaunchOrigin = (typeof STREAM_LAUNCH_ORIGINS)[number];
 
@@ -143,6 +150,22 @@ export type StreamSessionOrchestratorDeps = {
 	 * was already running is not a new commitment to anything.
 	 */
 	readonly onStreamCommitted?: () => void;
+	/**
+	 * Called at that same commit point to ARM the restoration marker. It is a
+	 * second hook rather than more work inside `onStreamCommitted` because the
+	 * two answer different questions — one remembers which DEVICE went live, the
+	 * other remembers that a stream WAS live — and each has to be provable on its
+	 * own.
+	 */
+	readonly onStreamArmed?: () => void;
+	/**
+	 * Called with the operator-or-machine CAUSE of every stop, before the stop
+	 * itself runs. The engine-loss path and an operator Stop reach the identical
+	 * `stop()`, so without an explicit cause the marker cannot tell "the operator
+	 * is done" from "the engine died" — and would either forget every crash or
+	 * restart a stream the operator deliberately ended.
+	 */
+	readonly onStreamStopped?: (cause: StreamStopCause) => void;
 };
 
 type ActiveAttempt = {
@@ -160,6 +183,7 @@ type ActiveConfigChange = {
 
 type QueuedStop = {
 	readonly promise: Promise<StopResult>;
+	readonly cause: StreamStopCause;
 	readonly release: (result: StopResult | Promise<StopResult>) => void;
 	readonly cancelDeadline: () => void;
 };
@@ -173,7 +197,7 @@ export const RECONFIGURE_STOP_TIMEOUT_REASON = "reconfigure_stop_timeout";
 
 export type StreamSessionOrchestrator = {
 	readonly start: (request: StreamStartRequest) => Promise<StartResult>;
-	readonly stop: () => Promise<StopResult>;
+	readonly stop: (cause: StreamStopCause) => Promise<StopResult>;
 	readonly reconcile: () => Promise<LifecycleState>;
 	readonly snapshot: () => StreamSessionSnapshot;
 	readonly changeConfig: (
@@ -355,6 +379,11 @@ export function createStreamSessionOrchestrator(
 		} catch (error) {
 			logger.warn("stream commit bookkeeping failed", { attemptId, error });
 		}
+		try {
+			deps.onStreamArmed?.();
+		} catch (error) {
+			logger.warn("stream restoration arming failed", { attemptId, error });
+		}
 		return { result: "started", attemptId };
 	};
 
@@ -371,7 +400,7 @@ export function createStreamSessionOrchestrator(
 	 * journal carried not one line about it. Unbounded and unlogged, that
 	 * silence had no ceiling at all.
 	 */
-	const parkStop = (): QueuedStop => {
+	const parkStop = (cause: StreamStopCause): QueuedStop => {
 		let release!: (result: StopResult | Promise<StopResult>) => void;
 		const promise = new Promise<StopResult>((resolve) => {
 			release = resolve;
@@ -403,16 +432,26 @@ export function createStreamSessionOrchestrator(
 			attemptId,
 			budgetMs,
 		});
-		return { promise, release, cancelDeadline: () => cancelTimeout(timer) };
+		return {
+			promise,
+			cause,
+			release,
+			cancelDeadline: () => cancelTimeout(timer),
+		};
 	};
 
-	const stop = async (): Promise<StopResult> => {
+	const stop = async (cause: StreamStopCause): Promise<StopResult> => {
+		// The cause is reported from the INTENT, ahead of the outcome. An operator
+		// who pressed Stop meant it whether or not the engine answered, and a stop
+		// that parks behind a transaction must not leave the marker armed for the
+		// minute it waits.
+		deps.onStreamStopped?.(cause);
 		// A change transaction already owns the engine's lifecycle mutex and the
 		// capture hardware. Racing a 12 s stop deadline against it would report a
 		// healthy 65 s transaction as `stop_failed`, so the stop WAITS and is then
 		// answered against whatever state the transaction actually settled into.
 		if (state === "reconfiguring") {
-			if (queuedStop === undefined) queuedStop = parkStop();
+			if (queuedStop === undefined) queuedStop = parkStop(cause);
 			return queuedStop.promise;
 		}
 		if (state === "idle") return { result: "stopped" };
@@ -483,7 +522,7 @@ export function createStreamSessionOrchestrator(
 		if (pending === undefined) return false;
 		queuedStop = undefined;
 		pending.cancelDeadline();
-		pending.release(stop());
+		pending.release(stop(pending.cause));
 		return true;
 	};
 
@@ -647,6 +686,21 @@ const productionOrchestrator = createStreamSessionOrchestrator({
 				logger.warn("stream commit bookkeeping failed", { error }),
 			);
 	},
+	// Lazily imported for the same module-ordering reason as the hook above:
+	// `stream-restoration.ts` reaches the streamloop and the source graph, both
+	// of which already point back at this module.
+	onStreamArmed: () => {
+		void import("./stream-restoration.ts")
+			.then(({ armStreamRestoration }) => armStreamRestoration())
+			.catch((error) =>
+				logger.warn("stream restoration arming failed", { error }),
+			);
+	},
+	// Statically imported, unlike the arming hook: `armed-stream-marker.ts` holds
+	// no streaming-graph edges, and a SYNCHRONOUS clear is what guarantees an
+	// operator Stop has disarmed restoration before anything else can read the
+	// marker.
+	onStreamStopped: noteStreamStopped,
 });
 
 export function startStreamSession(
@@ -655,8 +709,8 @@ export function startStreamSession(
 	return productionOrchestrator.start(request);
 }
 
-export function stopStreamSession(): Promise<StopResult> {
-	return productionOrchestrator.stop();
+export function stopStreamSession(cause: StreamStopCause): Promise<StopResult> {
+	return productionOrchestrator.stop(cause);
 }
 
 export function reconcileStreamSession(): Promise<LifecycleState> {

--- a/apps/backend/src/modules/streaming/streamloop/session.ts
+++ b/apps/backend/src/modules/streaming/streamloop/session.ts
@@ -284,6 +284,6 @@ export function stop(): void {
 	setPendingAudioFollowAsrc(null);
 	if (isAsrcProbeRejectResolved()) clearAsrcProbeReject();
 	void import("../stream-session-orchestrator.ts").then(
-		({ stopStreamSession }) => stopStreamSession(),
+		({ stopStreamSession }) => stopStreamSession("operator"),
 	);
 }

--- a/apps/backend/src/modules/streaming/streamloop/start-stream.ts
+++ b/apps/backend/src/modules/streaming/streamloop/start-stream.ts
@@ -118,6 +118,14 @@ function resolveLaunchConfig(config: RuntimeConfig): RuntimeConfig {
 	return buildAutoLaunchConfig(config, resolution);
 }
 
+/**
+ * `configOverride` exists for ONE caller: the engine-death restoration, which
+ * must relaunch the configuration the engine was actually RUNNING. `config.json`
+ * is not that — a save with no `apply_now` persists a restart-requiring field
+ * while the live session keeps encoding the previous one, so restoring from disk
+ * would apply an edit the operator deferred to their next start. Absent (every
+ * other caller), the live config is read exactly as before.
+ */
 export async function startStream(
 	pipeline: Pipeline,
 	srtlaAddr: string,
@@ -125,8 +133,12 @@ export async function startStream(
 	streamid: string,
 	audioDeps: AudioProbeDeps = {},
 	attemptId = "legacy-start",
+	configOverride?: Partial<RuntimeConfig>,
 ): Promise<StartStreamResult> {
-	const config = getConfig();
+	const config =
+		configOverride === undefined
+			? getConfig()
+			: ({ ...getConfig(), ...configOverride } as RuntimeConfig);
 	const launchConfig = resolveLaunchConfig(config);
 	getStreamingBackend().setBitrate(launchConfig);
 

--- a/apps/backend/src/modules/system/software-updates.ts
+++ b/apps/backend/src/modules/system/software-updates.ts
@@ -25,6 +25,7 @@ import { isDevelopment } from "../../mocks/mock-config.ts";
 import { shouldUseMocks } from "../../mocks/mock-service.ts";
 import { queueUpdateGw } from "../network/gateways.ts";
 import { setup } from "../setup.ts";
+import { notePlannedShutdown } from "../streaming/armed-stream-marker.ts";
 import { getIsStreaming } from "../streaming/streaming.ts";
 import {
 	notificationBroadcast,
@@ -822,6 +823,12 @@ export function startSoftwareUpdate(): UpdateStartOutcome {
 	if (!aptUpdatesEnabled()) return refuseUpdateStart("updates_disabled");
 	if (getIsStreaming()) return refuseUpdateStart("streaming");
 	if (isUpdating()) return refuseUpdateStart("already_updating");
+
+	// An update restarts `ceralive` (and usually reboots) WITHOUT changing the
+	// boot id, so a stream armed before an engine crash earlier in this same boot
+	// would otherwise be restored by the post-update backend. Suppress it here,
+	// where the update is known to be going ahead.
+	notePlannedShutdown("software_update");
 
 	// A fresh install supersedes any prior terminal outcome (Todo 24).
 	currentUpdateIdentity = availableIdentity;

--- a/apps/backend/src/rpc/procedures/streaming.procedure.ts
+++ b/apps/backend/src/rpc/procedures/streaming.procedure.ts
@@ -374,7 +374,7 @@ export const streamingStopProcedure = authedProcedure
 			setPendingAudioFollowAsrc(null);
 			setStreamingState(false);
 		}
-		const result = await stopStreamSession();
+		const result = await stopStreamSession("operator");
 		return { ...result, success: result.result !== "stop_failed" };
 	});
 

--- a/apps/backend/src/rpc/procedures/system.procedure.ts
+++ b/apps/backend/src/rpc/procedures/system.procedure.ts
@@ -31,6 +31,7 @@ import {
 	getCloudProviders,
 	setRemoteConfig,
 } from "../../modules/remote/remote.ts";
+import { notePlannedShutdown } from "../../modules/streaming/armed-stream-marker.ts";
 import { getIsStreaming } from "../../modules/streaming/streaming.ts";
 import { setAutostart } from "../../modules/streaming/streamloop.ts";
 import {
@@ -155,6 +156,7 @@ export const poweroffProcedure = authedProcedure
 			return { success: false };
 		}
 		logger.info("System: poweroff requested");
+		notePlannedShutdown("poweroff");
 		powerCommandRunner("poweroff");
 		return { success: true };
 	});
@@ -175,6 +177,10 @@ export const rebootProcedure = authedProcedure
 			return { success: false };
 		}
 		logger.info("System: reboot requested");
+		// Belt and braces: a reboot changes the boot id, which already blocks
+		// restoration. This also covers the window between the request and the
+		// kernel actually going down, where the backend can still be restarted.
+		notePlannedShutdown("reboot");
 		powerCommandRunner("reboot");
 		return { success: true };
 	});

--- a/apps/backend/src/tests/config-change-orchestrator.test.ts
+++ b/apps/backend/src/tests/config-change-orchestrator.test.ts
@@ -329,7 +329,7 @@ describe("stop during a config-change transaction", () => {
 
 		// When a stop is requested mid-transaction.
 		let stopSettled = false;
-		const stop = h.orchestrator.stop().then((result) => {
+		const stop = h.orchestrator.stop("operator").then((result) => {
 			stopSettled = true;
 			return result;
 		});
@@ -354,7 +354,7 @@ describe("stop during a config-change transaction", () => {
 		await bringToStreaming(h);
 		const change = h.orchestrator.changeConfig({ framerate: 60 });
 		await settleMicrotasks();
-		const stop = h.orchestrator.stop();
+		const stop = h.orchestrator.stop("operator");
 		await settleMicrotasks();
 
 		// When the engine's rollback also fails, right at the declared bound.
@@ -377,8 +377,8 @@ describe("stop during a config-change transaction", () => {
 		await bringToStreaming(h);
 		const change = h.orchestrator.changeConfig({ framerate: 30 });
 		await settleMicrotasks();
-		const first = h.orchestrator.stop();
-		const second = h.orchestrator.stop();
+		const first = h.orchestrator.stop("operator");
+		const second = h.orchestrator.stop("operator");
 		await settleMicrotasks();
 
 		// When the transaction applies.
@@ -423,7 +423,7 @@ describe("a parked stop is bounded and announced", () => {
 		void h.orchestrator.changeConfig({ resolution: "3840x2160" });
 		await settleMicrotasks();
 		let settled: StopResult | undefined;
-		const stop = h.orchestrator.stop().then((result) => {
+		const stop = h.orchestrator.stop("operator").then((result) => {
 			settled = result;
 			return result;
 		});
@@ -453,7 +453,7 @@ describe("a parked stop is bounded and announced", () => {
 		await settleMicrotasks();
 
 		// When a stop is parked behind the transaction.
-		void h.orchestrator.stop();
+		void h.orchestrator.stop("operator");
 		await settleMicrotasks();
 
 		// Then the wait is named, with the budget it is allowed.
@@ -471,7 +471,7 @@ describe("a parked stop is bounded and announced", () => {
 		await bringToStreaming(h);
 		const change = h.orchestrator.changeConfig({ framerate: 30 });
 		await settleMicrotasks();
-		const stop = h.orchestrator.stop();
+		const stop = h.orchestrator.stop("operator");
 		await settleMicrotasks();
 		h.settleChange({ phase: "applied" });
 		await change;
@@ -494,7 +494,7 @@ describe("a parked stop is bounded and announced", () => {
 		const stuck = harness();
 		stuck.stopRuntimeSettles = false;
 		await bringToStreaming(stuck);
-		const stop = stuck.orchestrator.stop();
+		const stop = stuck.orchestrator.stop("operator");
 		await settleMicrotasks();
 
 		// When the stop deadline expires.
@@ -522,7 +522,7 @@ describe("engine escalation during reconfiguring", () => {
 		await bringToStreaming(h);
 		const change = h.orchestrator.changeConfig({ resolution: "3840x2160" });
 		await settleMicrotasks();
-		const stop = h.orchestrator.stop();
+		const stop = h.orchestrator.stop("operator");
 		await settleMicrotasks();
 		expect(h.orchestrator.snapshot().state).toBe("reconfiguring");
 		const attemptId = changeAttemptId(h);

--- a/apps/backend/src/tests/engine-session-connection-loss.test.ts
+++ b/apps/backend/src/tests/engine-session-connection-loss.test.ts
@@ -328,7 +328,7 @@ describe("engine restart mid-session — the session control connection is the s
 
 		// The production hook routes into exactly this stop; drive it here so the
 		// assertion is on the orchestrator's own recovery, not on the wiring.
-		await orchestrator.stop();
+		await orchestrator.stop("engine_loss");
 		expect(streaming).toBe(false);
 		expect(orchestrator.snapshot().state).toBe("idle");
 

--- a/apps/backend/src/tests/lost-device-retention.test.ts
+++ b/apps/backend/src/tests/lost-device-retention.test.ts
@@ -578,7 +578,7 @@ describe("the state-transition table", () => {
 		await orchestrator.start({ origin: "ui", launch: async () => {} });
 		expect(commits).toHaveLength(1);
 
-		const stopped = await orchestrator.stop();
+		const stopped = await orchestrator.stop("operator");
 		expect(stopped.result).toBe("stopped");
 		expect(commits).toHaveLength(1);
 		expect(getConfig().last_streamed_source).toBe("video0");

--- a/apps/backend/src/tests/stop-wedge-recovery.test.ts
+++ b/apps/backend/src/tests/stop-wedge-recovery.test.ts
@@ -155,7 +155,7 @@ describe("a stop that never settles must not poison the session", () => {
 		await orchestrator.start({ origin: "ui", launch: async () => {} });
 		expect(streamingStatus).toBe(true);
 
-		const stopping = orchestrator.stop();
+		const stopping = orchestrator.stop("operator");
 		deadlineCallback?.();
 		expect(await stopping).toEqual({
 			result: "stop_failed",

--- a/apps/backend/src/tests/stream-restoration.test.ts
+++ b/apps/backend/src/tests/stream-restoration.test.ts
@@ -1,0 +1,833 @@
+/*
+ * Todo 42 — one-shot stream restoration after engine death.
+ *
+ * Wave3 measured 0/6 stream-level resumptions after a SIGKILL + systemd restart:
+ * `noteConnectionLoss` retired the session and nothing ever tried again. These
+ * cases pin the replacement, and the thing they mostly pin is when it must NOT
+ * fire.
+ *
+ * Every named gate gets its own case that flips ONE condition and proves the
+ * restoration does not happen — a table where all the rows pass together would
+ * not tell us which gate is load-bearing. The discrimination table
+ * (adopt / restore / neither) and the stop-cause table get the same treatment,
+ * and the one-shot property is asserted by RUNNING the runner twice against a
+ * real on-disk marker rather than by reading the code.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs, { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { LifecycleState } from "@ceraui/rpc/schemas";
+
+import {
+	type ArmedStreamConfig,
+	type ArmedStreamMarker,
+	type ArmedStreamMarkerDeps,
+	clearArmedStreamMarker,
+	decideStreamRestoration,
+	notePlannedShutdown,
+	noteStreamStopped,
+	RESTORATION_BOUND_MS,
+	readArmedStreamMarker,
+	type StreamStopCause,
+	writeArmedStreamMarker,
+} from "../modules/streaming/armed-stream-marker.ts";
+import {
+	armStreamRestoration,
+	type RestorationLaunchOutcome,
+	type RestorationRunOutcome,
+	runStreamRestoration,
+	type StreamRestorationDeps,
+	settleStreamRestoration,
+} from "../modules/streaming/stream-restoration.ts";
+import { createStreamSessionOrchestrator } from "../modules/streaming/stream-session-orchestrator.ts";
+import type { EngineRuntimeState } from "../modules/streaming/streaming-backend.ts";
+
+const BOOT_A = "11111111-1111-4111-8111-111111111111";
+const BOOT_B = "22222222-2222-4222-8222-222222222222";
+
+const SAMPLE_CONFIG: ArmedStreamConfig = {
+	delay: 0,
+	pipeline: "hdmi",
+	acodec: "opus",
+	asrc: "Auto",
+	srtla_addr: "ingest.example.tv",
+	srtla_port: 5000,
+	srt_streamid: "abc",
+	srt_latency: 2000,
+	max_br: 6000,
+	resolution: "1080p",
+	framerate: 30,
+	source: "/dev/video0",
+};
+
+let markerDir: string;
+let markerPath: string;
+let bootId: string | undefined;
+
+function markerDeps(): ArmedStreamMarkerDeps {
+	return {
+		markerPath,
+		readMarker: (path) => {
+			try {
+				return fs.readFileSync(path, "utf8");
+			} catch {
+				return undefined;
+			}
+		},
+		writeMarker: (path, contents) => fs.writeFileSync(path, contents),
+		removeMarker: (path) => {
+			try {
+				fs.unlinkSync(path);
+			} catch {
+				// already gone
+			}
+		},
+		readBootId: () => bootId,
+	};
+}
+
+function plant(overrides: Partial<ArmedStreamMarker> = {}): ArmedStreamMarker {
+	const marker: ArmedStreamMarker = {
+		armedAt: 1_000,
+		bootId: BOOT_A,
+		config: SAMPLE_CONFIG,
+		...overrides,
+	};
+	fs.writeFileSync(markerPath, JSON.stringify(marker));
+	return marker;
+}
+
+function onDisk(): ArmedStreamMarker | undefined {
+	return readArmedStreamMarker(markerDeps());
+}
+
+beforeEach(() => {
+	markerDir = mkdtempSync(join(tmpdir(), "ceraui-armed-"));
+	markerPath = join(markerDir, "stream.armed.json");
+	bootId = BOOT_A;
+});
+
+afterEach(async () => {
+	await settleStreamRestoration();
+	rmSync(markerDir, { recursive: true, force: true });
+});
+
+const eligible = {
+	marker: {
+		armedAt: 1_000,
+		bootId: BOOT_A,
+		config: SAMPLE_CONFIG,
+	} satisfies ArmedStreamMarker,
+	runtimeState: "idle" as EngineRuntimeState,
+	lifecycleState: "idle" as LifecycleState,
+	currentBootId: BOOT_A,
+	elapsedMs: 0,
+};
+
+describe("decideStreamRestoration — every gate blocks on its own", () => {
+	test("all gates satisfied — and only then — restores", () => {
+		expect(decideStreamRestoration(eligible)).toEqual({ action: "restore" });
+	});
+
+	test("a streaming engine is ADOPTED, never restored (the singleton rule)", () => {
+		expect(
+			decideStreamRestoration({ ...eligible, runtimeState: "streaming" }),
+		).toEqual({ action: "adopt" });
+	});
+
+	test("adoption does not need a marker — a backend-only restart still adopts", () => {
+		expect(
+			decideStreamRestoration({
+				...eligible,
+				marker: undefined,
+				runtimeState: "streaming",
+			}),
+		).toEqual({ action: "adopt" });
+	});
+
+	test("adoption OUTRANKS a marker that has already been attempted", () => {
+		expect(
+			decideStreamRestoration({
+				...eligible,
+				runtimeState: "streaming",
+				marker: {
+					...eligible.marker,
+					attempt: {
+						outcome: "failed",
+						at: 5,
+						elapsedMs: 5,
+						withinBound: true,
+					},
+				},
+			}),
+		).toEqual({ action: "adopt" });
+	});
+
+	test("no marker blocks", () => {
+		expect(decideStreamRestoration({ ...eligible, marker: undefined })).toEqual(
+			{ action: "blocked", reason: "no_marker" },
+		);
+	});
+
+	test("a RECOVERED attempt blocks — one shot means one, in both directions", () => {
+		expect(
+			decideStreamRestoration({
+				...eligible,
+				marker: {
+					...eligible.marker,
+					attempt: {
+						outcome: "recovered",
+						at: 5,
+						elapsedMs: 900,
+						withinBound: true,
+					},
+				},
+			}),
+		).toEqual({ action: "blocked", reason: "already_attempted" });
+	});
+
+	test("a FAILED attempt blocks", () => {
+		expect(
+			decideStreamRestoration({
+				...eligible,
+				marker: {
+					...eligible.marker,
+					attempt: {
+						outcome: "failed",
+						reason: "start_failed",
+						at: 5,
+						elapsedMs: 900,
+						withinBound: true,
+					},
+				},
+			}),
+		).toEqual({ action: "blocked", reason: "already_attempted" });
+	});
+
+	test("a planned shutdown blocks", () => {
+		expect(
+			decideStreamRestoration({
+				...eligible,
+				marker: {
+					...eligible.marker,
+					plannedShutdown: { reason: "software_update", at: 5 },
+				},
+			}),
+		).toEqual({ action: "blocked", reason: "planned_shutdown" });
+	});
+
+	test("a boot_id mismatch blocks — a reboot NEVER auto-restarts a stream", () => {
+		expect(
+			decideStreamRestoration({ ...eligible, currentBootId: BOOT_B }),
+		).toEqual({ action: "blocked", reason: "boot_id_mismatch" });
+	});
+
+	test("an UNREADABLE boot id fails closed, exactly like a mismatch", () => {
+		expect(
+			decideStreamRestoration({ ...eligible, currentBootId: undefined }),
+		).toEqual({ action: "blocked", reason: "boot_id_mismatch" });
+	});
+
+	test("an unknown runtime state waits inside the sub-deadline", () => {
+		expect(
+			decideStreamRestoration({
+				...eligible,
+				runtimeState: "unknown",
+				elapsedMs: 9_999,
+				unknownDeadlineMs: 10_000,
+			}),
+		).toEqual({ action: "wait", reason: "runtime_state_unknown" });
+	});
+
+	test("an unknown runtime state at the sub-deadline is TERMINAL", () => {
+		expect(
+			decideStreamRestoration({
+				...eligible,
+				runtimeState: "unknown",
+				elapsedMs: 10_000,
+				unknownDeadlineMs: 10_000,
+			}),
+		).toEqual({ action: "give_up", reason: "runtime_state_unknown" });
+	});
+
+	test("a busy lifecycle waits rather than racing a config-change transaction", () => {
+		expect(
+			decideStreamRestoration({
+				...eligible,
+				lifecycleState: "reconfiguring",
+				elapsedMs: 500,
+			}),
+		).toEqual({ action: "wait", reason: "lifecycle_busy" });
+	});
+
+	test("a lifecycle that never frees up is terminal too", () => {
+		expect(
+			decideStreamRestoration({
+				...eligible,
+				lifecycleState: "reconfiguring",
+				elapsedMs: 10_000,
+			}),
+		).toEqual({ action: "give_up", reason: "lifecycle_busy" });
+	});
+
+	test("a decidable refusal is settled BEFORE any polling is spent on it", () => {
+		expect(
+			decideStreamRestoration({
+				...eligible,
+				runtimeState: "unknown",
+				currentBootId: BOOT_B,
+				elapsedMs: 0,
+			}),
+		).toEqual({ action: "blocked", reason: "boot_id_mismatch" });
+	});
+});
+
+describe("the marker on disk", () => {
+	test("arming records the config snapshot and the current boot", () => {
+		expect(
+			armStreamRestoration({
+				marker: markerDeps(),
+				captureConfig: () => SAMPLE_CONFIG,
+				now: () => 4_242,
+			}),
+		).toBe(true);
+
+		const marker = onDisk();
+		expect(marker?.bootId).toBe(BOOT_A);
+		expect(marker?.armedAt).toBe(4_242);
+		expect(marker?.config).toMatchObject(SAMPLE_CONFIG);
+		expect(marker?.attempt).toBeUndefined();
+	});
+
+	test("no readable boot id arms NOTHING — failing closed costs a restoration, failing open restarts across a power cycle", () => {
+		bootId = undefined;
+		expect(
+			armStreamRestoration({
+				marker: markerDeps(),
+				captureConfig: () => SAMPLE_CONFIG,
+			}),
+		).toBe(false);
+		expect(fs.existsSync(markerPath)).toBe(false);
+	});
+
+	test("an engine session id may be RECORDED but is never a gate", () => {
+		armStreamRestoration({
+			marker: markerDeps(),
+			captureConfig: () => SAMPLE_CONFIG,
+			diagnostics: { engineSessionId: "cs-1", origin: "ui" },
+		});
+		const marker = onDisk();
+		expect(marker?.diagnostics?.engineSessionId).toBe("cs-1");
+
+		// The same id from a RESTARTED engine names a different session (the ids
+		// are process-local counters), so the decision must be identical with and
+		// without it.
+		expect(
+			decideStreamRestoration({
+				...eligible,
+				marker: marker as ArmedStreamMarker,
+			}),
+		).toEqual({ action: "restore" });
+	});
+
+	test("an unreadable marker is discarded rather than trusted", () => {
+		fs.writeFileSync(markerPath, "{not json");
+		expect(onDisk()).toBeUndefined();
+		expect(fs.existsSync(markerPath)).toBe(false);
+	});
+
+	test("the snapshot carries no credential fields", () => {
+		armStreamRestoration({
+			marker: markerDeps(),
+			captureConfig: () =>
+				({
+					...SAMPLE_CONFIG,
+					password_hash: "$2b$10$nope",
+					ssh_pass: "hunter2",
+					remote_key: "v4.public.nope",
+				}) as unknown as ArmedStreamConfig,
+		});
+		const raw = fs.readFileSync(markerPath, "utf8");
+		expect(raw).not.toContain("hunter2");
+		expect(raw).not.toContain("password_hash");
+		expect(raw).not.toContain("remote_key");
+	});
+});
+
+describe("the stop-cause table", () => {
+	const causes: Array<[StreamStopCause, "cleared" | "preserved"]> = [
+		["operator", "cleared"],
+		["engine_loss", "preserved"],
+		["reconfigure", "preserved"],
+	];
+
+	for (const [cause, expected] of causes) {
+		test(`cause=${cause} leaves the marker ${expected}`, () => {
+			plant();
+			noteStreamStopped(cause, markerDeps());
+			expect(onDisk() === undefined ? "cleared" : "preserved").toBe(expected);
+		});
+	}
+
+	test("an operator stop with no marker is a clean no-op", () => {
+		expect(() => noteStreamStopped("operator", markerDeps())).not.toThrow();
+		expect(fs.existsSync(markerPath)).toBe(false);
+	});
+});
+
+describe("planned-shutdown suppression", () => {
+	test("it is stamped onto an armed marker", () => {
+		plant();
+		expect(
+			notePlannedShutdown("software_update", {
+				marker: markerDeps(),
+				now: () => 77,
+			}),
+		).toBe(true);
+		expect(onDisk()?.plannedShutdown).toEqual({
+			reason: "software_update",
+			at: 77,
+		});
+	});
+
+	test("with nothing armed there is nothing to suppress — and no orphan flag left behind", () => {
+		expect(notePlannedShutdown("reboot", { marker: markerDeps() })).toBe(false);
+		expect(fs.existsSync(markerPath)).toBe(false);
+	});
+
+	test("it never overwrites the first suppression reason", () => {
+		plant();
+		notePlannedShutdown("software_update", {
+			marker: markerDeps(),
+			now: () => 1,
+		});
+		notePlannedShutdown("reboot", { marker: markerDeps(), now: () => 2 });
+		expect(onDisk()?.plannedShutdown?.reason).toBe("software_update");
+	});
+
+	test("the next armed stream starts from a clean marker", () => {
+		plant({ plannedShutdown: { reason: "software_update", at: 1 } });
+		armStreamRestoration({
+			marker: markerDeps(),
+			captureConfig: () => SAMPLE_CONFIG,
+		});
+		expect(onDisk()?.plannedShutdown).toBeUndefined();
+	});
+});
+
+type RunHarness = {
+	readonly deps: Partial<StreamRestorationDeps>;
+	readonly launches: ArmedStreamConfig[];
+	readonly published: RestorationRunOutcome[];
+	readonly waits: number[];
+};
+
+function harness(options: {
+	runtimeStates?: EngineRuntimeState[];
+	lifecycleStates?: LifecycleState[];
+	launchOutcome?: RestorationLaunchOutcome;
+	stepMs?: number;
+}): RunHarness {
+	const launches: ArmedStreamConfig[] = [];
+	const published: RestorationRunOutcome[] = [];
+	const waits: number[] = [];
+	const runtimeStates = [...(options.runtimeStates ?? ["idle"])];
+	const lifecycleStates = [...(options.lifecycleStates ?? ["idle"])];
+	const step = options.stepMs ?? 1_000;
+	let clock = 0;
+
+	return {
+		launches,
+		published,
+		waits,
+		deps: {
+			marker: markerDeps(),
+			runtimeState: async () =>
+				(runtimeStates.length > 1
+					? runtimeStates.shift()
+					: runtimeStates[0]) as EngineRuntimeState,
+			lifecycleState: () =>
+				(lifecycleStates.length > 1
+					? lifecycleStates.shift()
+					: lifecycleStates[0]) as LifecycleState,
+			launch: async (config) => {
+				launches.push(config);
+				return options.launchOutcome ?? { ok: true };
+			},
+			publish: (outcome) => published.push(outcome),
+			wait: async (ms) => {
+				waits.push(ms);
+				clock += step;
+			},
+			now: () => clock,
+			logger: { info: () => {}, warn: () => {} },
+			pollIntervalMs: 1_000,
+			unknownDeadlineMs: 10_000,
+		},
+	};
+}
+
+describe("the runner — adopt vs restore vs neither", () => {
+	test("an idle engine with an armed marker restores EXACTLY once", async () => {
+		plant();
+		const h = harness({});
+		const outcome = await runStreamRestoration(h.deps);
+
+		expect(outcome.result).toBe("recovered");
+		expect(h.launches).toHaveLength(1);
+		expect(h.launches[0]).toMatchObject(SAMPLE_CONFIG);
+		expect(h.published).toEqual([{ result: "recovered", elapsedMs: 0 }]);
+		expect(onDisk()?.attempt?.outcome).toBe("recovered");
+	});
+
+	test("a SECOND run can never retry — the terminal state is the one-shot", async () => {
+		plant();
+		const first = harness({});
+		await runStreamRestoration(first.deps);
+		const second = harness({});
+		const outcome = await runStreamRestoration(second.deps);
+
+		expect(outcome).toEqual({ result: "blocked", reason: "already_attempted" });
+		expect(second.launches).toHaveLength(0);
+	});
+
+	test("a FAILED attempt is just as terminal as a successful one", async () => {
+		plant();
+		const first = harness({
+			launchOutcome: { ok: false, reason: "start_failed" },
+		});
+		const failed = await runStreamRestoration(first.deps);
+		expect(failed).toEqual({
+			result: "failed",
+			reason: "start_failed",
+			elapsedMs: 0,
+		});
+		expect(onDisk()?.attempt).toMatchObject({
+			outcome: "failed",
+			reason: "start_failed",
+		});
+
+		const second = harness({});
+		await runStreamRestoration(second.deps);
+		expect(second.launches).toHaveLength(0);
+	});
+
+	test("a SUCCESSFUL restoration re-arms for the NEXT engine death (board-found)", async () => {
+		// The restored session is a NEW commitment, and the orchestrator's outcome
+		// gate arms a fresh marker for it. Retiring that fresh marker would leave a
+		// live stream with no attempt left, so the SECOND crash of a long broadcast
+		// would be unrecoverable. Measured on a board before this was fixed:
+		// SIGKILL #1 restored in 11.5 s, #2 and #3 did nothing at all.
+		plant();
+		const h = harness({});
+		const rearm = { ...h.deps };
+		rearm.launch = async (config) => {
+			h.launches.push(config);
+			// What the real launch does: a committed start arms a fresh marker.
+			armStreamRestoration({
+				marker: markerDeps(),
+				captureConfig: () => SAMPLE_CONFIG,
+				now: () => 99_999,
+			});
+			return { ok: true };
+		};
+
+		expect((await runStreamRestoration(rearm)).result).toBe("recovered");
+
+		const after = onDisk();
+		expect(after?.armedAt).toBe(99_999);
+		expect(after?.attempt).toBeUndefined();
+
+		// …and the next engine death gets its own single attempt.
+		const next = harness({});
+		expect((await runStreamRestoration(next.deps)).result).toBe("recovered");
+		expect(next.launches).toHaveLength(1);
+	});
+
+	test("a still-streaming engine is adopted and the marker is left ALONE", async () => {
+		plant();
+		const h = harness({ runtimeStates: ["streaming"] });
+		const outcome = await runStreamRestoration(h.deps);
+
+		expect(outcome).toEqual({ result: "adopted" });
+		expect(h.launches).toHaveLength(0);
+		// No attempt is burned: the session never ended, so nothing was recovered
+		// and nothing failed.
+		expect(onDisk()?.attempt).toBeUndefined();
+	});
+
+	test("unknown that RESOLVES to idle inside the window restores", async () => {
+		plant();
+		const h = harness({
+			runtimeStates: ["unknown", "unknown", "idle"],
+		});
+		const outcome = await runStreamRestoration(h.deps);
+
+		expect(outcome.result).toBe("recovered");
+		expect(h.waits).toEqual([1_000, 1_000]);
+		expect(h.launches).toHaveLength(1);
+	});
+
+	test("unknown that RESOLVES to streaming inside the window adopts", async () => {
+		plant();
+		const h = harness({ runtimeStates: ["unknown", "streaming"] });
+		const outcome = await runStreamRestoration(h.deps);
+
+		expect(outcome).toEqual({ result: "adopted" });
+		expect(h.launches).toHaveLength(0);
+		expect(onDisk()?.attempt).toBeUndefined();
+	});
+
+	test("unknown for the WHOLE window is terminal, and does not re-arm later", async () => {
+		plant();
+		const h = harness({ runtimeStates: ["unknown"] });
+		const outcome = await runStreamRestoration(h.deps);
+
+		expect(outcome).toMatchObject({
+			result: "failed",
+			reason: "runtime_state_unknown",
+		});
+		expect(h.launches).toHaveLength(0);
+		expect(onDisk()?.attempt).toMatchObject({
+			outcome: "failed",
+			reason: "runtime_state_unknown",
+		});
+
+		const later = harness({});
+		expect(await runStreamRestoration(later.deps)).toEqual({
+			result: "blocked",
+			reason: "already_attempted",
+		});
+		expect(later.launches).toHaveLength(0);
+	});
+
+	test("a restoration WAITS for an in-flight config change instead of racing it", async () => {
+		plant();
+		const h = harness({
+			lifecycleStates: ["reconfiguring", "reconfiguring", "idle"],
+		});
+		const outcome = await runStreamRestoration(h.deps);
+
+		expect(outcome.result).toBe("recovered");
+		expect(h.waits).toHaveLength(2);
+		expect(h.launches).toHaveLength(1);
+	});
+
+	test("a boot_id mismatch launches nothing and retires the dead marker", async () => {
+		plant({ bootId: BOOT_B });
+		const h = harness({});
+		const outcome = await runStreamRestoration(h.deps);
+
+		expect(outcome).toEqual({ result: "blocked", reason: "boot_id_mismatch" });
+		expect(h.launches).toHaveLength(0);
+		expect(fs.existsSync(markerPath)).toBe(false);
+	});
+
+	test("a planned shutdown launches nothing and burns no attempt", async () => {
+		plant({ plannedShutdown: { reason: "software_update", at: 5 } });
+		const h = harness({});
+		const outcome = await runStreamRestoration(h.deps);
+
+		expect(outcome).toEqual({ result: "blocked", reason: "planned_shutdown" });
+		expect(h.launches).toHaveLength(0);
+		expect(onDisk()?.attempt).toBeUndefined();
+	});
+
+	test("an operator stop before the engine dies means there is nothing to restore", async () => {
+		plant();
+		noteStreamStopped("operator", markerDeps());
+		const h = harness({});
+
+		expect(await runStreamRestoration(h.deps)).toEqual({
+			result: "blocked",
+			reason: "no_marker",
+		});
+		expect(h.launches).toHaveLength(0);
+	});
+
+	test("overlapping triggers JOIN one run rather than launching twice", async () => {
+		plant();
+		const h = harness({});
+		const [a, b] = await Promise.all([
+			runStreamRestoration(h.deps),
+			runStreamRestoration(h.deps),
+		]);
+
+		expect(a).toEqual(b);
+		expect(h.launches).toHaveLength(1);
+	});
+
+	test("the elapsed time is recorded against the declared bound, both ways", async () => {
+		plant();
+		const slow = harness({
+			runtimeStates: ["unknown", "idle"],
+			stepMs: 45_000,
+		});
+		await runStreamRestoration(slow.deps);
+
+		const attempt = onDisk()?.attempt;
+		expect(attempt?.elapsedMs).toBe(45_000);
+		expect(attempt?.withinBound).toBe(false);
+		expect(RESTORATION_BOUND_MS).toBe(30_000);
+	});
+});
+
+describe("coexistence with the apply-now config-change marker (todo 14)", () => {
+	test("neither marker reads or writes the other", async () => {
+		const inflightPath = join(markerDir, "config.inflight.json");
+		const inflight = JSON.stringify({
+			attemptId: "att_x",
+			startedAt: 1,
+			candidate: { resolution: "1080p" },
+			previous: { resolution: "720p" },
+		});
+		fs.writeFileSync(inflightPath, inflight);
+		plant();
+
+		const h = harness({});
+		await runStreamRestoration(h.deps);
+
+		expect(fs.readFileSync(inflightPath, "utf8")).toBe(inflight);
+		expect(onDisk()?.attempt?.outcome).toBe("recovered");
+	});
+
+	test("an engine that died mid-transaction leaves BOTH, and both survive to be judged", () => {
+		const inflightPath = join(markerDir, "config.inflight.json");
+		fs.writeFileSync(inflightPath, "{}");
+		plant();
+		noteStreamStopped("engine_loss", markerDeps());
+
+		expect(fs.existsSync(inflightPath)).toBe(true);
+		expect(onDisk()).toBeDefined();
+	});
+});
+
+describe("the orchestrator commit + stop seams", () => {
+	function build(overrides: Record<string, unknown> = {}) {
+		const armed: number[] = [];
+		const stops: StreamStopCause[] = [];
+		let streaming = false;
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: () => "att_test",
+			setStreamingStatus: (value) => {
+				streaming = value;
+			},
+			getStreamingStatus: () => streaming,
+			stopRuntime: async () => {},
+			queryRuntime: async () => "idle",
+			onStreamArmed: () => armed.push(1),
+			onStreamStopped: (cause) => stops.push(cause),
+			...overrides,
+		});
+		return { orchestrator, armed, stops };
+	}
+
+	test("the marker is armed at the outcome gate, once per committed start", async () => {
+		const h = build();
+		await h.orchestrator.start({ origin: "ui", launch: async () => {} });
+		expect(h.armed).toHaveLength(1);
+	});
+
+	test("a FAILED start arms nothing", async () => {
+		const h = build();
+		const result = await h.orchestrator.start({
+			origin: "ui",
+			launch: async () => {
+				throw new Error("nope");
+			},
+		});
+		expect(result.result).toBe("failed");
+		expect(h.armed).toHaveLength(0);
+	});
+
+	test("ADOPTING an already-running session is not a new commitment", async () => {
+		const h = build({ queryRuntime: async () => "streaming" });
+		await h.orchestrator.reconcile();
+		expect(h.orchestrator.snapshot().state).toBe("streaming");
+		expect(h.armed).toHaveLength(0);
+	});
+
+	test("a restoration origin is admitted through the same mutex", async () => {
+		const h = build();
+		const result = await h.orchestrator.start({
+			origin: "restoration",
+			launch: async () => {},
+		});
+		expect(result.result).toBe("started");
+
+		const second = await h.orchestrator.start({
+			origin: "restoration",
+			launch: async () => {},
+		});
+		expect(second.result).toBe("busy");
+	});
+
+	test("every stop reports its cause, including one parked behind a transaction", async () => {
+		const h = build({
+			changeRuntimeConfig: () => new Promise(() => {}),
+			reconfigureDeadlineMs: 20,
+			stopDeadlineMs: 10,
+		});
+		await h.orchestrator.start({ origin: "ui", launch: async () => {} });
+		void h.orchestrator.changeConfig({ resolution: "720p" });
+		const parked = h.orchestrator.stop("operator");
+
+		expect(h.stops).toEqual(["operator"]);
+		await parked;
+		// The release replays the SAME cause; a parked operator stop must never
+		// come back as something else.
+		expect(new Set(h.stops)).toEqual(new Set(["operator"]));
+	});
+
+	test("a bookkeeping failure never turns a live stream into a failed start", async () => {
+		const h = build({
+			onStreamArmed: () => {
+				throw new Error("disk full");
+			},
+		});
+		const result = await h.orchestrator.start({
+			origin: "ui",
+			launch: async () => {},
+		});
+		expect(result.result).toBe("started");
+	});
+});
+
+describe("todo 22's retention slot is untouched by a restoration", () => {
+	test("a restoration start still routes through the SAME idempotent commit hook", async () => {
+		// The slot's own no-move guarantee is proven where it lives
+		// (`lost-device-retention.test.ts` → "a restoration re-commit of the SAME
+		// configuration NEVER moves the slot"). What matters here is that
+		// restoration was not given a private commit path that could bypass it.
+		const commits: string[] = [];
+		const orchestrator = createStreamSessionOrchestrator({
+			createAttemptId: () => "att_test",
+			setStreamingStatus: () => {},
+			stopRuntime: async () => {},
+			queryRuntime: async () => "idle",
+			onStreamCommitted: () => commits.push("committed"),
+		});
+		await orchestrator.start({ origin: "restoration", launch: async () => {} });
+		expect(commits).toEqual(["committed"]);
+	});
+});
+
+describe("clearArmedStreamMarker", () => {
+	test("clearing an absent marker is the desired end state, not an error", () => {
+		expect(() => clearArmedStreamMarker(markerDeps())).not.toThrow();
+	});
+
+	test("a rewrite replaces the previous marker wholesale", () => {
+		plant({
+			attempt: { outcome: "failed", at: 1, elapsedMs: 1, withinBound: true },
+		});
+		writeArmedStreamMarker(
+			{ armedAt: 9, bootId: BOOT_A, config: SAMPLE_CONFIG },
+			markerDeps(),
+		);
+		expect(onDisk()?.attempt).toBeUndefined();
+	});
+});

--- a/apps/backend/src/tests/stream-session-orchestrator.test.ts
+++ b/apps/backend/src/tests/stream-session-orchestrator.test.ts
@@ -436,7 +436,7 @@ describe("stream session orchestrator", () => {
 		await Promise.resolve();
 
 		// When stop interrupts the pending backoff.
-		expect(await orchestrator.stop()).toEqual({ result: "stopped" });
+		expect(await orchestrator.stop("operator")).toEqual({ result: "stopped" });
 		const result = await start;
 
 		// Then no stale timer launches again and cancellation notifies nothing.
@@ -540,7 +540,7 @@ describe("stream session orchestrator", () => {
 		});
 
 		// When stop races the in-flight launch and the old launch completes late.
-		const stopResult = await orchestrator.stop();
+		const stopResult = await orchestrator.stop("operator");
 		engineConfirmed.resolve();
 		const startResult = await start;
 
@@ -568,7 +568,7 @@ describe("stream session orchestrator", () => {
 		).toMatchObject({ result: "started" });
 
 		// When the confirmed stream is stopped.
-		const result = await orchestrator.stop();
+		const result = await orchestrator.stop("operator");
 
 		// Then no late start completion is required to settle the lifecycle.
 		expect(result).toEqual({ result: "stopped" });
@@ -592,7 +592,7 @@ describe("stream session orchestrator", () => {
 		});
 		await orchestrator.start({ origin: "ui", launch: async () => {} });
 
-		const stopping = orchestrator.stop();
+		const stopping = orchestrator.stop("operator");
 		deadlineCallback?.();
 
 		expect(await stopping).toEqual({
@@ -615,7 +615,7 @@ describe("stream session orchestrator", () => {
 			origin: "ui",
 			launch: async () => firstBarrier.promise,
 		});
-		await orchestrator.stop();
+		await orchestrator.stop("operator");
 		firstBarrier.resolve();
 		expect(await first).toEqual({
 			result: "cancelled",

--- a/apps/backend/src/tests/streaming-backend-contract.test.ts
+++ b/apps/backend/src/tests/streaming-backend-contract.test.ts
@@ -533,7 +533,7 @@ describe("CerastreamBackend behavioural contract", () => {
 			generation: 3,
 		});
 
-		await orchestrator.stop();
+		await orchestrator.stop("operator");
 		await backend.settle();
 	});
 

--- a/packages/i18n/src/ar/index.ts
+++ b/packages/i18n/src/ar/index.ts
@@ -1606,6 +1606,9 @@ const ar = {
 		bitrateRange: "يجب أن يكون معدل البت بين 2000 و12000 كيلوبت/ثانية",
 	},
 	notifications: {
+		streamRecovered: "تمت استعادة البث تلقائيًا بعد إعادة تشغيل محرك البث.",
+		streamRecoveryFailed:
+			"تعذّرت استعادة البث بعد إعادة تشغيل محرك البث. افتح الإعدادات ← سجلات النظام لمعرفة التفاصيل.",
 		streamAutostartNoLinksFailed:
 			"فشل بدء البث التلقائي: لم تتوفر روابط شبكة بعد {attempt}/{maxAttempts} فحوصات. افتح الإعدادات ← سجلات النظام لمعرفة التفاصيل.",
 		streamStartEngineUnavailableRetrying:

--- a/packages/i18n/src/de/index.ts
+++ b/packages/i18n/src/de/index.ts
@@ -893,6 +893,10 @@ const de = {
 		bitrateRange: "Die Bitrate muss zwischen 2000 und 12000 Kbps liegen",
 	},
 	notifications: {
+		streamRecovered:
+			"Der Stream wurde nach dem Neustart der Streaming-Engine automatisch wiederhergestellt.",
+		streamRecoveryFailed:
+			"Der Stream konnte nach dem Neustart der Streaming-Engine nicht wiederhergestellt werden. Öffnen Sie Einstellungen → Systemprotokolle für Details.",
 		streamAutostartNoLinksFailed:
 			"Automatischer Streamstart fehlgeschlagen: nach {attempt}/{maxAttempts} Prüfungen waren keine Netzwerkverbindungen verfügbar. Öffnen Sie Einstellungen → Systemprotokolle für Details.",
 		streamStartEngineUnavailableRetrying:

--- a/packages/i18n/src/en/index.ts
+++ b/packages/i18n/src/en/index.ts
@@ -868,6 +868,10 @@ const en = {
 		bitrateRange: "Bitrate must be between 2000 and 12000 Kbps",
 	},
 	notifications: {
+		streamRecovered:
+			"The stream was restored automatically after the streaming engine restarted.",
+		streamRecoveryFailed:
+			"The stream could not be restored after the streaming engine restarted. Open Settings → System Logs for details.",
 		streamAutostartNoLinksFailed:
 			"Automatic stream start failed: no network links became available after {attempt:number}/{maxAttempts:number} checks. Open Settings → System Logs for details.",
 		streamStartEngineUnavailableRetrying:

--- a/packages/i18n/src/es/index.ts
+++ b/packages/i18n/src/es/index.ts
@@ -894,6 +894,10 @@ const es = {
 		bitrateRange: "El bitrate debe estar entre 2000 y 12000 Kbps",
 	},
 	notifications: {
+		streamRecovered:
+			"La transmisión se restauró automáticamente tras reiniciarse el motor de streaming.",
+		streamRecoveryFailed:
+			"No se pudo restaurar la transmisión tras reiniciarse el motor de streaming. Abre Ajustes → Registros del sistema para ver los detalles.",
 		streamAutostartNoLinksFailed:
 			"El inicio automático falló: no hubo enlaces de red tras {attempt}/{maxAttempts} comprobaciones. Abre Ajustes → Registros del sistema para ver los detalles.",
 		streamStartEngineUnavailableRetrying:

--- a/packages/i18n/src/fr/index.ts
+++ b/packages/i18n/src/fr/index.ts
@@ -1677,6 +1677,10 @@ const fr = {
 		bitrateRange: "Le débit doit être compris entre 2000 et 12000 Kbps",
 	},
 	notifications: {
+		streamRecovered:
+			"Le flux a été rétabli automatiquement après le redémarrage du moteur de diffusion.",
+		streamRecoveryFailed:
+			"Le flux n'a pas pu être rétabli après le redémarrage du moteur de diffusion. Ouvrez Paramètres → Journaux système pour plus de détails.",
 		streamAutostartNoLinksFailed:
 			"Échec du démarrage automatique : aucun lien réseau après {attempt}/{maxAttempts} vérifications. Ouvrez Paramètres → Journaux système pour plus de détails.",
 		streamStartEngineUnavailableRetrying:

--- a/packages/i18n/src/hi/index.ts
+++ b/packages/i18n/src/hi/index.ts
@@ -1467,6 +1467,10 @@ const hi = {
 		bitrateRange: "बिटरेट 2000 और 12000 Kbps के बीच होना चाहिए",
 	},
 	notifications: {
+		streamRecovered:
+			"स्ट्रीमिंग इंजन के पुनः आरंभ होने के बाद स्ट्रीम स्वचालित रूप से बहाल हो गई।",
+		streamRecoveryFailed:
+			"स्ट्रीमिंग इंजन के पुनः आरंभ होने के बाद स्ट्रीम बहाल नहीं हो सकी। विवरण के लिए सेटिंग्स → सिस्टम लॉग खोलें।",
 		streamAutostartNoLinksFailed:
 			"स्वचालित स्ट्रीम शुरू नहीं हुई: {attempt}/{maxAttempts} जाँचों के बाद कोई नेटवर्क लिंक उपलब्ध नहीं था। विवरण के लिए सेटिंग्स → सिस्टम लॉग खोलें।",
 		streamStartEngineUnavailableRetrying:

--- a/packages/i18n/src/ja/index.ts
+++ b/packages/i18n/src/ja/index.ts
@@ -1511,6 +1511,9 @@ const ja = {
 		bitrateRange: "ビットレートは2000から12000 Kbpsの間でなければなりません",
 	},
 	notifications: {
+		streamRecovered: "配信エンジンの再起動後、配信が自動的に復旧しました。",
+		streamRecoveryFailed:
+			"配信エンジンの再起動後、配信を復旧できませんでした。詳細は 設定 → システムログ を開いてください。",
 		streamAutostartNoLinksFailed:
 			"自動配信を開始できませんでした：{attempt}/{maxAttempts} 回確認してもネットワークリンクを利用できません。詳細は 設定 → システムログ を開いてください。",
 		streamStartEngineUnavailableRetrying:

--- a/packages/i18n/src/ko/index.ts
+++ b/packages/i18n/src/ko/index.ts
@@ -1485,6 +1485,10 @@ const ko = {
 		bitrateRange: "비트레이트는 2000에서 12000 Kbps 사이여야 합니다",
 	},
 	notifications: {
+		streamRecovered:
+			"스트리밍 엔진이 다시 시작된 뒤 스트림이 자동으로 복구되었습니다.",
+		streamRecoveryFailed:
+			"스트리밍 엔진이 다시 시작된 뒤 스트림을 복구하지 못했습니다. 자세한 내용은 설정 → 시스템 로그를 열어 확인하세요.",
 		streamAutostartNoLinksFailed:
 			"자동 스트림 시작에 실패했습니다: {attempt}/{maxAttempts}회 확인 후에도 네트워크 링크가 없습니다. 자세한 내용은 설정 → 시스템 로그를 열어 확인하세요.",
 		streamStartEngineUnavailableRetrying:

--- a/packages/i18n/src/pt-BR/index.ts
+++ b/packages/i18n/src/pt-BR/index.ts
@@ -1653,6 +1653,10 @@ const ptBR = {
 		bitrateRange: "A taxa de bits deve estar entre 2000 e 12000 Kbps",
 	},
 	notifications: {
+		streamRecovered:
+			"A transmissão foi restaurada automaticamente após o motor de streaming reiniciar.",
+		streamRecoveryFailed:
+			"Não foi possível restaurar a transmissão após o motor de streaming reiniciar. Abra Configurações → Logs do sistema para ver os detalhes.",
 		streamAutostartNoLinksFailed:
 			"Falha no início automático: nenhum link de rede após {attempt}/{maxAttempts} verificações. Abra Configurações → Logs do sistema para ver os detalhes.",
 		streamStartEngineUnavailableRetrying:

--- a/packages/i18n/src/zh/index.ts
+++ b/packages/i18n/src/zh/index.ts
@@ -1414,6 +1414,9 @@ const zh = {
 		bitrateRange: "比特率必须在 2000 到 12000 Kbps 之间",
 	},
 	notifications: {
+		streamRecovered: "流媒体引擎重启后，直播流已自动恢复。",
+		streamRecoveryFailed:
+			"流媒体引擎重启后无法恢复直播流。打开 设置 → 系统日志 查看详情。",
 		streamAutostartNoLinksFailed:
 			"自动流启动失败：检查 {attempt}/{maxAttempts} 次后仍无可用网络链路。打开 设置 → 系统日志 查看详情。",
 		streamStartEngineUnavailableRetrying:


### PR DESCRIPTION
## What

A stream that is live when `cerastream` dies now comes back by itself — **once**, within the
same boot. Wave3 measured **0/6** stream-level resumptions after a SIGKILL + systemd restart:
`noteConnectionLoss` retired the session, the engine restarted, and nothing ever tried again.

An **armed-stream marker** (`stream.armed.json`) is written at the orchestrator's
`transition("streaming")` outcome gate, carrying the *running* config snapshot plus the current
`boot_id`. Three seams judge it — the engine-loss retirement, backend boot, and the
engine-reconnect heal — through one self-serialising runner.

## Why these particular rules

**Adoption wins, first and unconditionally.** If the engine reports any streaming session it is
adopted and nothing is restored. A marker survives a backend restart exactly as it survives an
engine death, and *only the engine* can tell those apart — asking the marker first is how a
device ends up with two sessions.

**Restoration needs every gate to hold:** marker present ∧ engine authoritatively idle ∧
`boot_id` matches ∧ not cleared by an operator stop ∧ no planned-shutdown stamp ∧ no prior
attempt. Each is independently blocking, and each has a test that flips only that condition.

**Stops now carry an explicit cause.** The engine-loss path and an operator Stop reach the
identical `stopStreamSession()`, so without a cause the marker either forgets every crash or
restarts a stream the operator deliberately ended. `operator` clears it; `engine_loss` and
`reconfigure` preserve it. The cause is reported from *intent*, ahead of the outcome, so a stop
parked behind a 65 s config-change transaction does not leave the marker armed while it waits.

**`unknown` triggers neither.** It polls at the reconciliation cadence for ≤10 s, then writes a
terminal `stream_recovery_failed{runtime_state_unknown}` that does not re-arm.

**One-shot is the feature.** Both outcomes write a terminal attempted-state, so the answer to
"what happens on the next backend restart" is always "nothing". No retry, no backoff.

**The engine session id is diagnostics only.** Four facts, each re-verified against current code
rather than taken on trust: the adoption seam exposes only `streaming|idle|unknown`; `start()`
drops the `session_id` the engine really does return; status events carry no session identity;
and engine ids are process-local counters, so a restarted engine re-issues `cs-1` for a
*different* session.

Two smaller decisions worth flagging: the marker snapshots the **running** config rather than
`config.json` (a non-`apply_now` save persists a restart-requiring field the engine is not yet
running, and restoring from disk would apply an edit the operator deferred), and the marker is
schema-parsed **on write** — the snapshot is copied out of a config that also holds
`password_hash`/`ssh_pass`/`remote_key`, and a test proves that barrier holds.

## How to verify

Local: `bun tsc --noEmit` clean · `biome check` clean on all 29 changed files ·
**2822 backend tests pass, 0 fail** · 282 rpc · `check:tech-debt` OK.

Rather than assert the gates pass together, each was **neutered one at a time** — ten neuters,
ten distinct non-overlapping red sets. That is what shows the suite is load-bearing rather than
53 cases that happen to agree.

Board (`192.168.78.131`, Rock 5B+, eMMC, engine `2026.7.2`) — full transcripts in
`.omo/evidence/device-platform-wave4/task-42-board-proof.md`, hashed into the commit trailer:

| Drill | Result |
|---|---|
| SIGKILL `cerastream` mid-stream ×3 | **3/3 restored** — 11 634 / 11 468 / 11 560 ms, all under the declared 30 000 ms bound, `stream_recovered` published each time, frames advancing after each |
| Backend-only restart mid-stream | **Adopted** — engine PID *and* `ActiveEnterTimestamp` unchanged, frame counter continued 1291→1387 rather than resetting, no attempt burned, **no second session** |
| Operator stop, then SIGKILL | **No restoration** — marker cleared, lifecycle never left `idle` across 60 s (kill verified real: `NRestarts` 8→9) |
| Reboot with marker present | ⏸ **Pending** a coordinated reboot — held off deliberately so the 7.1.5 SD-boot validation can run as its own step |

**The board caught a real bug the unit suite could not.** The first candidate restored *once*
and then went silent: `recordAttempt` stamped the terminal state onto the marker it had read
before launching, clobbering the fresh marker that the successful restoration's own commit hook
had just armed — retiring a stream that was live at that moment. Unit tests missed it because
the harness's `launch` stub never re-arms. Fixed with a compare-and-set on `armedAt` (same shape
as the existing source-selection write token) and locked by a regression test whose stub arms
the way the real launch does. Both board transcripts are retained as an A/B on identical
hardware, minutes apart.

## Risks

- `stopStreamSession(cause)` is now a **required** parameter — deliberately, so the compiler
  catches a forgotten call site instead of a default silently mis-classifying one. All 4
  production call sites updated.
- `startStream` gained an optional `configOverride`; absent (every existing caller) the
  behaviour is byte-identical.
- A backend restart still kills `srtla_send` (same cgroup, `KillMode=mixed`) — pre-existing and
  out of scope. It is recorded in the board proof because the engine died as a knock-on ~90 s
  later and restoration recovered it in 8 733 ms, an unplanned 4th success.
