### PR TITLE
fix(hdmi): let the EMI/cable advisory clear, and stop it re-firing

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -75,8 +75,8 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 | Regulatory domain + kernel-derived hotspot channels (`iw reg set` / `iw phy` parser, regdb precheck, armed restore timer) | `modules/wifi/regdomain.ts` (`applyRegulatoryDomain`, `deriveApChannels`, `checkWirelessRegdbSupport`, `buildRegdomainRestoreCommand`) |
 | Persisted country → apply → re-derive → hotspot restart | `modules/wifi/wifi-country.ts` (`setWifiCountry`, `reconcileHotspotChannels`) |
 | Policy-route self-check for bonded wifi/modem interfaces (`policy_route_missing`) | `modules/network/policy-route-check.ts` |
-| Retracting the `hdmi_error` "No HDMI signal detected" notification once the link relocks | `modules/system/hdmi-signal-notification.ts` (`clearHdmiSignalErrorOnRecovery`, hooked into `sources.ts` `commitEngineDevices`); contract below → A PERSISTENT NOTIFICATION MUST BE RETRACTABLE |
-| Scoping the `hdmi_error` "No HDMI signal detected" RAISE to a relevant selection | `modules/system/hdmi-signal-notification.ts` (`provesSelectionIsNotHdmi`) + `modules/system/sensors.ts` (`handleRk3588HdmiDmesg`); contract below → …AND ITS RAISE MUST BE SCOPED LIKE ITS RETRACTION |
+| Retracting the `hdmi_error` notification (BOTH the no-signal message and the EMI/cable advisory) once the link relocks | `modules/system/hdmi-signal-notification.ts` (`clearHdmiSignalErrorOnRecovery`, `HDMI_MSGS_CLEARED_BY_LOCKED_SIGNAL`, hooked into `sources.ts` `commitEngineDevices`); contract below → A PERSISTENT NOTIFICATION MUST BE RETRACTABLE |
+| Scoping the `hdmi_error` "No HDMI signal detected" RAISE to a relevant selection, and dedup-guarding the EMI/cable advisory's raise | `modules/system/hdmi-signal-notification.ts` (`provesSelectionIsNotHdmi`) + `modules/system/sensors.ts` (`handleRk3588HdmiDmesg`); contract below → …AND ITS RAISE MUST BE SCOPED LIKE ITS RETRACTION |
 | Retracting the `cerastream` `capture_video_error` notification at a healthy session boundary | `modules/streaming/cerastream-backend.ts` (`standingEngineError`, `clearRecoveredEngineError`, `ENGINE_ERRORS_CLEARED_BY_HEALTHY_SESSION`) |
 | **One row per physical camera + per-device mode ladders (`inputModes`, `selectedInputMode`, coarse USB placeholder suppression)** | `modules/streaming/sources.ts` (`SUPPRESSED_COARSE_PIPELINE_IDS`, `buildInputModes`, `resolveSelectedInputMode`, mode-aware `deriveEngineRouting`) |
 | **Last-streamed-config retention (the ONE remembered `lost` device)** | `modules/streaming/sources.ts` (`collectLostCandidates`, `noteStreamedSourceCommitted`) + `config.last_streamed_source` in `helpers/config-schemas.ts`; commit hook wired at `stream-session-orchestrator.ts` `onStreamCommitted` |
@@ -3208,7 +3208,7 @@ Two notifications shipped that way, and both were confirmed on a board.
 
 | Notification | Raised by | Why it could never clear |
 |---|---|---|
-| `hdmi_error` / "No HDMI signal detected" | `modules/system/sensors.ts`, off the RK3588 dmesg line `hdmirx-controller: Err, timing is invalid` | the kernel logs the failure and prints NOTHING when the link relocks, so the only event the watcher can see is the bad one |
+| `hdmi_error` — BOTH "No HDMI signal detected" and the EMI/cable advisory | `modules/system/sensors.ts`, off the RK3588 dmesg lines `hdmirx-controller: Err, timing is invalid` (no-signal) and `hdmirx_wait_lock_and_get_timing signal not lock` / `hdmirx_delayed_work_audio: audio underflow` (advisory) | the kernel logs the failure and prints NOTHING when the link relocks, so the only event the watcher can see is the bad one |
 | the `cerastream` channel carrying `capture_video_error` | `cerastream-backend.ts` `handleErrorEvent()` | the engine reports the Tier-2 error and never revokes it; the condition cleared and the engine returned to idle/healthy with the error still on screen |
 
 **The retraction runs on the same evidence the source list already trusts, never
