### PR TITLE
fix(system): preserve self-updates across service restarts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,9 @@ CeraUI/
 │           ├── encoder-load.ts        # per-core VEPU580 load; probes BOTH kernel realities
 │           │   ├── device-detection.ts    # isRealDevice() — gates all add-on ops
 │           │   ├── kiosk.ts               # Kiosk DC-2 state machine; toggle runs the cog-display add-on via the manager
-│           │   └── software-updates.ts    # apt/size parsing; APT_PACKAGE_NAME_RE
+│           │   ├── software-updates.ts    # apt/size parsing; APT_PACKAGE_NAME_RE
+│           │   ├── software-update-service.ts # transient-unit lifecycle + retained exit status
+│           │   └── software-update-process.ts # durable progress polling + restart reattachment
 │           └── modules/addons/
 │               └── manager.ts             # Add-on enable/disable state machine (T28)
 ├── packages/
@@ -735,6 +737,25 @@ post-boot reconciler. Both are the default-parameter values for their respective
 public functions, so existing tests that pass deps explicitly are unaffected.
 
 **Software-update + SSH dev mock seams (T8):**
+- Production self-updates run through `software-update-process.ts` as a
+  PID-1-owned transient service, never as a direct child of `ceralive.service`:
+  the CeraUI package's own restart must not kill the `apt-get`/`dpkg` transaction.
+  Progress comes from fixed, root-owned, no-follow mode-0600 append files under
+  `/run/ceralive`, not `systemd-run --pipe` or a caller-owned scope, so the status
+  parsers are not coupled to the backend process lifetime or file-read chunking.
+  `RemainAfterExit` preserves the terminal result; boot verifies the exact unit id,
+  transient fragment and effective `[Service]` append destinations, no-hook service
+  posture, and canonical
+  upgrade argv before reattaching. An
+  unreadable probe fails closed before the periodic refresh and retries until it can
+  resume that loop; concurrent recovery callers join one attempt. Fresh starts reject
+  an existing unit and non-upgrade apt argv;
+  observation errors retain independently-advanced cursors, final output must drain
+  completely before cleanup (bounded exhaustion retains the unit for recovery), and
+  cleanup failure is terminally visible rather than reported as success. Discovery
+  is single-flight. Every apt call names `/usr/bin/apt-get` explicitly; refresh
+  and read-only discovery are argv-only and locally bounded, while the detached
+  install transaction remains deliberately unbounded.
 - `simulateMockSoftwareUpdate()` (internal, called by `startSoftwareUpdate()` under
   `shouldUseMocks()`) broadcasts a realistic sequence of `{updating: SoftUpdateStatus}`
   frames — initial zero totals, then downloading/unpacking/setting-up counts, then

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -2542,8 +2542,57 @@ never refuses in silence.
 - **`resetSoftwareUpdateState()`** is a test seam (mirrors the `reset*Runner`
   seams): it drops the in-flight latch and the last terminal outcome. Never call
   it from production code — it would discard a real in-flight update.
+- **The package transaction is NOT a child of `ceralive.service`.** On
+  2026-08-29 the update path was confirmed to kill itself: upgrading CeraUI runs
+  a package script that restarts `ceralive.service`, and systemd then terminates
+  every process left in that unit's cgroup — including the `apt-get`/`dpkg`
+  transaction performing the upgrade. `software-update-process.ts` launches the
+  transaction as a PID-1-owned transient service instead. This is a service, not
+  `systemd-run --scope`: a scope remains caller-owned and did not survive the
+  parent-unit teardown in the rootful regression drill.
+- **Progress is durable, never pipe-owned.** `systemd-run --pipe` couples the
+  transaction's output to the backend process and produced `SIGPIPE` after the
+  parent unit stopped. The transient service appends stdout/stderr under
+  fixed `/run/ceralive/software-update.{stdout,stderr}` files; the backend polls
+  them and feeds the unchanged apt parsers and `SoftUpdateStatus` broadcasts.
+  The root-owned directory is not peer-writable, file creation is exclusive and
+  no-follow, and the files are mode 0600. Caller-selected paths are rejected.
+  Progress is derived from the cumulative log, so tokens split across arbitrary
+  file reads are still counted exactly once. No wall-clock deadline is added: a
+  valid package transaction may run for minutes.
+- **A restarted backend reattaches; it never starts a second apt.** The transient
+  service uses `RemainAfterExit` so PID 1 retains both a running transaction and
+  its terminal `ExecMainStatus`. During boot, `main.ts` awaits the bounded
+  recovery probe BEFORE starting the periodic apt refresh. Adoption requires the
+  exact unit id and transient fragment path, transient-service description/type,
+  exact non-duplicated `[Service]` stdout/stderr append destinations, no pre/post
+  hooks, and the canonical
+  `/usr/bin/apt-get` upgrade argv; a foreign same-named unit is never trusted. An
+  unreadable probe keeps discovery and starts gated
+  instead of treating uncertainty as absence, and schedules a coalesced retry that
+  resumes the periodic loop after a conclusive answer. Concurrent recovery callers
+  join one probe/observer, so only one consumer can replay and settle the retained
+  unit. Before a fresh launch, a
+  second probe rejects any existing unit before output is reset; the command builder
+  also refuses any apt operation outside the upgrade/install-held-packages contract.
+  Once attached, transient read/probe failures are retried without clearing
+  `softUpdateStatus`; stdout and stderr advance independently, so one failed read
+  cannot replay the other, and the terminal unit is retained until BOTH final drains
+  succeed. A permanently unreadable final output is bounded to 20 local attempts,
+  reports failure, and deliberately leaves the terminal unit intact for the next
+  recovery instead of deleting evidence. Only a complete drain permits stop/reset.
+  Cleanup failure is an explicit failed outcome. Package discovery is single-flight;
+  delayed starts while a refresh/discovery is active are coalesced to one timer, and
+  a later refusal is published as a terminal failure rather than disappearing.
+  The package-list refresh and read-only `dist-upgrade --assume-no` discovery are
+  argv-only `/usr/bin/apt-get` `spawnWithTimeout` calls too (5-minute and 2-minute
+  local bounds respectively); no privileged apt call resolves through `PATH`. Those
+  bounds cover checks only and never cap the detached package transaction. A non-zero
+  `systemctl show` is unknowable and retries fail-closed even if it emitted
+  valid-looking properties; only an explicit `LoadState=not-found` is absence.
 
-Coverage: `tests/software-updates-start-refusal.test.ts`.
+Coverage: `tests/software-updates-start-refusal.test.ts`,
+`tests/software-updates-apt.test.ts`.
 
 ## SOFTWARE-UPDATE CHECK CONTRACT [EXISTS]
 

--- a/apps/backend/src/helpers/spawn-policy.ts
+++ b/apps/backend/src/helpers/spawn-policy.ts
@@ -1,18 +1,18 @@
 /*
-    CeraUI - web UI for the CERALIVE project
-    Copyright (C) 2024-2025 CeraLive project
+	CeraUI - web UI for the CERALIVE project
+	Copyright (C) 2024-2025 CeraLive project
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /*
@@ -331,22 +331,92 @@ export const SPAWN_POLICY: readonly SpawnSite[] = [
 			"spawnWatcher runs dmesg -w with shutdown-abort cleanup and no process-lifetime timeout",
 	},
 	{
-		id: "softwareUpdates.aptGet",
+		id: "softwareUpdates.refreshPackageLists",
 		file: "modules/system/software-updates.ts",
-		symbol: "doSoftwareUpdate",
-		command: "[apt-get, ...upgradeArgs]",
+		symbol: "checkForSoftwareUpdates",
+		command: "[/usr/bin/apt-get, update, --allow-releaseinfo-change]",
 		class: "bounded-command",
 		contract: {
-			timed: false,
+			timed: true,
 			startupTimeout: false,
 			shutdownCleanup: false,
 			shutdownAbort: false,
 			lifetimeTimeoutExempt: false,
-			streamingExempt: true,
 		},
 		status: "enforced",
 		mechanism:
-			"streams stdout to parse + broadcast apt progress; a wall-clock cap is wrong (an upgrade legitimately runs minutes). Bounded by output parsing, not time",
+			"spawnWithTimeout runs the package-list refresh argv-only and bounds a repository/network stall without changing the apt transaction lifetime",
+	},
+	{
+		id: "softwareUpdates.discoverUpgrade",
+		file: "modules/system/software-updates.ts",
+		symbol: "getSoftwareUpdateSize",
+		command:
+			"[/usr/bin/apt-get, dist-upgrade|install, --assume-no, ...packages]",
+		class: "bounded-probe",
+		contract: {
+			timed: true,
+			startupTimeout: false,
+			shutdownCleanup: false,
+			shutdownAbort: false,
+			lifetimeTimeoutExempt: false,
+		},
+		status: "enforced",
+		mechanism:
+			"spawnWithTimeout runs the read-only upgrade discovery argv-only with a bounded local probe window",
+	},
+	{
+		id: "softwareUpdates.startTransient",
+		file: "modules/system/software-update-service.ts",
+		symbol: "defaultDetachedAptServiceDeps.start",
+		command:
+			"[systemd-run, ...serviceArgs, --, /usr/bin/apt-get, ...upgradeArgs]",
+		class: "bounded-command",
+		contract: {
+			timed: true,
+			startupTimeout: false,
+			shutdownCleanup: false,
+			shutdownAbort: false,
+			lifetimeTimeoutExempt: false,
+		},
+		status: "enforced",
+		mechanism:
+			"spawnWithTimeout bounds only the local systemd-run submission; PID 1 owns the apt/dpkg service with no runtime deadline, so a ceralive.service restart cannot kill the transaction",
+	},
+	{
+		id: "softwareUpdates.inspectTransient",
+		file: "modules/system/software-update-service.ts",
+		symbol: "inspectService",
+		command:
+			"[systemctl, show, ceralive-software-update.service, ...properties]",
+		class: "bounded-probe",
+		contract: {
+			timed: true,
+			startupTimeout: false,
+			shutdownCleanup: false,
+			shutdownAbort: false,
+			lifetimeTimeoutExempt: false,
+		},
+		status: "enforced",
+		mechanism:
+			"spawnWithTimeout bounds each local state read; adoption verifies the exact unit id, no-hook transient-service posture, and canonical apt-get upgrade argv, while an unreadable or unknown state stays fail-closed behind a coalesced recovery retry",
+	},
+	{
+		id: "softwareUpdates.cleanupTransient",
+		file: "modules/system/software-update-service.ts",
+		symbol: "defaultDetachedAptServiceDeps.cleanup",
+		command: "[systemctl, stop|reset-failed, ceralive-software-update.service]",
+		class: "bounded-command",
+		contract: {
+			timed: true,
+			startupTimeout: false,
+			shutdownCleanup: false,
+			shutdownAbort: false,
+			lifetimeTimeoutExempt: false,
+		},
+		status: "enforced",
+		mechanism:
+			"spawnWithTimeout bounds terminal service cleanup after stdout/stderr and ExecMainStatus have been consumed; cleanup failure remains an explicit failed update outcome rather than being reported as success",
 	},
 	{
 		id: "addons.runValidateCmd",

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -1,18 +1,18 @@
 /*
-    CeraUI - web UI for the CeraLive project
-    Copyright (C) 2024-2025 CeraLive project
+	CeraUI - web UI for the CeraLive project
+	Copyright (C) 2024-2025 CeraLive project
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 import pkg from "../package.json" with { type: "json" };
@@ -138,7 +138,10 @@ import {
 	initHardwareMonitoring,
 	stopDmesgWatchers,
 } from "./modules/system/sensors.ts";
-import { periodicCheckForSoftwareUpdates } from "./modules/system/software-updates.ts";
+import {
+	periodicCheckForSoftwareUpdates,
+	recoverSoftwareUpdateIfRunning,
+} from "./modules/system/software-updates.ts";
 import {
 	ensureSshPasswordProvisioned,
 	ensureSshPasswordSynced,
@@ -387,6 +390,9 @@ setInterval(updateGwWrapper, UPDATE_GW_INT);
 
 // Self-gating: it no-ops when updates are disabled for this device or when the
 // host is a dev/mock box (a dev machine must never be handed to apt).
+await guardNonCritical("software-update-recovery", async () => {
+	await recoverSoftwareUpdateIfRunning();
+});
 periodicCheckForSoftwareUpdates();
 
 initNetworkInterfaceMonitoring();

--- a/apps/backend/src/modules/system/software-update-output.ts
+++ b/apps/backend/src/modules/system/software-update-output.ts
@@ -1,0 +1,161 @@
+/*
+	CeraUI - web UI for the CERALIVE project
+	Copyright (C) 2024-2025 CeraLive project
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+*/
+
+import { constants } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const RUN_DIR = "/run/ceralive";
+const MAX_READ_BYTES = 64 * 1024;
+
+export type SoftwareUpdateOutputPaths = {
+	readonly stdout: string;
+	readonly stderr: string;
+};
+
+export type SoftwareUpdateOutputRead = {
+	readonly bytes: Uint8Array;
+	readonly nextOffset: number;
+};
+
+export class UnsafeSoftwareUpdateOutputPathError extends Error {
+	constructor(
+		readonly outputPath: string,
+		reason: string,
+	) {
+		super(`unsafe software-update output path: ${reason}`);
+		this.name = "UnsafeSoftwareUpdateOutputPathError";
+	}
+}
+
+export function softwareUpdateOutputPaths(): SoftwareUpdateOutputPaths {
+	return {
+		stdout: path.join(RUN_DIR, "software-update.stdout"),
+		stderr: path.join(RUN_DIR, "software-update.stderr"),
+	};
+}
+
+async function secureOutputDirectory(
+	directory: string,
+	expectedUid: number,
+): Promise<void> {
+	await fs.mkdir(directory, { recursive: true, mode: 0o700 });
+	const stat = await fs.lstat(directory);
+	if (!stat.isDirectory() || stat.isSymbolicLink()) {
+		throw new UnsafeSoftwareUpdateOutputPathError(directory, "not a directory");
+	}
+	if (stat.uid !== expectedUid) {
+		throw new UnsafeSoftwareUpdateOutputPathError(directory, "wrong owner");
+	}
+	if ((stat.mode & 0o022) !== 0) {
+		throw new UnsafeSoftwareUpdateOutputPathError(
+			directory,
+			"writable by peers",
+		);
+	}
+	await fs.chmod(directory, 0o700);
+}
+
+async function createOutputFile(
+	filePath: string,
+	expectedUid: number,
+): Promise<void> {
+	await fs.rm(filePath, { force: true });
+	const handle = await fs.open(
+		filePath,
+		constants.O_WRONLY |
+			constants.O_CREAT |
+			constants.O_EXCL |
+			constants.O_NOFOLLOW,
+		0o600,
+	);
+	try {
+		const stat = await handle.stat();
+		if (!stat.isFile() || stat.uid !== expectedUid || stat.nlink !== 1) {
+			throw new UnsafeSoftwareUpdateOutputPathError(
+				filePath,
+				"not a private regular file",
+			);
+		}
+		await handle.chmod(0o600);
+	} finally {
+		await handle.close();
+	}
+}
+
+export async function prepareSoftwareUpdateOutput(
+	paths: SoftwareUpdateOutputPaths,
+	expectedUid = 0,
+): Promise<void> {
+	const directories = new Set([
+		path.dirname(paths.stdout),
+		path.dirname(paths.stderr),
+	]);
+	if (directories.size !== 1) {
+		throw new UnsafeSoftwareUpdateOutputPathError(
+			paths.stdout,
+			"stdout and stderr do not share a directory",
+		);
+	}
+	const directory = directories.values().next().value;
+	if (directory === undefined) {
+		throw new UnsafeSoftwareUpdateOutputPathError(
+			paths.stdout,
+			"missing directory",
+		);
+	}
+	await secureOutputDirectory(directory, expectedUid);
+	await createOutputFile(paths.stdout, expectedUid);
+	await createOutputFile(paths.stderr, expectedUid);
+}
+
+export async function readSoftwareUpdateOutput(
+	filePath: string,
+	offset: number,
+): Promise<SoftwareUpdateOutputRead> {
+	const paths = softwareUpdateOutputPaths();
+	if (filePath !== paths.stdout && filePath !== paths.stderr) {
+		throw new UnsafeSoftwareUpdateOutputPathError(
+			filePath,
+			"runtime paths are fixed",
+		);
+	}
+	const handle = await fs.open(
+		filePath,
+		constants.O_RDONLY | constants.O_NOFOLLOW,
+	);
+	try {
+		const stat = await handle.stat();
+		if (
+			!stat.isFile() ||
+			stat.uid !== 0 ||
+			stat.nlink !== 1 ||
+			(stat.mode & 0o777) !== 0o600
+		) {
+			throw new UnsafeSoftwareUpdateOutputPathError(
+				filePath,
+				"not a private root-owned regular file",
+			);
+		}
+		if (stat.size < offset) return { bytes: new Uint8Array(), nextOffset: 0 };
+		if (stat.size === offset)
+			return { bytes: new Uint8Array(), nextOffset: offset };
+
+		const length = Math.min(stat.size - offset, MAX_READ_BYTES);
+		const buffer = Buffer.alloc(length);
+		const { bytesRead } = await handle.read(buffer, 0, length, offset);
+		return {
+			bytes: Uint8Array.from(buffer.subarray(0, bytesRead)),
+			nextOffset: offset + bytesRead,
+		};
+	} finally {
+		await handle.close();
+	}
+}

