### PR TITLE
fix(sources): a live capture device is never silently dropped

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -350,10 +350,19 @@ Live source list AND in the "Configured" summary line above it.
 `modules/streaming/onboard-display-names.ts` is the video counterpart of the audio
 tier-0 rule and shares its key folding: `normalizeOnboardKey` lives there and
 `audio-naming.ts` imports it, so both media types key their rules identically.
-`ONBOARD_VIDEO_DISPLAY_RULES` maps `rkhdmirx` / `rockchiphdmirx` /
-`rockchiphdmirxcontroller` → `HDMI Input` — deliberately the SAME name the audio
-ladder gives `rockchip,hdmiin`, because the two are the video and audio halves of
-ONE physical port. Like the audio rule it is code-level only: no UI, no RPC, no
+`ONBOARD_VIDEO_DISPLAY_RULES` maps `rkhdmirx` / `streamhdmirx` / `snpshdmirx` /
+`rockchiphdmirx` / `rockchiphdmirxcontroller` → `HDMI Input` — deliberately the
+SAME name the audio ladder gives `rockchip,hdmiin`, because the two are the video
+and audio halves of ONE physical port.
+
+**One node has SEVERAL spellings, and which one arrives depends on the engine
+build.** The v4l2 CARD TYPE and the v4l2 DRIVER name are different strings for the
+same block: a Rock 5B+ HDMI-RX reports card type `stream_hdmirx` but driver
+`snps_hdmirx` (Synopsys DesignWare HDMI-RX — the IP Rockchip licenses).
+Board-confirmed: after the engine moved to naming the node after its driver, the
+raw `snps_hdmirx` rendered verbatim in the operator's source picker. Keying the
+rule on the IP block rather than on a node path or board model is what makes it
+work on every board carrying the same receiver. Like the audio rule it is code-level only: no UI, no RPC, no
 config field. Adding a board is a code change.
 
 **It is applied at the device-construction seam, not at each render site.** The
@@ -1929,6 +1938,56 @@ table driven through the REAL procedure, the persistence-untouched guarantee, an
 the fail-open negatives) + `tests/capability-truth-clamp.test.ts` (the Osmo
 1080p60-on-H.264 migration, the one-time notification, and the never-clamp cases).
 
+## A LIVE CAPTURE DEVICE IS NEVER SILENTLY DROPPED [EXISTS]
+
+`buildSources` folds each device into the coarse capability entry its kind bridges
+to. That is an INTERSECTION of two INDEPENDENTLY-VERSIONED vocabularies — the
+engine's `capabilities.sources[]` ids and `DEVICE_KIND_TO_PIPELINE_ID` — and when
+they disagree the intersection is EMPTY, so EVERY camera disappears at once.
+
+Board-confirmed on a Rock 5B+ (operator-reported): the device ran the released
+cerastream `2026.7.2` (commit `5544fe3`, `SCHEMA_VERSION 0.4.0`), whose catalog
+advertises the retired `camlink` / `v4l_mjpeg` ids, against a CeraUI that bridges
+`hdmi` / `usb_mjpeg`. A connected, locked **1920x1080@59.94** HDMI-RX input and a
+connected RØDE USB camera BOTH vanished, and because `SUPPRESSED_COARSE_PIPELINE_IDS`
+drops the legacy coarse rows unconditionally, the picker collapsed to the single
+virtual test pattern — indistinguishable from "no hardware attached".
+
+Diagnostic note worth keeping: the engine's `devices` list was CORRECT throughout
+(`/dev/video1`, `kind: "hdmi"`), and `v4l2-ctl --query-dv-timings` reported the real
+signal. The loss was entirely in this projection. The USB camera disappearing
+alongside the HDMI one is what rules out any kernel/HDMI-RX explanation — a
+receiver fault cannot unlist a USB webcam.
+
+`buildUnofferedCaptureEntry` renders such a device `available: false` with
+`live.education.reason.pipelineNotOffered` instead of `continue`-ing past it. This
+is the same FAIL-CLOSED-AND-VISIBLE rule `networkAvailability` already applies to an
+inactive gateway ("still emitted, just unavailable, never dropped") and the house
+rule that an unsupported option is disabled-with-a-reason, never hidden.
+
+Three scoping rules are load-bearing:
+
+- **Only when NOTHING in the catalog speaks for the pipeline** (`basePipelineIds`).
+  A `test`-kind device bridges to `test`, which exists as the VIRTUAL row and
+  already represents it; without this check that row doubles. A regression test
+  caught exactly this.
+- **Only for kinds that DO name a video pipeline.** An unrecognised engine kind
+  collapses to `"other"` in `mapEngineDeviceKind`, which is the SAME bucket as the
+  SoC codec/scaler nodes (`rockchip-rga`, the `hantro-vpu` dec/enc/av1 nodes), so
+  CeraUI cannot tell an unknown camera from a non-camera there. Rendering them all
+  would put four codec blocks in the operator's picker. Dropping stays correct —
+  this is a KNOWN, accepted boundary, not an oversight.
+- **Appended last, never interleaved**, so it displaces and reorders nothing.
+
+It is a SAFETY NET, not a substitute for a current engine: the row is deliberately
+not selectable, because the pipeline really is not offered and a start would fail at
+`pipeline_not_in_offered_set`.
+
+Coverage: `tests/unoffered-capture-visibility.test.ts` (the real board payload, the
+`test`-only regression lock, the conservative-facet and wire-schema assertions, and
+the four negatives: codec nodes, audio class, the virtual/network double-render, and
+row-order stability).
+
 ## ONE ROW PER PHYSICAL CAMERA + PER-DEVICE MODE SELECTION [EXISTS]
 
 A capability source is a PIPELINE; an operator points at a DEVICE. Conflating the
