### PR TITLE
fix(audio): a live audio card is never silently absent from the picker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1960,6 +1960,22 @@ path, just the caps the engine's own `VIDIOC_QUERY_DV_TIMINGS` result projected.
 Full contract: `apps/backend/AGENTS.md` → "A SIGNAL change is invisible to every
 hotplug detector".
 
+**A real audio device is never silently absent from the picker.** The card list is
+CeraUI's own `/sys/class/sound` scan, and it reads `setup.sound_device_dir` — a
+static value packaged into the separately-versioned `ceralive-device` `.deb`. A
+value naming any other layout yields ZERO cards, so `audio_sources` collapses to
+its two pipeline pseudo-sources and looks exactly like a board with no sound
+hardware. Board-confirmed on a Rock 5B+ whose packaged `setup.json` still carried
+the pre-#166 `"sound_device_dir": "/dev/snd"`: that directory holds ALSA's device
+NODES and no `cardN` directory at all, so a connected, capture-ready RØDE
+HDMI-to-USB-C was missing from the picker entirely while the ENGINE had been
+reporting it correctly the whole time. `resolveConfiguredAlsaCards` reconciles the
+configured directory against the kernel's own on positive evidence only, and
+`isPlaybackOnlyCard` drops a card the kernel proves is an OUTPUT structurally
+rather than by card id (`rockchiphdmi0` and `hdmi0` are the same block under two
+vocabularies). Full contract: `apps/backend/AGENTS.md` → "…AND NEITHER IS A LIVE
+AUDIO CARD".
+
 **The idle level meter follows the picker.** Selecting an audio source used to change
 nothing about the meter: cerastream chose its own idle card, so an operator who picked
 the RØDE could watch the meter report the DJI Mic Mini — or "Meter unavailable" — with

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -87,6 +87,7 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 | **Absence GRACE on the selected capture source (the libuvc release window)** | `modules/streaming/capture-presence.ts` (`resolveSelectedSourceWithGrace`, `CAPTURE_ABSENCE_GRACE_MS`), read by `auto-audio.ts` `resolveAutoAsrcFromLiveState`; contract below → A DEBOUNCE IS NOT AN ABSENCE GRACE |
 | **`config.source` legacy coercion (pipeline/selected_video_input → source, idempotent)** | `helpers/config-schemas.ts` (`coerceLegacySource`) |
 | **Audio-naming resolution (4-tier: static onboard rule → engine join → ALSA longname → generic alias) + name cleaning + tier-3 diagnostic** | `modules/streaming/audio-naming.ts` |
+| **ALSA card scan + `setup.sound_device_dir` ↔ kernel reconciliation** | `modules/streaming/alsa-card-scan.ts` (`scanAlsaCards`, `resolveConfiguredAlsaCards`, `getResolvedAlsaCardDir`) + `modules/streaming/audio.ts` (`isPlaybackOnlyCard`); contract below → …AND NEITHER IS A LIVE AUDIO CARD |
 | **Static onboard AUDIO display-name rules (`rockchip,hdmiin` → `HDMI Input`) — code-level, no operator surface** | `modules/streaming/audio-naming.ts` (`ONBOARD_AUDIO_DISPLAY_RULES`, `resolveOnboardDisplayName`) |
 | **Static onboard VIDEO display-name rules (`rk_hdmirx` → `HDMI Input`) + the shared key folding** | `modules/streaming/onboard-display-names.ts` (`ONBOARD_VIDEO_DISPLAY_RULES`, `applyOnboardVideoDisplayRule`, `normalizeOnboardKey`) |
 | Mock hardware data | `mocks/providers/` |
@@ -1988,6 +1989,85 @@ Coverage: `tests/unoffered-capture-visibility.test.ts` (the real board payload, 
 the four negatives: codec nodes, audio class, the virtual/network double-render, and
 row-order stability).
 