--- a/apps/backend/src/modules/system/software-update-process.ts
+++ b/apps/backend/src/modules/system/software-update-process.ts
@@ -1,0 +1,235 @@
+/*
+	CeraUI - web UI for the CERALIVE project
+	Copyright (C) 2024-2025 CeraLive project
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+*/
+
+import {
+	buildDetachedAptUpgradeCommand,
+	type DetachedAptServiceDeps,
+	type DetachedAptServiceState,
+	defaultDetachedAptServiceDeps,
+	type SoftwareUpdateOutputPaths,
+} from "./software-update-service.ts";
+
+export type { SoftwareUpdateOutputPaths } from "./software-update-service.ts";
+export { buildDetachedAptUpgradeCommand } from "./software-update-service.ts";
+
+const OUTPUT_POLL_INTERVAL_MS = 250;
+const FINAL_DRAIN_MAX_FAILURES = 20;
+
+export type SoftwareUpdateOutputHandlers = {
+	readonly onStdout: (chunk: string) => void;
+	readonly onStderr: (chunk: string) => void;
+	readonly onAttached?: () => void;
+	readonly onObserverError?: (error: unknown) => void;
+};
+
+export type DetachedAptUpgradeDeps = DetachedAptServiceDeps;
+
+export type RecoveredDetachedAptUpgrade = {
+	readonly completion: Promise<number>;
+};
+
+type OutputCursor = {
+	readonly path: string;
+	readonly offset: number;
+	readonly decoder: TextDecoder;
+	readonly emit: (chunk: string) => void;
+};
+
+export class DetachedAptServiceVanishedError extends Error {
+	constructor() {
+		super("software-update transient service vanished after launch");
+		this.name = "DetachedAptServiceVanishedError";
+	}
+}
+
+export class DetachedAptServiceAlreadyExistsError extends Error {
+	constructor() {
+		super("a detached apt transaction already exists");
+		this.name = "DetachedAptServiceAlreadyExistsError";
+	}
+}
+
+export class DetachedAptServiceCleanupError extends Error {
+	constructor(
+		readonly transactionExitCode: number,
+		readonly cleanupError: unknown,
+	) {
+		super("apt transaction finished, but its transient service cleanup failed");
+		this.name = "DetachedAptServiceCleanupError";
+	}
+}
+
+export class DetachedAptOutputUnavailableError extends Error {
+	constructor() {
+		super(
+			"detached apt output remained unreadable after the transaction finished",
+		);
+		this.name = "DetachedAptOutputUnavailableError";
+	}
+}
+
+function reportObserverError(
+	handlers: SoftwareUpdateOutputHandlers,
+	error: unknown,
+): void {
+	handlers.onObserverError?.(error);
+}
+
+async function drainOutputCursor(
+	cursor: OutputCursor,
+	read: DetachedAptUpgradeDeps["readOutput"],
+): Promise<OutputCursor> {
+	const next = await read(cursor.path, cursor.offset);
+	if (next.bytes.byteLength > 0) {
+		const text = cursor.decoder.decode(next.bytes, { stream: true });
+		if (text.length > 0) cursor.emit(text);
+	}
+	return { ...cursor, offset: next.nextOffset };
+}
+
+async function drainAvailableOutput(
+	stdoutCursor: OutputCursor,
+	stderrCursor: OutputCursor,
+	handlers: SoftwareUpdateOutputHandlers,
+	readOutput: DetachedAptUpgradeDeps["readOutput"],
+): Promise<{
+	readonly stdout: OutputCursor;
+	readonly stderr: OutputCursor;
+	readonly complete: boolean;
+}> {
+	const [stdoutResult, stderrResult] = await Promise.allSettled([
+		drainOutputCursor(stdoutCursor, readOutput),
+		drainOutputCursor(stderrCursor, readOutput),
+	]);
+	if (stdoutResult.status === "rejected") {
+		reportObserverError(handlers, stdoutResult.reason);
+	}
+	if (stderrResult.status === "rejected") {
+		reportObserverError(handlers, stderrResult.reason);
+	}
+	return {
+		stdout:
+			stdoutResult.status === "fulfilled" ? stdoutResult.value : stdoutCursor,
+		stderr:
+			stderrResult.status === "fulfilled" ? stderrResult.value : stderrCursor,
+		complete:
+			stdoutResult.status === "fulfilled" &&
+			stderrResult.status === "fulfilled",
+	};
+}
+
+function createOutputCursors(
+	paths: SoftwareUpdateOutputPaths,
+	handlers: SoftwareUpdateOutputHandlers,
+): readonly [OutputCursor, OutputCursor] {
+	return [
+		{
+			path: paths.stdout,
+			offset: 0,
+			decoder: new TextDecoder(),
+			emit: handlers.onStdout,
+		},
+		{
+			path: paths.stderr,
+			offset: 0,
+			decoder: new TextDecoder(),
+			emit: handlers.onStderr,
+		},
+	];
+}
+
+async function observeDetachedAptUpgrade(
+	initialState: Exclude<DetachedAptServiceState, { readonly kind: "absent" }>,
+	handlers: SoftwareUpdateOutputHandlers,
+	deps: DetachedAptUpgradeDeps,
+): Promise<number> {
+	let state: DetachedAptServiceState = initialState;
+	let [stdoutCursor, stderrCursor] = createOutputCursors(
+		deps.outputPaths,
+		handlers,
+	);
+
+	while (state.kind === "running") {
+		const drained = await drainAvailableOutput(
+			stdoutCursor,
+			stderrCursor,
+			handlers,
+			deps.readOutput,
+		);
+		stdoutCursor = drained.stdout;
+		stderrCursor = drained.stderr;
+		await deps.sleep(OUTPUT_POLL_INTERVAL_MS);
+		try {
+			state = await deps.inspect();
+		} catch (error) {
+			reportObserverError(handlers, error);
+			continue;
+		}
+		if (state.kind === "absent") throw new DetachedAptServiceVanishedError();
+	}
+	if (state.kind !== "finished") throw new DetachedAptServiceVanishedError();
+
+	let finalDrainComplete = false;
+	let finalDrainFailures = 0;
+	while (!finalDrainComplete) {
+		const drained = await drainAvailableOutput(
+			stdoutCursor,
+			stderrCursor,
+			handlers,
+			deps.readOutput,
+		);
+		stdoutCursor = drained.stdout;
+		stderrCursor = drained.stderr;
+		finalDrainComplete = drained.complete;
+		if (!finalDrainComplete) {
+			finalDrainFailures++;
+			if (finalDrainFailures >= FINAL_DRAIN_MAX_FAILURES) {
+				throw new DetachedAptOutputUnavailableError();
+			}
+			await deps.sleep(OUTPUT_POLL_INTERVAL_MS);
+		}
+	}
+	const stdoutTail = stdoutCursor.decoder.decode();
+	if (stdoutTail.length > 0) handlers.onStdout(stdoutTail);
+	const stderrTail = stderrCursor.decoder.decode();
+	if (stderrTail.length > 0) handlers.onStderr(stderrTail);
+	try {
+		await deps.cleanup(state);
+	} catch (error) {
+		throw new DetachedAptServiceCleanupError(state.exitCode, error);
+	}
+	return state.exitCode;
+}
+
+export async function runDetachedAptUpgrade(
+	aptArgs: readonly string[],
+	handlers: SoftwareUpdateOutputHandlers,
+	deps: DetachedAptUpgradeDeps = defaultDetachedAptServiceDeps(),
+): Promise<number> {
+	const existing = await deps.inspect();
+	if (existing.kind !== "absent") {
+		throw new DetachedAptServiceAlreadyExistsError();
+	}
+	await deps.prepareOutput();
+	await deps.start(buildDetachedAptUpgradeCommand(aptArgs, deps.outputPaths));
+	return observeDetachedAptUpgrade({ kind: "running" }, handlers, deps);
+}
+
+export async function recoverDetachedAptUpgrade(
+	handlers: SoftwareUpdateOutputHandlers,
+	deps: DetachedAptUpgradeDeps = defaultDetachedAptServiceDeps(),
+): Promise<RecoveredDetachedAptUpgrade | null> {
+	const state = await deps.inspect();
+	if (state.kind === "absent") return null;
+	handlers.onAttached?.();
+	return {
+		completion: observeDetachedAptUpgrade(state, handlers, deps),
+	};
+}