@@ -3331,6 +3390,9 @@ config, an anchored path still held by its own device, and a live row with no
   healthy observation reset the run, and don't widen it past `physical_group_id`
   absence into re-asserting a remembered `caps`/`signal` — that is the latch
   `withKnownEngineMetadata` already refuses for good reason.
+- **Don't `continue` past a live capture device whose pipeline the engine does not offer** — that intersection couples two independently-versioned vocabularies, and when they disagree EVERY camera vanishes at once behind a picker that looks exactly like "no hardware attached" (board-confirmed: a locked 1080p59.94 HDMI input and a USB camera both gone, `test` the only row). Route it through `buildUnofferedCaptureEntry` so it renders disabled-with-a-reason. Don't drop the `basePipelineIds` guard either — a `test`-kind device is already the virtual row and would double — and don't widen the fallback to kinds that bridge to nothing: `mapEngineDeviceKind` collapses an unrecognised kind onto the same `"other"` as the SoC codec/scaler nodes, so widening puts `rockchip-rga` and three `hantro-vpu` blocks in the picker.
+- Don't assume a missing HDMI row is a kernel/HDMI-RX fault before checking whether OTHER capture devices vanished too — a receiver fault cannot unlist a USB webcam, and the engine's own `devices` list (`kind: "hdmi"`) plus `v4l2-ctl --query-dv-timings` will both still be correct while the projection is what dropped it.
+- Don't add only ONE spelling of an onboard node to `ONBOARD_VIDEO_DISPLAY_RULES` — the v4l2 card type (`stream_hdmirx`) and driver name (`snps_hdmirx`) are different strings for the same block, and which one reaches CeraUI depends on the engine build.
 - Don't re-add a coarse USB-capture placeholder row (`usb_mjpeg`, `v4l_mjpeg`, `libuvch264`, `camlink`) — a pipeline is not a device, the row is unactionable in every state, and one dual-format camera answers to two of them. And don't extend `SUPPRESSED_COARSE_PIPELINE_IDS` to `hdmi`/`rtmp`/`srt`/`test`: each names a real always-present board capability, so its coarse row is truthful with nothing plugged in.
 - Don't publish a device mode family whose pipeline the engine does not offer — the pick dies at `pipeline_not_in_offered_set` AFTER the operator committed to it. Gate `buildInputModes` on the coarse capability set, and don't union two media types' ladders (ADR-0008 §10).
 - **Don't add a field to `captureDeviceSchema` without adding it to `probeEngineDevices`'s whitelist copy too.** That copy (`sources.ts`) is the ONE seam a real `list-devices` payload crosses, and an unlisted field is DROPPED SILENTLY — no error, no warning. `modes[]` was unlisted for a whole wave, so todo 21's per-format families never reached the wire on real hardware: every dual-format camera published `selectedInputMode` with no `inputModes` beside it, the picker had nothing to offer, and the encoder ladder fell back to the device's UNIONED flat list (the exact ADR-0008 §10 defect the scoping exists to prevent). Read the field defensively (`const extra = d as {…}`), like the audio join keys beside it. And cover it with a test that drives the MOCK PROVIDER through the real boot path (`tests/mock-sources-parity.test.ts` `bootLikeMain`) — a test that hands `buildSources` a hand-built device literal bypasses this seam entirely, which is exactly why todo 21's 36-case suite stayed green while the feature was dead on the board.