@@ -3237,11 +3237,23 @@ nothing. Four properties are load-bearing:
 - **Scoped to `kind === "hdmi"`.** The kind heuristic tests usb/uvc BEFORE hdmi
   precisely so a "RØDE HDMI to USB-C" dongle is not mislabelled, so a working
   webcam can never retract a claim about the board's HDMI-RX port.
-- **Scoped to the EXACT message.** The name `hdmi_error` is SHARED with the
-  EMI/cable-quality advisory ("HDMI signal issues detected…"), which describes a
-  different condition a relocked link does not falsify — the raise site already
-  keys on the same string to avoid overwriting it. Retracting by name alone would
-  silently drop it.
+- **Scoped to a KNOWN message, and BOTH of them qualify.** The name `hdmi_error`
+  is ONE slot shared by two claims — "No HDMI signal detected" and the
+  EMI/cable-quality advisory ("HDMI signal issues detected…") — so
+  `HDMI_MSGS_CLEARED_BY_LOCKED_SIGNAL` is the membership table, exactly as
+  `ENGINE_ERRORS_CLEARED_BY_HEALTHY_SESSION` is for the engine channel. A blind
+  remove-by-name would retract a future third claim this evidence says nothing
+  about.
+
+  **The advisory used to be EXEMPT, and that was the bug.** It was read as a claim
+  about cable QUALITY, which a relocked link does not falsify. Operators reported
+  the consequence — *"an infinite notification for something that is already
+  corrected"* — and the board agrees with them: the two kernel lines behind it fire
+  during ORDINARY link locking, so a plain unplug/replug raised an advisory with no
+  retraction path at all, which then stood for the rest of the session. An
+  engine-authored "this port is carrying a picture" falsifies both claims equally,
+  so there is no longer any reason to treat them differently for RETRACTION. They
+  are still different for RAISING: each keeps its own trigger.
 - **Idempotent.** `notificationExists` answers `undefined` once it is gone, so the
   healthy steady state costs one map lookup and broadcasts nothing.
 
@@ -3272,8 +3284,9 @@ the only recourse when it cannot run.
 
 Coverage: `tests/notification-recovery-clearing.test.ts` (the pure verdict, the
 persists-while-severed and unreachable-engine controls, the real `remove` frame
-pushed to a connected client, the EMI-advisory and foreign-device negatives, the
-idle-is-not-proof and shared-slot negatives, and the repeat-heartbeat idempotence)
+pushed to a connected client, the SAME three assertions repeated for the EMI
+advisory, the foreign-device negatives, the idle-is-not-proof and shared-slot
+negatives, and the repeat-heartbeat idempotence)
 plus the frontend half `apps/frontend/src/tests/notification-recovery-ingestion.test.ts`
 (the `remove` frame drops the entry from the persistent panel).
 
@@ -3321,20 +3334,35 @@ It can only ever withhold a raise PROVEN irrelevant:
 - **A renumbered camera is still recognised**, through the `previousIds` aliases
   the successor publishes — otherwise a libuvc camera would lose its own
   selection on exactly the cycle that matters.
-- **The EMI/cable advisory is deliberately UNGATED.** Its two kernel lines are
-  emitted only while the receiver is actually locking or clocking a link, so they
-  already describe work somebody asked for. Do not extend this gate to it.
+- **The EMI/cable advisory does not take this SELECTION gate.** Its two kernel
+  lines are emitted only while the receiver is actually locking or clocking a
+  link, so they already describe work somebody asked for. Do not extend
+  `provesSelectionIsNotHdmi` to it.
 - **`hdmiNoSignalRaiseAllowed()` (the production wiring in `sensors.ts`) is
   FAIL-OPEN.** A throw reading config or the sources list is not evidence about
   the operator, so it must never be the reason a real fault goes unreported.
 