--- a/apps/backend/src/modules/system/software-update-recovery.ts
+++ b/apps/backend/src/modules/system/software-update-recovery.ts
@@ -1,0 +1,59 @@
+/*
+	CeraUI - web UI for the CERALIVE project
+	Copyright (C) 2024-2025 CeraLive project
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+*/
+
+export type SoftwareUpdateRecoveryCoordinatorDeps = {
+	readonly attempt: () => Promise<boolean>;
+	readonly scheduleRetry: (retry: () => void) => void;
+	readonly resumePeriodicChecks: () => void;
+	readonly reportRetryError: (error: unknown) => void;
+};
+
+let recoveryInconclusive = false;
+let recoveryPromise: Promise<boolean> | undefined;
+
+export function isSoftwareUpdateRecoveryInconclusive(): boolean {
+	return recoveryInconclusive;
+}
+
+export function resetSoftwareUpdateRecovery(): void {
+	recoveryPromise = undefined;
+	recoveryInconclusive = false;
+}
+
+async function runRecovery(
+	deps: SoftwareUpdateRecoveryCoordinatorDeps,
+): Promise<boolean> {
+	recoveryInconclusive = true;
+	try {
+		const recovered = await deps.attempt();
+		recoveryInconclusive = false;
+		return recovered;
+	} catch (error) {
+		deps.scheduleRetry(() => {
+			void recoverSoftwareUpdateWithCoordination(deps)
+				.then(() => deps.resumePeriodicChecks())
+				.catch(deps.reportRetryError);
+		});
+		throw error;
+	}
+}
+
+export function recoverSoftwareUpdateWithCoordination(
+	deps: SoftwareUpdateRecoveryCoordinatorDeps,
+): Promise<boolean> {
+	if (recoveryPromise) return recoveryPromise;
+	const completion = runRecovery(deps);
+	recoveryPromise = completion;
+	const clear = () => {
+		if (recoveryPromise === completion) recoveryPromise = undefined;
+	};
+	void completion.then(clear, clear);
+	return completion;
+}

--- a/apps/backend/src/modules/system/software-update-service-contract.ts
+++ b/apps/backend/src/modules/system/software-update-service-contract.ts
@@ -1,0 +1,154 @@
+/*
+	CeraUI - web UI for the CERALIVE project
+	Copyright (C) 2024-2025 CeraLive project
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+*/
+
+import { APT_PACKAGE_NAME_RE } from "./apt-package-name.ts";
+import { softwareUpdateOutputPaths } from "./software-update-output.ts";
+
+export const SOFTWARE_UPDATE_UNIT = "ceralive-software-update.service";
+export const SOFTWARE_UPDATE_DESCRIPTION = "CeraLive software update";
+export const SOFTWARE_UPDATE_FRAGMENT_PATH = `/run/systemd/transient/${SOFTWARE_UPDATE_UNIT}`;
+
+const APT_UPGRADE_PREFIX = [
+	"/usr/bin/apt-get",
+	"-y",
+	"-o",
+	"Dpkg::Options::=--force-confdef",
+	"-o",
+	"Dpkg::Options::=--force-confold",
+] as const;
+
+export class DetachedAptServiceCommandError extends Error {
+	constructor(
+		readonly command: readonly string[],
+		readonly exitCode: number,
+		readonly stderr: string,
+	) {
+		super(
+			stderr.trim() ||
+				`${command[0] ?? "systemd command"} exited with code ${exitCode}`,
+		);
+		this.name = "DetachedAptServiceCommandError";
+	}
+}
+
+export class DetachedAptServiceIdentityError extends Error {
+	constructor(readonly reason: string) {
+		super(`refusing unknown software-update service: ${reason}`);
+		this.name = "DetachedAptServiceIdentityError";
+	}
+}
+
+export class InvalidDetachedAptUpgradeArgumentsError extends Error {
+	constructor() {
+		super(
+			"detached apt transaction arguments do not match the upgrade contract",
+		);
+		this.name = "InvalidDetachedAptUpgradeArgumentsError";
+	}
+}
+
+export function isExpectedAptUpgradeArgv(argv: readonly string[]): boolean {
+	if (!APT_UPGRADE_PREFIX.every((value, index) => argv[index] === value)) {
+		return false;
+	}
+	const tail = argv.slice(APT_UPGRADE_PREFIX.length);
+	return (
+		(tail.length === 1 && tail[0] === "dist-upgrade") ||
+		(tail[0] === "install" &&
+			tail.length > 1 &&
+			tail
+				.slice(1)
+				.every((packageName) => APT_PACKAGE_NAME_RE.test(packageName)))
+	);
+}
+
+function parseProperties(output: string): Map<string, string> {
+	const properties = new Map<string, string>();
+	for (const line of output.split("\n")) {
+		const separator = line.indexOf("=");
+		if (separator <= 0) continue;
+		properties.set(line.slice(0, separator), line.slice(separator + 1));
+	}
+	return properties;
+}
+
+export function validateDetachedAptServiceIdentity(output: string): void {
+	const properties = parseProperties(output);
+	const expected = new Map([
+		["Id", SOFTWARE_UPDATE_UNIT],
+		["FragmentPath", SOFTWARE_UPDATE_FRAGMENT_PATH],
+		["Description", SOFTWARE_UPDATE_DESCRIPTION],
+		["Transient", "yes"],
+		["Type", "exec"],
+		["RemainAfterExit", "yes"],
+		["StandardOutput", "append"],
+		["StandardError", "append"],
+		["User", ""],
+		["ExecStartPre", ""],
+		["ExecStartPost", ""],
+	]);
+	for (const [name, value] of expected) {
+		if (properties.get(name) !== value) {
+			throw new DetachedAptServiceIdentityError(`${name} does not match`);
+		}
+	}
+
+	const execStart = properties.get("ExecStart") ?? "";
+	const argvMarker = "argv[]=";
+	const argvStart = execStart.indexOf(argvMarker);
+	const argvEnd = execStart.indexOf(" ;", argvStart);
+	if (
+		!execStart.startsWith("{ path=/usr/bin/apt-get ; ") ||
+		argvStart < 0 ||
+		argvEnd < 0
+	) {
+		throw new DetachedAptServiceIdentityError("ExecStart is not apt-get");
+	}
+	const argv = execStart
+		.slice(argvStart + argvMarker.length, argvEnd)
+		.trim()
+		.split(/\s+/);
+	if (!isExpectedAptUpgradeArgv(argv)) {
+		throw new DetachedAptServiceIdentityError(
+			"apt-get operation does not match",
+		);
+	}
+}
+
+export function validateDetachedAptServiceFragment(fragment: string): void {
+	const paths = softwareUpdateOutputPaths();
+	const expected = new Map([
+		["StandardOutput", `append:${paths.stdout}`],
+		["StandardError", `append:${paths.stderr}`],
+	]);
+	const observed = new Map<string, string>();
+	let section = "";
+	for (const rawLine of fragment.split("\n")) {
+		const line = rawLine.trim();
+		if (line.startsWith("[") && line.endsWith("]")) {
+			section = line.slice(1, -1);
+			continue;
+		}
+		if (section !== "Service") continue;
+		const separator = line.indexOf("=");
+		if (separator <= 0) continue;
+		const name = line.slice(0, separator);
+		if (!expected.has(name)) continue;
+		if (observed.has(name)) {
+			throw new DetachedAptServiceIdentityError(`${name} is duplicated`);
+		}
+		observed.set(name, line.slice(separator + 1));
+	}
+	for (const [name, value] of expected) {
+		if (observed.get(name) !== value) {
+			throw new DetachedAptServiceIdentityError(`${name} path does not match`);
+		}
+	}
+}

--- a/apps/backend/src/modules/system/software-update-service-state.ts
+++ b/apps/backend/src/modules/system/software-update-service-state.ts
@@ -1,0 +1,118 @@
+/*
+	CeraUI - web UI for the CERALIVE project
+	Copyright (C) 2024-2025 CeraLive project
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+*/
+
+import type { SpawnWithTimeoutResult } from "../../helpers/spawn-policy.ts";
+import {
+	DetachedAptServiceCommandError,
+	DetachedAptServiceIdentityError,
+	validateDetachedAptServiceIdentity,
+} from "./software-update-service-contract.ts";
+
+export type DetachedAptServiceState =
+	| { readonly kind: "absent" }
+	| { readonly kind: "running" }
+	| {
+			readonly kind: "finished";
+			readonly exitCode: number;
+			readonly cleanup: "stop" | "reset-failed";
+	  };
+
+export type FinishedDetachedAptServiceState = Extract<
+	DetachedAptServiceState,
+	{ readonly kind: "finished" }
+>;
+
+export class DetachedAptServiceStateError extends Error {
+	constructor(
+		readonly activeState: string,
+		readonly subState: string,
+	) {
+		super(
+			`unrecognized detached apt service state: ${activeState}/${subState}`,
+		);
+		this.name = "DetachedAptServiceStateError";
+	}
+}
+
+function parseProperties(output: string): Map<string, string> {
+	const properties = new Map<string, string>();
+	for (const line of output.split("\n")) {
+		const separator = line.indexOf("=");
+		if (separator <= 0) continue;
+		properties.set(line.slice(0, separator), line.slice(separator + 1));
+	}
+	return properties;
+}
+
+function processExitCode(mainCode: number, mainStatus: number): number {
+	if (mainCode === 1) return mainStatus;
+	return mainStatus > 0 ? 128 + mainStatus : 1;
+}
+
+export function parseDetachedAptServiceState(
+	output: string,
+): DetachedAptServiceState {
+	const properties = parseProperties(output);
+	if (properties.get("LoadState") !== "loaded") return { kind: "absent" };
+
+	const activeState = properties.get("ActiveState") ?? "inactive";
+	const subState = properties.get("SubState") ?? "dead";
+	const mainCode = Number.parseInt(properties.get("ExecMainCode") ?? "0", 10);
+	const mainStatus = Number.parseInt(
+		properties.get("ExecMainStatus") ?? "0",
+		10,
+	);
+
+	if (activeState === "failed" || subState === "failed") {
+		return {
+			kind: "finished",
+			exitCode: processExitCode(mainCode, mainStatus),
+			cleanup: "reset-failed",
+		};
+	}
+	if (subState === "exited") {
+		return { kind: "finished", exitCode: mainStatus, cleanup: "stop" };
+	}
+	if (
+		activeState === "active" ||
+		activeState === "activating" ||
+		activeState === "reloading" ||
+		activeState === "deactivating"
+	) {
+		return { kind: "running" };
+	}
+	throw new DetachedAptServiceStateError(activeState, subState);
+}
+
+export function parseDetachedAptServiceProbe(
+	result: SpawnWithTimeoutResult,
+	command: readonly string[],
+): DetachedAptServiceState {
+	const state = parseDetachedAptServiceState(result.stdout);
+	if (result.exitCode !== 0) {
+		if (
+			state.kind === "absent" &&
+			result.stdout.includes("LoadState=not-found")
+		) {
+			return state;
+		}
+		throw new DetachedAptServiceCommandError(
+			command,
+			result.exitCode,
+			result.stderr,
+		);
+	}
+	if (state.kind === "absent") {
+		if (result.stdout.includes("LoadState=not-found")) return state;
+		throw new DetachedAptServiceIdentityError("unit state was not readable");
+	}
+	validateDetachedAptServiceIdentity(result.stdout);
+	return state;
+}

