### PR TITLE
fix: display CeraUI version from package metadata

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -5473,6 +5473,77 @@ engine version — and one contract that is easy to break from either side.
 Board-proven on a Rock 5B+ across a full engine stop/start with NO backend
 restart: `2026.7.2` → `engine unreachable` → `2026.7.2`.
 
+## …AND A BUILD-TIME VERSION IS NOT A COMMIT [EXISTS]
+
+The row above is the LIVE-read one. `revisions.ceralive` is the opposite kind of
+fact — a static build-time stamp — and it was published as the wrong fact
+entirely: the `CeraUI` row read as a bare git short-SHA (`8738fd63`) beside four
+rows showing real CalVer versions.
+
+**The fallback chain was never broken, and that is the whole diagnosis.** On a
+packaged device the PRIMARY read succeeds — `build-debian-package.sh` stamps
+`/opt/ceralive/revision` precisely so `git rev-parse` is not the always-taken
+path — so what was wrong is WHAT that file carries. The commit is build
+metadata; it was occupying a slot an operator reads as a version.
+
+**Two stamps now, and the second is a SIBLING rather than a repurposing.**
+`revision` keeps its exact meaning and byte-identical content; the build script
+additionally stamps `/opt/ceralive/version` with the CalVer read from the root
+`package.json` (`get_ceraui_version`, `shared-build-functions.sh`). Widening the
+`revision` file's content instead would silently change the meaning of a file
+whose NAME says commit, and would leave a consumer unable to read either fact on
+its own.
+
+**`resolveCeraUiRevision` is the ladder, and its three rungs answer three
+different questions:**
+
+| Rung | Source | When it answers |
+|---|---|---|
+| 1 | the `version` stamp | a packaged device — the version of the build that is RUNNING |
+| 2 | `dpkg-query -W -f='${Version}' ceralive-device` | a real device whose stamp is gone |
+| 3 | none — the row falls back to the commit alone | a dev checkout, which genuinely has no packaged version |
+
+- **The stamp OUTRANKS `dpkg`, deliberately.** The stamp names the build whose
+  binary is executing; `dpkg` names what the package manager last recorded, and
+  the two come apart during an upgrade or a `dev-sync` push.
+- **The `dpkg` rung is `isRealDevice()`-gated.** A developer who once installed
+  the `.deb` on their workstation would otherwise have their git checkout report
+  that unrelated package's version as the running build — a plausible wrong
+  answer, which is worse than the honest SHA.
+- **Rung 3 is PRESERVED EXACTLY, not tolerated.** A dev checkout has no packaged
+  version, so the bare `git rev-parse --short HEAD` value is the truthful answer
+  there and its output is byte-identical to before this change. Nothing readable
+  at all still yields the pre-existing `"unknown revision"`.
+- **The commit is DEMOTED, never discarded.** `composeCeraUiRevision` emits
+  `<version> (<commit>)` — the SAME shape `srtla_send -v` already emits — so the
+  frontend's existing `splitVersionValue` promotes the version and demotes the
+  commit to the row's secondary line with NO schema change, NO new wire field and
+  NO row-specific branch in `VersionsDialog`. A `dpkg` version whose iteration
+  already embeds the commit is left alone rather than repeating it.
+- **`probe(argv)` is a separate primitive from `readRevision(cmd)`**, because the
+  ladder must tell "this rung had no answer" from "this rung answered":
+  `readRevision` answers the literal `"unknown revision"`, which is a fine value
+  to RENDER and useless to RESOLVE with. It is registered separately in
+  `SPAWN_POLICY` (`revisions.installedPackageVersion`, bounded-probe) so a hung
+  `dpkg` lock is capped like every other probe.
+- **`CeraUiRevisionSources` is the seam** (the `*Deps` convention, not
+  `set*Runner`), passed as an optional argument to `initRevisions`, so the whole
+  ladder is drivable with no packaged tree, no `dpkg` database and no git
+  checkout — and `initRevisions()` with no argument is byte-unchanged for every
+  existing caller.
+
+Both stamps are read RELATIVE to the working directory, matching the original
+`revision` read and `ceralive.service`'s `WorkingDirectory=/opt/ceralive`. Do NOT
+absolutize them: a dev checkout having neither file is exactly what keeps rung 3
+reachable.
+
+Coverage: `tests/ceraui-version-revision.test.ts` (all three rungs against a real
+staged temp tree, the empty-stamp fall-through, the no-duplication rule, the
+gated `dpkg` reader, and the dev-checkout regression lock) +
+`scripts/build/deb-version-stamp.test.sh` (wired into
+`bun run test:release-package-contracts`: the version source is EXECUTED against
+`package.json`, and both stamping lines are pinned).
+
 ## TERMINATION CLEANUP [EXISTS]
 
 `helpers/shutdown.ts` owns the process-level `SIGTERM`/`SIGINT` lifecycle. The first
