### PR TITLE
fix(network): the bond toggle excludes a link, it does not disable the interface

### DIFF
--- a/apps/frontend/src/lib/components/custom/BondToggle.svelte
+++ b/apps/frontend/src/lib/components/custom/BondToggle.svelte
@@ -31,7 +31,8 @@ type Props = {
 	 * Optional async guard run ONLY before a DISABLE toggle. Resolve `false`
 	 * to abort (the switch stays in its current state); resolve `true` to
 	 * proceed with `rpc.network.configure`. Used by Ethernet to surface a
-	 * management-interruption confirm before pulling a wired link from the bond.
+	 * bandwidth-loss confirm before pulling a wired link from the bond. The
+	 * toggle only changes BOND MEMBERSHIP — the interface itself stays up.
 	 */
 	onBeforeDisable?: () => boolean | Promise<boolean>;
 	class?: string;

--- a/apps/frontend/src/main/network/EthernetSection.svelte
+++ b/apps/frontend/src/main/network/EthernetSection.svelte
@@ -21,10 +21,13 @@ interface Props {
 
 const { wiredEntries, isFullyStale, staleInterfaces, onConfigure }: Props = $props();
 
-// Ethernet footgun guard: disabling a wired link can drop the operator's
-// management / SSH / LAN path, so the BondToggle's disable action is gated
-// behind a confirm. One dialog instance serves every row via a pending
-// promise resolver — BondToggle awaits `confirmDisable()` before mutating.
+// Bandwidth footgun guard: the wired link is usually the fattest member of the
+// bond, so excluding it can gut an in-flight stream's throughput — hence the
+// confirm on the BondToggle's disable action. It does NOT touch the interface
+// itself (the backend `enabled` flag only filters `genSrtlaIpList()`), so
+// management / SSH / LAN over eth0 are unaffected and the copy must not claim
+// otherwise. One dialog instance serves every row via a pending promise
+// resolver — BondToggle awaits `confirmDisable()` before mutating.
 let confirmOpen = $state(false);
 let pendingName = $state('');
 let resolveConfirm: ((proceed: boolean) => void) | null = null;
@@ -114,7 +117,7 @@ function settle(proceed: boolean) {
 	</div>
 </section>
 
-<!-- Management-interruption confirm: gates BondToggle disable on wired links. -->
+<!-- Bond-exclusion confirm: gates BondToggle disable on wired links. -->
 <AlertDialog.Root bind:open={confirmOpen} onOpenChange={(open) => !open && settle(false)}>
 	<AlertDialog.Content>
 		<AlertDialog.Header>

--- a/packages/i18n/src/ar/index.ts
+++ b/packages/i18n/src/ar/index.ts
@@ -402,8 +402,9 @@ const ar = {
 		},
 
 		dialogs: {
-			enableInterface: "تفعيل الواجهة",
-			enableInterfaceDesc: "استخدم هذه الواجهة للبث المجمّع.",
+			enableInterface: "استخدامها في التجميع",
+			enableInterfaceDesc:
+				"تضمين هذه الواجهة في البث المجمّع. إيقاف الخيار لا يفصل الواجهة \u2014 تبقى الإدارة وSSH تعملان.",
 			staticIp: "عنوان IP ثابت",
 			ipPlaceholder: "192.168.1.50",
 			dhcpHint: "اتركه فارغاً لاستخدام DHCP (العنونة التلقائية).",
@@ -622,14 +623,14 @@ const ar = {
 			comingSoon: "{feature} قادمة في تحديث مستقبلي",
 			speed: "Speed",
 			totalBandwidth: "Total Bandwidth",
-			inBond: "In Bond",
-			excluded: "Excluded",
-			enableBond: "Enable Bond",
-			disableBond: "Disable Bond",
-			lastActiveError: "Cannot disable the only active connection",
-			wiredDisableTitle: "Disable Ethernet?",
+			inBond: "ضمن التجميع",
+			excluded: "مستبعدة",
+			enableBond: "إضافة إلى التجميع",
+			disableBond: "إزالة من التجميع",
+			lastActiveError: "لا يمكن تعطيل الاتصال النشط الوحيد",
+			wiredDisableTitle: "استبعاد إيثرنت من التجميع؟",
 			wiredDisableBody:
-				"Disabling Ethernet may interrupt device management and SSH access.",
+				"هذا يزيل الوصلة من مجموعة التجميع فقط. تبقى الواجهة متصلة \u2014 وتستمر إدارة الجهاز وSSH والوصول إلى الشبكة المحلية في العمل. وإذا كان هناك بث جارٍ، فسينخفض عرض النطاق المتاح له.",
 			modemModel: "Model",
 			modemManufacturer: "Manufacturer",
 			switchToHotspot: "Switch to Hotspot",

--- a/packages/i18n/src/de/index.ts
+++ b/packages/i18n/src/de/index.ts
@@ -1178,9 +1178,9 @@ const de = {
 		},
 
 		dialogs: {
-			enableInterface: "Schnittstelle aktivieren",
+			enableInterface: "Für Bonding verwenden",
 			enableInterfaceDesc:
-				"Diese Schnittstelle für gebündeltes Streaming verwenden.",
+				"Bindet diese Schnittstelle in den gebündelten Stream ein. Das Ausschalten trennt sie nicht \u2013 Verwaltung und SSH funktionieren weiterhin.",
 			staticIp: "Statische IP-Adresse",
 			ipPlaceholder: "192.168.1.50",
 			dhcpHint:
@@ -1410,14 +1410,15 @@ const de = {
 			comingSoon: "{feature} kommt in einem zukünftigen Update",
 			speed: "Speed",
 			totalBandwidth: "Total Bandwidth",
-			inBond: "In Bond",
-			excluded: "Excluded",
-			enableBond: "Enable Bond",
-			disableBond: "Disable Bond",
-			lastActiveError: "Cannot disable the only active connection",
-			wiredDisableTitle: "Disable Ethernet?",
+			inBond: "Im Bond",
+			excluded: "Ausgeschlossen",
+			enableBond: "Zum Bond hinzufügen",
+			disableBond: "Aus Bond entfernen",
+			lastActiveError:
+				"Die einzige aktive Verbindung kann nicht deaktiviert werden",
+			wiredDisableTitle: "Ethernet aus dem Bonding ausschließen?",
 			wiredDisableBody:
-				"Disabling Ethernet may interrupt device management and SSH access.",
+				"Damit wird die Verbindung nur aus dem Bonding-Pool entfernt. Die Schnittstelle bleibt verbunden \u2013 Geräteverwaltung, SSH und LAN-Zugriff funktionieren weiterhin. Läuft gerade ein Stream, sinkt dessen verfügbare Bandbreite.",
 			modemModel: "Model",
 			modemManufacturer: "Manufacturer",
 			switchToHotspot: "Switch to Hotspot",

--- a/packages/i18n/src/en/index.ts
+++ b/packages/i18n/src/en/index.ts
@@ -1163,8 +1163,9 @@ const en = {
 			unavailable: "Kiosk mode is only available on a physical device.",
 		},
 		dialogs: {
-			enableInterface: "Enable interface",
-			enableInterfaceDesc: "Use this interface for bonded streaming.",
+			enableInterface: "Use for bonding",
+			enableInterfaceDesc:
+				"Include this interface in the bonded stream. Turning it off doesn't disconnect it \u2014 management and SSH keep working.",
 			staticIp: "Static IP address",
 			ipPlaceholder: "192.168.1.50",
 			dhcpHint: "Leave blank to use DHCP (automatic addressing).",
@@ -1398,9 +1399,9 @@ const en = {
 			enableBond: "Enable Bond",
 			disableBond: "Disable Bond",
 			lastActiveError: "Cannot disable the only active connection",
-			wiredDisableTitle: "Disable Ethernet?",
+			wiredDisableTitle: "Exclude Ethernet from bonding?",
 			wiredDisableBody:
-				"Disabling Ethernet may interrupt device management and SSH access.",
+				"This only removes the link from the bonding pool. The interface stays connected \u2014 device management, SSH and LAN access keep working. If a stream is running, its available bandwidth drops.",
 			modemModel: "Model",
 			modemManufacturer: "Manufacturer",
 			switchToHotspot: "Switch to Hotspot",

--- a/packages/i18n/src/es/index.ts
+++ b/packages/i18n/src/es/index.ts
@@ -1191,8 +1191,9 @@ const es = {
 		},
 
 		dialogs: {
-			enableInterface: "Habilitar interfaz",
-			enableInterfaceDesc: "Usa esta interfaz para transmisión combinada.",
+			enableInterface: "Usar para agregación",
+			enableInterfaceDesc:
+				"Incluye esta interfaz en la transmisión agregada. Desactivarla no la desconecta: la administración y SSH siguen funcionando.",
 			staticIp: "Dirección IP estática",
 			ipPlaceholder: "192.168.1.50",
 			dhcpHint:
@@ -1426,14 +1427,14 @@ const es = {
 			comingSoon: "{feature} llegará en una actualización futura",
 			speed: "Speed",
 			totalBandwidth: "Total Bandwidth",
-			inBond: "In Bond",
-			excluded: "Excluded",
-			enableBond: "Enable Bond",
-			disableBond: "Disable Bond",
-			lastActiveError: "Cannot disable the only active connection",
-			wiredDisableTitle: "Disable Ethernet?",
+			inBond: "En agregación",
+			excluded: "Excluida",
+			enableBond: "Incluir en agregación",
+			disableBond: "Excluir de agregación",
+			lastActiveError: "No se puede desactivar la única conexión activa",
+			wiredDisableTitle: "¿Excluir Ethernet de la agregación?",
 			wiredDisableBody:
-				"Disabling Ethernet may interrupt device management and SSH access.",
+				"Esto solo quita el enlace del grupo de agregación. La interfaz sigue conectada: la administración del dispositivo, SSH y el acceso a la LAN siguen funcionando. Si hay una transmisión en curso, se reduce su ancho de banda disponible.",
 			modemModel: "Model",
 			modemManufacturer: "Manufacturer",
 			switchToHotspot: "Switch to Hotspot",

--- a/packages/i18n/src/fr/index.ts
+++ b/packages/i18n/src/fr/index.ts
@@ -432,9 +432,9 @@ const fr = {
 		},
 
 		dialogs: {
-			enableInterface: "Activer l'interface",
+			enableInterface: "Utiliser pour l'agrégation",
 			enableInterfaceDesc:
-				"Utiliser cette interface pour la diffusion agrégée.",
+				"Inclut cette interface dans le flux agrégé. La désactiver ne la déconnecte pas : la gestion et SSH continuent de fonctionner.",
 			staticIp: "Adresse IP statique",
 			ipPlaceholder: "192.168.1.50",
 			dhcpHint: "Laissez vide pour utiliser DHCP (adressage automatique).",
@@ -662,14 +662,14 @@ const fr = {
 			comingSoon: "{feature} arrive dans une future mise à jour",
 			speed: "Speed",
 			totalBandwidth: "Total Bandwidth",
-			inBond: "In Bond",
-			excluded: "Excluded",
-			enableBond: "Enable Bond",
-			disableBond: "Disable Bond",
-			lastActiveError: "Cannot disable the only active connection",
-			wiredDisableTitle: "Disable Ethernet?",
+			inBond: "Dans l'agrégation",
+			excluded: "Exclue",
+			enableBond: "Ajouter à l'agrégation",
+			disableBond: "Retirer de l'agrégation",
+			lastActiveError: "Impossible de désactiver la seule connexion active",
+			wiredDisableTitle: "Exclure Ethernet de l'agrégation ?",
 			wiredDisableBody:
-				"Disabling Ethernet may interrupt device management and SSH access.",
+				"Cela retire uniquement le lien du pool d'agrégation. L'interface reste connectée : la gestion de l'appareil, SSH et l'accès au réseau local continuent de fonctionner. Si un flux est en cours, sa bande passante disponible diminue.",
 			modemModel: "Model",
 			modemManufacturer: "Manufacturer",
 			switchToHotspot: "Switch to Hotspot",

--- a/packages/i18n/src/hi/index.ts
+++ b/packages/i18n/src/hi/index.ts
@@ -263,8 +263,9 @@ const hi = {
 		},
 
 		dialogs: {
-			enableInterface: "इंटरफेस सक्षम करें",
-			enableInterfaceDesc: "बॉन्डेड स्ट्रीमिंग के लिए इस इंटरफेस का उपयोग करें।",
+			enableInterface: "बॉन्डिंग के लिए उपयोग करें",
+			enableInterfaceDesc:
+				"इस इंटरफ़ेस को बॉन्डेड स्ट्रीम में शामिल करें। इसे बंद करने से यह डिस्कनेक्ट नहीं होता \u2014 प्रबंधन और SSH काम करते रहते हैं।",
 			staticIp: "स्टैटिक IP पता",
 			ipPlaceholder: "192.168.1.50",
 			dhcpHint: "DHCP (स्वचालित एड्रेसिंग) का उपयोग करने के लिए खाली छोड़ें।",
@@ -484,14 +485,14 @@ const hi = {
 			comingSoon: "{feature} भविष्य के अपडेट में आ रहा है",
 			speed: "Speed",
 			totalBandwidth: "Total Bandwidth",
-			inBond: "In Bond",
-			excluded: "Excluded",
-			enableBond: "Enable Bond",
-			disableBond: "Disable Bond",
-			lastActiveError: "Cannot disable the only active connection",
-			wiredDisableTitle: "Disable Ethernet?",
+			inBond: "बॉन्ड में",
+			excluded: "बाहर",
+			enableBond: "बॉन्ड में जोड़ें",
+			disableBond: "बॉन्ड से हटाएँ",
+			lastActiveError: "एकमात्र सक्रिय कनेक्शन को अक्षम नहीं किया जा सकता",
+			wiredDisableTitle: "ईथरनेट को बॉन्डिंग से हटाएँ?",
 			wiredDisableBody:
-				"Disabling Ethernet may interrupt device management and SSH access.",
+				"इससे लिंक केवल बॉन्डिंग पूल से हटता है। इंटरफ़ेस जुड़ा रहता है \u2014 डिवाइस प्रबंधन, SSH और LAN एक्सेस काम करते रहते हैं। यदि कोई स्ट्रीम चल रही है, तो उसकी उपलब्ध बैंडविड्थ घट जाएगी।",
 			modemModel: "Model",
 			modemManufacturer: "Manufacturer",
 			switchToHotspot: "Switch to Hotspot",

--- a/packages/i18n/src/ja/index.ts
+++ b/packages/i18n/src/ja/index.ts
@@ -275,9 +275,9 @@ const ja = {
 		},
 
 		dialogs: {
-			enableInterface: "インターフェースを有効化",
+			enableInterface: "ボンディングに使用",
 			enableInterfaceDesc:
-				"このインターフェースをボンディングストリーミングに使用します。",
+				"このインターフェースをボンディング配信に含めます。オフにしても切断はされず、管理と SSH は引き続き利用できます。",
 			staticIp: "静的IPアドレス",
 			ipPlaceholder: "192.168.1.50",
 			dhcpHint: "DHCP（自動アドレス割り当て）を使用する場合は空欄にします。",
@@ -504,14 +504,14 @@ const ja = {
 			comingSoon: "{feature}は今後のアップデートで提供されます",
 			speed: "Speed",
 			totalBandwidth: "Total Bandwidth",
-			inBond: "In Bond",
-			excluded: "Excluded",
-			enableBond: "Enable Bond",
-			disableBond: "Disable Bond",
-			lastActiveError: "Cannot disable the only active connection",
-			wiredDisableTitle: "Disable Ethernet?",
+			inBond: "ボンディング中",
+			excluded: "除外中",
+			enableBond: "ボンディングに追加",
+			disableBond: "ボンディングから除外",
+			lastActiveError: "唯一のアクティブな接続は無効にできません",
+			wiredDisableTitle: "イーサネットをボンディングから除外しますか？",
 			wiredDisableBody:
-				"Disabling Ethernet may interrupt device management and SSH access.",
+				"リンクをボンディングの対象から外すだけです。インターフェースは接続されたままなので、デバイス管理・SSH・LAN アクセスは引き続き利用できます。配信中の場合は利用可能な帯域が減少します。",
 			modemModel: "Model",
 			modemManufacturer: "Manufacturer",
 			switchToHotspot: "Switch to Hotspot",

--- a/packages/i18n/src/ko/index.ts
+++ b/packages/i18n/src/ko/index.ts
@@ -268,8 +268,9 @@ const ko = {
 		},
 
 		dialogs: {
-			enableInterface: "인터페이스 활성화",
-			enableInterfaceDesc: "이 인터페이스를 본딩 스트리밍에 사용합니다.",
+			enableInterface: "본딩에 사용",
+			enableInterfaceDesc:
+				"이 인터페이스를 본딩 스트리밍에 포함합니다. 꺼도 연결이 끊기지 않으며 관리와 SSH는 계속 동작합니다.",
 			staticIp: "고정 IP 주소",
 			ipPlaceholder: "192.168.1.50",
 			dhcpHint: "DHCP(자동 주소 할당)를 사용하려면 비워 두세요.",
@@ -493,14 +494,14 @@ const ko = {
 			comingSoon: "{feature}은(는) 향후 업데이트에서 제공됩니다",
 			speed: "Speed",
 			totalBandwidth: "Total Bandwidth",
-			inBond: "In Bond",
-			excluded: "Excluded",
-			enableBond: "Enable Bond",
-			disableBond: "Disable Bond",
-			lastActiveError: "Cannot disable the only active connection",
-			wiredDisableTitle: "Disable Ethernet?",
+			inBond: "본딩 사용 중",
+			excluded: "제외됨",
+			enableBond: "본딩에 추가",
+			disableBond: "본딩에서 제외",
+			lastActiveError: "유일한 활성 연결은 비활성화할 수 없습니다",
+			wiredDisableTitle: "이더넷을 본딩에서 제외할까요?",
 			wiredDisableBody:
-				"Disabling Ethernet may interrupt device management and SSH access.",
+				"이 링크를 본딩 대상에서만 제외합니다. 인터페이스는 계속 연결되어 있어 기기 관리, SSH, LAN 접속은 그대로 동작합니다. 스트리밍 중이라면 사용 가능한 대역폭이 줄어듭니다.",
 			modemModel: "Model",
 			modemManufacturer: "Manufacturer",
 			switchToHotspot: "Switch to Hotspot",

--- a/packages/i18n/src/pt-BR/index.ts
+++ b/packages/i18n/src/pt-BR/index.ts
@@ -430,8 +430,9 @@ const ptBR = {
 		},
 
 		dialogs: {
-			enableInterface: "Ativar interface",
-			enableInterfaceDesc: "Use esta interface para transmissão agregada.",
+			enableInterface: "Usar na agregação",
+			enableInterfaceDesc:
+				"Inclui esta interface na transmissão agregada. Desativá-la não a desconecta \u2014 o gerenciamento e o SSH continuam funcionando.",
 			staticIp: "Endereço IP estático",
 			ipPlaceholder: "192.168.1.50",
 			dhcpHint: "Deixe em branco para usar DHCP (endereçamento automático).",
@@ -661,14 +662,14 @@ const ptBR = {
 			comingSoon: "{feature} chegará em uma atualização futura",
 			speed: "Speed",
 			totalBandwidth: "Total Bandwidth",
-			inBond: "In Bond",
-			excluded: "Excluded",
-			enableBond: "Enable Bond",
-			disableBond: "Disable Bond",
-			lastActiveError: "Cannot disable the only active connection",
-			wiredDisableTitle: "Disable Ethernet?",
+			inBond: "Na agregação",
+			excluded: "Excluída",
+			enableBond: "Incluir na agregação",
+			disableBond: "Remover da agregação",
+			lastActiveError: "Não é possível desativar a única conexão ativa",
+			wiredDisableTitle: "Remover a Ethernet da agregação?",
 			wiredDisableBody:
-				"Disabling Ethernet may interrupt device management and SSH access.",
+				"Isso apenas remove o link do grupo de agregação. A interface continua conectada \u2014 o gerenciamento do dispositivo, o SSH e o acesso à rede local continuam funcionando. Se houver uma transmissão em andamento, a largura de banda disponível diminui.",
 			modemModel: "Model",
 			modemManufacturer: "Manufacturer",
 			switchToHotspot: "Switch to Hotspot",

--- a/packages/i18n/src/zh/index.ts
+++ b/packages/i18n/src/zh/index.ts
@@ -256,8 +256,9 @@ const zh = {
 		},
 
 		dialogs: {
-			enableInterface: "启用接口",
-			enableInterfaceDesc: "将此接口用于绑定流媒体传输。",
+			enableInterface: "用于绑定",
+			enableInterfaceDesc:
+				"将此接口加入绑定推流。关闭它不会断开连接——设备管理和 SSH 仍可正常使用。",
 			staticIp: "静态 IP 地址",
 			ipPlaceholder: "192.168.1.50",
 			dhcpHint: "留空以使用 DHCP（自动分配地址）。",
@@ -470,14 +471,14 @@ const zh = {
 			comingSoon: "{feature} 将在未来更新中提供",
 			speed: "Speed",
 			totalBandwidth: "Total Bandwidth",
-			inBond: "In Bond",
-			excluded: "Excluded",
-			enableBond: "Enable Bond",
-			disableBond: "Disable Bond",
-			lastActiveError: "Cannot disable the only active connection",
-			wiredDisableTitle: "Disable Ethernet?",
+			inBond: "已绑定",
+			excluded: "已排除",
+			enableBond: "加入绑定",
+			disableBond: "移出绑定",
+			lastActiveError: "无法停用唯一的活动连接",
+			wiredDisableTitle: "将以太网移出绑定？",
 			wiredDisableBody:
-				"Disabling Ethernet may interrupt device management and SSH access.",
+				"这只会把该链路移出绑定池。接口仍保持连接——设备管理、SSH 和局域网访问不受影响。如果正在推流，可用带宽会下降。",
 			modemModel: "Model",
 			modemManufacturer: "Manufacturer",
 			switchToHotspot: "Switch to Hotspot",


### PR DESCRIPTION
## What

The Ethernet bond toggle's confirm dialog said the wrong thing. It was titled
**"Disable Ethernet?"** and warned that *"Disabling Ethernet may interrupt device
management and SSH access"* — while its own confirm button read **"Disable Bond"**.
The button was right; the prose described an action the toggle does not perform.

Corrected copy (all 10 locales):

| Key | Before | After |
|---|---|---|
| `network.view.wiredDisableTitle` | Disable Ethernet? | Exclude Ethernet from bonding? |
| `network.view.wiredDisableBody` | Disabling Ethernet may interrupt device management and SSH access. | This only removes the link from the bonding pool. The interface stays connected — device management, SSH and LAN access keep working. If a stream is running, its available bandwidth drops. |
| `settings.dialogs.enableInterface` | Enable interface | Use for bonding |
| `settings.dialogs.enableInterfaceDesc` | Use this interface for bonded streaming. | Include this interface in the bonded stream. Turning it off doesn't disconnect it — management and SSH keep working. |

## Why

Traced the toggle before rewriting anything. `BondToggle` calls
`rpc.network.configure({name, ip, enabled})`, which reaches `handleNetif`
(`modules/network/network-interfaces.ts`). For `enabled: false` it does exactly
two things: sets the in-memory `int.enabled` flag and calls
`triggerNetworkInterfacesChange()`. The only consumer of that flag on the
streaming path is `genSrtlaIpList()` (`modules/streaming/srtla.ts`), which builds
the SRTLA source-IP file; the change listener regenerates it and SIGHUPs
`srtla_send`.

Nothing in that path brings a link down, calls NetworkManager, or touches
routing. Management, SSH and LAN over the interface are unaffected, so the
warning was not merely imprecise — it was false, and it was alarming enough to
discourage a normal operation.

The real cost of pulling the wired link out of the bond is **bandwidth**, so the
new copy names that instead. (The backend separately refuses to exclude the last
active interface — `countActiveNetif() === 1` → `netif_disable_all`.)

Two follow-on points:

- `settings.dialogs.enableInterface` in `NetifDialog` mutates the **same**
  `enabled` field and carried the same misnomer, so it is fixed too. WiFi and
  Cellular `BondToggle`s pass no `onBeforeDisable`, so Ethernet is the only
  interface type with this dialog — nothing else to change.
- The entire `network.view` bond block (`inBond` / `excluded` / `enableBond` /
  `disableBond` / `lastActiveError` plus the two dialog keys) was an untranslated
  English stub in all ten locales. Translating it alongside the fix avoids a
  translated dialog sitting above an English confirm button. English
  `disableBond` deliberately stays **"Disable Bond"**: it was already accurate,
  and `tests/e2e/visual/task-1-switch.visual.spec.ts` matches the confirm action
  on `/confirm|disable|continue|yes/i`.

The two stale source comments that justified the dialog as a
"management-interruption confirm" are corrected in the same change, so the next
reader is not re-taught the thing that caused this.

## How to verify

1. Network → Ethernet → flip the "In Bond" switch off. The dialog now asks about
   bonding, promises nothing about SSH, and warns about stream bandwidth.
2. Confirm, then `ssh` to the device over that same interface — still reachable,
   which is the whole point.
3. Settings → Ethernet → Configure: the toggle reads "Use for bonding".
4. Switch locale (e.g. `es`, `ja`, `ar`) and repeat step 1 — no English strings
   left in that dialog.

Gate on this branch: `svelte-check` 0 errors; frontend vitest **2113/2113** tests
pass; backend `bun test` **2822 pass / 0 fail**; `check:tech-debt` OK; `biome check`
clean on every touched path.

## Risks

Copy only — no logic, schema or RPC change. `enabled` still means exactly what it
meant before.

The local pre-push gate reports six reds; all six reproduce on pristine `main` or
are host-specific, and none involve the touched files:

- `test-be` — pre-existing repo-wide `biome` findings (`noNonNullAssertion`,
  `noFloatingPromises`, `noConfusingVoidType`); identical count with the change
  stashed.
- `test-fe` — one suite fails to import with `database is locked`. This is the
  documented Node ≥ 25 `--localstorage-file` contention (`apps/frontend/AGENTS.md`);
  pristine `main` fails the same way on a different, randomly-scheduled file, and the
  suite passes in isolation. Every test passes in both runs.
- `test-e2e/*` — `playwright install-deps` exits 127 (`apt-get: command not found`);
  this host is not Debian/Ubuntu. CI runs them.