--- a/apps/backend/src/modules/system/software-update-service.ts
+++ b/apps/backend/src/modules/system/software-update-service.ts
@@ -1,0 +1,157 @@
+/*
+	CeraUI - web UI for the CERALIVE project
+	Copyright (C) 2024-2025 CeraLive project
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+*/
+
+import { spawnWithTimeout } from "../../helpers/spawn-policy.ts";
+import {
+	prepareSoftwareUpdateOutput,
+	readSoftwareUpdateOutput,
+	type SoftwareUpdateOutputPaths,
+	type SoftwareUpdateOutputRead,
+	softwareUpdateOutputPaths,
+	UnsafeSoftwareUpdateOutputPathError,
+} from "./software-update-output.ts";
+import {
+	DetachedAptServiceCommandError,
+	InvalidDetachedAptUpgradeArgumentsError,
+	isExpectedAptUpgradeArgv,
+	SOFTWARE_UPDATE_DESCRIPTION,
+	SOFTWARE_UPDATE_FRAGMENT_PATH,
+	SOFTWARE_UPDATE_UNIT,
+	validateDetachedAptServiceFragment,
+} from "./software-update-service-contract.ts";
+import {
+	type DetachedAptServiceState,
+	type FinishedDetachedAptServiceState,
+	parseDetachedAptServiceProbe,
+} from "./software-update-service-state.ts";
+
+const SYSTEMD_COMMAND_TIMEOUT_MS = 10_000;
+
+export type {
+	SoftwareUpdateOutputPaths,
+	SoftwareUpdateOutputRead,
+} from "./software-update-output.ts";
+export {
+	DetachedAptServiceCommandError,
+	DetachedAptServiceIdentityError,
+	InvalidDetachedAptUpgradeArgumentsError,
+	validateDetachedAptServiceFragment,
+	validateDetachedAptServiceIdentity,
+} from "./software-update-service-contract.ts";
+export type {
+	DetachedAptServiceState,
+	FinishedDetachedAptServiceState,
+} from "./software-update-service-state.ts";
+export {
+	DetachedAptServiceStateError,
+	parseDetachedAptServiceProbe,
+	parseDetachedAptServiceState,
+} from "./software-update-service-state.ts";
+
+export type DetachedAptServiceDeps = {
+	readonly outputPaths: SoftwareUpdateOutputPaths;
+	readonly prepareOutput: () => Promise<void>;
+	readonly start: (command: readonly string[]) => Promise<void>;
+	readonly inspect: () => Promise<DetachedAptServiceState>;
+	readonly cleanup: (state: FinishedDetachedAptServiceState) => Promise<void>;
+	readonly readOutput: (
+		file: string,
+		offset: number,
+	) => Promise<SoftwareUpdateOutputRead>;
+	readonly sleep: (milliseconds: number) => Promise<void>;
+};
+
+export function buildDetachedAptUpgradeCommand(
+	aptArgs: readonly string[],
+	outputPaths: SoftwareUpdateOutputPaths,
+): string[] {
+	if (!isExpectedAptUpgradeArgv(["/usr/bin/apt-get", ...aptArgs])) {
+		throw new InvalidDetachedAptUpgradeArgumentsError();
+	}
+	const trustedPaths = softwareUpdateOutputPaths();
+	if (
+		outputPaths.stdout !== trustedPaths.stdout ||
+		outputPaths.stderr !== trustedPaths.stderr
+	) {
+		throw new UnsafeSoftwareUpdateOutputPathError(
+			outputPaths.stdout,
+			"runtime paths are fixed",
+		);
+	}
+	return [
+		"systemd-run",
+		`--unit=${SOFTWARE_UPDATE_UNIT}`,
+		`--description=${SOFTWARE_UPDATE_DESCRIPTION}`,
+		"--remain-after-exit",
+		"--quiet",
+		"--service-type=exec",
+		"--expand-environment=no",
+		`--property=StandardOutput=append:${outputPaths.stdout}`,
+		`--property=StandardError=append:${outputPaths.stderr}`,
+		"--",
+		"/usr/bin/apt-get",
+		...aptArgs,
+	];
+}
+
+async function requireSuccessfulCommand(command: string[]): Promise<string> {
+	const result = await spawnWithTimeout(command, {
+		timeoutMs: SYSTEMD_COMMAND_TIMEOUT_MS,
+	});
+	if (result.exitCode !== 0) {
+		throw new DetachedAptServiceCommandError(
+			command,
+			result.exitCode,
+			result.stderr,
+		);
+	}
+	return result.stdout;
+}
+
+async function inspectService(): Promise<DetachedAptServiceState> {
+	const command = [
+		"systemctl",
+		"show",
+		SOFTWARE_UPDATE_UNIT,
+		"--property=Id,FragmentPath,Description,LoadState,ActiveState,SubState,Transient,Type,RemainAfterExit,User,ExecMainCode,ExecMainStatus,ExecStart,ExecStartPre,ExecStartPost,StandardOutput,StandardError",
+		"--no-pager",
+	];
+	const result = await spawnWithTimeout(command, {
+		timeoutMs: SYSTEMD_COMMAND_TIMEOUT_MS,
+	});
+	const state = parseDetachedAptServiceProbe(result, command);
+	if (state.kind !== "absent") {
+		validateDetachedAptServiceFragment(
+			await Bun.file(SOFTWARE_UPDATE_FRAGMENT_PATH).text(),
+		);
+	}
+	return state;
+}
+
+export function defaultDetachedAptServiceDeps(): DetachedAptServiceDeps {
+	const paths = softwareUpdateOutputPaths();
+	return {
+		outputPaths: paths,
+		prepareOutput: () => prepareSoftwareUpdateOutput(paths),
+		start: async (command) => {
+			await requireSuccessfulCommand([...command]);
+		},
+		inspect: inspectService,
+		cleanup: async (state) => {
+			await requireSuccessfulCommand([
+				"systemctl",
+				state.cleanup,
+				SOFTWARE_UPDATE_UNIT,
+			]);
+		},
+		readOutput: readSoftwareUpdateOutput,
+		sleep: Bun.sleep,
+	};
+}

