### PR TITLE
chore(deps): bump Vitest and oRPC prereleases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -755,10 +755,10 @@ Override for tests: set `CERALIVE_DEVICE_TYPE=emulated` or `=real` in `beforeEac
 
 | Package | Version |
 |---------|---------|
-| `@orpc/server` (backend), `@orpc/contract` (packages/rpc) | 2.0.0-beta.30 — EXACT pin, see below |
+| `@orpc/server` (backend), `@orpc/contract` (packages/rpc) | 2.0.0-beta.31 — EXACT pin, see below |
 | Bun pin (`.bun-version`) | 1.4.0 |
 | `svelte` | 5.56.10 |
-| `vitest` | 5.0.0-rc.2 — EXACT pin (a PRERELEASE; see the note below the table) |
+| `vitest` | 5.0.0-rc.3 — EXACT pin (a PRERELEASE; see the note below the table) |
 | `vite` | 8.2.2 |
 | `jsdom` | 30.0.1 (requires Node ≥ 24.15; satisfied by the Node 26 pin) |
 | Node | **26 wherever Node runs at all** — REQUIRED baseline, not a canary. `build-check.yml`, `publish-deb.yml`, and `publish-release.yml` all pin `NODE_VERSION: "26"`; `mise.toml` and both `volta.node` fields (root + `apps/frontend`) match. No cache key is keyed on the version, so the flip needs no cache bust. The `test-fe` job is the one job with NO `setup-node` step — every command in it is Bun (see the Vitest note below). |
@@ -781,9 +781,9 @@ Override for tests: set `CERALIVE_DEVICE_TYPE=emulated` or `=real` in `beforeEac
 runtime verdict — which is now ACTED ON, not merely recorded.** Under `vitest@4.1.10` the
 frontend suite could not be collected under Bun at all — 110 of 281 files died on a shared
 `undefined is not an object (evaluating 'z.enum')` in the Zod schema import graph — and that is
-why the frontend suite ran on Node for as long as it did. Under `5.0.0-rc.2` Bun 1.4.0 runs the
-suite at **281 files / 3,780 tests, 0 failures — identical to Node 26**, reproduced across
-separate runs. Nothing in the v5 migration guide needed a source or config change here:
+why the frontend suite ran on Node for as long as it did. Under `5.0.0-rc.3` Bun 1.4.0 runs the
+current suite at **354 files / 5,779 tests, 0 failures**, matching the pre-bump `5.0.0-rc.2`
+baseline exactly. Nothing in the rc.2→rc.3 release notes needed a source or config change here:
 `clearMocks` now defaults to `true` and the suite is unaffected, and the repo uses none of the
 removed surfaces (`test.sequential`, `vitest/reporters`/`vitest/coverage`/`vitest/suite`, `bench`
 at module scope, `VITEST_WORKER_ID`, `populateGlobal`, unawaited `.resolves`). **The frontend
@@ -800,7 +800,7 @@ before the flip it was running Vitest on whatever Node the runner shipped. It is
 Bun 1.4.0 like every other command in it. That job's own step ORDER is a separate, documented
 contract (vitest must stay immediately after `bun install`) and is untouched.
 
-**oRPC is pinned EXACT on a 2.0 beta.** `^2.0.0-beta.30` would range forward across betas and into stable
+**oRPC is pinned EXACT on a 2.0 beta.** `^2.0.0-beta.31` would range forward across betas and into stable
 2.0.0, which is not acceptable for a device runtime. CeraUI is insulated from v2's biggest break — the RPC
 serializer / error-body wire-format change — because `apps/backend/src/rpc/adapter.ts` speaks its own Bun
 WebSocket `{id, path, input}` protocol and calls oRPC's `call()` directly; there is no `RPCHandler` or
