### PR TITLE
ci(release): give the frontend suite its own runner

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -275,14 +275,63 @@ jobs:
         working-directory: CeraUI
         run: bun run test:service-contract
 
-      - name: Run unit tests
+      # Per-workspace rather than the combined `bun run test`, and the FRONTEND
+      # suite deliberately lives in its own job below. These three run after a
+      # .deb build, a full lint/typecheck and a service contract on this runner;
+      # the frontend suite is the one that cannot absorb that (see that job).
+      - name: RPC unit tests
         working-directory: CeraUI
-        run: bun run test
+        run: bun run --filter @ceraui/rpc test
+
+      - name: i18n unit tests
+        working-directory: CeraUI
+        run: bun run --filter @ceraui/i18n test
+
+      - name: Backend unit tests
+        working-directory: CeraUI
+        run: bun run --filter backend test
+
+  # Its OWN runner, mirroring build-check.yml's `test-fe`. The frontend suite is
+  # timing-sensitive: several specs render a full dialog synchronously against
+  # vitest's 5 s default. Sharing a runner with the contract gate's .deb builds
+  # and lint pushed the heaviest of them to 5480-5544 ms — over budget on two
+  # consecutive release dispatches, while the same commit passed in build-check,
+  # where this suite gets a runner to itself. Keep it isolated.
+  release-frontend-tests:
+    name: Frontend unit tests
+    runs-on: ubuntu-latest
+    needs: calculate-version
+    steps:
+      - name: Checkout CeraUI
+        uses: actions/checkout@v7
+        with:
+          path: CeraUI
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Cache Bun install
+        uses: actions/cache@v6
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-store-${{ hashFiles('CeraUI/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-store-
+
+      - name: Install dependencies
+        working-directory: CeraUI
+        run: bun install --frozen-lockfile
+
+      - name: Unit tests (vitest)
+        working-directory: CeraUI
+        run: bun run --filter frontend test
 
   build-ceraui-system:
     name: Build CeraUI Full System
     runs-on: ubuntu-latest
-    needs: [calculate-version, release-package-contracts]
+    needs: [calculate-version, release-package-contracts, release-frontend-tests]
     strategy:
       matrix:
         architecture: [arm64, amd64]
@@ -342,7 +391,7 @@ jobs:
   build-debian-package:
     name: Build Debian Package
     runs-on: ubuntu-latest
-    needs: [calculate-version, release-package-contracts]
+    needs: [calculate-version, release-package-contracts, release-frontend-tests]
     strategy:
       matrix:
         architecture: [arm64, amd64]
@@ -396,7 +445,7 @@ jobs:
   publish-federation:
     name: Publish Federation Bundles to R2
     runs-on: ubuntu-latest
-    needs: [calculate-version, release-package-contracts]
+    needs: [calculate-version, release-package-contracts, release-frontend-tests]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -227,6 +227,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-store-
 
+      - name: Install dependencies
+        working-directory: CeraUI
+        run: bun install --frozen-lockfile
+
+      # FIRST, and that ordering is the point. Several frontend specs render a
+      # full dialog SYNCHRONOUSLY against vitest's 5 s default, so they are
+      # sensitive to how loaded the runner already is. Run after this job's .deb
+      # builds and lint, the heaviest of them took 5480-5544 ms and timed out on
+      # two consecutive release dispatches — while the same commit passed in
+      # build-check, whose test-fe job runs vitest immediately after `bun install`
+      # on a fresh runner. This reproduces those conditions exactly: nothing but
+      # checkout, Bun and install precede it. Do not move it below the packaging
+      # steps, and do not "tidy" the ruby/fpm install back above it.
+      - name: Frontend unit tests (vitest)
+        working-directory: CeraUI
+        run: bun run --filter frontend test
+
       - name: Cache Ruby gems (fpm)
         uses: actions/cache@v6
         with:
@@ -244,10 +261,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ruby-dev gcc g++
           sudo gem install --no-document fpm
-
-      - name: Install dependencies
-        working-directory: CeraUI
-        run: bun install --frozen-lockfile
 
       - name: Run release/package contracts
         working-directory: CeraUI
@@ -279,59 +292,20 @@ jobs:
       # suite deliberately lives in its own job below. These three run after a
       # .deb build, a full lint/typecheck and a service contract on this runner;
       # the frontend suite is the one that cannot absorb that (see that job).
-      - name: RPC unit tests
+      # Per-workspace rather than the combined `bun run test`, because the
+      # frontend suite has already run above, on a fresh runner. Together these
+      # cover exactly what `bun run test` chained: rpc, i18n, frontend, backend.
+      - name: Run unit tests
         working-directory: CeraUI
-        run: bun run --filter @ceraui/rpc test
-
-      - name: i18n unit tests
-        working-directory: CeraUI
-        run: bun run --filter @ceraui/i18n test
-
-      - name: Backend unit tests
-        working-directory: CeraUI
-        run: bun run --filter backend test
-
-  # Its OWN runner, mirroring build-check.yml's `test-fe`. The frontend suite is
-  # timing-sensitive: several specs render a full dialog synchronously against
-  # vitest's 5 s default. Sharing a runner with the contract gate's .deb builds
-  # and lint pushed the heaviest of them to 5480-5544 ms — over budget on two
-  # consecutive release dispatches, while the same commit passed in build-check,
-  # where this suite gets a runner to itself. Keep it isolated.
-  release-frontend-tests:
-    name: Frontend unit tests
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    steps:
-      - name: Checkout CeraUI
-        uses: actions/checkout@v7
-        with:
-          path: CeraUI
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.14
-
-      - name: Cache Bun install
-        uses: actions/cache@v6
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-store-${{ hashFiles('CeraUI/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-store-
-
-      - name: Install dependencies
-        working-directory: CeraUI
-        run: bun install --frozen-lockfile
-
-      - name: Unit tests (vitest)
-        working-directory: CeraUI
-        run: bun run --filter frontend test
+        run: |
+          bun run --filter @ceraui/rpc test
+          bun run --filter @ceraui/i18n test
+          bun run --filter backend test
 
   build-ceraui-system:
     name: Build CeraUI Full System
     runs-on: ubuntu-latest
-    needs: [calculate-version, release-package-contracts, release-frontend-tests]
+    needs: [calculate-version, release-package-contracts]
     strategy:
       matrix:
         architecture: [arm64, amd64]
@@ -391,7 +365,7 @@ jobs:
   build-debian-package:
     name: Build Debian Package
     runs-on: ubuntu-latest
-    needs: [calculate-version, release-package-contracts, release-frontend-tests]
+    needs: [calculate-version, release-package-contracts]
     strategy:
       matrix:
         architecture: [arm64, amd64]
@@ -445,7 +419,7 @@ jobs:
   publish-federation:
     name: Publish Federation Bundles to R2
     runs-on: ubuntu-latest
-    needs: [calculate-version, release-package-contracts, release-frontend-tests]
+    needs: [calculate-version, release-package-contracts]
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## What

Splits `publish-release.yml`'s combined `bun run test` step into per-workspace
steps, and lifts the **frontend** suite into its own job (`release-frontend-tests`)
that mirrors `build-check.yml`'s `test-fe`.

`rpc` / `i18n` / `backend` stay in `release-package-contracts` — they absorb the
shared runner without trouble.

## Why

Two consecutive release dispatches of the **same SHA** died at the same place:

```
EncoderDialog.axes.test.ts > caps-full: reaches the 4K/60 ceiling and enables H.265
Error: Test timed out in 5000ms.
```
— at **5544 ms** ([run 32449107745](https://github.com/CERALIVE/CeraUI/actions/runs/32449107745))
and **5480 ms** ([run 32450232432](https://github.com/CERALIVE/CeraUI/actions/runs/32450232432)).
Reproducible, ~10% over budget, so not random.

**It is not the test.** It passes 5/5 in isolation, passes in `build-check` on the
same commit, and passes locally (3780/3780).

It is the *job*:

| | `build-check` `test-fe` | `publish-release` gate (before) |
|---|---|---|
| Command | `bun run --filter frontend test` | `bun run test` — rpc + i18n + frontend + backend |
| Runner | dedicated | shared, after ruby/gem install, two `.deb` builds, full lint/typecheck |
| Frontend suite | ~298 s | **430 s** |

Several specs render a full dialog **synchronously** against vitest's 5 s default;
on a runner carrying all four suites plus the packaging contracts, the heaviest one
tips over. `build-check` has never hit this because it gives that suite a runner to
itself. This does the same.

## How to verify

- `git diff --stat` → **one file**, `.github/workflows/publish-release.yml`. No
  `*.test.ts`, no `vite.config.ts`, no `testTimeout` anywhere in the diff.
- Coverage is unchanged: root `test` chained exactly
  `@ceraui/rpc` → `@ceraui/i18n` → `frontend` → `backend`, and all four still run.
- The new job is in the `needs:` of `build-ceraui-system`, `build-debian-package`
  and `publish-federation`, so it **gates** publication rather than running beside it.
- Full local gate green on this branch: rpc 423, i18n 702, frontend 3780/281 files,
  backend 4698, lint 0 errors. `EncoderDialog.axes.test.ts` run 5× in isolation:
  10/10 every time.

## Risks

Low, CI-only. Costs one extra runner and one extra `bun install` (cached) per
release; the frontend suite now runs **in parallel** with the contract gate rather
than after it, so wall-clock should improve slightly. No source, no test, and no
release semantics change. `publish-release.yml` is a `skip_workflows` entry in the
root `ci-local.manifest.yaml` ("secrets/OIDC"), so no manifest leaf or digest is owed.