+**The advisory DOES take a DEDUP guard, which is a different question.** Its raise
+was unconditional — every matching kernel line called `raise()`, and a link that is
+merely settling prints them repeatedly, so one replug cycle could re-fire the toast
+several times over and could also overwrite a standing "No HDMI signal detected" on
+the slot the two share. Both properties are fixed by ONE check: it raises only when
+`peek(HDMI_ERROR_NOTIFICATION)` is `undefined`, i.e. only onto a free channel.
+
+Note the deliberate asymmetry with the sibling no-signal raise, which DOES re-raise
+over its own standing notification (`!hdmiNotif || hdmiNotif.msg === HDMI_NO_SIGNAL_MSG`).
+That one re-asserts a condition the operator is being asked to act on; the advisory
+is one-shot guidance about the physical link, and repeating it teaches nothing new.
+
 The dmesg callback was extracted to the exported `handleRk3588HdmiDmesg(data,
 deps)` so both raise conditions are drivable without a `dmesg -w` process.
 Coverage: `tests/hdmi-raise-scope.test.ts` (the pure verdict table incl. the
-coarse/renumber/persisted-fallback arms, the sweep raising nothing, and the
-negative controls: a selected HDMI input with no cable still raises, the EMI
-advisory still raises under the same gate, and the standing-advisory
-non-overwrite is unchanged).
+coarse/renumber/persisted-fallback arms, the sweep raising nothing, the advisory's
+dedup guard — free channel raises, own-advisory and no-signal standing both refuse,
+a five-line settling burst costs exactly one raise, and the audio-underflow trigger
+under the same guard — and the negative controls: a selected HDMI input with no
+cable still raises, the advisory still raises past the selection gate, and the
+no-signal raise's own standing-advisory non-overwrite is unchanged).
 
 ## AN INFERENCE MAY NOT OUTRANK THE OPERATOR, AND A SHARED NODE PATH NAMES NOBODY [EXISTS]
 
@@ -3518,9 +3546,15 @@ config, an anchored path still held by its own device, and a live row with no
   authoritative recovery signal (see A PERSISTENT NOTIFICATION MUST BE RETRACTABLE).
 - Don't retract a notification whose NAME is shared by more than one claim without
   discriminating WHICH claim is standing — `hdmi_error` carries both the no-signal
-  and the EMI/cable advisory, and the `cerastream` channel carries every non-srtla
-  engine error. Key on the message (`HDMI_NO_SIGNAL_MSG`) or on the recorded code
-  (`standingEngineError`), never on the bare name.
+  message and the EMI/cable advisory, and the `cerastream` channel carries every
+  non-srtla engine error. Key on an explicit membership table
+  (`HDMI_MSGS_CLEARED_BY_LOCKED_SIGNAL`) or on the recorded code
+  (`standingEngineError`), never on the bare name. Note that membership is a
+  question about the EVIDENCE, not about how the claim was raised: a locked HDMI
+  signal falsifies BOTH `hdmi_error` messages, so both are in that table. Don't
+  re-exempt the advisory — it has no other retraction path, and its kernel lines
+  fire during ordinary link locking, which is how it became the operator-reported
+  "infinite notification for something that is already corrected".
 - Don't move the HDMI recovery hook off `commitEngineDevices` or gate it on a
   changed payload — it must see every engine-authored device view, including the
   ones that are byte-identical to the last.
@@ -3530,7 +3564,14 @@ config, an anchored path still held by its own device, and a live row with no
   `provesSelectionIsNotHdmi()`, and don't turn that suppression-only test into a
   fail-closed one: absence of evidence is not evidence, and refusing to raise on
   an unset/unresolvable selection would drop a genuine no-signal report. The
-  EMI/cable advisory stays UNGATED.
+  EMI/cable advisory keeps its own trigger and does NOT take that selection gate.
+- Don't raise the EMI/cable advisory onto an occupied `hdmi_error` channel — its
+  kernel lines repeat while a link merely settles, so an unconditional raise
+  re-fires a fresh toast per line and can overwrite a standing no-signal claim.
+  Raise only when `peek(HDMI_ERROR_NOTIFICATION)` is `undefined`. And don't
+  "unify" that with the no-signal guard's `|| msg === HDMI_NO_SIGNAL_MSG` arm:
+  the no-signal raise re-asserting itself is deliberate, the advisory doing so is
+  the defect.
 - Don't answer "is the selected capture device present" with a bare
   `sources.find(...)` on the Auto-audio path — the engine's device view has a
   real, NORMAL hole on every libuvc release (≈400 ms, up to 2 s), and resolving