@@ -809,6 +809,13 @@ WebSocket `{id, path, input}` protocol and calls oRPC's `call()` directly; there
 are declared as a bare `oc`. Do not reintroduce route metadata — CeraUI serves no OpenAPI surface.
 Reserved router keys in v2 (`then`, `bind`, `valueOf`, `toString`, `toJSON`) must never be used as a
 procedure or child-router key.
+
+Beta.31's breaking change is likewise outside CeraUI's surface: it changes only
+`CORSHandlerPlugin`'s HTTP response default from reflected origin to `*` and permits async
+`origin`/`timingOrigin` resolvers. CeraUI instantiates no handler or CORS plugin; the Bun WebSocket
+adapter navigates the router and invokes `call()` directly. The other beta.31 contract/server edits
+are fixes (including prototype-safe error-code lookup) and do not change the `oc.router()` /
+`oc.input()` / `oc.output()` declarations used in `packages/rpc`.
 
 ### TypeScript: two majors, deliberately
 
@@ -921,8 +928,8 @@ Four further Build Check facts, all landed 2026-08-14:
   (`NODE_VERSION: "26"`, still set at workflow level and still consumed by
   `test-be`, `setup-e2e`, `test-e2e`, `merge-e2e-reports` and `build`). The Vitest
   blocker was `vitest@4.1.10`'s collection failure, not Bun's: under the
-  `vitest@5.0.0-rc.2` pin the suite is green at **281 files / 3,780 tests —
-  identical to Node 26**, reproduced across separate runs, so the frontend `test`
+  `vitest@5.0.0-rc.3` pin the current suite is green at **354 files / 5,779 tests —
+  identical to the pre-bump rc.2 baseline**, so the frontend `test`
   script now invokes `bun --bun vitest run` and `test-fe` carries no `setup-node`
   step at all. **The Playwright half is NOT flipped and has never produced a green
   parity run** — that lane keeps Node 26, and nothing here authorises moving it.

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -15,7 +15,7 @@
 		"@ceralive/srtla-send": "2026.8.0",
 		"@ceraui/rpc": "workspace:*",
 		"@httptoolkit/dbus-native": "0.1.5",
-		"@orpc/server": "2.0.0-beta.30",
+		"@orpc/server": "2.0.0-beta.31",
 		"finalhandler": "^2.1.1",
 		"zod": "catalog:",
 		"http-proxy": "^1.18.1",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -71,7 +71,7 @@
 		"vaul-svelte": "1.0.0-next.7",
 		"vite": "^8.2.2",
 		"vite-plugin-pwa": "^1.3.0",
-		"vitest": "5.0.0-rc.2",
+		"vitest": "5.0.0-rc.3",
 		"workbox-window": "^7.4.1"
 	},
 	"volta": {

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
         "@ceralive/srtla-send": "2026.8.0",
         "@ceraui/rpc": "workspace:*",
         "@httptoolkit/dbus-native": "0.1.5",
-        "@orpc/server": "2.0.0-beta.30",
+        "@orpc/server": "2.0.0-beta.31",
         "finalhandler": "^2.1.1",
         "http-proxy": "^1.18.1",
         "serve-static": "^2.2.1",
@@ -88,7 +88,7 @@
         "vaul-svelte": "1.0.0-next.7",
         "vite": "^8.2.2",
         "vite-plugin-pwa": "^1.3.0",
-        "vitest": "5.0.0-rc.2",
+        "vitest": "5.0.0-rc.3",
         "workbox-window": "^7.4.1",
       },
     },
