### PR TITLE
chore(deps): pin @ceralive/cerastream 2026.8.1 so device_address survives parse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ setup.json are coerced to `"cerastream"` at parse time with a warning).
 The backend resolves both streaming deps as public-npm registry packages — no sibling checkout, no vendored tarball:
 
 ```
-"@ceralive/cerastream":  "2026.8.0"   (public npm, @ceralive scope)
+"@ceralive/cerastream":  "2026.8.1"   (public npm, @ceralive scope)
 "@ceralive/srtla-send":  "2026.8.0"   (public npm, @ceralive scope)
 ```
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -9,7 +9,7 @@
 		"bun": ">=1.3.0"
 	},
 	"dependencies": {
-		"@ceralive/cerastream": "2026.8.0",
+		"@ceralive/cerastream": "2026.8.1",
 		"@ceralive/control-protocol": "2026.7.0",
 		"@ceralive/modem-control": "1.3.0",
 		"@ceralive/srtla-send": "2026.8.0",

--- a/apps/backend/src/tests/cerastream-bindings-skew.test.ts
+++ b/apps/backend/src/tests/cerastream-bindings-skew.test.ts
@@ -213,6 +213,33 @@ describe("cerastream bindings version-skew guard", () => {
 		expect(withKind.kind).toBe("uvc_h264");
 	});
 
+	test("captureDeviceSchema carries device_address through .parse()", () => {
+		// cerastream PR #126 added this field; CeraUI shipped BT-mic code reading
+		// it under the 2026.8.0 pin, which predates that PR — and because the
+		// consumers declared their own local `device_address?: string`, typecheck
+		// stayed green while Zod stripped the field on every device.
+		// Reading it WITHOUT a cast is the compile-time half of the guard; the
+		// equality is the runtime half.
+		const address = "AA:BB:CC:DD:EE:FF";
+		const withAddress = bindings.captureDeviceSchema.parse({
+			input_id: "bluez_input.AA_BB_CC_DD_EE_FF",
+			device_path: "hw:CARD=btmic",
+			display_name: "Bluetooth Microphone",
+			media_class: "audio",
+			device_address: address,
+		});
+		expect(withAddress.device_address).toBe(address);
+
+		// Additive-optional: a producer that published none gets no fabricated one.
+		const withoutAddress = bindings.captureDeviceSchema.parse({
+			input_id: "video0",
+			device_path: "/dev/video0",
+			display_name: "USB Camera",
+			media_class: "video",
+		});
+		expect(withoutAddress.device_address).toBeUndefined();
+	});
+
 	test("0.4.0 surface: statusEventSchema has additive optional active_encode field", () => {
 		// Minimal status (backward compat)
 		const minimal = bindings.statusEventSchema.parse({

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -19,7 +19,7 @@ Svelte 5 PWA for CeraUI — the on-device control plane for CeraLive streaming h
 The `backend` app consumes both streaming bindings as pinned public npm packages:
 
 ```
-"@ceralive/cerastream": "2026.8.0"   (public npm, @ceralive scope)
+"@ceralive/cerastream": "2026.8.1"   (public npm, @ceralive scope)
 "@ceralive/srtla-send": "2026.8.0"   (public npm, @ceralive scope)
 ```
 

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
       "name": "backend",
       "version": "2026.6.2",
       "dependencies": {
-        "@ceralive/cerastream": "2026.8.0",
+        "@ceralive/cerastream": "2026.8.1",
         "@ceralive/control-protocol": "2026.7.0",
         "@ceralive/modem-control": "1.3.0",
         "@ceralive/srtla-send": "2026.8.0",
@@ -337,7 +337,7 @@
 
     "@ceralive/biome-config": ["@ceralive/biome-config@2026.8.1", "", {}, "sha512-SAqNoi2sc21HMwtY1UqrVqJtNMdcfrjEqVI+RMbbr+nhRC/vPkbHfRzavrNA5IYXeL6wJNDVhFWlyWDw3R3TtA=="],
 
-    "@ceralive/cerastream": ["@ceralive/cerastream@2026.8.0", "", { "dependencies": { "zod": "^4.4.3" } }, "sha512-pHRoPhScd6f7E6QOp5MpVEE2rmmUbaEx8S6v+4rCsxezS2tvKEwP2CuhOvxuAQIOdk+IqB1FldKkTZ9QGL/fKA=="],
+    "@ceralive/cerastream": ["@ceralive/cerastream@2026.8.1", "", { "dependencies": { "zod": "^4.4.3" } }, "sha512-B4/gNOXga8tl/KNQOGijdUyIWGYYuSputq6mVKZmxLZbILtDolQw4UmtpeurUTdiB6tBwrrDUOJXp3wr6BC3tA=="],
 
     "@ceralive/control-protocol": ["@ceralive/control-protocol@2026.7.0", "", { "dependencies": { "zod": "^4.3.5" } }, "sha512-/pLQpo3bTUzzxaQJK0zta4XKS6EJWr26p5jj2YST69ejxafQiCCjXKgdOkMWU9VjKm0XeMNQehxXOb6ylMGGHg=="],
 


### PR DESCRIPTION
## What

Bumps `apps/backend`'s `@ceralive/cerastream` pin from `2026.8.0` to `2026.8.1` (plus `bun.lock` and the two docs that quote the pin), and adds one regression test to the binding-skew suite asserting `captureDeviceSchema.parse()` carries `device_address` through.

## Why

PR #303 shipped Bluetooth-microphone code reading `node.device_address` while the pin was still `2026.8.0` — a version whose schema does not carry that field at all. Zod's default `z.object()` strips unrecognized keys silently, so the field was dropped before any of that code ran: no error, no warning, on every real device.

Typecheck could not catch it either, because `bluetooth-audio.ts`, `sources.ts` and `audio-naming.ts` each declare their own local `device_address?: string` rather than importing the producer's type. `2026.8.1` is the cerastream release that publishes the field (PR #126), so the bump closes the runtime half.

The new test is the check that would have caught this before merge. It reads `.device_address` off the parsed value **without a cast**, so a pin that loses the field fails to compile as well as to run — the compile-time half is deliberate, not incidental.

The workspace-level rule this follows from (no shadow wire-types; publish before consume) lands separately in CERALIVE/ceralive#100.

## How to verify

```
bun install
bun run --filter backend check                       # 0 errors
cd apps/backend && bun test                          # 5567 pass / 0 fail / 2 skip
bun test src/tests/cerastream-bindings-skew.test.ts  # 15 pass
```

The assertion is falsifiable, not decorative — the two installed tarballs differ exactly where it matters:

```
2026.8.0/dist/types.js: device_address occurrences = 0
2026.8.1/dist/types.js: device_address occurrences = 1
```

So on the previous pin the new test fails on both halves: the property access does not typecheck, and the parsed value comes back `undefined`.

## Risks

Low. The bump is schema-additive — `2026.8.1` adds an optional field and changes nothing else the backend consumes, which the unchanged binding-skew suite (`SCHEMA_VERSION`, the nine event topics, the eight v1 methods, the error-code enums) re-asserts. The full backend suite is green.

Out of scope by design: removing the three local shadow-type declarations. That is a larger refactor and its own follow-up; this PR is the pin, the docs and the regression check.