### PR TITLE
fix(test): give the signal-detail dialog spec the render budget its siblings carry

### DIFF
--- a/apps/frontend/src/main/dialogs/ModemConfigDialog.signalDetail.test.ts
+++ b/apps/frontend/src/main/dialogs/ModemConfigDialog.signalDetail.test.ts
@@ -161,6 +161,15 @@ beforeEach(() => {
 	resetModemsFeed();
 });
 
+// All 21 cases mount the WHOLE dialog, so this file is render-bound rather than
+// assertion-bound — the reasoning `ModemConfigDialog.detail.test.ts` records for
+// its own budget. This spec shipped without one and was the last heavy dialog
+// file on vitest's 5000 ms default; it timed out a release runner at 71 s wall,
+// with case slots reaching 16.7 s. That is past the 15 s sibling budget, so this
+// matches `src/tests/modem-raw-token-sweep.test.ts` instead. A budget, not a
+// tolerance: nothing is relaxed or skipped, and a hung render still fails.
+vi.setConfig({ testTimeout: 30000 });
+
 describe("the extended radio measurements", () => {
 	it("renders every measurement the modem reported, each with its own unit", async () => {
 		await open(modemWith({ signal_detail: lteSignalDetail() }));


### PR DESCRIPTION
**Affected repo & language:** CeraUI — TypeScript (frontend test)

## What

Adds the file-scoped render budget that every other heavy dialog spec in
`apps/frontend/src/main/dialogs/` already carries to
`ModemConfigDialog.signalDetail.test.ts`:

```ts
vi.setConfig({ testTimeout: 30000 });
```

One line plus its rationale. No assertion, fixture or case is touched.

## Why

That spec mounts the **whole** `ModemConfigDialog` in all 21 of its cases, so its
wall-clock tracks Svelte transform cost and machine load rather than anything it
asserts — locally the run is 67% transform, 7% tests. It shipped without a budget
and was the last such file relying on vitest's 5000 ms default.

That default is not enough on a loaded runner, and it stopped a release:
`publish-release.yml` run
[32932175177](https://github.com/CERALIVE/CeraUI/actions/runs/32932175177) failed
in its `Frontend unit tests (vitest)` step with three
`Error: Test timed out in 5000ms.` — 353 of 354 files passed, 5722 of 5725 tests
passed, and **not one assertion failed**. The file took 71 s wall for 21 cases
there, with individual case slots reaching 16.7 s. The same commit had passed the
identical file in `build-check` two minutes earlier, which is what identifies this
as runner load rather than a defect.

The workflow already anticipates this class — the comment above that very step
records that dialog specs rendering synchronously against the 5 s default "timed
out on two consecutive release dispatches" and that running the step first is a
mitigation. It was not sufficient here, because this file is heavier than the ones
that mitigation was tuned for.

**Why 30 s and not the 15 s its siblings use:** case slots were measured past
15000 ms on that runner, so the sibling budget would not have cleared it.
`src/tests/modem-raw-token-sweep.test.ts` — the other whole-surface sweep — already
uses 30000, so this follows existing precedent rather than inventing a number.

This is a **budget, not a tolerance**, and deliberately not a Rule-E weakening:
nothing is relaxed, skipped or deleted, and a genuinely hung render still fails —
just not on a runner that is merely slow.

## How to verify

```sh
cd apps/frontend
bun --bun vitest run src/main/dialogs/ModemConfigDialog.signalDetail.test.ts
```

21/21 pass. Run three times back to back on this branch: 21/21 each, 14.72 s /
15.10 s / 15.15 s, transform 67% every run.

Full frontend suite on this branch is unchanged at **354 files / 5,725 tests, 0
failures** (`bun run --filter frontend test`).

The real check is the release gate itself: the `Frontend unit tests (vitest)` step
of the next `publish-release.yml` dispatch should pass where it previously failed.

## Risks

Effectively none. The change is one `vi.setConfig` call scoped to a single spec
file — it cannot affect application code, and it cannot affect any other spec,
because vitest applies it per module.

The one thing it genuinely trades away is detection latency: if a case in this file
ever truly hangs, it now takes 30 s to say so instead of 5 s. That is the same
trade the eight sibling specs already made, and it is the correct side of it for a
file whose honest runtime is ~15 s under parallel load.

If the same three cases time out again *even at 30 s*, that would no longer be a
budget mismatch — it would be a real performance regression in the dialog, and
should be treated as one rather than by widening the number again.

---

**Checklist**

- [x] Docs updated if behavior or structure changed (Rule A: AGENTS.md, README, docs/, ARCHITECTURE.md, versions.yaml)
- [x] Started from updated main; branch rebased on latest canonical branch (Rule B)
- [x] Rule D local-scratch reference check passes for tracked files
- [x] Tests pass; QA evidence attached or linked