@@ -105,7 +105,7 @@
       "name": "@ceraui/rpc",
       "version": "2026.6.1",
       "dependencies": {
-        "@orpc/contract": "2.0.0-beta.30",
+        "@orpc/contract": "2.0.0-beta.31",
         "zod": "catalog:",
       },
       "devDependencies": {
@@ -421,13 +421,13 @@
 
     "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
 
-    "@orpc/client": ["@orpc/client@2.0.0-beta.30", "", { "dependencies": { "@orpc/shared": "2.0.0-beta.30", "@standardserver/core": "^0.8.0", "@standardserver/fetch": "^0.8.0", "@standardserver/peer": "^0.8.0" } }, "sha512-WpV+S2m43qxl+ZLZxnpTYMpJdpTGakzcd3Hej5q22PTKfY1FMe4O25RWUZZ8ClVPh5f0BBqjrIZpIE8L/8yrWg=="],
+    "@orpc/client": ["@orpc/client@2.0.0-beta.31", "", { "dependencies": { "@orpc/shared": "2.0.0-beta.31", "@standardserver/core": "^0.8.0", "@standardserver/fetch": "^0.8.0", "@standardserver/peer": "^0.8.0" } }, "sha512-ngyjG9Qv5dO0Iz6WK7CMC7cMUb64c7mG4nliQVZPGOEQaz+EIPWDMYgHXRp+m+q7zWvzpJECH8n9lU/I1hQZeA=="],
 
-    "@orpc/contract": ["@orpc/contract@2.0.0-beta.30", "", { "dependencies": { "@orpc/client": "2.0.0-beta.30", "@orpc/shared": "2.0.0-beta.30", "@standard-schema/spec": "^1.1.0" } }, "sha512-Drccy5KJaEqsbWYrn7XDEadQ8Wt0o2db1GaWzwtHEq9Cq8fVp3Iozw9nS0ccI6hsi/Uvwqpnu/J+C+F/68aAyg=="],
+    "@orpc/contract": ["@orpc/contract@2.0.0-beta.31", "", { "dependencies": { "@orpc/client": "2.0.0-beta.31", "@orpc/shared": "2.0.0-beta.31", "@standard-schema/spec": "^1.1.0" } }, "sha512-Ut+n79Mp2t11GDkXKL34MGDlH2kcp6uTwDekfPxUgFaaSl6B7no4VtIVn9hFFq39lSkGfiTFn8jnaFcm66YYvQ=="],
 
-    "@orpc/server": ["@orpc/server@2.0.0-beta.30", "", { "dependencies": { "@orpc/client": "2.0.0-beta.30", "@orpc/contract": "2.0.0-beta.30", "@orpc/shared": "2.0.0-beta.30", "@standardserver/aws-lambda": "^0.8.0", "@standardserver/core": "^0.8.0", "@standardserver/fastify": "^0.8.0", "@standardserver/fetch": "^0.8.0", "@standardserver/node": "^0.8.0", "@standardserver/peer": "^0.8.0", "cookie": "^2.0.1" }, "peerDependencies": { "crossws": ">=0.3.4", "fastify": ">=5.6.1" }, "optionalPeers": ["crossws", "fastify"] }, "sha512-7/R4vsykEorXty8B3bF1SbhmJoQxwRuC1jF9ntalcfT7F8paSr2E7ZiZH7A605bSTCvUazdnWHJcnCFQgByLDQ=="],
+    "@orpc/server": ["@orpc/server@2.0.0-beta.31", "", { "dependencies": { "@orpc/client": "2.0.0-beta.31", "@orpc/contract": "2.0.0-beta.31", "@orpc/shared": "2.0.0-beta.31", "@standardserver/aws-lambda": "^0.8.0", "@standardserver/core": "^0.8.0", "@standardserver/fastify": "^0.8.0", "@standardserver/fetch": "^0.8.0", "@standardserver/node": "^0.8.0", "@standardserver/peer": "^0.8.0", "cookie": "^2.0.1" }, "peerDependencies": { "crossws": ">=0.3.4", "fastify": ">=5.6.1" }, "optionalPeers": ["crossws", "fastify"] }, "sha512-fUzSlR5so8fpe4ZlnwY8C+cYvJ4392WCIPawG0rfMcHgCp7p428GnWw4km7JDfxzHMvE+3IwzqUf/sKmBQXvqQ=="],
 
-    "@orpc/shared": ["@orpc/shared@2.0.0-beta.30", "", { "dependencies": { "@standardserver/shared": "^0.8.0", "radash": "^12.1.1", "type-fest": "^5.3.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-zQNMlVyc4P6c8vEwoskAaQtUA6sw3uDrwyZibJs4RGlUjxN5koZexyAmmfyywyjedVi70/IPef3g+bhlf1Njew=="],
+    "@orpc/shared": ["@orpc/shared@2.0.0-beta.31", "", { "dependencies": { "@standardserver/shared": "^0.8.0", "radash": "^12.1.1", "type-fest": "^5.3.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-KUpoUL0MtNDnkFZCmZgIMfLkUYn0JCCLiqxOn/OuBGNE8l20P39Tjr2PLyW+2NNdaPY7cEGoDn9XSMxkpfBpew=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.144.0", "", {}, "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg=="],
 
@@ -667,9 +667,9 @@
 
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
-    "@vitest/mocker": ["@vitest/mocker@5.0.0-rc.2", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.31", "@vitest/spy": "5.0.0-rc.2", "estree-walker": "^3.0.3", "magic-string": "^1.2.0" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-nbUdBsadb3otfazI0v99+PQuSWiBzz5obMM5Pb1mpLzdPSEG6gVHYiVLuj0PC2dcoqPjd6dgsB5o0t70RXbs2A=="],
+    "@vitest/mocker": ["@vitest/mocker@5.0.0-rc.3", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.31", "@vitest/spy": "5.0.0-rc.3", "estree-walker": "^3.0.3", "magic-string": "^1.2.2" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-TmShKXB4NlnHHP4OPueGSKWeLKf5rKF4tarwNxKzC7wAAiGYu3Syurl2eX9nYfV7FhSjEdsxDSzeqdkvITR/4A=="],
 
-    "@vitest/spy": ["@vitest/spy@5.0.0-rc.2", "", {}, "sha512-6/p30efajxGxC3KzLae67vRazEKB8Z8s4l0DwbVJLobXyCHDAQPoVMXeS7nKP8aWHOi8Ec9XBUxFvFPF/NRnYA=="],
+    "@vitest/spy": ["@vitest/spy@5.0.0-rc.3", "", {}, "sha512-GzbrDjTgFGqCNJA2uTJ+/vKeP98Q9VFnYD4z1DYqzS8IYiHfN30ecu/Rg/1clfffSgwPagl4uVZBJxVYLWTpew=="],
 
     "@zip.js/zip.js": ["@zip.js/zip.js@2.8.49", "", {}, "sha512-TY3fKR/IQqPJqrOQAohvW6kv7Qd1aehzU7M7hbqhNNKxVP8uKSMO+aUlBwtdWzTCd62E0YOB+HHW9N0hMihrWw=="],
 
@@ -1475,7 +1475,7 @@
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
-    "vitest": ["vitest@5.0.0-rc.2", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/mocker": "5.0.0-rc.2", "chai": "^6.2.2", "es-module-lexer": "^2.3.1", "expect-type": "^1.4.0", "magic-string": "^1.2.0", "obug": "^2.1.4", "picomatch": "^4.0.5", "std-env": "^4.2.0", "tinybench": "6.1.3", "tinyexec": "1.3.0", "tinyglobby": "^0.2.17", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "5.0.0-rc.2", "@vitest/browser-preview": "5.0.0-rc.2", "@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0", "@vitest/coverage-istanbul": "5.0.0-rc.2", "@vitest/coverage-v8": "5.0.0-rc.2", "@vitest/ui": "5.0.0-rc.2", "happy-dom": "*", "jsdom": "*", "vite": "^6.4.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-tSdrRylWxqWHYhyHWUdFd3ASHGXxqGmRcPfjRvir+bcFzJ5se9DLzhvzMPS7F4yLWOPsaaILSMPBbWzMzgC1VA=="],
+    "vitest": ["vitest@5.0.0-rc.3", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/mocker": "5.0.0-rc.3", "chai": "^6.2.2", "es-module-lexer": "^2.3.2", "expect-type": "^1.4.0", "magic-string": "^1.2.2", "obug": "^2.1.4", "picomatch": "^4.0.7", "std-env": "^4.2.0", "tinybench": "6.1.3", "tinyexec": "1.3.0", "tinyglobby": "^0.2.17", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "5.0.0-rc.3", "@vitest/browser-preview": "5.0.0-rc.3", "@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0", "@vitest/coverage-istanbul": "5.0.0-rc.3", "@vitest/coverage-v8": "5.0.0-rc.3", "@vitest/ui": "5.0.0-rc.3", "happy-dom": "*", "jsdom": "*", "vite": "^6.4.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-5f6cbCjWyuX7YzydWJgOTwGRooN/r3W92oJGssTgRADdG6jNv52gT0YlVS0UxNTxqR5SSSfI4mp0B7+/4Qhdag=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 
@@ -1601,7 +1601,7 @@
 
     "@types/xml2js/@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
 
-    "@vitest/mocker/magic-string": ["magic-string@1.2.0", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-ptco+HFxTLgjafSLim2LojBSwfg5feBjd+SqyiwdGkzC38UPdZy3zgrHMI2CoTf5fJL38tbHMYWVzIH8BxGqJw=="],
+    "@vitest/mocker/magic-string": ["magic-string@1.2.3", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g=="],
 
     "backend/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
@@ -1641,9 +1641,11 @@
 
     "vite/postcss": ["postcss@8.5.26", "", { "dependencies": { "nanoid": "^3.3.17", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ=="],
 
-    "vitest/magic-string": ["magic-string@1.2.0", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-ptco+HFxTLgjafSLim2LojBSwfg5feBjd+SqyiwdGkzC38UPdZy3zgrHMI2CoTf5fJL38tbHMYWVzIH8BxGqJw=="],
+    "vitest/magic-string": ["magic-string@1.2.3", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g=="],
 
     "vitest/obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
+
+    "vitest/picomatch": ["picomatch@4.0.7", "", {}, "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA=="],
 
     "workbox-build/glob": ["glob@11.1.0", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.1.1", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw=="],
 

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -26,7 +26,7 @@
 		"lint:fix": "echo 'RPC fixing handled by root Biome'"
 	},
 	"dependencies": {
-		"@orpc/contract": "2.0.0-beta.30",
+		"@orpc/contract": "2.0.0-beta.31",
 		"zod": "catalog:"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## What
- bump `vitest` from `5.0.0-rc.2` to exact `5.0.0-rc.3`
- bump `@orpc/server` and `@orpc/contract` from beta.30 to exact `2.0.0-beta.31`
- regenerate `bun.lock` and document the compatibility verdict

## Why
These prerelease updates are required by the current toolchain wave. Exact pins prevent an unreviewed beta or stable release from entering the device runtime.

## How to verify
- `bun run --filter frontend test` — 354 files / 5,779 tests
- `bun run --filter frontend check`
- `bun run --filter backend check`
- `bun run --filter backend test` — 5,567 pass / 2 skip
- `bun run --filter @ceraui/rpc check`
- `bun run --filter @ceraui/rpc test` — 454 pass
- `bunx biome check .` — existing warnings only
- `bun run --filter frontend test:e2e -- tests/e2e/reconnect-banner-grace.spec.ts --project=desktop` — 2 pass

## Risks
- Vitest remains a release candidate. The complete frontend suite produced identical file and test counts before and after the bump.
- oRPC beta.31 changes `CORSHandlerPlugin` defaults, but CeraUI does not instantiate an HTTP handler or CORS plugin; its Bun WebSocket adapter invokes `call()` directly.