--- a/apps/backend/src/modules/system/hdmi-signal-notification.ts
+++ b/apps/backend/src/modules/system/hdmi-signal-notification.ts
@@ -15,22 +15,27 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-// The retraction half of the `hdmi_error` "No HDMI signal detected" notification.
+// The retraction half of the `hdmi_error` notification channel, and the home of
+// BOTH messages `sensors.ts`'s RK3588 dmesg watcher raises onto it.
 //
-// `sensors.ts`'s RK3588 dmesg watcher RAISES it off the kernel line
-// `hdmirx-controller: Err, timing is invalid`. The kernel prints nothing when
-// the link comes back, and a persistent notification never expires on a timer
-// (`notification-liveness.ts`), so the raise was permanent: the operator read
-// "No HDMI signal detected" for a port that had relocked minutes earlier.
+// The watcher RAISES "No HDMI signal detected" off `hdmirx-controller: Err,
+// timing is invalid`, and the EMI/cable advisory off `hdmirx_wait_lock_and_get_timing
+// signal not lock` / `hdmirx_delayed_work_audio: audio underflow`. The kernel
+// prints nothing when the link comes back, and a persistent notification never
+// expires on a timer (`notification-liveness.ts`), so a raise with no retraction
+// is permanent: the operator read a stale HDMI complaint for a port that had
+// relocked minutes earlier.
 //
 // The recovery evidence is the SAME one the source list already trusts: the
 // engine's own `VIDIOC_QUERY_DV_TIMINGS` projection, stamped as
 // `CaptureDevice.signal` at `fromEngineDevice` — the one seam that knows the
 // ENGINE authored the row. `signal: "present"` on an HDMI-RX capture device is a
-// positive, engine-authored statement that the port is carrying a picture, which
-// is precisely the claim the notification denies. NOTHING here is a timer: an
-// unreachable engine, a fallback v4l2 scan row (`signal` unset ⇒ `unknown`), and
-// a still-severed link all fail the test and leave the notification standing.
+// positive, engine-authored statement that the port is carrying a picture, and
+// that falsifies BOTH claims: neither "there is no signal" nor "the link is too
+// impaired to carry one" survives the port delivering a locked picture. NOTHING
+// here is a timer: an unreachable engine, a fallback v4l2 scan row (`signal`
+// unset ⇒ `unknown`), and a still-severed link all fail the test and leave the
+// notification standing.
 
 import { deviceKindToPipelineId } from "@ceraui/rpc";
 import { notificationExists, notificationRemove } from "../ui/notifications.ts";
@@ -44,15 +49,26 @@ const HDMI_PIPELINE_ID = deviceKindToPipelineId(HDMI_DEVICE_KIND);
 /** Persistent-notification name shared by both `sensors.ts` HDMI raise sites. */
 export const HDMI_ERROR_NOTIFICATION = "hdmi_error";
 
-/**
- * The EXACT wire message of the no-signal raise. It is the discriminator, not
- * decoration: the name `hdmi_error` is shared with the EMI/cable-quality advisory
- * ("HDMI signal issues detected…"), which describes a DIFFERENT condition that a
- * relocked link does not falsify — the raise site already keys on this same
- * string to avoid overwriting that advisory. Retracting on anything less
- * specific would silently drop it.
- */
+/** The EXACT wire message of the no-signal raise. */
 export const HDMI_NO_SIGNAL_MSG = "No HDMI signal detected";