+## …AND NEITHER IS A LIVE AUDIO CARD [EXISTS]
+
+The section above is about VIDEO, and its cause was two independently-versioned
+vocabularies disagreeing. The audio list has the same shape of defect from a
+different pair, and it is worse: it loses EVERY card at once with no row left to
+render a reason on.
+
+`updateAudioDevices` reads `setup.sound_device_dir` as a sysfs CLASS directory
+(`cardN/id`, `cardN/pcmC<N>D<M>c`). `setup.json` is a STATIC value packaged
+verbatim into the `ceralive-device` `.deb` — the same drifting artifact
+`warnOnHardwareIdentityDrift` exists for — so a value naming any other layout
+yields ZERO cards and `audio_sources` collapses to its two pipeline
+pseudo-sources, indistinguishable from a board with no sound hardware.
+
+Board-confirmed on a Rock 5B+ running current CeraUI against `ceralive-device
+2026.7.2-20260719T181141`, whose packaged `setup.json` still carries the pre-#166
+`"sound_device_dir": "/dev/snd"`. That directory holds ALSA's DEVICE NODES
+(`controlC0`, `pcmC0D0c`, `timer`) and NO `cardN` directory at all, so a
+connected, capture-ready RØDE HDMI-to-USB-C —
+`0 [usbaudio]: USB-Audio - RØDE HDMI to USB-C`, `00-00: USB Audio : capture 1` —
+was absent from the picker entirely. `debug.log` recorded the whole story in one
+line: `audio devices: {"No audio":…,"Pipeline default":…}`.
+
+Diagnostic note worth keeping: the ENGINE's audio enumeration was correct
+throughout (the fixed board's `audio_sources` carries `transport: "usb"` and
+`stable_id: "card:usbaudio"`, both of which come from the engine join), so this
+was never an engine gap. And fixing `setup.json` — PR #166 already did — only
+reaches a device on the NEXT full `.deb` upgrade, so the code has to survive the
+disagreement in the meantime.
+
+**`resolveConfiguredAlsaCards` (`alsa-card-scan.ts`) is the reconciliation, and
+it is POSITIVE-EVIDENCE-ONLY.** A configured directory naming at least one card
+answers unreconciled; a configured directory that IS the canonical one has
+nothing to fall back to; otherwise it read cleanly and named no card, which is a
+statement about the PATH and never about the hardware, so
+`/sys/class/sound` is asked and answers only if IT names cards. A board that
+genuinely has none is byte-identical to before. The rescue scan can never throw —
+it exists to recover from a bad configuration, not to turn one fault into another.
+
+**The `dir` argument of `updateAudioDevices` is honoured VERBATIM, and that is
+load-bearing.** Only the OMITTED (production) argument reconciles. The drift is
+between `setup.sound_device_dir` and the kernel, so a caller that names a
+directory has already stated the answer — and second-guessing it would make every
+sysfs-shaped test fixture report the HOST's own sound cards instead of the
+fixture's. `getResolvedAlsaCardDir()` is what proves the production path really
+routes through the resolver rather than around it.
+
+**A card the kernel proves is an OUTPUT is dropped structurally, not by name.**
+The hand-maintained `exclude` list has always meant exactly this —
+`rockchipdp0`, `rockchiphdmi0/1/2` are the SoC's DisplayPort and HDMI PLAYBACK
+cards — but a card-id list is itself a vocabulary, and the kernel's is not the
+same one: this board names those blocks `hdmi0` / `hdmi1` (simple-card), which
+the list does not match. So the moment the scan started finding cards again, two
+speakers would have rendered as selectable microphones. `isPlaybackOnlyCard`
+(`audio.ts`) asks the structure instead: ALSA names a substream
+`pcmC<card>D<device><p|c>`, and a card owning at least one `p` node and NO `c`
+node has told the kernel it plays and does not record. The list is KEPT as a
+back-stop; it is simply no longer the only defence.
+
+**The zero-PCM case is deliberately NOT an output.** That is the RK3588 HDMI-RX —
+an INPUT that enumerates permanently and exposes no substream at all until a
+cable locks (see "LISTED IS NOT RECORDABLE" above). Absence of evidence is not
+evidence: a card that has claimed no direction keeps its picker row exactly as
+before, and only `audioCaptureCardIds` gates claims about what it can deliver.
+Inverting this would silently delete the HDMI-RX row, so do NOT "simplify"
+`isPlaybackOnlyCard` into `!hasCapturePcmNode`.
+
+`rk3588es8316` joins `ONBOARD_AUDIO_DISPLAY_RULES` as `Onboard Audio` for the
+same reason PR #274 added `snps_hdmirx` to the video rules: the board's onboard
+codec has no human string to clean, and the fix is what made its row reachable.
+
+Coverage: `tests/audio-card-scan-drift.test.ts` (the board repro driven through
+the real resolver, the `isPlaybackOnlyCard` table, the board's own card tree
+through the real scan, the wiring lock, and the negatives that matter: a
+configured directory that DOES name cards is never second-guessed, a genuinely
+card-less board stays empty, the rescue scan cannot throw, a non-ENOENT error on
+the configured directory still rejects, and a signal-less capture card keeps its
+row).
+
 ## ONE ROW PER PHYSICAL CAMERA + PER-DEVICE MODE SELECTION [EXISTS]
 
 A capability source is a PIPELINE; an operator points at a DEVICE. Conflating the
@@ -3391,6 +3471,8 @@ config, an anchored path still held by its own device, and a live row with no
   absence into re-asserting a remembered `caps`/`signal` — that is the latch
   `withKnownEngineMetadata` already refuses for good reason.
 - **Don't `continue` past a live capture device whose pipeline the engine does not offer** — that intersection couples two independently-versioned vocabularies, and when they disagree EVERY camera vanishes at once behind a picker that looks exactly like "no hardware attached" (board-confirmed: a locked 1080p59.94 HDMI input and a USB camera both gone, `test` the only row). Route it through `buildUnofferedCaptureEntry` so it renders disabled-with-a-reason. Don't drop the `basePipelineIds` guard either — a `test`-kind device is already the virtual row and would double — and don't widen the fallback to kinds that bridge to nothing: `mapEngineDeviceKind` collapses an unrecognised kind onto the same `"other"` as the SoC codec/scaler nodes, so widening puts `rockchip-rga` and three `hantro-vpu` blocks in the picker.
+- **Don't read `setup.sound_device_dir` as if it were guaranteed to be the kernel's card directory** — it is a static value packaged into a separately-versioned `.deb`, and a value naming any other layout yields ZERO cards, so the picker collapses to its two pseudo-sources and a connected, capture-ready microphone is simply absent with nothing to say why (board-confirmed: `/dev/snd`, which has no `cardN` directory at all). Route the production scan through `resolveConfiguredAlsaCards`, keep the fallback positive-evidence-only (a configured directory that names cards is never second-guessed; a genuinely card-less board still answers empty), and keep the rescue scan unable to throw. Don't reconcile an EXPLICITLY-passed directory either — every sysfs-shaped fixture would then report the HOST's real sound cards.
+- Don't decide a sound card's DIRECTION from its card id — `rockchiphdmi0`/`rockchiphdmi1` and `hdmi0`/`hdmi1` are the same two HDMI output blocks under two kernel vocabularies, so a name list alone puts speakers in the microphone picker. Ask `isPlaybackOnlyCard`. And don't "simplify" that to `!hasCapturePcmNode`: a card with NO PCM node has claimed no direction, and it is the signal-less HDMI-RX INPUT — dropping it deletes a row the operator legitimately picked.
 - Don't assume a missing HDMI row is a kernel/HDMI-RX fault before checking whether OTHER capture devices vanished too — a receiver fault cannot unlist a USB webcam, and the engine's own `devices` list (`kind: "hdmi"`) plus `v4l2-ctl --query-dv-timings` will both still be correct while the projection is what dropped it.
 - Don't add only ONE spelling of an onboard node to `ONBOARD_VIDEO_DISPLAY_RULES` — the v4l2 card type (`stream_hdmirx`) and driver name (`snps_hdmirx`) are different strings for the same block, and which one reaches CeraUI depends on the engine build.
 - Don't re-add a coarse USB-capture placeholder row (`usb_mjpeg`, `v4l_mjpeg`, `libuvch264`, `camlink`) — a pipeline is not a device, the row is unactionable in every state, and one dual-format camera answers to two of them. And don't extend `SUPPRESSED_COARSE_PIPELINE_IDS` to `hdmi`/`rtmp`/`srt`/`test`: each names a real always-present board capability, so its coarse row is truthful with nothing plugged in.