--- a/apps/backend/src/modules/system/software-updates.ts
+++ b/apps/backend/src/modules/system/software-updates.ts
@@ -1,25 +1,28 @@
 /*
-    CeraUI - web UI for the CERALIVE project
-    Copyright (C) 2024-2025 CeraLive project
+	CeraUI - web UI for the CERALIVE project
+	Copyright (C) 2024-2025 CeraLive project
 
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { execPNR } from "../../helpers/exec.ts";
 import { invariant } from "../../helpers/invariant.ts";
 import { logger } from "../../helpers/logger.ts";
 import { run } from "../../helpers/run.ts";
+import {
+	type SpawnWithTimeoutResult,
+	spawnWithTimeout,
+} from "../../helpers/spawn-policy.ts";
 import { getms, oneHour, oneMinute } from "../../helpers/time.ts";
 import { isDevelopment } from "../../mocks/mock-config.ts";
 import { shouldUseMocks } from "../../mocks/mock-service.ts";
@@ -41,6 +44,17 @@ import {
 	parseOk,
 } from "./cli-parse.ts";
 import {
+	DetachedAptServiceCleanupError,
+	recoverDetachedAptUpgrade,
+	runDetachedAptUpgrade,
+	type SoftwareUpdateOutputHandlers,
+} from "./software-update-process.ts";
+import {
+	isSoftwareUpdateRecoveryInconclusive,
+	recoverSoftwareUpdateWithCoordination,
+	resetSoftwareUpdateRecovery,
+} from "./software-update-recovery.ts";
+import {
 	deriveUpdateIdentity,
 	deriveUpdateState,
 	type UpdateCheckFailureReason,
@@ -57,7 +71,7 @@ let availableUpdates:
 	  }
 	| null
 	| false = aptUpdatesEnabled() ? null : false;
-type SoftUpdateStatus = {
+export type SoftUpdateStatus = {
 	total: number;
 	downloading: number;
 	unpacking: number;
@@ -66,8 +80,29 @@ type SoftUpdateStatus = {
 };
 let softUpdateStatus: SoftUpdateStatus | null = null;
 let aptGetUpdating = false;
+let aptDiscoveryRunning = false;
 let aptGetUpdateFailures = 0;
 let aptHeldBackPackages: string | undefined;
+let delayedSoftwareUpdateStart: ReturnType<typeof setTimeout> | undefined;
+let softwareUpdateRecoveryRetryTimer: ReturnType<typeof setTimeout> | undefined;
+const SOFTWARE_UPDATE_RECOVERY_RETRY_MS = 3_000;
+const APT_REFRESH_TIMEOUT_MS = 5 * oneMinute;
+const APT_DISCOVERY_TIMEOUT_MS = 2 * oneMinute;
+
+async function runAptCommand(
+	argv: string[],
+	timeoutMs: number,
+): Promise<SpawnWithTimeoutResult> {
+	try {
+		return await spawnWithTimeout(argv, { timeoutMs });
+	} catch (error) {
+		return {
+			exitCode: 1,
+			stdout: "",
+			stderr: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
 
 // Unified-update-state signals (Todo 24). The identity of the currently-available
 // update; the identity being installed; and the terminal outcome of the last run.
@@ -132,6 +167,14 @@ export function isUpdating() {
 // and the last terminal outcome so a suite that leaves an update mid-flight
 // cannot refuse the next test's start with `already_updating`.
 export function resetSoftwareUpdateState(): void {
+	if (delayedSoftwareUpdateStart) clearTimeout(delayedSoftwareUpdateStart);
+	if (softwareUpdateRecoveryRetryTimer) {
+		clearTimeout(softwareUpdateRecoveryRetryTimer);
+	}
+	delayedSoftwareUpdateStart = undefined;
+	softwareUpdateRecoveryRetryTimer = undefined;
+	resetSoftwareUpdateRecovery();
+	aptDiscoveryRunning = false;
 	softUpdateStatus = null;
 	currentUpdateIdentity = null;
 	lastUpdateFailure = null;
@@ -139,6 +182,29 @@ export function resetSoftwareUpdateState(): void {
 	lastCheckFailure = null;
 	lastCheckedAt = null;
 }
+
+export type SoftwareUpdateRecoveryDeps = {
+	readonly recover: typeof recoverDetachedAptUpgrade;
+	readonly scheduleRetry: (retry: () => void) => void;
+	readonly resumePeriodicChecks: () => void;
+};
+
+function scheduleSoftwareUpdateRecoveryRetry(retry: () => void): void {
+	if (softwareUpdateRecoveryRetryTimer) return;
+	softwareUpdateRecoveryRetryTimer = setTimeout(() => {
+		softwareUpdateRecoveryRetryTimer = undefined;
+		retry();
+	}, SOFTWARE_UPDATE_RECOVERY_RETRY_MS);
+	softwareUpdateRecoveryRetryTimer.unref?.();
+}
+
+const defaultSoftwareUpdateRecoveryDeps: SoftwareUpdateRecoveryDeps = {
+	recover: recoverDetachedAptUpgrade,
+	scheduleRetry: scheduleSoftwareUpdateRecoveryRetry,
+	resumePeriodicChecks: periodicCheckForSoftwareUpdates,
+};
+
+export { isSoftwareUpdateRecoveryInconclusive };
 
 export function getUpdateState(): UpdateState {
 	const available =
@@ -154,7 +220,7 @@ export function getUpdateState(): UpdateState {
 					}
 				: null;
 	return deriveUpdateState({
-		checking: aptGetUpdating,
+		checking: aptGetUpdating || aptDiscoveryRunning,
 		available,
 		updating:
 			softUpdateStatus && softUpdateStatus.result === undefined
@@ -279,14 +345,13 @@ export function buildAptUpgradeArgs(heldBackPackages?: string[]): string[] {
 }
 
 async function aptAssumeNoInstall(packages: string[]): Promise<string> {
-	try {
-		return await run("apt-get", buildAptInstallArgs(packages));
-	} catch (err) {
-		// --assume-no aborts non-zero whenever changes would be made, so run()
-		// rejects; the summary we parse is still on the rejection's stdout.
-		const e = err as { stdout?: unknown };
-		return typeof e.stdout === "string" ? e.stdout : "";
-	}
+	const result = await runAptCommand(
+		["/usr/bin/apt-get", ...buildAptInstallArgs(packages)],
+		APT_DISCOVERY_TIMEOUT_MS,
+	);
+	// --assume-no exits non-zero whenever changes would be made; its summary is
+	// still authoritative stdout and must be parsed on that expected refusal.
+	return result.stdout;
 }
 
 function packageListIncludes(list: string, includes: Array<string>) {
@@ -382,7 +447,15 @@ async function getSoftwareUpdateSize() {
 	if (getIsStreaming() || isUpdating() || aptGetUpdating) return "busy";
 
 	// First see if any packages can be upgraded by dist-upgrade
-	const upgrade = await execPNR("apt-get dist-upgrade --assume-no");
+	const upgradeResult = await runAptCommand(
+		["/usr/bin/apt-get", "dist-upgrade", "--assume-no"],
+		APT_DISCOVERY_TIMEOUT_MS,
+	);
+	const upgrade = {
+		code: upgradeResult.exitCode,
+		stdout: upgradeResult.stdout,
+		stderr: upgradeResult.stderr,
+	};
 	if (reportUpdateCheckFailure(upgrade)) {
 		failCurrentCheck("discovery_failed");
 		return null;
@@ -505,7 +578,14 @@ function checkForSoftwareUpdates(
 	callback: (err: SoftwareUpdateError, aptGetUpdateFailures: number) => unknown,
 ): boolean {
 	if (!aptUpdatesEnabled()) return false;
-	if (getIsStreaming() || isUpdating() || aptGetUpdating) return false;
+	if (
+		getIsStreaming() ||
+		isUpdating() ||
+		aptGetUpdating ||
+		aptDiscoveryRunning
+	) {
+		return false;
+	}
 
 	// A fresh cycle supersedes the previous one's verdict, and the `checking`
 	// transition is BROADCAST: it is derivable server-side the moment this flag
@@ -516,11 +596,12 @@ function checkForSoftwareUpdates(
 	broadcastUpdateState();
 
 	void (async () => {
-		const res = await Bun.$`apt-get update --allow-releaseinfo-change`
-			.nothrow()
-			.quiet();
-		const stdout = res.stdout.toString();
-		const stderr = res.stderr.toString();
+		const res = await runAptCommand(
+			["/usr/bin/apt-get", "update", "--allow-releaseinfo-change"],
+			APT_REFRESH_TIMEOUT_MS,
+		);
+		const stdout = res.stdout;
+		const stderr = res.stderr;
 
 		aptGetUpdating = false;
 
@@ -604,11 +685,16 @@ export function resetSoftwareUpdateSizeRunner(): void {
 // already carries it) and always emits a terminal frame — discovery has several
 // early returns that broadcast nothing, and each of those used to leave the
 // operator on whatever the dialog happened to be showing.
-async function runUpdateDiscoveryAndReport(): Promise<SoftwareUpdateError> {
+export async function runUpdateDiscoveryAndReport(): Promise<SoftwareUpdateError> {
+	if (aptDiscoveryRunning) return "busy";
+	aptDiscoveryRunning = true;
 	lastCheckedAt = Date.now();
-	const discovery = await softwareUpdateSizeRunner();
-	broadcastUpdateState();
-	return discovery;
+	try {
+		return await softwareUpdateSizeRunner();
+	} finally {
+		aptDiscoveryRunning = false;
+		broadcastUpdateState();
+	}
 }
 
 let nextCheckForSoftwareUpdates = getms();
@@ -627,6 +713,7 @@ export function periodicCheckForSoftwareUpdates() {
 	// A dev/CI host must never be handed to apt. The manual check has its own
 	// mock branch; this background loop simply does not run there.
 	if (shouldUseMocks()) return;
+	if (isSoftwareUpdateRecoveryInconclusive()) return;
 	if (nextCheckForSoftwareUpdatesTimer) {
 		clearTimeout(nextCheckForSoftwareUpdatesTimer);
 		nextCheckForSoftwareUpdatesTimer = undefined;
@@ -660,8 +747,16 @@ export function periodicCheckForSoftwareUpdates() {
 // Reuses the periodic discovery + skip guard but never touches its timer.
 // Returns false when skipped (streaming/updating/apt busy).
 export function triggerManualUpdateCheck(): boolean {
+	if (isSoftwareUpdateRecoveryInconclusive()) return false;
 	if (shouldUseMocks()) {
-		if (getIsStreaming() || isUpdating() || aptGetUpdating) return false;
+		if (
+			getIsStreaming() ||
+			isUpdating() ||
+			aptGetUpdating ||
+			aptDiscoveryRunning
+		) {
+			return false;
+		}
 		lastUpdateFailure = null;
 		lastUpdateSucceeded = false;
 		lastCheckFailure = null;
@@ -823,6 +918,9 @@ export function startSoftwareUpdate(): UpdateStartOutcome {
 	if (!aptUpdatesEnabled()) return refuseUpdateStart("updates_disabled");
 	if (getIsStreaming()) return refuseUpdateStart("streaming");
 	if (isUpdating()) return refuseUpdateStart("already_updating");
+	if (isSoftwareUpdateRecoveryInconclusive()) {
+		return refuseUpdateStart("check_unavailable");
+	}
 
 	// An update restarts `ceralive` (and usually reboots) WITHOUT changing the
 	// boot id, so a stream armed before an engine crash earlier in this same boot
@@ -836,8 +934,27 @@ export function startSoftwareUpdate(): UpdateStartOutcome {
 	lastUpdateSucceeded = false;
 
 	// if an apt-get update is already in progress, retry later
-	if (aptGetUpdating) {
-		setTimeout(startSoftwareUpdate, 3 * 1000);
+	if (aptGetUpdating || aptDiscoveryRunning) {
+		if (!delayedSoftwareUpdateStart) {
+			delayedSoftwareUpdateStart = setTimeout(() => {
+				delayedSoftwareUpdateStart = undefined;
+				const outcome = startSoftwareUpdate();
+				if (!outcome.started) {
+					lastUpdateSucceeded = false;
+					lastUpdateFailure = {
+						reason: `Software update could not start after waiting for package discovery: ${outcome.reason}`,
+						...((currentUpdateIdentity ?? availableIdentity)
+							? {
+									identity: (currentUpdateIdentity ??
+										availableIdentity) as UpdateIdentity,
+								}
+							: {}),
+					};
+					broadcastUpdateState();
+				}
+			}, 3 * 1000);
+			delayedSoftwareUpdateStart.unref?.();
+		}
 		return { started: true };
 	}
 
@@ -852,158 +969,216 @@ export function startSoftwareUpdate(): UpdateStartOutcome {
 	return softwareUpdateRunner();
 }
 
-function doSoftwareUpdate() {
-	if (!aptUpdatesEnabled() || getIsStreaming()) return;
+type SoftwareUpdateProcessMonitor = {
+	readonly handlers: SoftwareUpdateOutputHandlers;
+	readonly finish: (completion: Promise<number>) => void;
+};
 
+export function deriveAptProgress(
+	current: SoftUpdateStatus,
+	output: string,
+): SoftUpdateStatus {
+	const parsedTotal = parseUpgradePackageCount(output);
+	const total = parsedTotal.ok ? parsedTotal.value : current.total;
+	let highestGet = current.downloading;
+	for (const match of output.matchAll(/Get:(\d+)/g)) {
+		highestGet = Math.max(highestGet, Number.parseInt(match[1] ?? "", 10));
+	}
+	const unpacking = Math.min(output.match(/Unpacking /g)?.length ?? 0, total);
+	const settingUp = Math.min(output.match(/Setting up /g)?.length ?? 0, total);
+	return {
+		...current,
+		total,
+		downloading: unpacking > 0 ? total : Math.min(highestGet, total),
+		unpacking,
+		setting_up: settingUp,
+	};
+}
+
+function createSoftwareUpdateProcessMonitor(): SoftwareUpdateProcessMonitor {
 	let rebootAfterUpgrade = false;
 	let aptLog = "";
 	let aptErr = "";
 
-	const heldBack = aptHeldBackPackages
-		? parseHeldBackPackages(aptHeldBackPackages)
-		: undefined;
-	const aptUpgrade = Bun.spawn(["apt-get", ...buildAptUpgradeArgs(heldBack)], {
-		stdout: "pipe",
-		stderr: "pipe",
-	});
-
 	const handleStdoutChunk = (data: string) => {
-		let sendUpdate = false;
-
 		aptLog += data;
 
 		if (!softUpdateStatus) return;
-
-		if (softUpdateStatus.total === 0) {
+		const previous = softUpdateStatus;
+		const next = deriveAptProgress(previous, aptLog);
+		softUpdateStatus = next;
+		if (next.total === 0 && aptLog.includes(" upgraded")) {
 			const count = parseUpgradePackageCount(aptLog);
-			if (count.ok) {
-				softUpdateStatus.total = count.value;
-				sendUpdate = true;
-
-				const packageList = parseAptUpgradedPackages(aptLog);
-				if (
-					packageList.ok &&
-					packageList.value !== undefined &&
-					packageListIncludes(packageList.value, rebootPackageList)
-				) {
-					rebootAfterUpgrade = true;
-				}
-			} else if (aptLog.includes(" upgraded")) {
-				logParseError(count);
-			}
+			if (!count.ok) logParseError(count);
 		}
-
-		if (softUpdateStatus.downloading !== softUpdateStatus.total) {
-			const getMatch = data.match(/Get:(\d+)/);
-			if (getMatch) {
-				const i = Number.parseInt(getMatch[1] ?? "", 10);
-				if (i > softUpdateStatus.downloading) {
-					softUpdateStatus.downloading = Math.min(i, softUpdateStatus.total);
-					sendUpdate = true;
-				}
-			}
+		if (!rebootAfterUpgrade && next.total > 0) {
+			const packageList = parseAptUpgradedPackages(aptLog);
+			rebootAfterUpgrade =
+				packageList.ok &&
+				packageList.value !== undefined &&
+				packageListIncludes(packageList.value, rebootPackageList);
 		}
-
-		const unpacking = data.match(/Unpacking /g);
-		if (unpacking) {
-			softUpdateStatus.downloading = softUpdateStatus.total;
-			softUpdateStatus.unpacking += unpacking.length;
-			softUpdateStatus.unpacking = Math.min(
-				softUpdateStatus.unpacking,
-				softUpdateStatus.total,
-			);
-			sendUpdate = true;
-		}
-
-		const setting_up = data.match(/Setting up /g);
-		if (setting_up) {
-			softUpdateStatus.setting_up += setting_up.length;
-			softUpdateStatus.setting_up = Math.min(
-				softUpdateStatus.setting_up,
-				softUpdateStatus.total,
-			);
-			sendUpdate = true;
-		}
-
-		if (sendUpdate) {
+		if (
+			previous.total !== next.total ||
+			previous.downloading !== next.downloading ||
+			previous.unpacking !== next.unpacking ||
+			previous.setting_up !== next.setting_up
+		) {
 			broadcastMsg("status", { updating: softUpdateStatus });
 		}
 	};
 
-	void (async () => {
-		const stdoutDecoder = new TextDecoder();
-		const drainStdout = (async () => {
-			for await (const chunk of aptUpgrade.stdout as ReadableStream<Uint8Array>) {
-				handleStdoutChunk(stdoutDecoder.decode(chunk, { stream: true }));
+	const handlers: SoftwareUpdateOutputHandlers = {
+		onStdout: handleStdoutChunk,
+		onStderr: (data) => {
+			aptErr += data;
+		},
+		onObserverError: (error) => {
+			logger.warn(
+				"Software update observer retrying after a local read failure",
+				{
+					error,
+				},
+			);
+		},
+	};
+
+	const finish = (completion: Promise<number>): void => {
+		void (async () => {
+			let code: number;
+			try {
+				code = await completion;
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				aptErr += aptErr.length > 0 ? `\n${message}` : message;
+				code =
+					err instanceof DetachedAptServiceCleanupError &&
+					err.transactionExitCode !== 0
+						? err.transactionExitCode
+						: 1;
 			}
-		})();
 
-		const stderrDecoder = new TextDecoder();
-		const drainStderr = (async () => {
-			for await (const chunk of aptUpgrade.stderr as ReadableStream<Uint8Array>) {
-				aptErr += stderrDecoder.decode(chunk, { stream: true });
-			}
-		})();
-
-		const [, , code] = await Promise.all([
-			drainStdout,
-			drainStderr,
-			aptUpgrade.exited,
-		]);
-
-		if (softUpdateStatus) {
-			if (code === 0) {
-				lastUpdateSucceeded = true;
-				lastUpdateFailure = null;
-			} else {
-				lastUpdateSucceeded = false;
-				lastUpdateFailure = {
-					reason: aptErr.trim() || `apt-get exited with code ${code}`,
-					...((currentUpdateIdentity ?? availableIdentity)
-						? {
-								identity: (currentUpdateIdentity ??
-									availableIdentity) as UpdateIdentity,
-							}
-						: {}),
-				};
-				notificationBroadcast(
-					"ceralive_update_failed",
-					"error",
-					"The software update failed. Open Settings → Software Updates to see the reason and retry.",
-					0,
-					true,
-					true,
-					true,
-					"notifications.ceraliveUpdateFailed",
-					undefined,
-					{
-						action: {
-							schema: 1,
-							kind: "navigate",
-							target: "updates-dialog",
-							labelKey: "notifications.openUpdates",
+			if (softUpdateStatus) {
+				if (code === 0) {
+					lastUpdateSucceeded = true;
+					lastUpdateFailure = null;
+				} else {
+					lastUpdateSucceeded = false;
+					lastUpdateFailure = {
+						reason: aptErr.trim() || `apt-get exited with code ${code}`,
+						...((currentUpdateIdentity ?? availableIdentity)
+							? {
+									identity: (currentUpdateIdentity ??
+										availableIdentity) as UpdateIdentity,
+								}
+							: {}),
+					};
+					notificationBroadcast(
+						"ceralive_update_failed",
+						"error",
+						"The software update failed. Open Settings → Software Updates to see the reason and retry.",
+						0,
+						true,
+						true,
+						true,
+						"notifications.ceraliveUpdateFailed",
+						undefined,
+						{
+							action: {
+								schema: 1,
+								kind: "navigate",
+								target: "updates-dialog",
+								labelKey: "notifications.openUpdates",
+							},
 						},
-					},
-				);
+					);
+				}
+				softUpdateStatus.result = code === 0 ? code : aptErr;
+				broadcastMsg("status", {
+					updating: softUpdateStatus,
+					update_state: getUpdateState(),
+				});
+				softUpdateStatus = null;
+				broadcastUpdateState();
 			}
-			softUpdateStatus.result = code === 0 ? code : aptErr;
+
+			if (aptLog) logger.info(aptLog);
+			if (aptErr) logger.error(aptErr);
+
+			if (code === 0) {
+				if (rebootAfterUpgrade) {
+					rebootAfterUpdate();
+				} else {
+					invariant(
+						false,
+						"software update complete; exiting to restart CeraUI",
+					);
+				}
+			}
+		})();
+	};
+
+	return { handlers, finish };
+}
+
+function doSoftwareUpdate() {
+	if (!aptUpdatesEnabled() || getIsStreaming()) return;
+
+	const heldBack = aptHeldBackPackages
+		? parseHeldBackPackages(aptHeldBackPackages)
+		: undefined;
+	const monitor = createSoftwareUpdateProcessMonitor();
+
+	// 2026-08-29: apt can restart ceralive.service from a package script;
+	// running it in this unit's cgroup then lets that restart kill the package
+	// transaction itself. PID 1 owns this service, and the next backend process
+	// reattaches to its durable output instead of relaunching apt.
+	monitor.finish(
+		runDetachedAptUpgrade(buildAptUpgradeArgs(heldBack), monitor.handlers),
+	);
+}
+
+async function recoverSoftwareUpdate(
+	deps: SoftwareUpdateRecoveryDeps = defaultSoftwareUpdateRecoveryDeps,
+): Promise<boolean> {
+	if (!aptUpdatesEnabled() || shouldUseMocks() || isUpdating()) return false;
+
+	const monitor = createSoftwareUpdateProcessMonitor();
+	const recovered = await deps.recover({
+		...monitor.handlers,
+		onAttached: () => {
+			softUpdateStatus = {
+				total: 0,
+				downloading: 0,
+				unpacking: 0,
+				setting_up: 0,
+			};
+			lastUpdateFailure = null;
+			lastUpdateSucceeded = false;
+			logger.warn(
+				"Software update: reattached to the detached apt transaction",
+			);
 			broadcastMsg("status", {
 				updating: softUpdateStatus,
 				update_state: getUpdateState(),
 			});
-			softUpdateStatus = null;
-			broadcastUpdateState();
-		}
+		},
+	});
+	if (!recovered) return false;
 
-		if (aptLog) logger.info(aptLog);
-		if (aptErr) logger.error(aptErr);
+	monitor.finish(recovered.completion);
+	return true;
+}
 
-		if (code === 0) {
-			if (rebootAfterUpgrade) {
-				rebootAfterUpdate();
-			} else {
-				invariant(false, "software update complete; exiting to restart CeraUI");
-			}
-		}
-	})();
+export function recoverSoftwareUpdateIfRunning(
+	deps: SoftwareUpdateRecoveryDeps = defaultSoftwareUpdateRecoveryDeps,
+): Promise<boolean> {
+	return recoverSoftwareUpdateWithCoordination({
+		attempt: () => recoverSoftwareUpdate(deps),
+		scheduleRetry: deps.scheduleRetry,
+		resumePeriodicChecks: deps.resumePeriodicChecks,
+		reportRetryError: (error) => {
+			logger.warn("Software update recovery probe will retry", { error });
+		},
+	});
 }

--- a/apps/backend/src/tests/software-updates-apt.test.ts
+++ b/apps/backend/src/tests/software-updates-apt.test.ts
@@ -7,14 +7,96 @@
  *     metacharacters or whitespace is rejected before it can reach apt-get.
  */
 import { describe, expect, it } from "bun:test";