--- a/apps/backend/src/modules/streaming/onboard-display-names.ts
+++ b/apps/backend/src/modules/streaming/onboard-display-names.ts
@@ -32,9 +32,21 @@
  * `normalizeOnboardKey` folds punctuation and case, so ONE entry matches every
  * spelling of the same block — `rk_hdmirx` (the engine `display_name`),
  * `stream_hdmirx` (the sysfs `Card type` the engine-down v4l2 scan reads on a
- * ROCK 5B+), `rockchip,hdmirx-controller` (the device-tree compatible), and the
+ * ROCK 5B+), `snps_hdmirx` (the v4l2 DRIVER name of the same node),
+ * `rockchip,hdmirx-controller` (the device-tree compatible), and the
  * ALSA card id `rockchiphdmiin` alike. It is shared with the audio ladder's
  * `ONBOARD_AUDIO_DISPLAY_RULES` so both media types fold keys identically.
+ *
+ * WHY a node needs several spellings: the CARD TYPE and the DRIVER name are two
+ * different v4l2 strings for one block, and which of them reaches CeraUI depends
+ * on the engine build. A Rock 5B+ HDMI-RX reports card type `stream_hdmirx` but
+ * driver `snps_hdmirx` (Synopsys DesignWare HDMI-RX — the IP block Rockchip
+ * licenses), so an engine that names the node after its driver publishes a raw
+ * `snps_hdmirx` the operator then reads in the source picker. Board-confirmed on
+ * a Rock 5B+ after the engine moved to the driver name. Both keys map to the one
+ * name because they are the one port; keying on the IP block rather than on a
+ * node path or board model is what makes this rule work on every board carrying
+ * the same receiver.
  */
 
 /** Fold a raw hardware string to its rule key: letters + digits, lowercased. */
