### PR TITLE
docs: document network and addon compatibility contracts

### DIFF
--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -101,6 +101,29 @@ src/
 
 `lib/rpc/subscriptions.svelte.ts` exports `initSubscriptions()` — this registers the `onMessage` and `onConnectionChange` handlers that feed all non-deprecated getters (`getConfig`, `getModems`, `getWifi`, `getIsStreaming`, etc.). It is called in `main.ts` before mount. **Any store or component that reads from `subscriptions.svelte` getters depends on this call being present.** If you remove or move it, the HUD, all destination views, and the disconnected banner will show stale/empty data.
 
+## NETWORK VIEW STRUCTURE [EXISTS]
+
+The Network destination deliberately separates operator identity from transient
+enumeration detail. `WifiSection.svelte` derives one `modeView` per radio and
+uses it for the row badge, status line, hotspot setup, and mode popover; the
+station/hotspot/hybrid identity is therefore stated once beside the radio name,
+while mode selection and capability details remain available on request. A
+station or hybrid radio retains its connection and bond actions; an exclusive
+hotspot radio does not.
+
+`EthernetSection.svelte` treats a `shared-lan` port as a client-zone row rather
+than an uplink: one combined role/zone pill names what the port is and whether
+the zone is serving or starting, while the bond-exclusion reason moves into the
+adjacent info popover and remains the toggle's accessible reason. It does not
+render the shared port as connected/off uplink state.
+
+`SharingSection.svelte` derives one headline as the card's state authority.
+Per-uplink status is muted when it merely repeats that headline; probe details,
+subordinate bands, shaping priority, coexistence diagnostics, and the DNS note
+are folded into the Diagnostics disclosure, while each uplink's own probe data
+stays behind its row disclosure. These structures de-noise transient interface
+enumeration churn from operator-visible state without dropping diagnostic facts.
+
 ## RPC PATTERN
 
 ### Uplink-health state [EXISTS]

--- a/packages/rpc/AGENTS.md
+++ b/packages/rpc/AGENTS.md
@@ -579,6 +579,17 @@ convention). Device contract: [`apps/backend/AGENTS.md`](../../apps/backend/AGEN
 
 ## CONVENTIONS
 
+## ADD-ON `versionId` TRANSITION CONTRACT [EXISTS]
+
+`AddonDescriptorSchema.versionId` accepts the numeric OS identities `'12'`
+(Debian bookworm) and `'13'` (Debian trixie) during the platform transition.
+This is compatibility for mixed fleets, not a claim that every device runs
+trixie: the add-on reconciler still compares the descriptor's materialized OS
+identity with the live `/etc/os-release` `VERSION_ID` before reuse. Keep both
+values accepted until the bookworm fleet is retired; do not narrow the schema
+back to a bookworm-only literal or treat acceptance of `'13'` as an image-suite
+migration by itself.
+
 - Contracts use `@orpc/contract` (`oc.*`). No runtime logic here — contracts are pure type/schema declarations.
 - Schemas use Zod v4 (`zod@^4`). Import from `zod`, not `zod/v4`.
 - One contract file per domain. One schema file per domain. Names must match (`streaming.contract.ts` ↔ `streaming.schema.ts`).


### PR DESCRIPTION
## What
- Document the Network view structural contracts for WiFi, Ethernet shared-LAN, and Internet Sharing.
- Document the add-on versionId 12/13 mixed-fleet transition contract.

## Why
Closes Rule-A documentation gaps for the merged network UI (PR #303) and add-on schema behavior (todo 40).

## How to verify
`git diff` — 2 files, 34 lines, docs-only.

## Risks
None — documentation-only change against current `main`.

Replaces #304, which was accidentally built on a stale pre-squash base of PR #303 and carried its entire (already-merged) diff along with it.