@@ -8480,6 +8551,7 @@ config, an anchored path still held by its own device, and a live row with no
 - Don't re-serialise the DNS health check ahead of the caller's query in `dnsCacheResolve`, and don't share one `Resolver` between them — the check only GATES the answer, and a shared c-ares channel's `cancel()` would abort the sibling leg. Both legs sit inside the per-attempt launch deadline (see DNS ON THE STREAM-START CRITICAL PATH).
 - Don't use `process.exit` directly — use `invariant` from `helpers/invariant.ts`.
 - Don't serve `revisions.cerastream` from a cache, and don't retain the last-known value when the engine is unreachable — the engine is a separate systemd-owned process that can be restarted or upgraded mid-session, so a retained version keeps naming a build that may not be installed. Re-probe (`refreshEngineRevision`) and report `ENGINE_UNREACHABLE_REVISION` honestly.
+- Don't publish a COMMIT as `revisions.ceralive` — a short-SHA in a version slot is the defect, not the fallback. Route it through `resolveCeraUiRevision`, which promotes the packaged CalVer and demotes the commit through `composeCeraUiRevision`'s `<version> (<commit>)` shape. Don't delete the `git rev-parse` rung (a dev checkout genuinely has no packaged version and the bare SHA is the truthful answer there), don't repurpose the `revision` stamp to carry a version (it is the commit, and a second file is what keeps both facts readable alone), don't absolutize either stamp path (their CWD-relative form is what makes a dev checkout fall through), and don't un-gate the `dpkg` rung — an unrelated `.deb` installed on a developer's workstation would otherwise be reported as the running build.
 - Don't read config files with raw `fs` — use `helpers/config-loader.ts`.
 - Don't drive the engine directly — route through `getStreamingBackend()`, never
   the `cerastreamBackend` singleton.