+
+/** The EXACT wire message of the EMI/cable-quality advisory raise. */
+export const EMI_ADVISORY_MSG =
+	"HDMI signal issues detected. This is usually caused either by EMI or a by a faulty cable. " +
+	"Try to move any modems away from the HDMI cable and the encoder. " +
+	"If that fails, try out a different HDMI cable or to manually set a lower HDMI resolution/framerate on your camera";
+
+/**
+ * The claims a locked HDMI signal falsifies, and the discriminator the retraction
+ * keys on. `hdmi_error` is ONE notification slot shared by two raise sites, so a
+ * blind remove-by-name would retract whatever happened to be standing — including
+ * a future third claim this evidence says nothing about. Membership is explicit
+ * for the same reason `ENGINE_ERRORS_CLEARED_BY_HEALTHY_SESSION` is.
+ */
+const HDMI_MSGS_CLEARED_BY_LOCKED_SIGNAL: readonly string[] = [
+	HDMI_NO_SIGNAL_MSG,
+	EMI_ADVISORY_MSG,
+];
 
 /** The two device fields the verdict reads; `CaptureDevice` satisfies it. */
 export interface HdmiSignalObservation {
@@ -180,9 +196,15 @@ export function setHdmiSignalRecoveryDepsForTest(
 }
 
 /**
- * Retract the standing "No HDMI signal detected" notification once an HDMI
- * receiver reports a locked signal again. Returns whether a removal was emitted,
- * so a caller (and a test) can assert the edge without inspecting the broadcast.
+ * Retract the standing `hdmi_error` notification once an HDMI receiver reports a
+ * locked signal again. Returns whether a removal was emitted, so a caller (and a
+ * test) can assert the edge without inspecting the broadcast.
+ *
+ * Both claims the channel carries are retracted, because the evidence falsifies
+ * both. The EMI/cable advisory was previously exempt, on the reading that it is
+ * about cable QUALITY rather than presence — but its kernel lines fire during
+ * ordinary link locking, so a routine replug raised an advisory that nothing
+ * could ever take back.
  *
  * Idempotent by construction: `notificationExists` answers `undefined` once the
  * notification is gone, so a steady stream of healthy device commits costs one
@@ -194,7 +216,8 @@ export function clearHdmiSignalErrorOnRecovery(
 ): boolean {
 	if (!provesHdmiSignalRecovered(devices)) return false;
 	const standing = deps.peek(HDMI_ERROR_NOTIFICATION);
-	if (standing?.msg !== HDMI_NO_SIGNAL_MSG) return false;
+	if (standing === undefined) return false;
+	if (!HDMI_MSGS_CLEARED_BY_LOCKED_SIGNAL.includes(standing.msg)) return false;
 	deps.remove(HDMI_ERROR_NOTIFICATION);
 	return true;
 }

--- a/apps/backend/src/modules/system/sensors.ts
+++ b/apps/backend/src/modules/system/sensors.ts
@@ -42,6 +42,7 @@ import {
 import { broadcastMsg } from "../ui/websocket-server.ts";
 import { getHardwareKindCached } from "./hardware-kind.ts";
 import {
+	EMI_ADVISORY_MSG,
 	HDMI_ERROR_NOTIFICATION,
 	HDMI_NO_SIGNAL_MSG,
 	provesSelectionIsNotHdmi,
@@ -189,11 +190,6 @@ export interface HdmiDmesgDeps {
 	noSignalRaiseAllowed: () => boolean;
 }
 
-const EMI_ADVISORY_MSG =
-	"HDMI signal issues detected. This is usually caused either by EMI or a by a faulty cable. " +
-	"Try to move any modems away from the HDMI cable and the encoder. " +
-	"If that fails, try out a different HDMI cable or to manually set a lower HDMI resolution/framerate on your camera";
-
 /**
  * FAIL-OPEN by construction: only a selection this device can positively read
  * AND positively identify as non-HDMI withholds the raise. A throw here (config
@@ -229,23 +225,29 @@ export function handleRk3588HdmiDmesg(
 	data: string,
 	deps: HdmiDmesgDeps = defaultHdmiDmesgDeps,
 ): void {
-	// The EMI/cable advisory is deliberately UNGATED: the kernel emits these two
-	// lines only while the receiver is actually locking or clocking a link, so
-	// they already describe work somebody asked for.
+	// The EMI/cable advisory keeps its own TRIGGER — it is not subject to the
+	// selection gate below, because the kernel emits these two lines only while
+	// the receiver is actually locking or clocking a link, so they already
+	// describe work somebody asked for. What it does NOT get is a free re-raise:
+	// a link that is merely settling prints them repeatedly, and each raise is a
+	// fresh toast. Refusing while ANYTHING stands on the shared channel gives the
+	// dedup and the "don't clobber the no-signal claim" symmetry in one test.
 	if (
 		data.match("hdmirx_wait_lock_and_get_timing signal not lock") ||
 		data.match("hdmirx_delayed_work_audio: audio underflow")
 	) {
-		deps.raise(
-			HDMI_ERROR_NOTIFICATION,
-			"error",
-			EMI_ADVISORY_MSG,
-			8,
-			true,
-			true,
-			true,
-			"notifications.hdmiError",
-		);
+		if (deps.peek(HDMI_ERROR_NOTIFICATION) === undefined) {
+			deps.raise(
+				HDMI_ERROR_NOTIFICATION,
+				"error",
+				EMI_ADVISORY_MSG,
+				8,
+				true,
+				true,
+				true,
+				"notifications.hdmiError",
+			);
+		}
 	}
 
 	if (data.match("hdmirx-controller: Err, timing is invalid")) {

--- a/apps/backend/src/tests/hdmi-raise-scope.test.ts
+++ b/apps/backend/src/tests/hdmi-raise-scope.test.ts
@@ -13,11 +13,16 @@
  * The gate is SUPPRESSION-ONLY: it may withhold a raise only when the selection is
  * PROVEN to be something other than an HDMI input. Every test below that asserts a
  * raise is a negative control for that rule.
+ *
+ * The EMI/cable advisory shares the `hdmi_error` channel and keeps its own
+ * trigger (it is not subject to the selection gate above), but its raise is no
+ * longer unconditional — see "the EMI/cable advisory's dedup guard" below.
  */
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import type { LastSeenDevice } from "../helpers/config-schemas.ts";
 import {
+	EMI_ADVISORY_MSG,
 	HDMI_ERROR_NOTIFICATION,
 	HDMI_NO_SIGNAL_MSG,
 	type HdmiSelectionObservation,
@@ -32,6 +37,8 @@ const NO_SIGNAL_LINE =
 	"[  812.443001] hdmirx-controller: Err, timing is invalid\n";
 const EMI_LINE =
 	"[  812.443001] hdmirx_wait_lock_and_get_timing signal not lock\n";
+const AUDIO_UNDERFLOW_LINE =
+	"[  812.443001] hdmirx_delayed_work_audio: audio underflow\n";
 
 interface RaisedNotification {
 	name: string;
@@ -170,11 +177,76 @@ describe("handleRk3588HdmiDmesg — the raise it is allowed to make", () => {
 			expect(h.raised).toEqual([]);
 		});
 
-		test("does not disturb the EMI/cable advisory, which stays ungated", () => {
+		test("does not disturb the EMI/cable advisory, whose own trigger is unchanged", () => {
 			handleRk3588HdmiDmesg(EMI_LINE, h.deps);
 			expect(h.raised).toHaveLength(1);
 			expect(h.raised[0]?.name).toBe(HDMI_ERROR_NOTIFICATION);
-			expect(h.raised[0]?.msg).toContain("HDMI signal issues detected");
+			expect(h.raised[0]?.msg).toBe(EMI_ADVISORY_MSG);
+		});
+	});
+
+	/*
+	 * DELIBERATE POLICY CHANGE — the test above previously read "…which stays
+	 * ungated" and was the whole of the advisory's coverage, because its raise
+	 * was unconditional.
+	 *
+	 * Its TRIGGER is still unchanged (the same two kernel lines, still outside
+	 * `noSignalRaiseAllowed`'s selection gate — that is what "ungated" meant and
+	 * still means). What is new is a DEDUP guard around the raise itself: the
+	 * kernel prints those lines repeatedly while a link merely settles, and an
+	 * unconditional raise re-fired a fresh toast on every one of them. The
+	 * sibling no-signal raise has always carried this kind of guard; the advisory
+	 * had none, so it could also overwrite a standing no-signal notification on
+	 * the channel the two share.
+	 */
+	describe("the EMI/cable advisory's dedup guard", () => {
+		test("raises when the channel is free", () => {
+			const scoped = harness(true);
+			handleRk3588HdmiDmesg(EMI_LINE, scoped.deps);
+			expect(scoped.raised).toEqual([
+				{ name: HDMI_ERROR_NOTIFICATION, msg: EMI_ADVISORY_MSG },
+			]);
+		});
+
+		test("does NOT re-fire over its own standing advisory", () => {
+			const scoped = harness(true, { msg: EMI_ADVISORY_MSG });
+			handleRk3588HdmiDmesg(EMI_LINE, scoped.deps);
+			expect(scoped.raised).toEqual([]);
+		});
+
+		test("does NOT clobber a standing no-signal notification", () => {
+			const scoped = harness(true, { msg: HDMI_NO_SIGNAL_MSG });
+			handleRk3588HdmiDmesg(EMI_LINE, scoped.deps);
+			expect(scoped.raised).toEqual([]);
+		});
+
+		test("a settling link printing the line repeatedly costs exactly one raise", () => {
+			let standing: { msg: string } | undefined;
+			const raised: RaisedNotification[] = [];
+			const deps: HdmiDmesgDeps = {
+				peek: () => standing,
+				raise: (name, _type, msg) => {
+					raised.push({ name, msg });
+					standing = { msg };
+				},
+				noSignalRaiseAllowed: () => true,
+			};
+
+			for (let i = 0; i < 5; i++) handleRk3588HdmiDmesg(EMI_LINE, deps);
+
+			expect(raised).toEqual([
+				{ name: HDMI_ERROR_NOTIFICATION, msg: EMI_ADVISORY_MSG },
+			]);
+		});
+
+		test("the audio-underflow line is still a trigger, under the same guard", () => {
+			const free = harness(true);
+			handleRk3588HdmiDmesg(AUDIO_UNDERFLOW_LINE, free.deps);
+			expect(free.raised).toHaveLength(1);
+
+			const occupied = harness(true, { msg: EMI_ADVISORY_MSG });
+			handleRk3588HdmiDmesg(AUDIO_UNDERFLOW_LINE, occupied.deps);
+			expect(occupied.raised).toEqual([]);
 		});
 	});
 

--- a/apps/backend/src/tests/notification-recovery-clearing.test.ts
+++ b/apps/backend/src/tests/notification-recovery-clearing.test.ts
@@ -41,6 +41,7 @@ import {
 	resetEngineDeviceCache,
 } from "../modules/streaming/sources.ts";
 import {
+	EMI_ADVISORY_MSG,
 	HDMI_ERROR_NOTIFICATION,
 	HDMI_NO_SIGNAL_MSG,
 	provesHdmiSignalRecovered,
@@ -54,9 +55,6 @@ import { addClient, removeClient } from "../rpc/events.ts";
 import type { AppWebSocket } from "../rpc/types.ts";
 
 const HDMI_RX_ID = "/dev/video0";
-
-const EMI_ADVISORY_MSG =
-	"HDMI signal issues detected. This is usually caused either by EMI or a by a faulty cable.";
 
 const LOCKED_1080P5994: ListDevicesResult["devices"][number]["caps"] = [
 	{ width: 1920, height: 1080, framerate: "60000/1001" },
@@ -175,6 +173,20 @@ function raiseNoHdmiSignal(): void {
 	);
 }
 
+/** The OTHER claim on the same channel, raised exactly as `sensors.ts` raises it. */
+function raiseEmiAdvisory(): void {
+	notificationBroadcast(
+		HDMI_ERROR_NOTIFICATION,
+		"error",
+		EMI_ADVISORY_MSG,
+		8,
+		true,
+		true,
+		true,
+		"notifications.hdmiError",
+	);
+}
+
 function probe(
 	devices: ListDevicesResult["devices"],
 ): Promise<void> | ReturnType<typeof recheckSourceSignals> {
@@ -274,23 +286,51 @@ describe("hdmi_error clears when the HDMI link relocks", () => {
 		expect(notificationExists(HDMI_ERROR_NOTIFICATION)).toBeDefined();
 	});
 
-	test("the EMI/cable advisory sharing the name is left alone — it is a different claim", async () => {
-		notificationBroadcast(
-			HDMI_ERROR_NOTIFICATION,
-			"error",
-			EMI_ADVISORY_MSG,
-			8,
-			true,
-			true,
-			true,
-			"notifications.hdmiError",
-		);
+	/*
+	 * DELIBERATE POLICY CHANGE — this test previously asserted the opposite
+	 * ("the EMI/cable advisory sharing the name is left alone — it is a different
+	 * claim"). The advisory was exempted from retraction on the reading that it
+	 * describes CABLE QUALITY, which a relocked link does not falsify.
+	 *
+	 * Operators reported the consequence: "an infinite notification for something
+	 * that is already corrected". The two kernel lines behind the advisory
+	 * (`hdmirx_wait_lock_and_get_timing signal not lock`, `hdmirx_delayed_work_audio:
+	 * audio underflow`) are printed during ORDINARY link locking — a plain
+	 * unplug/replug cycle emits them — not only during a sustained fault. With no
+	 * retraction path and no timer expiry, a routine cable swap left the advisory
+	 * standing for the rest of the session.
+	 *
+	 * An engine-authored `signal: "present"` on the HDMI-RX port is a positive
+	 * statement that the port is carrying a picture, and that falsifies BOTH claims
+	 * on this channel equally. The retraction is therefore symmetric now.
+	 */
+	test("the EMI/cable advisory sharing the name is retracted by the same evidence", async () => {
+		raiseEmiAdvisory();
 
 		const frames = await captureFrames(() =>
 			Promise.resolve(probe([hdmiRxEntry(LOCKED_1080P5994)])),
 		);
 
-		expect(removedIds(frames)).not.toContain(HDMI_ERROR_NOTIFICATION);
+		expect(removedIds(frames)).toContain(HDMI_ERROR_NOTIFICATION);
+		expect(notificationExists(HDMI_ERROR_NOTIFICATION)).toBeUndefined();
+	});
+
+	test("a severed link leaves the advisory standing, exactly like the no-signal claim", async () => {
+		raiseEmiAdvisory();
+
+		await probe([hdmiRxEntry()]);
+		await probe([hdmiRxEntry()]);
+
+		expect(notificationExists(HDMI_ERROR_NOTIFICATION)?.msg).toBe(
+			EMI_ADVISORY_MSG,
+		);
+	});
+
+	test("a different device's picture never retracts the advisory either", async () => {
+		raiseEmiAdvisory();
+
+		await probe([hdmiRxEntry(), usbDongleEntry()]);
+
 		expect(notificationExists(HDMI_ERROR_NOTIFICATION)?.msg).toBe(
 			EMI_ADVISORY_MSG,
 		);


### PR DESCRIPTION
## What
The "HDMI signal issues detected" (EMI/cable-quality) advisory notification could never be retracted, and could also re-fire a fresh toast repeatedly while the HDMI link was merely settling — even though the underlying condition had genuinely resolved.

## Why
Both this advisory and the separate "No HDMI signal detected" message share one persistent-notification channel (`hdmi_error`). Only the no-signal message had a retraction path (triggered by an engine-confirmed `signal: "present"` on the HDMI-RX port). The EMI advisory had none, by an earlier deliberate design choice recorded in the code — and its raise call had no dedup guard either, unlike its sibling. Since the two kernel dmesg lines behind it (`hdmirx_wait_lock_and_get_timing signal not lock`, `hdmirx_delayed_work_audio: audio underflow`) print during ordinary link-locking activity — not only during sustained faults — a routine cable reseat or signal renegotiation left the advisory standing indefinitely, and could re-trigger it repeatedly. Reported directly by an operator as "an infinite notification for something that is already corrected."

## How to verify
- `bun test` (backend): the two affected test files (`hdmi-raise-scope.test.ts`, `notification-recovery-clearing.test.ts`) cover both fixes with real kernel dmesg-line fixtures — the new retraction path, the new dedup guard (including a "5 repeated triggers costs exactly one raise" regression test), and negative controls proving a genuinely severed link still leaves the notification standing.
- Live-verified this session: deployed to a real Rock 5B+ board, backend restarted cleanly, `/api/health` reports healthy/idle, notification panel clean post-restart.

## Risks
Low. Scoped to two notification-channel raise/retraction functions; the sibling "No HDMI signal detected" path is untouched (verified byte-identical in review). No timer-based expiry introduced (this codebase has a documented house rule against that pattern). `apps/backend/AGENTS.md` updated in the same commit per Rule A.
