### PR TITLE
fix(streaming): derive audio device types from cerastream

### DIFF
--- a/apps/backend/src/modules/streaming/audio-naming.ts
+++ b/apps/backend/src/modules/streaming/audio-naming.ts
@@ -53,33 +53,30 @@
  * module-level dedup Set) and never at warn/error (a nameless card is normal).
  */
 
+import type { CaptureDevice as CerastreamCaptureDevice } from "@ceralive/cerastream";
 import { logger } from "../../helpers/logger.ts";
 import { normalizeOnboardKey } from "./onboard-display-names.ts";
 
 /**
- * The engine-audio join record — a DEDICATED local type carrying ONLY the three
- * fields the label join needs. Deliberately NOT the `@ceraui/rpc` `CaptureDevice`
- * (which has no `alsa_card_id` join key), NOT the output of `fromEngineDevice()`
- * (drops the join key), and NOT the video-cache whitelist copy (copies 6 video
- * fields, not `alsa_card_id`). The `alsa_card_id?` field is the LOAD-BEARING join
- * key preserved verbatim from the `list-devices` audio entry — it is `undefined`
- * on the pre-T18 pin (whose binding `captureDeviceSchema` strips it) and populated
- * once the bumped binding retains it.
+ * The engine-audio join record derives from the published cerastream device shape.
+ * This preserves the producer's schema version as the compile-time boundary: a
+ * stale binding cannot silently accept fields it strips at runtime.
  */
-export interface EngineAudioDevice {
-	input_id: string;
-	display_name: string;
-	alsa_card_id?: string;
-	product_name?: string;
-	transport?: AudioDeviceTransport;
-	stable_id?: string;
-	device_address?: string;
-	// `usb:<topology-token>` shared by every row of ONE physical device
-	// (cerastream ADR-0008) — the join key the "Auto" audio resolver matches on.
-	physical_group_id?: string;
-}
+export type EngineAudioDevice = Pick<
+	CerastreamCaptureDevice,
+	| "input_id"
+	| "display_name"
+	| "alsa_card_id"
+	| "product_name"
+	| "transport"
+	| "stable_id"
+	| "device_address"
+	| "physical_group_id"
+>;
 
-export type AudioDeviceTransport = "usb" | "hdmi" | "bluetooth" | "onboard";
+export type AudioDeviceTransport = NonNullable<
+	CerastreamCaptureDevice["transport"]
+>;
 
 export interface AudioDeviceIdentity {
 	product_name?: string;
@@ -505,11 +502,11 @@ export function resolveAudioIdentities(
 		// generic engine value (e.g. "usbaudio", equal to the card id) is never
 		// composed as `<Product Name> · <Transport>` — the transport tag still
 		// rides on its own, and the picker falls back to the longname-derived label.
-		const hasRealProduct =
-			match.product_name !== undefined &&
-			isHumanAudioName(match.product_name, cardId);
 		const identity: AudioDeviceIdentity = {
-			...(hasRealProduct ? { product_name: match.product_name } : {}),
+			...(match.product_name !== undefined &&
+			isHumanAudioName(match.product_name, cardId)
+				? { product_name: match.product_name }
+				: {}),
 			...(match.transport !== undefined ? { transport: match.transport } : {}),
 			...(match.stable_id !== undefined ? { stable_id: match.stable_id } : {}),
 		};

--- a/apps/backend/src/modules/streaming/sources.ts
+++ b/apps/backend/src/modules/streaming/sources.ts
@@ -1415,14 +1415,6 @@ async function probeEngineDevices(
 	try {
 		const result = await deps.fetchEngineDevices();
 		const devices = result.devices.map((d) => {
-			// `modes[]` is read defensively, exactly like the audio join keys below:
-			// this whitelist copy is the ONE seam a real engine payload crosses, and
-			// an unlisted field is DROPPED silently. It was, which made todo 21's
-			// per-format mode families reachable only from a hand-built fixture —
-			// every dual-format camera published `selectedInputMode` with no
-			// `inputModes` beside it, so the picker had nothing to offer and the
-			// encoder ladder fell back to the device's unioned flat list.
-			const extra = d as { modes?: readonly unknown[] };
 			return fromEngineDevice({
 				input_id: d.input_id,
 				device_path: d.device_path,
@@ -1430,7 +1422,7 @@ async function probeEngineDevices(
 				media_class: d.media_class,
 				kind: d.kind,
 				caps: d.caps,
-				...(extra.modes !== undefined ? { modes: extra.modes } : {}),
+				...(d.modes !== undefined ? { modes: d.modes } : {}),
 				stable_id: d.stable_id,
 				physical_group_id: d.physical_group_id,
 			});
@@ -1440,41 +1432,28 @@ async function probeEngineDevices(
 			devices,
 			selectionToken,
 			// Parallel AUDIO cache (T4): an EXPLICIT field copy of the audio entries
-			// that PRESERVES the `alsa_card_id` join key verbatim. It is read
-			// defensively (the pre-T18 binding schema strips it → `undefined`; the
-			// bumped schema retains it), and it is NOT routed through the video
-			// whitelist copy above or `fromEngineDevice()`, both of which drop it.
+			// that preserves the producer-owned join keys verbatim. It is NOT routed
+			// through the video whitelist copy above or `fromEngineDevice()`, both of
+			// which intentionally drop the audio-only fields.
 			audio: result.devices
 				.filter((d) => d.media_class === "audio")
 				.map((d) => {
-					const extra = d as {
-						alsa_card_id?: string;
-						product_name?: string;
-						transport?: EngineAudioDevice["transport"];
-						stable_id?: string;
-						device_address?: string;
-						physical_group_id?: string;
-					};
 					return {
 						input_id: d.input_id,
 						display_name: d.display_name,
-						...(extra.alsa_card_id !== undefined
-							? { alsa_card_id: extra.alsa_card_id }
+						...(d.alsa_card_id !== undefined
+							? { alsa_card_id: d.alsa_card_id }
 							: {}),
-						...(extra.product_name !== undefined
-							? { product_name: extra.product_name }
+						...(d.product_name !== undefined
+							? { product_name: d.product_name }
 							: {}),
-						...(extra.transport !== undefined
-							? { transport: extra.transport }
+						...(d.transport !== undefined ? { transport: d.transport } : {}),
+						...(d.stable_id !== undefined ? { stable_id: d.stable_id } : {}),
+						...(d.device_address !== undefined
+							? { device_address: d.device_address }
 							: {}),
-						...(extra.stable_id !== undefined
-							? { stable_id: extra.stable_id }
-							: {}),
-						...(extra.device_address !== undefined
-							? { device_address: extra.device_address }
-							: {}),
-						...(extra.physical_group_id !== undefined
-							? { physical_group_id: extra.physical_group_id }
+						...(d.physical_group_id !== undefined
+							? { physical_group_id: d.physical_group_id }
 							: {}),
 					};
 				}),


### PR DESCRIPTION
## What
- Derive engine audio records from the published `@ceralive/cerastream` `CaptureDevice` type.
- Read mode and audio fields directly from the package-owned device shape.

## Why
A stale binding pin can otherwise typecheck a field that Zod strips at runtime.

## How to verify
- `bun run --filter backend check`
- `bun test` (backend: 5,606 passed, 2 skipped)
- Temporarily pinning cerastream to `2026.8.0` makes the backend typecheck fail on `device_address`; the pin was restored to `2026.8.1`.

## Risks
Type-only change; runtime field projection is unchanged.