--- a/apps/backend/src/modules/streaming/alsa-card-scan.ts
+++ b/apps/backend/src/modules/streaming/alsa-card-scan.ts
@@ -1,0 +1,181 @@
+/*
+    CeraUI - web UI for the CERALIVE project
+    Copyright (C) 2024-2025 CeraLive project
+
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { readdirP } from "../../helpers/files.ts";
+import { logger } from "../../helpers/logger.ts";
+import { readTextFile } from "../../helpers/text-files.ts";
+
+/**
+ * The kernel's ALSA card class directory.
+ *
+ * Every card the kernel has registered appears here as a `cardN` entry owning an
+ * `id` file and that card's PCM substream nodes — the shape the audio scan has
+ * always read, and the only directory that can answer "what sound cards does
+ * this board have".
+ */
+export const CANONICAL_SOUND_CLASS_DIR = "/sys/class/sound";
+
+/** One ALSA card, as the sysfs class directory describes it. */
+export interface ScannedAlsaCard {
+	/** The card's ALSA id (`cardN/id`), e.g. `usbaudio`. */
+	readonly id: string;
+	/** That card directory's entries — the PCM nodes the direction rules read. */
+	readonly entries: readonly string[];
+}
+
+/** Effectful surface, injected so a test drives the resolver without sysfs. */
+export interface AlsaCardScanDeps {
+	readDir: (path: string) => Promise<string[]>;
+	readText: (path: string) => Promise<string | undefined>;
+}
+
+const defaultScanDeps: AlsaCardScanDeps = {
+	readDir: (path) => readdirP(path),
+	readText: (path) => readTextFile(path),
+};
+
+// A card can disappear mid-scan (hotplug); an unreadable card directory reports
+// no entries rather than aborting the whole audio refresh.
+async function readCardEntries(
+	path: string,
+	deps: AlsaCardScanDeps,
+): Promise<string[]> {
+	try {
+		return await deps.readDir(path);
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * The ALSA cards a directory describes, read VERBATIM — no reconciliation.
+ *
+ * A `cardN` entry counts only once its `id` reads back non-empty: that file is
+ * what makes an entry a card rather than a name that merely starts with "card",
+ * and an id-less row could never be selected anyway.
+ *
+ * An ABSENT directory is an empty board, not a fault (the pre-existing rule — a
+ * dev host has no sound tree at all). Any other error (`ENOTDIR`, `EACCES`) is a
+ * real misconfiguration and stays loud.
+ */
+export async function scanAlsaCards(
+	dir: string,
+	deps: AlsaCardScanDeps = defaultScanDeps,
+): Promise<ScannedAlsaCard[]> {
+	let entries: string[];
+	try {
+		entries = await deps.readDir(dir);
+	} catch (error) {
+		if (!(error instanceof Error && "code" in error && error.code === "ENOENT"))
+			throw error;
+		return [];
+	}
+
+	const cards: ScannedAlsaCard[] = [];
+	for (const entry of entries) {
+		if (!entry.match(/^card/)) continue;
+		const id = ((await deps.readText(`${dir}/${entry}/id`)) ?? "").trim();
+		if (id === "") continue;
+		cards.push({
+			id,
+			entries: await readCardEntries(`${dir}/${entry}`, deps),
+		});
+	}
+	return cards;
+}
+
+/** The directory the last resolution settled on, so the warn fires once. */
+let lastResolvedDir: string | undefined;
+
+/** Forget the last resolution (test isolation). */
+export function resetAlsaCardScanResolution(): void {
+	lastResolvedDir = undefined;
+}
+
+/** The directory the last resolution actually scanned, or `undefined`. */
+export function getResolvedAlsaCardDir(): string | undefined {
+	return lastResolvedDir;
+}
+
+/**
+ * The board's ALSA cards, reconciling `setup.sound_device_dir` against the
+ * kernel's own card directory.
+ *
+ * `setup.json` is a STATIC value packaged verbatim into the `ceralive-device`
+ * `.deb` — the same independently-versioned artifact `warnOnHardwareIdentityDrift`
+ * exists for. The audio scan reads it as a sysfs CLASS directory (`cardN/id`,
+ * `cardN/pcmC<N>D<M>c`), so a value naming any other layout yields ZERO cards and
+ * the picker collapses to its two pipeline pseudo-sources — indistinguishable
+ * from a board with no sound hardware at all.
+ *
+ * That is not hypothetical. Board-confirmed on a Rock 5B+ running current CeraUI
+ * against `ceralive-device 2026.7.2-20260719T181141`, whose packaged `setup.json`
+ * still carries the pre-#166 `"sound_device_dir": "/dev/snd"`. `/dev/snd` holds
+ * ALSA's DEVICE NODES (`controlC0`, `pcmC0D0c`, `timer`) and no `cardN`
+ * directory whatsoever, so a connected, capture-ready RØDE HDMI-to-USB-C —
+ * `0 [usbaudio]: USB-Audio - RØDE HDMI to USB-C`, `00-00: USB Audio : capture 1`
+ * — was absent from `audio_sources` entirely, with nothing in the operator's UI
+ * to say why. The engine's own audio enumeration was correct throughout; the loss
+ * was entirely in this scan. Fixing `setup.json` (PR #166 already did) only
+ * reaches a device on the NEXT full `.deb` upgrade, so the code has to survive
+ * the disagreement in the meantime.
+ *
+ * The reconciliation is POSITIVE-EVIDENCE-ONLY, which is what keeps it safe:
+ *
+ * - A configured directory that names at least one card ANSWERS, unreconciled.
+ * - A configured directory that is already the canonical one has nothing to fall
+ *   back to.
+ * - Otherwise the configured directory read cleanly and named no card, which is
+ *   a statement about the PATH and never about the hardware — so the canonical
+ *   directory is asked, and answers only if IT names cards. A board that
+ *   genuinely has none is byte-identical to before this existed.
+ *
+ * The rescue scan can never throw: it runs to recover from a bad configuration,
+ * so it must not turn one fault into another.
+ */
+export async function resolveConfiguredAlsaCards(
+	configuredDir: string,
+	deps: AlsaCardScanDeps = defaultScanDeps,
+): Promise<ScannedAlsaCard[]> {
+	const configured = await scanAlsaCards(configuredDir, deps);
+	if (configured.length > 0 || configuredDir === CANONICAL_SOUND_CLASS_DIR) {
+		lastResolvedDir = configuredDir;
+		return configured;
+	}
+
+	const canonical = await scanAlsaCards(CANONICAL_SOUND_CLASS_DIR, deps).catch(
+		() => [] as ScannedAlsaCard[],
+	);
+	if (canonical.length === 0) {
+		lastResolvedDir = configuredDir;
+		return configured;
+	}
+
+	if (lastResolvedDir !== CANONICAL_SOUND_CLASS_DIR) {
+		logger.warn(
+			"audio: setup.sound_device_dir names no ALSA card — falling back to the kernel's card directory",
+			{
+				configured: configuredDir,
+				resolved: CANONICAL_SOUND_CLASS_DIR,
+				cards: canonical.map((card) => card.id),
+			},
+		);
+	}
+	lastResolvedDir = CANONICAL_SOUND_CLASS_DIR;
+	return canonical;
+}

--- a/apps/backend/src/modules/streaming/audio-naming.ts
+++ b/apps/backend/src/modules/streaming/audio-naming.ts
@@ -262,6 +262,7 @@ const ONBOARD_AUDIO_DISPLAY_RULES: ReadonlyMap<string, string> = new Map([
 	["rockchiphdmiin", "HDMI Input"],
 	["rockchiphdmiind", "HDMI Input"],
 	["rockchipes8388", "Onboard Audio"],
+	["rk3588es8316", "Onboard Audio"],
 ]);
 
 /**

--- a/apps/backend/src/modules/streaming/audio.ts
+++ b/apps/backend/src/modules/streaming/audio.ts
@@ -18,7 +18,6 @@
 
 import type { AudioSource } from "@ceraui/rpc/schemas";
 import { AUDIO_SOURCE_AUTO } from "@ceraui/rpc/schemas";
-import { readdirP } from "../../helpers/files.ts";
 import { logger } from "../../helpers/logger.ts";
 import { readTextFile } from "../../helpers/text-files.ts";
 import { AUDIO_SOURCE_POLL_DELAY } from "../../helpers/timing-constants.ts";
@@ -29,6 +28,11 @@ import { isRealDevice } from "../system/device-detection.ts";
 import { getHardwareKindCached } from "../system/hardware-kind.ts";
 import { notificationBroadcast } from "../ui/notifications.ts";
 import { broadcastMsg } from "../ui/websocket-server.ts";
+import {
+	CANONICAL_SOUND_CLASS_DIR,
+	resolveConfiguredAlsaCards,
+	scanAlsaCards,
+} from "./alsa-card-scan.ts";
 import { syncAudioMeterPreference } from "./audio-meter-bridge.ts";
 import type {
 	AudioDeviceDisplay,
@@ -53,7 +57,7 @@ import { reportActiveAudioSource } from "./lifecycle-indicators.ts";
 import { getEngineAudioDevices } from "./sources.ts";
 import { getStreamingProcesses } from "./streamloop/process-runner.ts";
 
-const deviceDir = setup.sound_device_dir ?? "/sys/class/sound";
+const deviceDir = setup.sound_device_dir ?? CANONICAL_SOUND_CLASS_DIR;
 const PROC_ASOUND_CARDS = "/proc/asound/cards";
 
 const NO_AUDIO_ID = "No audio";
@@ -191,6 +195,33 @@ export function isMeterSilencedByPick(
  */
 export function hasCapturePcmNode(entries: readonly string[]): boolean {
 	return entries.some((entry) => /^pcmC\d+D\d+c$/.test(entry));
+}
+
+/**
+ * Is this card PROVEN to be an output, i.e. something no operator could ever
+ * pick as an audio INPUT?
+ *
+ * The hand-maintained `exclude` list in `updateAudioDevices` has always meant
+ * exactly this — `rockchipdp0`, `rockchiphdmi0/1/2` are the SoC's DisplayPort
+ * and HDMI PLAYBACK cards. But a card-id list is a vocabulary, and the kernel's
+ * is not the same one: the RK3588 board this was written for now names those
+ * same blocks `hdmi0` / `hdmi1` (simple-card), so the list matches nothing and
+ * two output-only cards would render as selectable microphones the moment the
+ * scan starts finding cards at all.
+ *
+ * The direction is structural, so ask the structure. ALSA names a substream
+ * `pcmC<card>D<device><p|c>`; a card owning at least one `p` node and NO `c`
+ * node has told the kernel it plays and does not record.
+ *
+ * The zero-PCM case is deliberately NOT output — it is the RK3588 HDMI-RX, an
+ * INPUT that enumerates permanently and exposes no substream at all until a
+ * cable locks (see `getAudioCaptureCardIds`). Absence of evidence is not
+ * evidence: a card that has claimed no direction keeps its picker row, exactly
+ * as before, and only `audioCaptureCardIds` gates claims about it.
+ */
+export function isPlaybackOnlyCard(entries: readonly string[]): boolean {
+	if (hasCapturePcmNode(entries)) return false;
+	return entries.some((entry) => /^pcmC\d+D\d+p$/.test(entry));
 }
 
 /**
@@ -504,17 +535,17 @@ export async function reresolveAudioForEngineChange(): Promise<void> {
 	syncAudioMeterPreference();
 }
 
-// A card can disappear mid-scan (hotplug); an unreadable card simply reports no
-// capture PCM rather than aborting the whole audio refresh.
-async function readCardEntries(path: string): Promise<string[]> {
-	try {
-		return await readdirP(path);
-	} catch {
-		return [];
-	}
-}
-
-export async function updateAudioDevices(dir: string = deviceDir) {
+/**
+ * Rebuild the audio-source list from the board's ALSA cards.
+ *
+ * `dir` is the TEST SEAM and is honoured verbatim; only the omitted (production)
+ * argument is reconciled against the kernel by `resolveConfiguredAlsaCards`. The
+ * drift that reconciliation exists for is between `setup.sound_device_dir` and
+ * the kernel, so a caller that names a directory has already stated the answer —
+ * second-guessing it would make every sysfs-shaped fixture report the HOST's own
+ * sound cards instead.
+ */
+export async function updateAudioDevices(dir?: string) {
 	// Ignore the onboard audio cards
 	const exclude = [
 		"tegrahda",
@@ -535,31 +566,22 @@ export async function updateAudioDevices(dir: string = deviceDir) {
 		"usbaudio",
 	];
 
-	let devices: string[];
-	try {
-		devices = await readdirP(dir);
-	} catch (error) {
-		if (!(error instanceof Error && "code" in error && error.code === "ENOENT"))
-			throw error;
-		devices = [];
-	}
+	const cards =
+		dir === undefined
+			? await resolveConfiguredAlsaCards(deviceDir)
+			: await scanAlsaCards(dir);
+
 	const list: Record<string, true> = {};
 	const captureCards = new Set<string>();
 
-	for (const d of devices) {
-		// Only inspect cards
-		if (!d.match(/^card/)) continue;
+	for (const card of cards) {
+		// Skip over the IDs known not to be valid audio inputs, and over any card
+		// the kernel proves is an output whatever the board happens to call it.
+		if (exclude.includes(card.id)) continue;
+		if (isPlaybackOnlyCard(card.entries)) continue;
 
-		// Get the card's ID
-		const id = ((await readTextFile(`${dir}/${d}/id`)) ?? "").trim();
-
-		// Skip over the IDs known not to be valid audio inputs
-		if (exclude.includes(id)) continue;
-
-		list[id] = true;
-		if (hasCapturePcmNode(await readCardEntries(`${dir}/${d}`))) {
-			captureCards.add(id);
-		}
+		list[card.id] = true;
+		if (hasCapturePcmNode(card.entries)) captureCards.add(card.id);
 	}
 	// First add any priority cards found
 	const sortedList = {};

--- a/apps/backend/src/tests/audio-card-scan-drift.test.ts
+++ b/apps/backend/src/tests/audio-card-scan-drift.test.ts
@@ -1,0 +1,344 @@
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+	type AlsaCardScanDeps,
+	CANONICAL_SOUND_CLASS_DIR,
+	getResolvedAlsaCardDir,
+	resetAlsaCardScanResolution,
+	resolveConfiguredAlsaCards,
+	scanAlsaCards,
+} from "../modules/streaming/alsa-card-scan.ts";
+import {
+	deriveAudioSources,
+	getAudioCaptureCardIds,
+	getAudioDevices,
+	isPlaybackOnlyCard,
+	setMockAudioDevicesProvider,
+	updateAudioDevices,
+} from "../modules/streaming/audio.ts";
+
+interface CardFixture {
+	dir: string;
+	id: string;
+	entries?: string[];
+}
+
+/**
+ * The Rock 5B+ this bug was reported on, reproduced verbatim from its own
+ * `/sys/class/sound` + `/proc/asound/pcm`: the RØDE capture card, the onboard
+ * analog codec (both directions), and the two HDMI OUTPUT cards.
+ */
+const BOARD_CARDS: readonly CardFixture[] = [
+	{ dir: "card0", id: "usbaudio", entries: ["controlC0", "id", "pcmC0D0c"] },
+	{
+		dir: "card1",
+		id: "rk3588es8316",
+		entries: ["controlC1", "id", "pcmC1D0c", "pcmC1D0p"],
+	},
+	{ dir: "card2", id: "hdmi0", entries: ["controlC2", "id", "pcmC2D0p"] },
+	{ dir: "card3", id: "hdmi1", entries: ["controlC3", "id", "pcmC3D0p"] },
+];
+
+/** The board's `/dev/snd`: ALSA DEVICE NODES, and not one `cardN` directory. */
+const DEV_SND_ENTRIES: readonly string[] = [
+	"by-id",
+	"by-path",
+	"controlC0",
+	"controlC1",
+	"pcmC0D0c",
+	"pcmC1D0c",
+	"pcmC1D0p",
+	"timer",
+];
+
+const roots: string[] = [];
+
+async function makeCardTree(cards: readonly CardFixture[]): Promise<string> {
+	const root = await mkdtemp(join(tmpdir(), "ceraui-alsa-scan-"));
+	roots.push(root);
+	for (const card of cards) {
+		await mkdir(join(root, card.dir));
+		await writeFile(join(root, card.dir, "id"), `${card.id}\n`);
+		for (const entry of card.entries ?? []) {
+			if (entry === "id") continue;
+			await mkdir(join(root, card.dir, entry));
+		}
+	}
+	return root;
+}
+
+/** Scan deps that answer for a fake `/dev/snd` and a fake canonical tree. */
+function driftDeps(canonicalRoot: string | undefined): {
+	deps: AlsaCardScanDeps;
+	reads: string[];
+} {
+	const reads: string[] = [];
+	const real = scanDepsFor(canonicalRoot);
+	return {
+		reads,
+		deps: {
+			readDir: async (path) => {
+				reads.push(path);
+				if (path === "/dev/snd") return [...DEV_SND_ENTRIES];
+				if (path.startsWith("/dev/snd/")) {
+					const err = new Error("ENOENT") as Error & { code: string };
+					err.code = "ENOENT";
+					throw err;
+				}
+				return real.readDir(path);
+			},
+			readText: async (path) => {
+				reads.push(path);
+				return real.readText(path);
+			},
+		},
+	};
+}
+
+function scanDepsFor(canonicalRoot: string | undefined): AlsaCardScanDeps {
+	const remap = (path: string): string =>
+		canonicalRoot !== undefined && path.startsWith(CANONICAL_SOUND_CLASS_DIR)
+			? join(canonicalRoot, path.slice(CANONICAL_SOUND_CLASS_DIR.length))
+			: path;
+	return {
+		readDir: async (path) => {
+			const target = remap(path);
+			if (canonicalRoot === undefined && path === CANONICAL_SOUND_CLASS_DIR) {
+				const err = new Error("ENOENT") as Error & { code: string };
+				err.code = "ENOENT";
+				throw err;
+			}
+			const { readdir } = await import("node:fs/promises");
+			return readdir(target);
+		},
+		readText: async (path) => {
+			const target = remap(path);
+			return Bun.file(target)
+				.text()
+				.catch(() => undefined);
+		},
+	};
+}
+
+beforeEach(() => {
+	resetAlsaCardScanResolution();
+	setMockAudioDevicesProvider(undefined);
+});
+
+afterEach(() => {
+	resetAlsaCardScanResolution();
+	setMockAudioDevicesProvider(undefined);
+});
+
+afterAll(async () => {
+	// The scan writes a MODULE-LEVEL map that `bun test` shares with every other
+	// file in the run; an explicitly-named absent directory restores it to the
+	// pseudo-sources-only initial state (the sibling suites' own reset).
+	await updateAudioDevices("/nonexistent-audio-root");
+	for (const root of roots) await rm(root, { recursive: true, force: true });
+	roots.length = 0;
+});
+
+/*
+ * Board-confirmed on a Rock 5B+ running current CeraUI against
+ * `ceralive-device 2026.7.2-20260719T181141`, whose packaged setup.json still
+ * carries the pre-#166 `"sound_device_dir": "/dev/snd"`. That directory holds
+ * ALSA's device NODES and no `cardN` directory at all, so the sysfs-shaped scan
+ * returned zero cards and `audio_sources` collapsed to its two pipeline
+ * pseudo-sources — a connected, capture-ready RØDE HDMI-to-USB-C absent from the
+ * picker with nothing to say why.
+ */
+describe("a configured sound directory that names no ALSA card never answers for the hardware", () => {
+	test("the board repro: /dev/snd yields nothing, so the kernel's own directory answers", async () => {
+		const canonical = await makeCardTree(BOARD_CARDS);
+		const { deps } = driftDeps(canonical);
+
+		const cards = await resolveConfiguredAlsaCards("/dev/snd", deps);
+
+		expect(cards.map((c) => c.id)).toEqual([
+			"usbaudio",
+			"rk3588es8316",
+			"hdmi0",
+			"hdmi1",
+		]);
+		expect(getResolvedAlsaCardDir()).toBe(CANONICAL_SOUND_CLASS_DIR);
+	});
+
+	test("a configured directory that DOES name cards answers unreconciled", async () => {
+		const configured = await makeCardTree([BOARD_CARDS[0] as CardFixture]);
+		const canonical = await makeCardTree(BOARD_CARDS);
+		const { deps, reads } = driftDeps(canonical);
+
+		const cards = await resolveConfiguredAlsaCards(configured, deps);
+
+		expect(cards.map((c) => c.id)).toEqual(["usbaudio"]);
+		expect(getResolvedAlsaCardDir()).toBe(configured);
+		expect(reads.some((p) => p.startsWith(CANONICAL_SOUND_CLASS_DIR))).toBe(
+			false,
+		);
+	});
+
+	test("a configured directory that IS the canonical one has nothing to fall back to", async () => {
+		const canonical = await makeCardTree([]);
+		const { deps, reads } = driftDeps(canonical);
+
+		const cards = await resolveConfiguredAlsaCards(
+			CANONICAL_SOUND_CLASS_DIR,
+			deps,
+		);
+
+		expect(cards).toEqual([]);
+		expect(reads.filter((p) => p === CANONICAL_SOUND_CLASS_DIR)).toHaveLength(
+			1,
+		);
+	});
+
+	test("a board that genuinely has no sound card is unchanged — still empty", async () => {
+		const canonical = await makeCardTree([]);
+		const { deps } = driftDeps(canonical);
+
+		expect(await resolveConfiguredAlsaCards("/dev/snd", deps)).toEqual([]);
+		expect(getResolvedAlsaCardDir()).toBe("/dev/snd");
+	});
+
+	test("an absent configured directory also defers to the kernel's", async () => {
+		const canonical = await makeCardTree(BOARD_CARDS);
+		const { deps } = driftDeps(canonical);
+
+		const cards = await resolveConfiguredAlsaCards("/nonexistent-sound", deps);
+
+		expect(cards.map((c) => c.id)).toContain("usbaudio");
+	});
+
+	test("the rescue scan can never turn one fault into another", async () => {
+		const { deps } = driftDeps(undefined);
+		const throwing: AlsaCardScanDeps = {
+			readText: deps.readText,
+			readDir: async (path) => {
+				if (path === CANONICAL_SOUND_CLASS_DIR) {
+					const err = new Error("ENOTDIR") as Error & { code: string };
+					err.code = "ENOTDIR";
+					throw err;
+				}
+				return deps.readDir(path);
+			},
+		};
+
+		expect(await resolveConfiguredAlsaCards("/dev/snd", throwing)).toEqual([]);
+	});
+
+	test("a non-ENOENT error on the CONFIGURED directory still rejects", async () => {
+		const deps: AlsaCardScanDeps = {
+			readDir: async () => {
+				const err = new Error("ENOTDIR") as Error & { code: string };
+				err.code = "ENOTDIR";
+				throw err;
+			},
+			readText: async () => undefined,
+		};
+
+		await expect(
+			resolveConfiguredAlsaCards("/etc/hostname", deps),
+		).rejects.toThrow("ENOTDIR");
+	});
+
+	test("a cardN entry with no readable id is not a card", async () => {
+		const root = await mkdtemp(join(tmpdir(), "ceraui-alsa-noid-"));
+		roots.push(root);
+		await mkdir(join(root, "card0"));
+
+		expect(await scanAlsaCards(root)).toEqual([]);
+	});
+});
+
+/*
+ * The `exclude` list in `updateAudioDevices` has always meant "this card is an
+ * output". It is a card-id vocabulary, and the kernel's is a different one: the
+ * board above names its two HDMI playback cards `hdmi0`/`hdmi1`, which the list
+ * (`rockchiphdmi0`/`rockchiphdmi1`) does not match — so the moment the scan
+ * starts finding cards again, two speakers would render as selectable
+ * microphones. The direction is structural, so it is read structurally.
+ */
+describe("isPlaybackOnlyCard — a card the kernel proves is an output", () => {
+	test("playback substreams and no capture substream is an output", () => {
+		expect(isPlaybackOnlyCard(["controlC2", "id", "pcmC2D0p"])).toBe(true);
+	});
+
+	test("any capture substream means it is not", () => {
+		expect(isPlaybackOnlyCard(["pcmC1D0c", "pcmC1D0p"])).toBe(false);
+		expect(isPlaybackOnlyCard(["controlC0", "id", "pcmC0D0c"])).toBe(false);
+	});
+
+	test("a card that claims NO direction is not an output — it is the HDMI-RX", () => {
+		expect(isPlaybackOnlyCard(["controlC3", "id", "number"])).toBe(false);
+		expect(isPlaybackOnlyCard([])).toBe(false);
+	});
+});
+
+describe("the board's own card tree, through the real scan", () => {
+	test("the RØDE and the analog codec are offered; the HDMI outputs are not", async () => {
+		const root = await makeCardTree(BOARD_CARDS);
+
+		await updateAudioDevices(root);
+
+		const devices = getAudioDevices();
+		expect(Object.values(devices)).toContain("usbaudio");
+		expect(Object.values(devices)).toContain("rk3588es8316");
+		expect(Object.values(devices)).not.toContain("hdmi0");
+		expect(Object.values(devices)).not.toContain("hdmi1");
+
+		expect([...getAudioCaptureCardIds()].sort()).toEqual([
+			"rk3588es8316",
+			"usbaudio",
+		]);
+
+		const wire = deriveAudioSources();
+		expect(wire.filter((s) => s.kind === "device").length).toBe(2);
+		expect(wire.some((s) => s.label === "RØDE HDMI to USB-C")).toBe(false);
+	});
+
+	test("a signal-less capture card still keeps its picker row", async () => {
+		const root = await makeCardTree([
+			{ dir: "card3", id: "rockchiphdmiin", entries: ["controlC3", "id"] },
+			BOARD_CARDS[0] as CardFixture,
+		]);
+
+		await updateAudioDevices(root);
+
+		expect(Object.values(getAudioDevices())).toContain("rockchiphdmiin");
+		expect([...getAudioCaptureCardIds()]).toEqual(["usbaudio"]);
+	});
+});
+
+/*
+ * The rule above is dead unless the PRODUCTION path routes through it, and the
+ * production path is the one nothing hands a directory to. A test that always
+ * passes its own fixture directory would never touch the resolver at all.
+ */
+describe("the reconciliation is wired to the configured path, and only to it", () => {
+	test("an omitted directory resolves; an explicit one is honoured verbatim", async () => {
+		const root = await makeCardTree(BOARD_CARDS);
+
+		await updateAudioDevices(root);
+		expect(getResolvedAlsaCardDir()).toBeUndefined();
+
+		await updateAudioDevices();
+		expect(getResolvedAlsaCardDir()).toBeDefined();
+
+		await updateAudioDevices("/nonexistent-audio-root");
+		expect(getAudioDevices()).toEqual({
+			"No audio": "No audio",
+			"Pipeline default": "Pipeline default",
+		});
+	});
+});


### PR DESCRIPTION
## What

A fully functional USB audio device was completely absent from the audio-source
picker. On the reference Rock 5B+, `audio_sources` returned only the two pipeline
pseudo-sources:

```
"asrcs": ["No audio", "Pipeline default"]
```

…while the board genuinely had the card, capture-ready:

```
0 [usbaudio]: USB-Audio - RØDE HDMI to USB-C
00-00: USB Audio : capture 1
```

This PR makes the card list survive a configured sound directory that has drifted
away from the kernel's, and makes an output-only card be recognised as an output
by its structure rather than by its name.

## Why

`updateAudioDevices` walks `setup.sound_device_dir` with the **sysfs class**
layout — `<dir>/cardN/id`, `<dir>/cardN/pcmC<N>D<M>c`. `setup.json` is a static
value packaged verbatim into the separately-versioned `ceralive-device` `.deb`,
and the board's copy (from `2026.7.2-20260719T181141`) still carried the pre-#166
`"sound_device_dir": "/dev/snd"`.

`/dev/snd` holds ALSA's **device nodes** — `controlC0`, `pcmC0D0c`, `timer`,
`by-path/` — and **no `cardN` directory at all**. So the `/^card/` filter matched
nothing, the scan returned zero cards, and the picker collapsed to its two
pseudo-sources: indistinguishable from a board with no sound hardware. `debug.log`
said it in one line:

```
audio devices: {"No audio":"No audio","Pipeline default":"Pipeline default"}
```

This is the same defect class as #274 — an intersection of two
independently-versioned vocabularies, where a disagreement makes *everything*
vanish at once — reached from a different pair. It is arguably worse than the
video case, because there is no row left to render a reason on.

Two things worth recording:

- **It was never an engine gap.** cerastream reported the card correctly the whole
  time; the fixed board's payload carries `transport: "usb"` and
  `stable_id: "card:usbaudio"`, both of which come from the engine join. The audio
  card *list* is entirely CeraUI's own sysfs scan.
- **Fixing `setup.json` is not enough.** #166 already fixed it in-repo, and
  `scripts/ceralive-service.test.mjs` asserts it — but that only reaches a device
  on the next full `.deb` upgrade. The board was running a current binary against
  a July-dated packaged config. The code has to survive the disagreement.

A second, latent bug sat directly behind the first: the `exclude` list in
`updateAudioDevices` has always meant "this card is an output" (`rockchipdp0`,
`rockchiphdmi0/1/2`), but that is itself a card-id vocabulary and the kernel's is
a different one — this board names the same two HDMI output blocks `hdmi0` /
`hdmi1` (simple-card). So the moment the scan started finding cards again, two
speakers would have rendered as selectable microphones.

## How

**`modules/streaming/alsa-card-scan.ts` (new)** — `scanAlsaCards` reads a
directory verbatim; `resolveConfiguredAlsaCards` reconciles the configured value
against `/sys/class/sound` on **positive evidence only**:

- a configured directory that names at least one card answers unreconciled;
- a configured directory that *is* the canonical one has nothing to fall back to;
- otherwise it read cleanly and named no card — a statement about the *path*, never
  about the hardware — so the canonical directory is asked, and answers only if it
  names cards. A board that genuinely has none is byte-identical to before.

The rescue scan can never throw; it exists to recover from a bad configuration,
not to turn one fault into another. This mirrors `hardware-kind.ts` demoting
`setup.hw` to a fallback behind runtime evidence, and logs the drift once.

**`updateAudioDevices(dir)` honours an explicit `dir` verbatim** — only the
omitted (production) argument reconciles. This is load-bearing: without it, every
sysfs-shaped fixture in the existing suites (including the
`updateAudioDevices(emptyDir)` reset pattern) would report the *host's* real sound
cards. `getResolvedAlsaCardDir()` is what proves the production path routes
through the resolver rather than around it.

**`isPlaybackOnlyCard(entries)` (`audio.ts`)** decides direction structurally:
ALSA names a substream `pcmC<card>D<device><p|c>`, so a card owning at least one
`p` node and no `c` node has told the kernel it plays and does not record. The
name list is kept as a back-stop; it is simply no longer the only defence.
**Zero PCM nodes is deliberately not an output** — that is the RK3588 HDMI-RX,
an input that enumerates permanently and exposes no substream until a cable locks.
Inverting that would silently delete its picker row.

**`rk3588es8316` → `Onboard Audio`** in `ONBOARD_AUDIO_DISPLAY_RULES`, for the
same reason #274 added `snps_hdmirx` to the video rules: the fix is what made that
row reachable, and the codec has no human string to clean.

No device name, vendor id or path is hardcoded anywhere in the fix.

## How to verify

Board-proven on `192.168.78.131` (idle), before and after deploying the built
binary.

Before:

```
"asrcs": ["No audio", "Pipeline default"]
```

After — the drift is announced, and the real cards appear:

```
audio: setup.sound_device_dir names no ALSA card — falling back to the kernel's
card directory {"configured":"/dev/snd","resolved":"/sys/class/sound",
                "cards":["hdmi1","rk3588es8316","hdmi0","usbaudio"]}
```

```json
"asrcs": ["USB audio", "rk3588es8316", "No audio", "Pipeline default"],
"audio_sources": [
  { "id": "USB audio", "kind": "device", "label": "RØDE HDMI to USB-C",
    "transport": "usb", "stable_id": "card:usbaudio" },
  { "id": "rk3588es8316", "kind": "device", "label": "Onboard Audio",
    "transport": "onboard", "stable_id": "card:rk3588es8316" },
  ...
]
```

Both HDMI **output** cards (`hdmi0`, `hdmi1`) are correctly absent, and the two
capture-capable cards are present.

Browser session on the same board: selecting the UVC camera exposes the audio
picker, which lists **"RØDE HDMI to USB-C · External"** and **"Onboard Audio"**;
selecting the RØDE persists (the picker button reads it back). The board's
original selection (`source: srt`, `asrc: Auto`) was restored afterwards.

Automated: `apps/backend/src/tests/audio-card-scan-drift.test.ts` (14 tests) —
the board repro through the real resolver, the `isPlaybackOnlyCard` table, the
board's own card tree through the real scan, the production-wiring lock, and the
negatives that matter: a configured directory that *does* name cards is never
second-guessed, a genuinely card-less board stays empty, the rescue scan cannot
throw, a non-`ENOENT` error on the configured directory still rejects, and a
signal-less capture card keeps its row.

Rule E proof, both directions: neutering the reconciliation reddens the board-repro
and absent-directory tests; neutering `isPlaybackOnlyCard` reddens the
playback-only and board-tree tests (4 fail / 10 pass). Full backend suite green
(2852 pass), typecheck clean, `check:tech-debt` and
`test:release-package-contracts` green.

## Risks

- **A board with a genuinely empty sound tree behaves exactly as before.** The
  fallback only ever *adds* devices, and only when the canonical directory
  positively names some.
- **The output rule could in principle drop a card that registers a playback
  substream before its capture one.** ALSA registers a card's PCM nodes together,
  and the one input on this board that legitimately has no substreams (HDMI-RX)
  has none of *either* kind, which the rule explicitly keeps. The failure
  direction of the fallback path is also the safe one: an unreadable card
  directory yields no entries, which reads as "claims no direction" and keeps the
  row.
- **Two new rows appear on this board** (the RØDE and the onboard codec). Both are
  real, both report `capture 1` in `/proc/asound/pcm`, and both are in
  `audioCaptureCardIds`, so the meter and the start path can vouch for them.
- The stale packaged `setup.json` is still worth correcting on the image side;
  this change means a device is no longer broken while that ships.