@@ -54,6 +66,7 @@ export function normalizeOnboardKey(value: string): string {
 const ONBOARD_VIDEO_DISPLAY_RULES: ReadonlyMap<string, string> = new Map([
 	["rkhdmirx", "HDMI Input"],
 	["streamhdmirx", "HDMI Input"],
+	["snpshdmirx", "HDMI Input"],
 	["rockchiphdmirx", "HDMI Input"],
 	["rockchiphdmirxcontroller", "HDMI Input"],
 ]);

--- a/apps/backend/src/modules/streaming/sources.ts
+++ b/apps/backend/src/modules/streaming/sources.ts
@@ -162,6 +162,9 @@ const GATEWAY_INACTIVE_REASON = "live.education.reason.gatewayInactive";
 /** The i18n reason surfaced when the operator disabled the protocol in Settings. */
 const DISABLED_IN_SETTINGS_REASON = "live.education.reason.disabledInSettings";
 
+/** The i18n reason surfaced when the engine does not offer a device's pipeline. */
+const PIPELINE_NOT_OFFERED_REASON = "live.education.reason.pipelineNotOffered";
+
 /** The `settings.sources.<id>` i18n key family PipelineHelper already resolves. */
 function sourceLabelKey(id: string): string {
 	return `settings.sources.${id}`;
@@ -429,6 +432,56 @@ function buildCaptureEntry(
  * unplugged grace state (`live.source.lostBody`) and a start/setConfig is refused
  * by the todo-12 gate.
  */
+/**
+ * A capture row for a live device whose pipeline this engine does not offer.
+ *
+ * The device→coarse fold intersects two INDEPENDENTLY-VERSIONED vocabularies —
+ * the engine's `capabilities.sources[]` ids and CeraUI's
+ * `DEVICE_KIND_TO_PIPELINE_ID` bridge — so when they disagree EVERY camera
+ * disappears at once. Board-confirmed on a Rock 5B+: an engine advertising the
+ * retired `camlink`/`v4l_mjpeg` ids produced an empty intersection, and a
+ * connected 1080p59.94 HDMI-RX input and a connected USB camera both vanished
+ * with nothing to distinguish it from "no hardware attached".
+ *
+ * Rendering it `available: false` with a reason is the same FAIL-CLOSED-AND-VISIBLE
+ * rule `networkAvailability` applies to an inactive gateway. It stays
+ * non-selectable because the pipeline really is not offered — a start would fail
+ * at `pipeline_not_in_offered_set`.
+ *
+ * Scoped to kinds that DO name a video pipeline: `audio`/`network` and the SoC
+ * codec/scaler nodes still drop, as they are not capture inputs. Facets are
+ * conservative because the capability entry that would supply them is precisely
+ * what is missing.
+ */
+function buildUnofferedCaptureEntry(
+	device: CaptureDevice,
+	pipelineId: string,
+): StreamSource {
+	return {
+		id: device.input_id,
+		pipelineId,
+		modes: [],
+		supportsAudio: false,
+		supportsResolutionOverride: false,
+		supportsFramerateOverride: false,
+		audioKind: "none",
+		available: false,
+		unavailableReason: PIPELINE_NOT_OFFERED_REASON,
+		signal: device.signal ?? "unknown",
+		origin: "capture",
+		kind: device.kind,
+		displayName: device.display_name,
+		devicePath: device.device_path,
+		...(device.stable_id !== undefined && device.stable_id !== ""
+			? { stableId: device.stable_id }
+			: {}),
+		...(device.physical_group_id !== undefined &&
+		device.physical_group_id !== ""
+			? { physicalGroupId: device.physical_group_id }
+			: {}),
+	};
+}
+
 function buildLostEntry(
 	snapshot: LastSeenDevice,
 	coarse: StreamSource,
@@ -650,6 +703,8 @@ export function buildSources(input: BuildSourcesInput): StreamSource[] {
 	};
 
 	const capturesByPipeline = new Map<string, StreamSource[]>();
+	const basePipelineIds = new Set(base.map((entry) => entry.pipelineId));
+	const unofferedCaptures: StreamSource[] = [];
 	// Live capture rows indexed by stable identity, so a remembered id the loop
 	// below decides has MIGRATED can be published as an alias on its successor.
 	const capturesByStableId = new Map<string, StreamSource[]>();
@@ -674,7 +729,16 @@ export function buildSources(input: BuildSourcesInput): StreamSource[] {
 		const bridged = deviceKindToPipelineId(device.kind);
 		if (bridged === undefined) continue;
 		const coarse = coarseByPipeline.get(bridged);
-		if (coarse === undefined) continue;
+		if (coarse === undefined) {
+			// Dropping an engine-classified capture device here is what made a real,
+			// connected camera vanish with no operator-visible reason — but only when
+			// NOTHING in the catalog speaks for its pipeline. A `test`-kind device
+			// bridges to the VIRTUAL test-pattern row, which already represents it.
+			if (!basePipelineIds.has(bridged)) {
+				unofferedCaptures.push(buildUnofferedCaptureEntry(device, bridged));
+			}
+			continue;
+		}
 		const entry = buildCaptureEntry(device, bridged, coarse, captureContext);
 		if (device.stable_id !== undefined && device.stable_id !== "") {
 			liveStableIds.add(device.stable_id);
@@ -740,6 +804,9 @@ export function buildSources(input: BuildSourcesInput): StreamSource[] {
 		}
 		out.push(entry);
 	}
+	// Appended last, and only ever ADDITIVE: these devices bridged to no offered
+	// coarse slot, so they displaced nothing above and cannot reorder it.
+	out.push(...unofferedCaptures);
 	return out;
 }
 

--- a/apps/backend/src/tests/unoffered-capture-visibility.test.ts
+++ b/apps/backend/src/tests/unoffered-capture-visibility.test.ts
@@ -1,0 +1,278 @@
+/*
+    CeraUI - web UI for the CeraLive project
+    Copyright (C) 2024-2025 CeraLive project
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { describe, expect, it } from "bun:test";
+import type { GetCapabilitiesResult } from "@ceralive/cerastream";
+import type {
+	CaptureDevice,
+	DeviceKind,
+	NetworkIngest,
+} from "@ceraui/rpc/schemas";
+import { streamSourceSchema } from "@ceraui/rpc/schemas";
+import { applyOnboardVideoDisplayRule } from "../modules/streaming/onboard-display-names.ts";
+import { buildSources } from "../modules/streaming/sources.ts";
+
+type CapabilitySource = GetCapabilitiesResult["sources"][number];
+
+const PIPELINE_NOT_OFFERED_REASON = "live.education.reason.pipelineNotOffered";
+
+const NO_INGEST: NetworkIngest = { rtmp: null, srt: null };
+
+function capSource(id: string): CapabilitySource {
+	return {
+		id,
+		supports_audio: false,
+		supports_resolution_override: true,
+		supports_framerate_override: true,
+		default_resolution: "1080p",
+		default_framerate: 30,
+	};
+}
+
+function captureDevice(
+	input_id: string,
+	kind: DeviceKind,
+	overrides: Partial<CaptureDevice> = {},
+): CaptureDevice {
+	return {
+		input_id,
+		device_path: overrides.device_path ?? input_id,
+		display_name: overrides.display_name ?? input_id,
+		media_class: overrides.media_class ?? "video",
+		kind,
+		...(overrides.stable_id !== undefined
+			? { stable_id: overrides.stable_id }
+			: {}),
+		...(overrides.signal !== undefined ? { signal: overrides.signal } : {}),
+	};
+}
+
+/**
+ * The EXACT payload a Rock 5B+ published while running the released cerastream
+ * 2026.7.2 (schema 0.4.0): a capability catalog naming the retired `camlink` /
+ * `v4l_mjpeg` pipeline ids, and two genuinely-connected cameras whose kinds
+ * bridge to `hdmi` / `usb_mjpeg`. The intersection is EMPTY.
+ */
+const LEGACY_ENGINE_CAP_SOURCES: CapabilitySource[] = [
+	capSource("camlink"),
+	capSource("v4l_mjpeg"),
+	capSource("test"),
+];
+
+function boardDevices(): CaptureDevice[] {
+	return [
+		captureDevice("/dev/video1", "hdmi", {
+			display_name: "snps_hdmirx",
+			signal: "present",
+			stable_id: "port:platform:fdee0000.hdmi_receiver",
+		}),
+		captureDevice("/dev/video5", "mjpeg", {
+			display_name: "RØDE HDMI to USB-C: RØDE HDMI",
+			signal: "present",
+			stable_id: "usb:19f7:0080:OC0001967",
+		}),
+	];
+}
+
+describe("a live capture device is never silently dropped (board regression)", () => {
+	it("renders BOTH cameras when the engine offers neither of their pipelines", () => {
+		const sources = buildSources({
+			sources: LEGACY_ENGINE_CAP_SOURCES,
+			devices: boardDevices(),
+			networkIngest: NO_INGEST,
+		});
+
+		const ids = sources.map((s) => s.id);
+		expect(ids).toContain("/dev/video1");
+		expect(ids).toContain("/dev/video5");
+	});
+
+	it("was the ONLY row before the fix — the picker collapsed to the test pattern", () => {
+		const sources = buildSources({
+			sources: LEGACY_ENGINE_CAP_SOURCES,
+			devices: boardDevices(),
+			networkIngest: NO_INGEST,
+		});
+
+		// The regression this locks: `test` alone is what the board actually served.
+		expect(sources.map((s) => s.id)).not.toEqual(["test"]);
+	});
+
+	it("marks them unavailable with the engine-support reason, never selectable", () => {
+		const sources = buildSources({
+			sources: LEGACY_ENGINE_CAP_SOURCES,
+			devices: boardDevices(),
+			networkIngest: NO_INGEST,
+		});
+
+		for (const id of ["/dev/video1", "/dev/video5"]) {
+			const row = sources.find((s) => s.id === id);
+			expect(row?.available).toBe(false);
+			expect(row?.unavailableReason).toBe(PIPELINE_NOT_OFFERED_REASON);
+			expect(row?.origin).toBe("capture");
+		}
+	});
+
+	it("claims no capability it cannot back — no audio, no overrides, no ladder", () => {
+		const row = buildSources({
+			sources: LEGACY_ENGINE_CAP_SOURCES,
+			devices: boardDevices(),
+			networkIngest: NO_INGEST,
+		}).find((s) => s.id === "/dev/video1");
+
+		expect(row?.supportsAudio).toBe(false);
+		expect(row?.audioKind).toBe("none");
+		expect(row?.supportsResolutionOverride).toBe(false);
+		expect(row?.supportsFramerateOverride).toBe(false);
+		expect(row?.modes).toEqual([]);
+	});
+
+	it("keeps the engine-authored identity + signal so the operator can tell WHICH device", () => {
+		const row = buildSources({
+			sources: LEGACY_ENGINE_CAP_SOURCES,
+			devices: boardDevices(),
+			networkIngest: NO_INGEST,
+		}).find((s) => s.id === "/dev/video1");
+
+		expect(row?.origin).toBe("capture");
+		if (row?.origin !== "capture") throw new Error("expected a capture row");
+		expect(row.kind).toBe("hdmi");
+		expect(row.signal).toBe("present");
+		expect(row.devicePath).toBe("/dev/video1");
+		expect(row.stableId).toBe("port:platform:fdee0000.hdmi_receiver");
+	});
+
+	it("emits rows that satisfy the published wire schema", () => {
+		const sources = buildSources({
+			sources: LEGACY_ENGINE_CAP_SOURCES,
+			devices: boardDevices(),
+			networkIngest: NO_INGEST,
+		});
+
+		for (const row of sources) {
+			expect(() => streamSourceSchema.parse(row)).not.toThrow();
+		}
+	});
+});
+
+describe("the fallback is scoped — it never invents a row", () => {
+	it("still drops SoC codec/scaler nodes that bridge to no video pipeline", () => {
+		const sources = buildSources({
+			sources: LEGACY_ENGINE_CAP_SOURCES,
+			devices: [
+				captureDevice("/dev/video0", "other", { display_name: "rockchip-rga" }),
+				captureDevice("/dev/video2", "other", {
+					display_name: "rockchip,rk3568-vpu-dec",
+				}),
+			],
+			networkIngest: NO_INGEST,
+		});
+
+		expect(sources.some((s) => s.id === "/dev/video0")).toBe(false);
+		expect(sources.some((s) => s.id === "/dev/video2")).toBe(false);
+	});
+
+	it("still ignores audio-class devices", () => {
+		const sources = buildSources({
+			sources: LEGACY_ENGINE_CAP_SOURCES,
+			devices: [captureDevice("audio:card0", "hdmi", { media_class: "audio" })],
+			networkIngest: NO_INGEST,
+		});
+
+		expect(sources.some((s) => s.id === "audio:card0")).toBe(false);
+	});
+
+	it("a test-kind device stays the ONE virtual row — it is already represented", () => {
+		const sources = buildSources({
+			sources: LEGACY_ENGINE_CAP_SOURCES,
+			devices: [captureDevice("videotest", "test")],
+			networkIngest: NO_INGEST,
+		});
+
+		expect(sources.filter((s) => s.origin === "virtual")).toHaveLength(1);
+		expect(sources.some((s) => s.origin === "capture")).toBe(false);
+	});
+
+	it("a network-backed row is likewise never duplicated as a capture row", () => {
+		const sources = buildSources({
+			sources: [capSource("rtmp"), capSource("test")],
+			devices: [captureDevice("/dev/video9", "network")],
+			networkIngest: NO_INGEST,
+		});
+
+		expect(sources.some((s) => s.origin === "capture")).toBe(false);
+	});
+
+	it("a device whose pipeline IS offered keeps the normal available row", () => {
+		const sources = buildSources({
+			sources: [capSource("hdmi"), capSource("test")],
+			devices: [captureDevice("/dev/video1", "hdmi")],
+			networkIngest: NO_INGEST,
+		});
+
+		const row = sources.find((s) => s.id === "/dev/video1");
+		expect(row?.available).toBe(true);
+		expect(row?.unavailableReason).toBeUndefined();
+	});
+
+	it("does not reorder or displace the rows an offered engine already produced", () => {
+		const offered = [capSource("hdmi"), capSource("test")];
+		const withoutUnoffered = buildSources({
+			sources: offered,
+			devices: [captureDevice("/dev/video1", "hdmi")],
+			networkIngest: NO_INGEST,
+		}).map((s) => s.id);
+
+		const withUnoffered = buildSources({
+			sources: offered,
+			devices: [
+				captureDevice("/dev/video1", "hdmi"),
+				captureDevice("/dev/video5", "mjpeg"),
+			],
+			networkIngest: NO_INGEST,
+		}).map((s) => s.id);
+
+		expect(withUnoffered.slice(0, withoutUnoffered.length)).toEqual(
+			withoutUnoffered,
+		);
+		expect(withUnoffered.at(-1)).toBe("/dev/video5");
+	});
+});
+
+describe("the HDMI-RX node is named for the operator, not for the driver", () => {
+	it("resolves the v4l2 DRIVER name the current engine reports", () => {
+		expect(applyOnboardVideoDisplayRule("snps_hdmirx")).toBe("HDMI Input");
+	});
+
+	it("still resolves the card-type and legacy engine spellings", () => {
+		expect(applyOnboardVideoDisplayRule("stream_hdmirx")).toBe("HDMI Input");
+		expect(applyOnboardVideoDisplayRule("rk_hdmirx")).toBe("HDMI Input");
+		expect(applyOnboardVideoDisplayRule("rockchip,hdmirx-controller")).toBe(
+			"HDMI Input",
+		);
+	});
+
+	it("leaves a real product name untouched", () => {
+		expect(applyOnboardVideoDisplayRule("RØDE HDMI to USB-C: RØDE HDMI")).toBe(
+			"RØDE HDMI to USB-C: RØDE HDMI",
+		);
+	});
+
+	it("is idempotent", () => {
+		expect(applyOnboardVideoDisplayRule("HDMI Input")).toBe("HDMI Input");
+	});
+});

--- a/packages/i18n/src/ar/index.ts
+++ b/packages/i18n/src/ar/index.ts
@@ -1489,6 +1489,7 @@ const ar = {
 				fixedBySource: "محدد بواسطة المصدر المختار",
 				unsupportedAtResolution: "غير متاح بهذه الدقة",
 				gatewayInactive: "بوابة استقبال الشبكة غير قيد التشغيل",
+				pipelineNotOffered: "غير مدعوم من محرك البث الحالي",
 				disabledInSettings: "معطّل في الإعدادات",
 				gatewayNoAddress:
 					"لا يوجد عنوان شبكة محلية أو نقطة اتصال يمكن الوصول إليه",

--- a/packages/i18n/src/de/index.ts
+++ b/packages/i18n/src/de/index.ts
@@ -770,6 +770,8 @@ const de = {
 				fixedBySource: "Durch die gewählte Quelle festgelegt",
 				unsupportedAtResolution: "Bei dieser Auflösung nicht verfügbar",
 				gatewayInactive: "Netzwerk-Ingest-Gateway läuft nicht",
+				pipelineNotOffered:
+					"Von der aktuellen Streaming-Engine nicht unterstützt",
 				disabledInSettings: "In den Einstellungen deaktiviert",
 				gatewayNoAddress: "Keine erreichbare LAN- oder Hotspot-Adresse",
 			},

--- a/packages/i18n/src/en/index.ts
+++ b/packages/i18n/src/en/index.ts
@@ -750,6 +750,7 @@ const en = {
 				fixedBySource: "Fixed by the selected source",
 				unsupportedAtResolution: "Not available at this resolution",
 				gatewayInactive: "Network ingest gateway is not running",
+				pipelineNotOffered: "Not supported by the current streaming engine",
 				disabledInSettings: "Disabled in Settings",
 				gatewayNoAddress: "No reachable LAN or hotspot address",
 			},

--- a/packages/i18n/src/es/index.ts
+++ b/packages/i18n/src/es/index.ts
@@ -774,6 +774,7 @@ const es = {
 				unsupportedAtResolution: "No disponible en esta resolución",
 				gatewayInactive:
 					"La puerta de enlace de ingesta de red no está en ejecución",
+				pipelineNotOffered: "No compatible con el motor de streaming actual",
 				disabledInSettings: "Desactivado en Ajustes",
 				gatewayNoAddress: "Sin dirección de LAN o punto de acceso accesible",
 			},

--- a/packages/i18n/src/fr/index.ts
+++ b/packages/i18n/src/fr/index.ts
@@ -1557,6 +1557,8 @@ const fr = {
 				fixedBySource: "Fixé par la source sélectionnée",
 				unsupportedAtResolution: "Indisponible à cette résolution",
 				gatewayInactive: "La passerelle d'ingestion réseau n'est pas active",
+				pipelineNotOffered:
+					"Non pris en charge par le moteur de streaming actuel",
 				disabledInSettings: "Désactivé dans les paramètres",
 				gatewayNoAddress: "Aucune adresse LAN ou point d'accès joignable",
 			},

--- a/packages/i18n/src/hi/index.ts
+++ b/packages/i18n/src/hi/index.ts
@@ -1353,6 +1353,7 @@ const hi = {
 				fixedBySource: "चयनित स्रोत द्वारा निर्धारित",
 				unsupportedAtResolution: "इस रिज़ॉल्यूशन पर उपलब्ध नहीं",
 				gatewayInactive: "नेटवर्क इंजेस्ट गेटवे नहीं चल रहा है",
+				pipelineNotOffered: "वर्तमान स्ट्रीमिंग इंजन द्वारा समर्थित नहीं",
 				disabledInSettings: "सेटिंग्स में अक्षम",
 				gatewayNoAddress: "कोई पहुँच योग्य LAN या हॉटस्पॉट पता नहीं",
 			},

--- a/packages/i18n/src/ja/index.ts
+++ b/packages/i18n/src/ja/index.ts
@@ -1392,6 +1392,8 @@ const ja = {
 				fixedBySource: "選択したソースによって固定されています",
 				unsupportedAtResolution: "この解像度では利用できません",
 				gatewayInactive: "ネットワーク受信ゲートウェイが実行されていません",
+				pipelineNotOffered:
+					"現在のストリーミングエンジンではサポートされていません",
 				disabledInSettings: "設定で無効化されています",
 				gatewayNoAddress:
 					"到達可能な LAN またはホットスポットのアドレスがありません",

--- a/packages/i18n/src/ko/index.ts
+++ b/packages/i18n/src/ko/index.ts
@@ -1369,6 +1369,7 @@ const ko = {
 				fixedBySource: "선택한 소스에 의해 고정됨",
 				unsupportedAtResolution: "이 해상도에서는 사용할 수 없음",
 				gatewayInactive: "네트워크 인제스트 게이트웨이가 실행 중이 아닙니다",
+				pipelineNotOffered: "현재 스트리밍 엔진에서 지원되지 않습니다",
 				disabledInSettings: "설정에서 비활성화됨",
 				gatewayNoAddress: "연결 가능한 LAN 또는 핫스팟 주소 없음",
 			},

--- a/packages/i18n/src/pt-BR/index.ts
+++ b/packages/i18n/src/pt-BR/index.ts
@@ -1534,6 +1534,7 @@ const ptBR = {
 				fixedBySource: "Fixado pela fonte selecionada",
 				unsupportedAtResolution: "Indisponível nesta resolução",
 				gatewayInactive: "O gateway de ingestão de rede não está em execução",
+				pipelineNotOffered: "Sem suporte no motor de streaming atual",
 				disabledInSettings: "Desativado nas Configurações",
 				gatewayNoAddress: "Nenhum endereço de LAN ou ponto de acesso acessível",
 			},

--- a/packages/i18n/src/zh/index.ts
+++ b/packages/i18n/src/zh/index.ts
@@ -1299,6 +1299,7 @@ const zh = {
 				fixedBySource: "由所选来源固定",
 				unsupportedAtResolution: "此分辨率下不可用",
 				gatewayInactive: "网络接入网关未运行",
+				pipelineNotOffered: "当前流媒体引擎不支持",
 				disabledInSettings: "已在设置中禁用",
 				gatewayNoAddress: "无可达的局域网或热点地址",
 			},


### PR DESCRIPTION
## What

A connected capture device whose pipeline the streaming engine does not advertise is no longer dropped from the source list. It now renders **unavailable with a reason** instead of disappearing.

Also maps the `snps_hdmirx` v4l2 driver name to `HDMI Input`, so the raw driver id stops leaking into the operator's source picker.

## Why

`buildSources` folds each device into the coarse capability entry its kind bridges to. That is an intersection of two **independently-versioned vocabularies** — the engine's `capabilities.sources[]` ids and CeraUI's `DEVICE_KIND_TO_PIPELINE_ID` — so when they disagree the intersection is empty and *every* camera disappears at once.

Reported by an operator and reproduced on a Rock 5B+ running the released cerastream `2026.7.2` (`SCHEMA_VERSION 0.4.0`), whose catalog advertises the retired `camlink` / `v4l_mjpeg` ids. A connected, locked **1920x1080@59.94** HDMI-RX input and a connected RØDE USB camera both vanished, and because the legacy coarse rows are suppressed unconditionally the picker collapsed to the single virtual test pattern — indistinguishable from "no hardware attached".

The engine's own `devices` list was correct throughout (`/dev/video1`, `kind: "hdmi"`), and `v4l2-ctl --query-dv-timings` reported the real signal. The loss was entirely in this projection. The USB camera disappearing alongside the HDMI one is what rules out any kernel / HDMI-RX explanation — a receiver fault cannot unlist a USB webcam.

The display-name half is a second, independent regression: the v4l2 **card type** (`stream_hdmirx`) and **driver name** (`snps_hdmirx`, Synopsys DesignWare HDMI-RX) are different strings for the same block, and only the former was mapped.

## How

`buildUnofferedCaptureEntry` renders the device `available: false` with `live.education.reason.pipelineNotOffered` — the same fail-closed-and-visible rule `networkAvailability` already applies to an inactive gateway. It stays non-selectable, because the pipeline really is not offered and a start would fail at `pipeline_not_in_offered_set`.

Scoped three ways, each load-bearing:

- **Only when nothing in the catalog speaks for the pipeline** (`basePipelineIds`) — a `test`-kind device is already the virtual row, and without this it double-renders. A regression test caught exactly that.
- **Only for kinds that name a video pipeline.** An unrecognised engine kind collapses to `"other"` in `mapEngineDeviceKind`, the same bucket as the SoC codec/scaler nodes (`rockchip-rga`, the `hantro-vpu` nodes), so widening would put four codec blocks in the picker. This is a known, documented boundary.
- **Appended last**, so no existing row is displaced or reordered.

No board-, device- or path-specific special-casing: the fallback keys on the engine-reported kind, and the display-name rule keys on the IP block, so it works on any board carrying the same receiver.

## How to verify

Board-proven on a Rock 5B+ (`192.168.78.131`), all three states measured live over the device's own WebSocket:

| Engine | CeraUI | `sources` result |
|---|---|---|
| `2026.7.2` (schema 0.4.0) | before | `[test]` — the reported bug |
| `2026.7.2` (schema 0.4.0) | this PR | `test` + `/dev/video1` `available:false` `pipelineNotOffered` |
| `f39e8c3` (schema 0.11.0) | this PR | **5 sources**; `/dev/video1` `available:true`, `signal:"present"`, `displayName:"HDMI Input"` |

The picker was then confirmed in a real browser against the device: **HDMI Input** and the RØDE both render as selectable rows, 0 console errors.

Gate: backend `bun test` **2838 pass / 0 fail**, `tsc --noEmit` clean, `biome check` clean, new copy in all 10 locales.

## Risks

Low. The change is purely additive to the projection — it only ever *adds* a row that was previously dropped, and the three scoping rules keep every existing path byte-identical (the full backend suite is green, including the `test`-pattern and lost-row cases that pin the surrounding behaviour). The new row is not selectable, so it cannot start a stream that would fail.

Note: this is a safety net that makes a version skew *visible*; it is not a substitute for shipping a current engine. A device on an old engine still needs the engine updated before the input is actually usable.