--- a/apps/backend/src/helpers/spawn-policy.ts
+++ b/apps/backend/src/helpers/spawn-policy.ts
@@ -383,6 +383,23 @@ export const SPAWN_POLICY: readonly SpawnSite[] = [
 			"git rev-parse / `<exec> -v` quick probes; Bun.spawnSync timeout caps a hung probe → 'unknown revision'",
 	},
 	{
+		id: "revisions.installedPackageVersion",
+		file: "modules/system/revisions.ts",
+		symbol: "defaultCeraUiRevisionSources.readInstalledPackageVersion",
+		command: "[dpkg-query, -W, -f=<Version>, ceralive-device]",
+		class: "bounded-probe",
+		contract: {
+			timed: true,
+			startupTimeout: false,
+			shutdownCleanup: false,
+			shutdownAbort: false,
+			lifetimeTimeoutExempt: false,
+		},
+		status: "enforced",
+		mechanism:
+			"isRealDevice()-gated one-shot at boot; Bun.spawnSync timeout caps a hung dpkg lock, and a non-zero exit or empty stdout resolves `undefined` so the ladder falls through to the git rung rather than throwing",
+	},
+	{
 		id: "srtlaSend.capabilityProbe",
 		file: "modules/streaming/srtla-capabilities.ts",
 		symbol: "probeSrtlaSenderCapabilities",

--- a/apps/backend/src/modules/system/revisions.ts
+++ b/apps/backend/src/modules/system/revisions.ts
@@ -25,6 +25,7 @@ import { logger } from "../../helpers/logger.ts";
 import { DEFAULT_SPAWN_TIMEOUT_MS } from "../../helpers/spawn-policy.ts";
 
 import { srtlaSendExec } from "../streaming/streamloop.ts";
+import { isRealDevice } from "./device-detection.ts";
 
 /**
  * Published for the cerastream row when the engine cannot be reached.
@@ -85,6 +86,8 @@ export async function refreshEngineRevision(): Promise<string> {
 	return revisions.cerastream;
 }
 
+const UNKNOWN_REVISION = "unknown revision";
+
 function readRevision(cmd: string) {
 	try {
 		const result = Bun.spawnSync(cmd.split(" "), {
@@ -92,20 +95,135 @@ function readRevision(cmd: string) {
 			timeout: DEFAULT_SPAWN_TIMEOUT_MS,
 		});
 		if (result.exitCode !== 0) {
-			return "unknown revision";
+			return UNKNOWN_REVISION;
 		}
 		return result.stdout.toString().trim();
 	} catch (_err) {
-		return "unknown revision";
+		return UNKNOWN_REVISION;
 	}
 }
 
-export async function initRevisions() {
+/**
+ * Argv-only sibling of `readRevision` for probes whose answer may legitimately
+ * be ABSENT. `readRevision` answers the literal `"unknown revision"`, which is a
+ * fine value to render in a version slot but useless to a resolution ladder —
+ * the ladder has to tell "this rung had no answer" from "this rung answered".
+ */
+function probe(argv: string[]): string | undefined {
 	try {
-		revisions.ceralive = (await Bun.file("revision").text()).trim();
+		const result = Bun.spawnSync(argv, {
+			stdout: "pipe",
+			stderr: "pipe",
+			timeout: DEFAULT_SPAWN_TIMEOUT_MS,
+		});
+		if (result.exitCode !== 0) return undefined;
+		const out = result.stdout.toString().trim();
+		return out.length > 0 ? out : undefined;
 	} catch (_err) {
-		revisions.ceralive = readRevision("git rev-parse --short HEAD");
+		return undefined;
 	}
+}
+
+/**
+ * Both stamps are read RELATIVE to the working directory, because that is what
+ * the original `revision` read did and `ceralive.service` sets
+ * `WorkingDirectory=/opt/ceralive`. A dev checkout has neither file, which is
+ * exactly how the git rung stays reachable.
+ */
+const VERSION_STAMP_FILE = "version";
+const BUILD_STAMP_FILE = "revision";
+
+/** The Debian package `ceralive-device` is CeraUI's own (`PACKAGE_NAME` in `scripts/build/build-debian-package.sh`). */
+const CERAUI_PACKAGE_NAME = "ceralive-device";
+
+async function readStamp(path: string): Promise<string | undefined> {
+	try {
+		const text = (await Bun.file(path).text()).trim();
+		return text.length > 0 ? text : undefined;
+	} catch (_err) {
+		return undefined;
+	}
+}
+
+/**
+ * The four facts the `CeraUI` row can be built from, injected so the whole
+ * ladder is drivable without a packaged tree, a `dpkg` database, or a git
+ * checkout (the `*Deps` convention `SshStatusDeps` / `ReconcilerDeps` follow).
+ */
+export interface CeraUiRevisionSources {
+	/** `/opt/ceralive/version` — the CalVer the `.deb` build stamped. */
+	readVersionStamp: () => Promise<string | undefined>;
+	/** `/opt/ceralive/revision` — the commit the `.deb` build stamped. */
+	readBuildStamp: () => Promise<string | undefined>;
+	/** The version `dpkg` records for the installed package, on a real device only. */
+	readInstalledPackageVersion: () => Promise<string | undefined>;
+	/** The working tree's own commit — the dev/git-checkout last resort. */
+	readWorkingTreeCommit: () => string | undefined;
+}
+
+export const defaultCeraUiRevisionSources: CeraUiRevisionSources = {
+	readVersionStamp: () => readStamp(VERSION_STAMP_FILE),
+	readBuildStamp: () => readStamp(BUILD_STAMP_FILE),
+	readInstalledPackageVersion: async () => {
+		// Gated on a REAL device on purpose: a developer who once installed the
+		// `.deb` on their workstation would otherwise have their git checkout
+		// report that unrelated package's version as the running build.
+		if (!(await isRealDevice())) return undefined;
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: dpkg-query's own field syntax, not a JS placeholder
+		const versionField = "-f=${Version}";
+		return probe(["dpkg-query", "-W", versionField, CERAUI_PACKAGE_NAME]);
+	},
+	readWorkingTreeCommit: () => probe(["git", "rev-parse", "--short", "HEAD"]),
+};
+
+/**
+ * A version is the PRIMARY value; a commit is build metadata demoted behind it.
+ *
+ * The `<version> (<build>)` shape is deliberate rather than a new wire field: it
+ * is the same shape `srtla_send -v` already emits, so the frontend's existing
+ * `splitVersionValue` promotes the version and demotes the commit to the row's
+ * secondary line with no schema change and no per-row special case.
+ *
+ * A version with NO commit renders as a bare version; a commit with NO version
+ * renders as the bare commit, which is byte-identical to what a dev checkout has
+ * always shown. A version that ALREADY embeds the commit (a `dpkg` version, whose
+ * iteration is `<date>.<commit>`) is left alone rather than repeating it.
+ */
+export function composeCeraUiRevision(
+	version: string | undefined,
+	build: string | undefined,
+): string {
+	if (version === undefined) return build ?? UNKNOWN_REVISION;
+	if (build === undefined || version.includes(build)) return version;
+	return `${version} (${build})`;
+}
+
+/**
+ * Resolve the `CeraUI` row: the packaged CalVer version first, the commit only
+ * as its build metadata — or, in a dev checkout that genuinely has no packaged
+ * version, as the whole value.
+ *
+ * Version rungs, strongest first:
+ *   1. the build-baked `version` stamp (a packaged device);
+ *   2. `dpkg-query` on the installed package (a real device whose stamp is gone);
+ *   3. none — the row falls back to the commit alone.
+ */
+export async function resolveCeraUiRevision(
+	overrides: Partial<CeraUiRevisionSources> = {},
+): Promise<string> {
+	const sources = { ...defaultCeraUiRevisionSources, ...overrides };
+	const version =
+		(await sources.readVersionStamp()) ??
+		(await sources.readInstalledPackageVersion());
+	const build =
+		(await sources.readBuildStamp()) ?? sources.readWorkingTreeCommit();
+	return composeCeraUiRevision(version, build);
+}
+
+export async function initRevisions(
+	revisionSources: Partial<CeraUiRevisionSources> = {},
+) {
+	revisions.ceralive = await resolveCeraUiRevision(revisionSources);
 
 	revisions.srtla = readRevision(`${srtlaSendExec} -v`);
 	revisions.bun = Bun.version;

--- a/apps/backend/src/tests/ceraui-version-revision.test.ts
+++ b/apps/backend/src/tests/ceraui-version-revision.test.ts
@@ -1,0 +1,186 @@
+/*
+ * Settings → Versions showed CeraUI's OWN row as a bare git short-SHA
+ * (`8738fd63`) while every other row beside it — cerastream, SRTLA, Bun, Kernel —
+ * showed a real CalVer version.
+ *
+ * The cause was NOT a broken fallback chain. On a packaged device the primary
+ * read SUCCEEDS: `build-debian-package.sh` stamps `/opt/ceralive/revision` and
+ * the backend reads it. What was wrong is WHAT that file carries — the commit,
+ * which is build metadata, published into a slot an operator reads as a version.
+ *
+ * So the fix is a resolution LADDER over two build-time facts, and these tests
+ * pin all three of its rungs plus the composition rule. The last rung is a
+ * regression lock: a dev checkout genuinely has no packaged version, and its
+ * bare-SHA behaviour must survive byte-identically.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+	composeCeraUiRevision,
+	defaultCeraUiRevisionSources,
+	getRevisions,
+	initRevisions,
+	resolveCeraUiRevision,
+	setEngineVersionProbe,
+} from "../modules/system/revisions.ts";
+
+afterEach(() => {
+	setEngineVersionProbe(null);
+});
+
+const NO_SOURCES = {
+	readVersionStamp: async () => undefined,
+	readBuildStamp: async () => undefined,
+	readInstalledPackageVersion: async () => undefined,
+	readWorkingTreeCommit: () => undefined,
+};
+
+describe("the CeraUI row — version rung 1: the build-baked stamp", () => {
+	test("a packaged device promotes the CalVer version and demotes the commit", async () => {
+		expect(
+			await resolveCeraUiRevision({
+				...NO_SOURCES,
+				readVersionStamp: async () => "2026.8.5",
+				readBuildStamp: async () => "8738fd63",
+			}),
+		).toBe("2026.8.5 (8738fd63)");
+	});
+
+	test("the stamp OUTRANKS dpkg — the running build, not whatever is installed", async () => {
+		expect(
+			await resolveCeraUiRevision({
+				...NO_SOURCES,
+				readVersionStamp: async () => "2026.8.5",
+				readInstalledPackageVersion: async () =>
+					"2026.8.4-20260101T000000.dead",
+			}),
+		).toBe("2026.8.5");
+	});
+
+	test("the REAL default readers resolve a stamped tree", async () => {
+		const staged = await mkdtemp(join(tmpdir(), "ceraui-version-stamp-"));
+		const cwd = process.cwd();
+		try {
+			await writeFile(join(staged, "version"), "2026.8.5\n");
+			await writeFile(join(staged, "revision"), "8738fd63\n");
+			process.chdir(staged);
+			// The dpkg rung is the only source a temp dir cannot stand in for, and
+			// it must not be reached here anyway — the stamp already answered.
+			expect(
+				await resolveCeraUiRevision({
+					readInstalledPackageVersion: async () => undefined,
+				}),
+			).toBe("2026.8.5 (8738fd63)");
+		} finally {
+			process.chdir(cwd);
+			await rm(staged, { recursive: true, force: true });
+		}
+	});
+
+	test("an empty stamp file is NOT a version and falls through", async () => {
+		const staged = await mkdtemp(join(tmpdir(), "ceraui-version-empty-"));
+		const cwd = process.cwd();
+		try {
+			await writeFile(join(staged, "version"), "\n");
+			process.chdir(staged);
+			expect(
+				await resolveCeraUiRevision({
+					readInstalledPackageVersion: async () => "2026.8.4",
+					readWorkingTreeCommit: () => undefined,
+				}),
+			).toBe("2026.8.4");
+		} finally {
+			process.chdir(cwd);
+			await rm(staged, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("the CeraUI row — version rung 2: the installed package", () => {
+	test("an absent stamp falls through to the installed package version", async () => {
+		expect(
+			await resolveCeraUiRevision({
+				...NO_SOURCES,
+				readInstalledPackageVersion: async () =>
+					"2026.8.5-20260829T181141.8738fd63",
+			}),
+		).toBe("2026.8.5-20260829T181141.8738fd63");
+	});
+
+	test("a dpkg version that already embeds the commit does not repeat it", async () => {
+		expect(
+			await resolveCeraUiRevision({
+				...NO_SOURCES,
+				readInstalledPackageVersion: async () =>
+					"2026.8.5-20260829T181141.8738fd63",
+				readWorkingTreeCommit: () => "8738fd63",
+			}),
+		).toBe("2026.8.5-20260829T181141.8738fd63");
+	});
+
+	test("the shipped dpkg reader is gated on a real device, so a dev host gets nothing", async () => {
+		expect(
+			await defaultCeraUiRevisionSources.readInstalledPackageVersion(),
+		).toBeUndefined();
+	});
+});
+
+describe("the CeraUI row — version rung 3: the dev checkout is unchanged", () => {
+	test("no version anywhere falls back to `git rev-parse --short HEAD`, bare", async () => {
+		expect(
+			await resolveCeraUiRevision({
+				...NO_SOURCES,
+				readWorkingTreeCommit: () => "8738fd63",
+			}),
+		).toBe("8738fd63");
+	});
+
+	test("a stamped commit with no version is likewise rendered bare", async () => {
+		expect(
+			await resolveCeraUiRevision({
+				...NO_SOURCES,
+				readBuildStamp: async () => "8738fd63",
+			}),
+		).toBe("8738fd63");
+	});
+
+	test("nothing readable at all keeps the pre-existing `unknown revision`", async () => {
+		expect(await resolveCeraUiRevision(NO_SOURCES)).toBe("unknown revision");
+	});
+
+	test("this checkout has no packaged stamp, so the git rung is genuinely reachable", async () => {
+		expect(
+			await defaultCeraUiRevisionSources.readVersionStamp(),
+		).toBeUndefined();
+		expect(defaultCeraUiRevisionSources.readWorkingTreeCommit()).toBeTruthy();
+	});
+});
+
+describe("composeCeraUiRevision", () => {
+	test("a version alone is the whole value", () => {
+		expect(composeCeraUiRevision("2026.8.5", undefined)).toBe("2026.8.5");
+	});
+
+	test("the composed shape is the one splitVersionValue already splits", () => {
+		// `<version> (<build>)` is srtla_send's own shape, so the Versions dialog
+		// promotes the version and demotes the commit with no schema change.
+		expect(composeCeraUiRevision("2026.8.5", "8738fd63")).toMatch(
+			/^\S+ \([^()]+\)$/,
+		);
+	});
+});
+
+describe("initRevisions wires the ladder onto the wire", () => {
+	test("the published `ceralive` row carries the version, not the bare commit", async () => {
+		setEngineVersionProbe(async () => undefined);
+		await initRevisions({
+			...NO_SOURCES,
+			readVersionStamp: async () => "2026.8.5",
+			readBuildStamp: async () => "8738fd63",
+		});
+		expect(getRevisions().ceralive).toBe("2026.8.5 (8738fd63)");
+	});
+});

--- a/apps/backend/src/tests/spawn-policy.test.ts
+++ b/apps/backend/src/tests/spawn-policy.test.ts
@@ -28,10 +28,10 @@ const alive = (proc: ManagedProcess): boolean =>
 	proc.exitCode === null && proc.signalCode === null;
 
 describe("spawn-policy registry consistency", () => {
-	it("classifies all 24 production spawn sites with unique ids", () => {
-		expect(SPAWN_POLICY).toHaveLength(24);
+	it("classifies all 25 production spawn sites with unique ids", () => {
+		expect(SPAWN_POLICY).toHaveLength(25);
 		const ids = new Set(SPAWN_POLICY.map((s) => s.id));
-		expect(ids.size).toBe(24);
+		expect(ids.size).toBe(25);
 	});
 
 	// The diagnostic's `nft list ruleset` is a READ on its own slow cadence, so it

--- a/apps/frontend/src/lib/system/version-display.ts
+++ b/apps/frontend/src/lib/system/version-display.ts
@@ -1,16 +1,20 @@
 /**
  * One presentation rule for every row of Settings → Versions.
  *
- * The rows come from four unrelated producers — a git hash, `Bun.version`,
- * `uname -r`, the engine's IPC `hello`, and `srtla_send -v` — and only the last
- * one carries build metadata. It used to render its whole CLI line verbatim
- * (`3.2.0 (main@974c8b9) [srtla_send]`) beside three bare version numbers, so
+ * The rows come from unrelated producers — `Bun.version`, `uname -r`, the
+ * engine's IPC `hello`, `srtla_send -v`, and CeraUI's own build stamps — and two
+ * of them carry build metadata. `srtla_send -v` used to render its whole CLI line
+ * verbatim (`3.2.0 (main@974c8b9) [srtla_send]`) beside bare version numbers, so
  * one row read as noise next to its neighbours.
  *
  * Splitting the line here means every row renders the SAME shape: a version as
  * the primary value, with any build metadata demoted to a secondary line. The
  * package tag is dropped outright — the row's own label already names the
  * component.
+ *
+ * It is also why the backend composes CeraUI's own row as
+ * `<version> (<commit>)`: reusing this shape demotes the commit with no wire
+ * change and no per-row branch in the dialog.
  */
 export interface VersionDisplay {
 	/** The version number, rendered as the row's primary value. */

--- a/apps/frontend/src/main/dialogs/VersionsDialog.test.ts
+++ b/apps/frontend/src/main/dialogs/VersionsDialog.test.ts
@@ -85,6 +85,31 @@ describe("VersionsDialog", () => {
 		});
 	});
 
+	// CeraUI's own row used to be a bare git short-SHA beside four real version
+	// numbers, because the .deb stamped only the commit. It now carries the
+	// packaged CalVer, and the commit rides the SAME `(...)` shape SRTLA already
+	// uses — so the existing splitVersionValue handles it with no row-specific
+	// branch and no wire change.
+	it("promotes CeraUI's packaged version and demotes its commit", async () => {
+		vi.mocked(rpc.system.getRevisions).mockResolvedValueOnce({
+			...pushed,
+			ceralive: "2026.8.5 (8738fd63)",
+		});
+		render(VersionsDialog, { props: { open: true } });
+		const container = document.body;
+		await waitFor(() => {
+			expect(rowValue(container, "CeraUI")).toEqual(["2026.8.5", "8738fd63"]);
+		});
+	});
+
+	it("still renders a dev checkout's bare commit as the whole value", async () => {
+		render(VersionsDialog, { props: { open: true } });
+		const container = document.body;
+		await waitFor(() => {
+			expect(rowValue(container, "CeraUI")).toEqual(["abc1234"]);
+		});
+	});
+
 	it("re-pulls the versions on open so a late engine is not reported unreachable forever", async () => {
 		vi.mocked(rpc.system.getRevisions).mockResolvedValueOnce({
 			...pushed,

--- a/scripts/build/build-debian-package.sh
+++ b/scripts/build/build-debian-package.sh
@@ -21,8 +21,19 @@ fi
 PACKAGE_NAME="ceralive-device"
 VERSION=$(get_version)
 COMMIT=$(get_commit)
+CERAUI_VERSION=$(get_ceraui_version)
 ARCHITECTURE=$(get_architecture)
 BUILD_DATE=$(get_build_date)
+
+# Fail closed: an unstampable version leaves the device's Versions row with no
+# CalVer to promote, which is the exact defect the stamp exists to remove.
+if ! printf '%s' "$CERAUI_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+    log_error "Could not read a CalVer version from package.json (got: '${CERAUI_VERSION}')"
+    exit 1
+fi
+if [ "$CERAUI_VERSION" != "$VERSION" ]; then
+    log_warning "package.json version ($CERAUI_VERSION) differs from the package version ($VERSION); stamping package.json's"
+fi
 
 # Generate dynamic iteration for APT version detection
 ITERATION="${BUILD_DATE}.${COMMIT}"
@@ -97,6 +108,11 @@ cp apps/backend/setup.json "$TEMP_DIR/opt/ceralive/"
 # `git rev-parse` fallback fail — "unknown revision" would be the always-taken path
 # on every real device.
 printf '%s\n' "$COMMIT" > "$TEMP_DIR/opt/ceralive/revision"
+# The same reasoning one level up: the commit alone is not a VERSION, so the
+# Versions row rendered a bare short-SHA where every other row showed CalVer.
+# `revision` keeps its exact meaning (the commit, demoted to build metadata) and
+# this sibling carries the version that is promoted in front of it.
+printf '%s\n' "$CERAUI_VERSION" > "$TEMP_DIR/opt/ceralive/version"
 ln -s /var/www/ceralive "$TEMP_DIR/opt/ceralive/public"
 cp dist/override-ceralive.sh "$TEMP_DIR/usr/local/bin/"
 cp dist/reset-to-default.sh "$TEMP_DIR/usr/local/bin/"

--- a/scripts/build/deb-version-stamp.test.sh
+++ b/scripts/build/deb-version-stamp.test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Package-contract test: the ceralive-device .deb MUST stamp BOTH build-time
+# facts into /opt/ceralive — the CalVer version the backend promotes, and the
+# commit it demotes behind it. A missing `version` file sends the device's
+# Versions row back to reporting CeraUI's own build as a bare git short-SHA
+# while every neighbouring row shows a real version.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+build_script="scripts/build/build-debian-package.sh"
+
+fail() { printf 'FAIL: %s\n' "$1" >&2; exit 1; }
+
+# --- Part A: the version source is package.json, executed rather than grepped --
+
+# shellcheck source=scripts/build/shared-build-functions.sh
+source scripts/build/shared-build-functions.sh
+
+stamped="$(get_ceraui_version)"
+declared="$(bun -p "require('./package.json').version")"
+
+[[ -n "$stamped" ]] || fail "get_ceraui_version produced nothing"
+[[ "$stamped" == "$declared" ]] \
+  || fail "get_ceraui_version ($stamped) does not match package.json ($declared)"
+
+printf '%s' "$stamped" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$' \
+  || fail "stamped version is not CalVer-shaped: $stamped"
+
+# --- Part B: static contract on the build script -------------------------------
+
+grep -Fq 'CERAUI_VERSION=$(get_ceraui_version)' "$build_script" \
+  || fail "build script does not derive CERAUI_VERSION from get_ceraui_version"
+
+grep -Fq 'printf '"'"'%s\n'"'"' "$CERAUI_VERSION" > "$TEMP_DIR/opt/ceralive/version"' "$build_script" \
+  || fail "build script does not stamp \$CERAUI_VERSION into opt/ceralive/version"
+
+# The commit stamp keeps its exact meaning; the version is a SIBLING, not a
+# repurposing of `revision` (which the backend still reads as build metadata).
+grep -Fq 'printf '"'"'%s\n'"'"' "$COMMIT" > "$TEMP_DIR/opt/ceralive/revision"' "$build_script" \
+  || fail "build script no longer stamps \$COMMIT into opt/ceralive/revision"
+
+# --- Part C: the staged tree really carries both files --------------------------
+# Replays the two stamping lines against a scratch tree staged exactly as the
+# build script stages them, so a typo in either path fails here rather than on a
+# device.
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+TEMP_DIR="$work/temp"
+mkdir -p "$TEMP_DIR/opt/ceralive"
+COMMIT="$(get_commit)"
+printf '%s\n' "$COMMIT" > "$TEMP_DIR/opt/ceralive/revision"
+printf '%s\n' "$stamped" > "$TEMP_DIR/opt/ceralive/version"
+
+[[ "$(cat "$TEMP_DIR/opt/ceralive/version")" == "$stamped" ]] \
+  || fail "staged version stamp does not round-trip"
+[[ -s "$TEMP_DIR/opt/ceralive/revision" ]] \
+  || fail "staged revision stamp is empty"
+
+printf 'PASS: the .deb stamps package.json CalVer into opt/ceralive/version and keeps the commit in opt/ceralive/revision\n'

--- a/scripts/build/release-package-contracts.sh
+++ b/scripts/build/release-package-contracts.sh
@@ -7,6 +7,7 @@ cd "$repo_root"
 bash scripts/build/build-provenance.test.sh
 bash scripts/build/shared-build-functions.test.sh
 bash scripts/build/deb-reconciler-staging.test.sh
+bash scripts/build/deb-version-stamp.test.sh
 bash scripts/build/deb-sourcemap-policy.test.sh
 bash scripts/build/documentation-contract.test.sh
 bash scripts/build/publish-federation-immutable.test.sh

--- a/scripts/build/shared-build-functions.sh
+++ b/scripts/build/shared-build-functions.sh
@@ -26,6 +26,16 @@ get_commit() {
     git -C "$BUILD_REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo "unknown"
 }
 
+# The repo's own CalVer bump artifact (docs/APT_VERSION_CONTROL.md → "Per-Repo
+# Bump Artifact": CeraUI owns its version in the root package.json). This is the
+# SAME source vite.federation.config.ts reads, so a device's Versions row, the
+# federation bundle path, and the release tag cannot name three different builds.
+# Deliberately NOT get_version(), which falls back to "1.0.0" in a tagless
+# checkout — an untagged local build must still stamp the real CalVer.
+get_ceraui_version() {
+    bun -p "require('$BUILD_REPO_ROOT/package.json').version" 2>/dev/null
+}
+
 get_build_date() {
     date -u +"%Y%m%dT%H%M%S"
 }
@@ -462,7 +472,7 @@ smart_build_monitored() {
 }
 
 # Export all functions for use in other scripts
-export -f get_version get_commit get_build_date get_architecture
+export -f get_version get_commit get_build_date get_architecture get_ceraui_version
 export -f get_git_hash hash_build_inputs get_frontend_hash get_backend_hash
 export -f is_frontend_cache_valid is_backend_cache_valid
 export -f build_frontend_only build_backend_only smart_build smart_build_monitored


### PR DESCRIPTION
## What
Display CeraUI's packaged CalVer as the primary version, retaining the git SHA as build metadata.

## Why
The version row exposed a git SHA instead of the user-facing release version, making installed version identification misleading.

## How to verify
- `bun run --filter backend check`
- `bun run --filter backend test` (previously verified green)
- `biome check .`

## Risks
Version reporting and packaging metadata only; no stream or runtime transport behavior changes.