+import {
+	lstat,
+	mkdtemp,
+	readFile,
+	rm,
+	symlink,
+	writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { isParseError } from "../modules/system/cli-parse.ts";
+import {
+	prepareSoftwareUpdateOutput,
+	readSoftwareUpdateOutput,
+} from "../modules/system/software-update-output.ts";
+import {
+	buildDetachedAptUpgradeCommand,
+	DetachedAptOutputUnavailableError,
+	DetachedAptServiceAlreadyExistsError,
+	DetachedAptServiceCleanupError,
+	recoverDetachedAptUpgrade,
+	runDetachedAptUpgrade,
+} from "../modules/system/software-update-process.ts";
+import {
+	DetachedAptServiceCommandError,
+	DetachedAptServiceIdentityError,
+	parseDetachedAptServiceProbe,
+	parseDetachedAptServiceState,
+	validateDetachedAptServiceFragment,
+	validateDetachedAptServiceIdentity,
+} from "../modules/system/software-update-service.ts";
 import {
 	buildAptInstallArgs,
 	buildAptUpgradeArgs,
 	classifyAptUpdateResult,
+	deriveAptProgress,
+	isSoftwareUpdateRecoveryInconclusive,
 	parseAptUpgradeSummary,
 	parseHeldBackPackages,
+	recoverSoftwareUpdateIfRunning,
+	resetSoftwareUpdateSizeRunner,
+	resetSoftwareUpdateState,
+	runUpdateDiscoveryAndReport,
+	setSoftwareUpdateSizeRunner,
 } from "../modules/system/software-updates.ts";
+
+const SOFTWARE_UPDATES_PATH = new URL(
+	"../modules/system/software-updates.ts",
+	import.meta.url,
+);
+const MAIN_PATH = new URL("../main.ts", import.meta.url);
+const DETACHED_APT_ARGS = [
+	"-y",
+	"-o",
+	"Dpkg::Options::=--force-confdef",
+	"-o",
+	"Dpkg::Options::=--force-confold",
+	"dist-upgrade",
+] as const;
+
+function serviceState(properties: {
+	readonly activeState: string;
+	readonly subState: string;
+	readonly execMainCode?: number;
+	readonly execMainStatus?: number;
+	readonly id?: string;
+	readonly user?: string;
+	readonly execStart?: string;
+}): string {
+	return [
+		`Id=${properties.id ?? "ceralive-software-update.service"}`,
+		"FragmentPath=/run/systemd/transient/ceralive-software-update.service",
+		"Description=CeraLive software update",
+		"LoadState=loaded",
+		`ActiveState=${properties.activeState}`,
+		`SubState=${properties.subState}`,
+		"Transient=yes",
+		"Type=exec",
+		"RemainAfterExit=yes",
+		`User=${properties.user ?? ""}`,
+		`ExecStart=${properties.execStart ?? "{ path=/usr/bin/apt-get ; argv[]=/usr/bin/apt-get -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold dist-upgrade ; }"}`,
+		"ExecStartPre=",
+		"ExecStartPost=",
+		"StandardOutput=append",
+		"StandardError=append",
+		`ExecMainCode=${properties.execMainCode ?? 0}`,
+		`ExecMainStatus=${properties.execMainStatus ?? 0}`,
+		"",
+	].join("\n");
+}
 
 describe("parseHeldBackPackages() — charset validation", () => {
 	it("splits a whitespace-separated list into individual package names", () => {
@@ -83,6 +165,757 @@ describe("buildAptUpgradeArgs() — argv mapping", () => {
 			"pkg-a",
 			"pkg-b",
 		]);
+	});
+});
+
+describe("buildDetachedAptUpgradeCommand() — service-cgroup isolation", () => {
+	it("runs apt in a PID-1-owned transient service with durable output sinks", () => {
+		const command = buildDetachedAptUpgradeCommand(DETACHED_APT_ARGS, {
+			stdout: "/run/ceralive/software-update.stdout",
+			stderr: "/run/ceralive/software-update.stderr",
+		});
+
+		expect(command).toEqual([
+			"systemd-run",
+			"--unit=ceralive-software-update.service",
+			"--description=CeraLive software update",
+			"--remain-after-exit",
+			"--quiet",
+			"--service-type=exec",
+			"--expand-environment=no",
+			"--property=StandardOutput=append:/run/ceralive/software-update.stdout",
+			"--property=StandardError=append:/run/ceralive/software-update.stderr",
+			"--",
+			"/usr/bin/apt-get",
+			...DETACHED_APT_ARGS,
+		]);
+		expect(command).not.toContain("--scope");
+		expect(command).not.toContain("--pipe");
+	});
+
+	it("rejects caller-selected output paths", () => {
+		expect(() =>
+			buildDetachedAptUpgradeCommand(DETACHED_APT_ARGS, {
+				stdout: "/tmp/update.stdout",
+				stderr: "/tmp/update.stderr",
+			}),
+		).toThrow(/runtime paths are fixed/);
+	});
+
+	it("rejects a detached apt operation outside the upgrade contract", () => {
+		expect(() =>
+			buildDetachedAptUpgradeCommand(["-y", "remove", "ceralui"], {
+				stdout: "/run/ceralive/software-update.stdout",
+				stderr: "/run/ceralive/software-update.stderr",
+			}),
+		).toThrow(/arguments do not match/);
+	});
+
+	it("keeps the production upgrade off the ceralive service cgroup", async () => {
+		const source = await Bun.file(SOFTWARE_UPDATES_PATH).text();
+		expect(source).toContain("runDetachedAptUpgrade,");
+		expect(source).toContain('from "./software-update-process.ts";');
+		expect(source).toContain(
+			"runDetachedAptUpgrade(buildAptUpgradeArgs(heldBack), monitor.handlers)",
+		);
+		expect(source).not.toContain(
+			'Bun.spawn(["apt-get", ...buildAptUpgradeArgs(heldBack)]',
+		);
+	});
+
+	it("runs apt refresh and discovery argv-only", async () => {
+		const source = await Bun.file(SOFTWARE_UPDATES_PATH).text();
+		expect(source).toContain(
+			'["/usr/bin/apt-get", "update", "--allow-releaseinfo-change"]',
+		);
+		expect(source).toContain(
+			'["/usr/bin/apt-get", "dist-upgrade", "--assume-no"]',
+		);
+		expect(source).toContain(
+			'["/usr/bin/apt-get", ...buildAptInstallArgs(packages)]',
+		);
+		expect(source).not.toContain("execPNR(");
+		expect(source).not.toContain("Bun.$`apt-get");
+	});
+
+	it("replaces a hostile output symlink without touching its target", async () => {
+		const directory = await mkdtemp(
+			path.join(tmpdir(), "ceralive-update-output-"),
+		);
+		const victim = path.join(directory, "victim");
+		const stdout = path.join(directory, "software-update.stdout");
+		const stderr = path.join(directory, "software-update.stderr");
+		try {
+			await writeFile(victim, "must remain intact");
+			await symlink(victim, stdout);
+			await prepareSoftwareUpdateOutput(
+				{ stdout, stderr },
+				process.getuid?.() ?? 0,
+			);
+
+			expect(await readFile(victim, "utf8")).toBe("must remain intact");
+			expect((await lstat(stdout)).isFile()).toBe(true);
+			expect((await lstat(stdout)).isSymbolicLink()).toBe(false);
+			expect((await lstat(stderr)).mode & 0o777).toBe(0o600);
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("refuses to read output from a caller-selected path", async () => {
+		await expect(
+			readSoftwareUpdateOutput("/tmp/update.stdout", 0),
+		).rejects.toThrow(/runtime paths are fixed/);
+	});
+
+	it("streams progress from durable files while the detached service runs", async () => {
+		const paths = {
+			stdout: "/run/ceralive/software-update.stdout",
+			stderr: "/run/ceralive/software-update.stderr",
+		};
+		const files = new Map<string, Uint8Array>();
+		const encoder = new TextEncoder();
+		let polls = 0;
+		let inspections = 0;
+		let finished = false;
+		let cleanupCalls = 0;
+		const stdout: string[] = [];
+		const stderr: string[] = [];
+
+		const code = await runDetachedAptUpgrade(
+			DETACHED_APT_ARGS,
+			{
+				onStdout: (chunk) => stdout.push(chunk),
+				onStderr: (chunk) => stderr.push(chunk),
+			},
+			{
+				outputPaths: paths,
+				prepareOutput: async () => {
+					files.set(paths.stdout, new Uint8Array());
+					files.set(paths.stderr, new Uint8Array());
+				},
+				start: async () => {},
+				inspect: async () => {
+					inspections++;
+					if (inspections === 1) return { kind: "absent" };
+					return finished
+						? { kind: "finished", exitCode: 0, cleanup: "stop" }
+						: { kind: "running" };
+				},
+				cleanup: async () => {
+					cleanupCalls++;
+				},
+				readOutput: async (file, offset) => {
+					const bytes = files.get(file) ?? new Uint8Array();
+					return { bytes: bytes.slice(offset), nextOffset: bytes.byteLength };
+				},
+				sleep: async () => {
+					polls++;
+					if (polls === 1) {
+						files.set(paths.stdout, encoder.encode("Get:1 package\n"));
+						files.set(paths.stderr, encoder.encode("apt warning\n"));
+						return;
+					}
+					files.set(
+						paths.stdout,
+						encoder.encode("Get:1 package\nSetting up package\n"),
+					);
+					finished = true;
+				},
+			},
+		);
+
+		expect(code).toBe(0);
+		expect(stdout.join("")).toBe("Get:1 package\nSetting up package\n");
+		expect(stderr.join("")).toBe("apt warning\n");
+		expect(cleanupCalls).toBe(1);
+	});
+
+	it("refuses to prepare output or launch when the named unit already exists", async () => {
+		let prepared = 0;
+		let started = 0;
+		const completion = runDetachedAptUpgrade(
+			DETACHED_APT_ARGS,
+			{ onStdout: () => {}, onStderr: () => {} },
+			{
+				outputPaths: {
+					stdout: "/run/ceralive/software-update.stdout",
+					stderr: "/run/ceralive/software-update.stderr",
+				},
+				prepareOutput: async () => {
+					prepared++;
+				},
+				start: async () => {
+					started++;
+				},
+				inspect: async () => ({ kind: "running" }),
+				cleanup: async () => {},
+				readOutput: async (_file, offset) => ({
+					bytes: new Uint8Array(),
+					nextOffset: offset,
+				}),
+				sleep: async () => {},
+			},
+		);
+
+		await expect(completion).rejects.toBeInstanceOf(
+			DetachedAptServiceAlreadyExistsError,
+		);
+		expect({ prepared, started }).toEqual({ prepared: 0, started: 0 });
+	});
+
+	it("retries transient output and state probe failures without ending the transaction", async () => {
+		let inspections = 0;
+		let reads = 0;
+		let observerErrors = 0;
+		const encoder = new TextEncoder();
+		const code = await runDetachedAptUpgrade(
+			DETACHED_APT_ARGS,
+			{
+				onStdout: () => {},
+				onStderr: () => {},
+				onObserverError: () => {
+					observerErrors++;
+				},
+			},
+			{
+				outputPaths: {
+					stdout: "/run/ceralive/software-update.stdout",
+					stderr: "/run/ceralive/software-update.stderr",
+				},
+				prepareOutput: async () => {},
+				start: async () => {},
+				inspect: async () => {
+					inspections++;
+					if (inspections === 1) return { kind: "absent" };
+					if (inspections === 2)
+						throw new Error("systemctl temporarily failed");
+					return { kind: "finished", exitCode: 0, cleanup: "stop" };
+				},
+				cleanup: async () => {},
+				readOutput: async (_file, offset) => {
+					reads++;
+					if (reads === 1) throw new Error("output temporarily unreadable");
+					const bytes =
+						offset === 0 ? encoder.encode("complete\n") : new Uint8Array();
+					return { bytes, nextOffset: offset + bytes.byteLength };
+				},
+				sleep: async () => {},
+			},
+		);
+
+		expect(code).toBe(0);
+		expect(observerErrors).toBe(2);
+	});
+
+	it("retains one output cursor when the other output read fails", async () => {
+		const paths = {
+			stdout: "/run/ceralive/software-update.stdout",
+			stderr: "/run/ceralive/software-update.stderr",
+		};
+		const stdoutBytes = new TextEncoder().encode("Unpacking package-a\n");
+		const stdoutOffsets: number[] = [];
+		const stdout: string[] = [];
+		let inspections = 0;
+		let stderrReads = 0;
+		let observerErrors = 0;
+		const code = await runDetachedAptUpgrade(
+			DETACHED_APT_ARGS,
+			{
+				onStdout: (chunk) => stdout.push(chunk),
+				onStderr: () => {},
+				onObserverError: () => {
+					observerErrors++;
+				},
+			},
+			{
+				outputPaths: paths,
+				prepareOutput: async () => {},
+				start: async () => {},
+				inspect: async () => {
+					inspections++;
+					if (inspections === 1) return { kind: "absent" };
+					if (inspections === 2) return { kind: "running" };
+					return { kind: "finished", exitCode: 0, cleanup: "stop" };
+				},
+				cleanup: async () => {},
+				readOutput: async (file, offset) => {
+					if (file === paths.stderr) {
+						stderrReads++;
+						if (stderrReads === 1)
+							throw new Error("stderr temporarily unreadable");
+						return { bytes: new Uint8Array(), nextOffset: offset };
+					}
+					stdoutOffsets.push(offset);
+					return {
+						bytes: stdoutBytes.slice(offset),
+						nextOffset: stdoutBytes.byteLength,
+					};
+				},
+				sleep: async () => {},
+			},
+		);
+
+		expect(code).toBe(0);
+		expect(stdout.join("")).toBe("Unpacking package-a\n");
+		expect(stdoutOffsets).toEqual([
+			0,
+			stdoutBytes.byteLength,
+			stdoutBytes.byteLength,
+		]);
+		expect(observerErrors).toBe(1);
+	});
+
+	it("retries the final output drain before cleaning up a terminal unit", async () => {
+		const paths = {
+			stdout: "/run/ceralive/software-update.stdout",
+			stderr: "/run/ceralive/software-update.stderr",
+		};
+		let inspections = 0;
+		let terminal = false;
+		let failedFinalRead = false;
+		let cleanupCalls = 0;
+		let observerErrors = 0;
+		const code = await runDetachedAptUpgrade(
+			DETACHED_APT_ARGS,
+			{
+				onStdout: () => {},
+				onStderr: () => {},
+				onObserverError: () => {
+					observerErrors++;
+				},
+			},
+			{
+				outputPaths: paths,
+				prepareOutput: async () => {},
+				start: async () => {},
+				inspect: async () => {
+					inspections++;
+					if (inspections === 1) return { kind: "absent" };
+					terminal = true;
+					return { kind: "finished", exitCode: 0, cleanup: "stop" };
+				},
+				cleanup: async () => {
+					cleanupCalls++;
+				},
+				readOutput: async (file, offset) => {
+					if (terminal && file === paths.stdout && !failedFinalRead) {
+						failedFinalRead = true;
+						throw new Error("terminal output temporarily unreadable");
+					}
+					return { bytes: new Uint8Array(), nextOffset: offset };
+				},
+				sleep: async () => {},
+			},
+		);
+
+		expect(code).toBe(0);
+		expect(observerErrors).toBe(1);
+		expect(failedFinalRead).toBe(true);
+		expect(cleanupCalls).toBe(1);
+	});
+
+	it("bounds a permanently unreadable final drain without deleting recovery evidence", async () => {
+		const paths = {
+			stdout: "/run/ceralive/software-update.stdout",
+			stderr: "/run/ceralive/software-update.stderr",
+		};
+		let inspections = 0;
+		let terminal = false;
+		let cleanupCalls = 0;
+		let observerErrors = 0;
+		const completion = runDetachedAptUpgrade(
+			DETACHED_APT_ARGS,
+			{
+				onStdout: () => {},
+				onStderr: () => {},
+				onObserverError: () => {
+					observerErrors++;
+				},
+			},
+			{
+				outputPaths: paths,
+				prepareOutput: async () => {},
+				start: async () => {},
+				inspect: async () => {
+					inspections++;
+					if (inspections === 1) return { kind: "absent" };
+					terminal = true;
+					return { kind: "finished", exitCode: 0, cleanup: "stop" };
+				},
+				cleanup: async () => {
+					cleanupCalls++;
+				},
+				readOutput: async (file, offset) => {
+					if (terminal && file === paths.stdout) {
+						throw new Error("terminal output permanently unreadable");
+					}
+					return { bytes: new Uint8Array(), nextOffset: offset };
+				},
+				sleep: async () => {},
+			},
+		);
+
+		await expect(completion).rejects.toBeInstanceOf(
+			DetachedAptOutputUnavailableError,
+		);
+		expect(observerErrors).toBe(20);
+		expect(cleanupCalls).toBe(0);
+	});
+
+	it("reports cleanup failure separately from the retained transaction exit", async () => {
+		let inspections = 0;
+		const completion = runDetachedAptUpgrade(
+			DETACHED_APT_ARGS,
+			{ onStdout: () => {}, onStderr: () => {} },
+			{
+				outputPaths: {
+					stdout: "/run/ceralive/software-update.stdout",
+					stderr: "/run/ceralive/software-update.stderr",
+				},
+				prepareOutput: async () => {},
+				start: async () => {},
+				inspect: async () => {
+					inspections++;
+					return inspections === 1
+						? { kind: "absent" }
+						: { kind: "finished", exitCode: 0, cleanup: "stop" };
+				},
+				cleanup: async () => {
+					throw new Error("systemctl stop failed");
+				},
+				readOutput: async (_file, offset) => ({
+					bytes: new Uint8Array(),
+					nextOffset: offset,
+				}),
+				sleep: async () => {},
+			},
+		);
+
+		await expect(completion).rejects.toMatchObject({
+			name: DetachedAptServiceCleanupError.name,
+			transactionExitCode: 0,
+		});
+	});
+
+	it("reattaches after a backend restart without preparing or relaunching apt", async () => {
+		const paths = {
+			stdout: "/run/ceralive/software-update.stdout",
+			stderr: "/run/ceralive/software-update.stderr",
+		};
+		const encoder = new TextEncoder();
+		const files = new Map<string, Uint8Array>([
+			[paths.stdout, encoder.encode("Get:1 package\n")],
+			[paths.stderr, new Uint8Array()],
+		]);
+		let finished = false;
+		let attached = 0;
+		let prepared = 0;
+		let started = 0;
+		let cleaned = 0;
+		const stdout: string[] = [];
+
+		const recovered = await recoverDetachedAptUpgrade(
+			{
+				onAttached: () => {
+					attached++;
+				},
+				onStdout: (chunk) => stdout.push(chunk),
+				onStderr: () => {},
+			},
+			{
+				outputPaths: paths,
+				prepareOutput: async () => {
+					prepared++;
+				},
+				start: async () => {
+					started++;
+				},
+				inspect: async () =>
+					finished
+						? { kind: "finished", exitCode: 0, cleanup: "stop" }
+						: { kind: "running" },
+				cleanup: async () => {
+					cleaned++;
+				},
+				readOutput: async (file, offset) => {
+					const bytes = files.get(file) ?? new Uint8Array();
+					return { bytes: bytes.slice(offset), nextOffset: bytes.byteLength };
+				},
+				sleep: async () => {
+					files.set(
+						paths.stdout,
+						encoder.encode("Get:1 package\nSetting up package\n"),
+					);
+					finished = true;
+				},
+			},
+		);
+
+		expect(recovered).not.toBeNull();
+		if (!recovered) throw new Error("expected detached update recovery");
+		expect(await recovered.completion).toBe(0);
+		expect(stdout.join("")).toBe("Get:1 package\nSetting up package\n");
+		expect({ attached, prepared, started, cleaned }).toEqual({
+			attached: 1,
+			prepared: 0,
+			started: 0,
+			cleaned: 1,
+		});
+	});
+
+	it("keeps recovery fail-closed and retries an inconclusive boot probe", async () => {
+		resetSoftwareUpdateState();
+		let recoverCalls = 0;
+		let retry: (() => void) | undefined;
+		let periodicResumes = 0;
+		const deps = {
+			recover: async () => {
+				recoverCalls++;
+				if (recoverCalls === 1) throw new Error("systemctl unavailable");
+				return null;
+			},
+			scheduleRetry: (callback: () => void) => {
+				retry = callback;
+			},
+			resumePeriodicChecks: () => {
+				periodicResumes++;
+			},
+		};
+
+		await expect(recoverSoftwareUpdateIfRunning(deps)).rejects.toThrow(
+			"systemctl unavailable",
+		);
+		expect(isSoftwareUpdateRecoveryInconclusive()).toBe(true);
+		expect(retry).toBeDefined();
+		retry?.();
+		await Bun.sleep(0);
+		expect(recoverCalls).toBe(2);
+		expect(isSoftwareUpdateRecoveryInconclusive()).toBe(false);
+		expect(periodicResumes).toBe(1);
+		resetSoftwareUpdateState();
+	});
+
+	it("joins concurrent recovery callers onto one probe", async () => {
+		resetSoftwareUpdateState();
+		let recoverCalls = 0;
+		let release: (() => void) | undefined;
+		const deps = {
+			recover: async () => {
+				recoverCalls++;
+				await new Promise<void>((resolve) => {
+					release = resolve;
+				});
+				return null;
+			},
+			scheduleRetry: () => {},
+			resumePeriodicChecks: () => {},
+		};
+		const first = recoverSoftwareUpdateIfRunning(deps);
+		const second = recoverSoftwareUpdateIfRunning(deps);
+		expect(second).toBe(first);
+		expect(recoverCalls).toBe(1);
+		release?.();
+		expect(await first).toBe(false);
+		expect(await second).toBe(false);
+		resetSoftwareUpdateState();
+	});
+
+	it("probes recovery before the periodic apt refresh can contend for the lock", async () => {
+		const source = await Bun.file(MAIN_PATH).text();
+		const recovery = source.indexOf(
+			'await guardNonCritical("software-update-recovery"',
+		);
+		const periodic = source.indexOf("periodicCheckForSoftwareUpdates();");
+		expect(recovery).toBeGreaterThan(-1);
+		expect(periodic).toBeGreaterThan(recovery);
+	});
+});
+
+describe("parseDetachedAptServiceState() — restart recovery", () => {
+	it("distinguishes an absent unit, a running transaction, and both terminal states", () => {
+		expect(
+			parseDetachedAptServiceState(
+				"LoadState=not-found\nActiveState=inactive\n",
+			),
+		).toEqual({ kind: "absent" });
+		expect(
+			parseDetachedAptServiceState(
+				serviceState({ activeState: "active", subState: "running" }),
+			),
+		).toEqual({ kind: "running" });
+		expect(
+			parseDetachedAptServiceState(
+				serviceState({
+					activeState: "active",
+					subState: "exited",
+					execMainCode: 1,
+				}),
+			),
+		).toEqual({ kind: "finished", exitCode: 0, cleanup: "stop" });
+		expect(
+			parseDetachedAptServiceState(
+				serviceState({
+					activeState: "failed",
+					subState: "failed",
+					execMainCode: 1,
+					execMainStatus: 100,
+				}),
+			),
+		).toEqual({ kind: "finished", exitCode: 100, cleanup: "reset-failed" });
+	});
+
+	it("treats activating and reloading as live but rejects unknown loaded states", () => {
+		for (const activeState of ["activating", "reloading"]) {
+			expect(
+				parseDetachedAptServiceState(
+					serviceState({ activeState, subState: "start" }),
+				),
+			).toEqual({ kind: "running" });
+		}
+		expect(() =>
+			parseDetachedAptServiceState(
+				serviceState({ activeState: "inactive", subState: "dead" }),
+			),
+		).toThrow(/unrecognized.*state/);
+	});
+
+	it("refuses a unit with a foreign id, user, command, or apt operation", () => {
+		for (const output of [
+			serviceState({
+				activeState: "active",
+				subState: "running",
+				id: "foreign.service",
+			}),
+			serviceState({
+				activeState: "active",
+				subState: "running",
+				user: "nobody",
+			}),
+			serviceState({
+				activeState: "active",
+				subState: "running",
+				execStart: "{ path=/bin/sleep ; argv[]=/bin/sleep 60 ; }",
+			}),
+			serviceState({
+				activeState: "active",
+				subState: "running",
+				execStart:
+					"{ path=/usr/bin/apt-get ; argv[]=/usr/bin/apt-get -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold remove ceralui ; }",
+			}),
+		]) {
+			expect(() => validateDetachedAptServiceIdentity(output)).toThrow(
+				DetachedAptServiceIdentityError,
+			);
+		}
+	});
+
+	it("binds recovered output to the exact durable files", () => {
+		expect(() =>
+			validateDetachedAptServiceFragment(`
+[Service]
+StandardOutput=append:/run/ceralive/software-update.stdout
+StandardError=append:/run/ceralive/software-update.stderr
+`),
+		).not.toThrow();
+		expect(() =>
+			validateDetachedAptServiceFragment(`
+[Service]
+StandardOutput=append:/tmp/foreign.stdout
+StandardError=append:/run/ceralive/software-update.stderr
+`),
+		).toThrow(/StandardOutput path does not match/);
+		expect(() =>
+			validateDetachedAptServiceFragment(`
+[Unit]
+StandardOutput=append:/run/ceralive/software-update.stdout
+[Service]
+StandardError=append:/run/ceralive/software-update.stderr
+`),
+		).toThrow(/StandardOutput path does not match/);
+		expect(() =>
+			validateDetachedAptServiceFragment(`
+[Service]
+StandardOutput=append:/run/ceralive/software-update.stdout
+StandardOutput=append:/tmp/foreign.stdout
+StandardError=append:/run/ceralive/software-update.stderr
+`),
+		).toThrow(/StandardOutput is duplicated/);
+	});
+
+	it("rejects a failed systemctl probe even when stdout looks adoptable", () => {
+		expect(() =>
+			parseDetachedAptServiceProbe(
+				{
+					exitCode: 1,
+					stdout: serviceState({ activeState: "active", subState: "running" }),
+					stderr: "transport failed",
+				},
+				["systemctl", "show", "ceralive-software-update.service"],
+			),
+		).toThrow(DetachedAptServiceCommandError);
+		expect(
+			parseDetachedAptServiceProbe(
+				{
+					exitCode: 1,
+					stdout: "LoadState=not-found\nActiveState=inactive\n",
+					stderr: "unit not found",
+				},
+				["systemctl", "show", "ceralive-software-update.service"],
+			),
+		).toEqual({ kind: "absent" });
+	});
+});
+
+describe("deriveAptProgress() — arbitrary output chunk boundaries", () => {
+	it("recognizes progress tokens split across several durable-file reads", () => {
+		let status = {
+			total: 0,
+			downloading: 0,
+			unpacking: 0,
+			setting_up: 0,
+		};
+		let output = "";
+		for (const chunk of [
+			"2 upgraded, 0 newly installed, 0 to remove.\nGet:",
+			"1 package\nUnpack",
+			"ing package-a\nSet",
+			"ting up package-a\n",
+		]) {
+			output += chunk;
+			status = deriveAptProgress(status, output);
+		}
+
+		expect(status).toEqual({
+			total: 2,
+			downloading: 2,
+			unpacking: 1,
+			setting_up: 1,
+		});
+	});
+});
+
+describe("update discovery admission", () => {
+	it("coalesces concurrent discovery cycles", async () => {
+		let calls = 0;
+		let release: (() => void) | undefined;
+		setSoftwareUpdateSizeRunner(
+			() =>
+				new Promise((resolve) => {
+					calls++;
+					release = () => resolve(null);
+				}),
+		);
+		try {
+			const first = runUpdateDiscoveryAndReport();
+			await Bun.sleep(0);
+			expect(await runUpdateDiscoveryAndReport()).toBe("busy");
+			expect(calls).toBe(1);
+			release?.();
+			expect(await first).toBeNull();
+		} finally {
+			resetSoftwareUpdateSizeRunner();
+		}
 	});
 });
 

--- a/apps/backend/src/tests/spawn-policy.test.ts
+++ b/apps/backend/src/tests/spawn-policy.test.ts
@@ -28,10 +28,10 @@ const alive = (proc: ManagedProcess): boolean =>
 	proc.exitCode === null && proc.signalCode === null;
 
 describe("spawn-policy registry consistency", () => {
-	it("classifies all 25 production spawn sites with unique ids", () => {
-		expect(SPAWN_POLICY).toHaveLength(25);
+	it("classifies all 29 production spawn sites with unique ids", () => {
+		expect(SPAWN_POLICY).toHaveLength(29);
 		const ids = new Set(SPAWN_POLICY.map((s) => s.id));
-		expect(ids.size).toBe(25);
+		expect(ids.size).toBe(29);
 	});
 
 	// The diagnostic's `nft list ruleset` is a READ on its own slow cadence, so it


### PR DESCRIPTION
## What
- run apt/dpkg upgrades in a PID-1-owned transient service
- persist stdout/stderr in validated root-owned runtime files and replay progress after backend restart
- recover or fail closed before periodic discovery, while preventing duplicate transactions
- register the new process sites and document the lifecycle contract

## Why
Upgrading CeraUI can restart `ceralive.service`. When apt ran inside that unit, systemd killed the package transaction together with the backend, potentially interrupting dpkg mid-upgrade. Pipe-owned output also disappeared with the restarting process.

## How to verify
- `bun run lint`
- `bun run --filter backend test` — 5,606 passed, 2 skipped, 0 failed
- `BUILD_ARCH=amd64 bun run --filter backend build:backend-only`

## Risks
- Recovery intentionally fails closed when systemd identity or output-path validation is inconclusive; periodic checks resume through a bounded retry.
- The detached install transaction remains intentionally unbounded, while local systemd probes and read-only apt checks retain explicit timeouts.
- No RPC schema or operator-facing status shape changes.