### PR TITLE
ci(release): install fpm for the release/package contract gate

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -227,6 +227,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-store-
 
+      - name: Cache Ruby gems (fpm)
+        uses: actions/cache@v6
+        with:
+          path: /var/lib/gems
+          key: ${{ runner.os }}-ruby-gems-fpm-v1
+          restore-keys: |
+            ${{ runner.os }}-ruby-gems-fpm-
+
+      # Two of the contracts this job runs BUILD a .deb to inspect its payload
+      # (deb-reconciler-staging, deb-sourcemap-policy), so fpm is a dependency of
+      # the gate itself — not only of build-debian-package, which installs it
+      # separately and runs later.
+      - name: Install Ruby and FPM
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ruby-dev gcc g++
+          sudo gem install --no-document fpm
+
       - name: Install dependencies
         working-directory: CeraUI
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## What

Adds the `Install Ruby and FPM` step (plus its gem cache) to the
`release-package-contracts` job in `publish-release.yml`, matching the step that
`build-check.yml`'s `test-be` job already has.

## Why

**The release path has been broken since 2026-07-24 and nothing could show it.**

Two of the contracts this job runs build a real `.deb` and inspect its payload:

| Contract | Landed |
|---|---|
| `deb-reconciler-staging.test.sh` (#194) | 2026-07-24 |
| `deb-sourcemap-policy.test.sh` (#288) | 2026-08-15 |

The last successful release was **v2026.7.2 on 2026-07-19** — five days before the
first of those arrived. The very next release dispatch
([run 32447963881](https://github.com/CERALIVE/CeraUI/actions/runs/32447963881))
died at the first gate:

```
FAIL: fpm not on PATH (required build dependency)
```

It stayed invisible because `build-check.yml`'s `test-be` job runs the **same**
contract suite and **does** install fpm — so every PR was green. Only the release
workflow's own gate lacked it. A gate exercised solely at release time reports its
own breakage solely at release time.

Nothing was published by that failed run: `publish-federation`, `build-debian-package`,
`build-ceraui-system`, `create-release` and `dispatch-apt-reindex` all show `skipped`,
so there is no tag, no GitHub release, and no R2 write to reconcile.

## How to verify

- `bun run test:release-package-contracts` passes locally (fpm present) and is the
  suite that was failing on the runner.
- The step and cache key are byte-identical to `build-check.yml`'s, so the two jobs
  cannot drift apart again.
- `build-debian-package` keeps its own fpm install — it runs later and independently;
  this does not remove or reroute it.
- YAML parses; step order verified (fpm install precedes `Run release/package contracts`).

## Risks

Low, and scoped to CI. Adds ~40 s of gem install to one release job, cached after the
first run. No source, no packaging logic, and no release semantics change — the job's
own contract assertions are untouched. `publish-release.yml` is a `skip_workflows`
entry in the root `ci-local.manifest.yaml` ("secrets/OIDC"), so no manifest leaf or
digest needs updating for this change.