### PR TITLE
fix(streaming): stop a stale geometry override from blocking every start

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -6721,6 +6721,58 @@ table driven through the REAL procedure, the persistence-untouched guarantee, an
 the fail-open negatives) + `tests/capability-truth-clamp.test.ts` (the Osmo
 1080p60-on-H.264 migration, the one-time notification, and the never-clamp cases).
 
+## …AND AN OVERRIDE THE PIPELINE CANNOT HONOR IS RESIDUE, NOT INTENT [EXISTS]
+
+The section above is about an override the DEVICE cannot deliver. This is the
+adjacent case — an override the PIPELINE has no use for at all — and the two
+resolve in opposite directions on purpose.
+
+`intersectCaps` collapses a non-override source's offering to its own
+`default_resolution`/`default_framerate`, so the Encoder dialog never renders the
+axis for an rtmp/srt ingest row: the geometry is whatever the publisher sends. A
+`resolution`/`framerate` sitting on such a config is therefore always RESIDUE from
+a previous source, and the wire cannot say otherwise — a start carries the WHOLE
+persisted config, so an echoed value and a typed one are the same bytes.
+
+Board-measured on a Rock 5B+ (2026-08-30). A `config.json` holding `720p`/`30` from
+an earlier HDMI session, with the RTMP row selected, failed EVERY start:
+
+```
+PipelineOverrideError: Pipeline does not support resolution override
+start_invalid  phase=params  retry=not_retriable
+```
+
+The operator could not clear it from anywhere — the axis is not on their source
+row — so the device was unstreamable until the config was hand-edited over SSH.
+
+`unsupportedPipelineOverrides` (`@ceraui/rpc` `capabilities/pipeline-override-truth.ts`)
+is the shared rule, in `@ceraui/rpc` for the reason `device-mode-truth.ts` is: a
+start that dies on a field the save path was happy to persist is the same
+offering-vs-save disagreement one layer down. Two seams consume it:
+
+- **The START drops it** (`streaming.ts` `validateConfig`, which no longer calls
+  `validatePipelineOverrides`) and warns. This is the operator-visible half.
+- **The SAVE clears it from disk** (`streaming.procedure.ts`, beside the existing
+  merge) so the config self-heals on the next write of any kind — including the
+  source switch that created the residue.
+
+**An EXPLICIT override for such a pipeline is still REFUSED, unchanged.** That is
+an operator action and answering it is the point; only the carried-forward value
+is cleared, decided by whether `input` mentions the field. Do not "unify" the two
+adjacent blocks in `setConfig` — they look contradictory and are not.
+
+The per-axis scoping is load-bearing: each field is judged against its OWN support
+flag, so a pipeline that refuses a resolution override while accepting a framerate
+one drops exactly one of them.
+
+Coverage: `packages/rpc/src/capabilities/pipeline-override-truth.test.ts` (the pure
+rule, incl. the absent-override and per-axis cases) +
+`tests/pipeline-override-residue.test.ts` (both seams driven through the REAL
+`validateConfig` and the REAL `setConfig` procedure, the board's own config shape,
+the honors-the-axes negatives, and the still-refused explicit write) +
+`tests/pipeline-validation.test.ts` (the start path's per-axis drop; its
+resolution-refusal case was INVERTED by this change and says so).
+
 ## A LIVE CAPTURE DEVICE IS NEVER SILENTLY DROPPED [EXISTS]
 
 `buildSources` folds each device into the coarse capability entry its kind bridges
@@ -8777,6 +8829,7 @@ config, an anchored path still held by its own device, and a live row with no
 - Don't re-apply an onboard display-name rule at a render site (a Svelte label, a summary derivation) — it belongs at the device-construction seam (`fromEngineDevice`), which is why the row and the "Configured" label are both fixed by one call.
 - Don't re-derive `pipeline`/`selected_video_input` resolution inline in a new procedure — route through `resolveSourceRouting()`/`deriveEngineRouting()` in `modules/streaming/sources.ts`.
 - Don't dispatch an `input_id` to the engine from ANY path without resolving it by stable identity first — the preview leg was the one that skipped it, and a renumbered device streamed while refusing to preview. And don't "upgrade" `resolvePreviewStartFrame` to `resolveSourceRouting`: preview must RESOLVE without REJECTING, or a true unplug loses the engine's typed `source-unavailable` reason to a silent drop.
+- Don't restore `validatePipelineOverrides` to the START path — a start carries the whole persisted config, so an override on a pipeline that cannot honor it is residue the UI never offered and the wire cannot distinguish from intent, and refusing it strands the operator on a start that fails naming a field their own source row does not display (board-measured). It is DROPPED there and CLEARED on the next save; the explicit-write refusal in `setConfig` is the one that stays.
 - Don't validate an encode target against a device ladder with a second, local copy of the rule — `@ceraui/rpc` `capabilities/device-mode-truth.ts` is shared with the frontend precisely so the offering and the save path cannot disagree. And don't turn its fail-open guards (no ladder, coarse source, un-normalizable payload) into refusals: blocking a save the hardware can honour is the same dishonesty as allowing one it cannot.
 - Don't report a `streaming.setConfig` result without reading `result.success` — a device-truth refusal RESOLVES, it does not throw, so a bare try/catch toasts "Saved" over a config the device rejected.
 - Don't add a country→channel table anywhere — the hotspot channel set is DERIVED by applying `iw reg set <CC>` and parsing `iw phy` back out (`regdomain.ts`), because the legal set depends on the kernel's regdb version, the radio, and self-managed adapters. And don't validate a channel with `isWifiChannelName` alone: that is a SHAPE check, and legality is `isChannelOffered` against the runtime-derived set.

--- a/apps/backend/src/modules/streaming/streaming.ts
+++ b/apps/backend/src/modules/streaming/streaming.ts
@@ -17,6 +17,7 @@
 */
 
 /* Stream starting, stopping, management and monitoring */
+import { unsupportedPipelineOverrides } from "@ceraui/rpc";
 import {
 	AUDIO_SOURCE_AUTO,
 	RIST_TRANSPORT,
@@ -29,6 +30,7 @@ import {
 	type Resolution,
 	runtimeConfigSchema,
 } from "../../helpers/config-schemas.ts";
+import { logger } from "../../helpers/logger.ts";
 import { getConfig, saveConfig } from "../config.ts";
 import {
 	convertManualToRemoteRelay,
@@ -47,7 +49,7 @@ import { getAudioDevices } from "./audio.ts";
 import { getSupportedTransports } from "./capabilities.ts";
 import { validateBitrate } from "./encoder.ts";
 import { AUDIO_CODECS } from "./pipeline-sources.ts";
-import { searchPipelines, validatePipelineOverrides } from "./pipelines.ts";
+import { searchPipelines } from "./pipelines.ts";
 import { noteSourceSelectionWrite } from "./sources.ts";
 import { resolveSrtla } from "./srtla.ts";
 import { resolveStreamEndpoint } from "./transport/resolve-endpoint.ts";
@@ -143,14 +145,22 @@ export async function validateConfig(params: Partial<ConfigParameters>) {
 	const pipeline = searchPipelines(validated.pipeline);
 	if (!pipeline) throw new Error("Pipeline not found");
 
-	validatePipelineOverrides(pipeline, {
-		...(validated.resolution !== undefined
-			? { resolution: validated.resolution }
-			: {}),
-		...(validated.framerate !== undefined
-			? { framerate: validated.framerate }
-			: {}),
-	});
+	// Residue from a previous source, never an operator intent: the UI does not
+	// offer the axis for such a pipeline, and the wire cannot tell a typed value
+	// from an echoed one. Refusing here only ever produced a start that died
+	// naming a field the operator's own source row does not display.
+	for (const field of unsupportedPipelineOverrides(pipeline, validated)) {
+		logger.warn(
+			`start: dropping stale ${field} override — pipeline '${pipeline.name}' cannot honor it`,
+			{
+				module: "streaming",
+				pipeline: pipeline.name,
+				dropped: String(validated[field]),
+			},
+		);
+		delete validated[field];
+		delete params[field];
+	}
 
 	// audio codec
 	if (pipeline.supportsAudio) {

--- a/apps/backend/src/rpc/procedures/streaming.procedure.ts
+++ b/apps/backend/src/rpc/procedures/streaming.procedure.ts
@@ -4,6 +4,7 @@
  */
 
 import { CerastreamRpcError } from "@ceralive/cerastream";
+import { unsupportedPipelineOverrides } from "@ceraui/rpc";
 import {
 	AUDIO_CODEC_UNSUPPORTED_TRANSPORT,
 	AUDIO_SOURCE_AUTO,
@@ -732,35 +733,49 @@ export const setConfigProcedure = authedProcedure
 		}
 
 		// Validate pipeline overrides at save time (QW-I)
+		const overridePipelineId = input.pipeline ?? config.pipeline;
+		const overridePipeline = searchPipelines(overridePipelineId ?? "");
 		if (
-			input.pipeline !== undefined ||
-			input.resolution !== undefined ||
-			input.framerate !== undefined
+			overridePipeline &&
+			(input.pipeline !== undefined ||
+				input.resolution !== undefined ||
+				input.framerate !== undefined)
 		) {
-			const pipelineId = input.pipeline ?? config.pipeline;
-			const pipeline = searchPipelines(pipelineId ?? "");
-			if (pipeline) {
-				try {
-					validatePipelineOverrides(pipeline, {
-						...(input.resolution !== undefined
-							? { resolution: input.resolution }
-							: {}),
-						...(input.framerate !== undefined
-							? { framerate: input.framerate }
-							: {}),
-					});
-				} catch (err) {
-					if (err instanceof PipelineOverrideError) {
-						return {
-							success: false,
-							error: `Pipeline does not support ${err.field} override`,
-							applied: {},
-						};
-					}
-					throw err;
+			try {
+				validatePipelineOverrides(overridePipeline, {
+					...(input.resolution !== undefined
+						? { resolution: input.resolution }
+						: {}),
+					...(input.framerate !== undefined
+						? { framerate: input.framerate }
+						: {}),
+				});
+			} catch (err) {
+				if (err instanceof PipelineOverrideError) {
+					return {
+						success: false,
+						error: `Pipeline does not support ${err.field} override`,
+						applied: {},
+					};
 				}
+				throw err;
 			}
 		}
+
+		// An EXPLICIT override for such a pipeline is still refused above — that is
+		// an operator action, and answering it is the point. What is cleared here is
+		// the PERSISTED residue a source switch leaves behind, which no later save
+		// mentions and which would otherwise sit on disk blocking every start.
+		const staleOverrides = overridePipeline
+			? unsupportedPipelineOverrides(overridePipeline, {
+					...(input.resolution === undefined
+						? { resolution: config.resolution }
+						: {}),
+					...(input.framerate === undefined
+						? { framerate: config.framerate }
+						: {}),
+				})
+			: [];
 
 		// Three orderings here are load-bearing (ADR-0008 §10 / todo 11a). It runs
 		// BEFORE the first config mutation, so a refusal leaves disk byte-identical
@@ -821,6 +836,17 @@ export const setConfigProcedure = authedProcedure
 		if (input.max_br !== undefined) config.max_br = clampBitrate(input.max_br);
 		if (input.resolution !== undefined) config.resolution = input.resolution;
 		if (input.framerate !== undefined) config.framerate = input.framerate;
+		for (const field of staleOverrides) {
+			logger.warn(
+				`setConfig: clearing stale ${field} override — pipeline '${overridePipeline?.name}' cannot honor it`,
+				{
+					module: "streaming",
+					pipeline: overridePipeline?.name,
+					dropped: String(config[field]),
+				},
+			);
+			config[field] = undefined;
+		}
 		if (input.video_codec !== undefined) config.video_codec = input.video_codec;
 		if (input.video_passthrough !== undefined)
 			config.video_passthrough = input.video_passthrough;

--- a/apps/backend/src/tests/pipeline-override-residue.test.ts
+++ b/apps/backend/src/tests/pipeline-override-residue.test.ts
@@ -1,0 +1,259 @@
+/*
+ * A geometry override the selected pipeline cannot honor is RESIDUE, not intent.
+ *
+ * Board-measured on a Rock 5B+ (2026-08-30): a `config.json` carrying
+ * `resolution: "720p"` + `framerate: 30` from an earlier HDMI session, with an
+ * RTMP ingest source selected, failed EVERY start:
+ *
+ *   PipelineOverrideError: Pipeline does not support resolution override
+ *   start_invalid  phase=params  retry=not_retriable
+ *
+ * The operator could not clear it: `intersectCaps` collapses a non-override
+ * source's offering to its own default, so the Encoder dialog never renders the
+ * axis for an ingest row — the start failed naming a field their own source row
+ * does not display, with no affordance anywhere to unset it.
+ *
+ * Two seams, one shared rule (`@ceraui/rpc` `unsupportedPipelineOverrides`):
+ * the start DROPS the residue rather than dying on it, and the save CLEARS it
+ * from disk so the config self-heals. An EXPLICIT override for such a pipeline
+ * is still refused — that one is an operator action worth answering.
+ */
+
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from "bun:test";
+
+import {
+	type GetCapabilitiesResult,
+	SCHEMA_VERSION,
+} from "@ceralive/cerastream";
+import { call } from "@orpc/server";
+
+import {
+	initMockService,
+	resetMockState,
+	setStreamingState,
+	stopMockService,
+} from "../mocks/mock-service.ts";
+import { getConfig } from "../modules/config.ts";
+import {
+	initPipelines,
+	setMockHardware,
+} from "../modules/streaming/pipelines.ts";
+import { resetEngineDeviceCache } from "../modules/streaming/sources.ts";
+import {
+	updateStatus,
+	validateConfig,
+} from "../modules/streaming/streaming.ts";
+import { setConfigProcedure } from "../rpc/procedures/streaming.procedure.ts";
+import type { AppWebSocket, RPCContext } from "../rpc/types.ts";
+
+type SourceCap = GetCapabilitiesResult["sources"][number];
+
+function source(id: string, overrides: Partial<SourceCap> = {}): SourceCap {
+	return {
+		id,
+		supports_audio: true,
+		supports_resolution_override: true,
+		supports_framerate_override: true,
+		default_resolution: "1080p",
+		default_framerate: 30,
+		...overrides,
+	};
+}
+
+const CAPS: GetCapabilitiesResult = {
+	platform: {
+		supports_h265: true,
+		hardware_accelerated: true,
+		max_resolution: "2160p",
+	},
+	encoder: {
+		codecs: ["h264", "h265"],
+		bitrate_range: { min: 500, max: 50000, unit: "kbps" },
+	},
+	sources: [
+		source("hdmi"),
+		// The board's own shape: an ingest pipeline honors NEITHER axis, because
+		// the geometry is whatever the publisher sends.
+		source("rtmp", {
+			supports_resolution_override: false,
+			supports_framerate_override: false,
+		}),
+	],
+};
+
+function provide() {
+	return {
+		fetchEngineCapabilities: async () => ({
+			caps: CAPS,
+			schemaVersion: SCHEMA_VERSION,
+		}),
+		fetchEngineDevices: async () => ({ devices: [] }),
+	};
+}
+
+function makeContext(): RPCContext {
+	const ws = {
+		send: () => {},
+		data: { isAuthenticated: true, lastActive: Date.now() },
+	} as unknown as AppWebSocket;
+	return {
+		ws,
+		isAuthenticated: () => true,
+		authenticate: () => {},
+		deauthenticate: () => {},
+		markActive: () => {},
+		getLastActive: () => 0,
+		setSenderId: () => {},
+		getSenderId: () => undefined,
+		clearSenderId: () => {},
+	};
+}
+
+describe("a geometry override the pipeline cannot honor is residue", () => {
+	const savedMockMode = process.env.MOCK_MODE;
+	let priorPipeline: string | undefined;
+	let priorResolution: ReturnType<typeof getConfig>["resolution"];
+	let priorFramerate: ReturnType<typeof getConfig>["framerate"];
+
+	beforeAll(async () => {
+		process.env.MOCK_MODE = "true";
+		initMockService("caps-full");
+		setMockHardware("rk3588");
+		await initPipelines(provide());
+	});
+	beforeEach(() => {
+		const config = getConfig();
+		priorPipeline = config.pipeline;
+		priorResolution = config.resolution;
+		priorFramerate = config.framerate;
+		resetEngineDeviceCache();
+	});
+	afterEach(() => {
+		const config = getConfig();
+		config.pipeline = priorPipeline;
+		config.resolution = priorResolution;
+		config.framerate = priorFramerate;
+		resetEngineDeviceCache();
+		setStreamingState(false);
+		updateStatus(false);
+		resetMockState();
+	});
+	afterAll(async () => {
+		stopMockService();
+		setMockHardware("rk3588");
+		await initPipelines();
+		if (savedMockMode === undefined) delete process.env.MOCK_MODE;
+		else process.env.MOCK_MODE = savedMockMode;
+	});
+
+	// ── The start path: the operator-visible half ──────────────────────────────
+	describe("the start drops it instead of dying on it", () => {
+		test("the board's exact config no longer dies on the override", async () => {
+			const params: Record<string, unknown> = {
+				delay: 0,
+				pipeline: "rtmp",
+				resolution: "1080p",
+				framerate: 30,
+			};
+
+			await expect(validateConfig(params)).rejects.not.toThrow(
+				"Pipeline does not support",
+			);
+			expect(params).not.toHaveProperty("resolution");
+			expect(params).not.toHaveProperty("framerate");
+		});
+
+		test("a pipeline that DOES honor the axes keeps them", async () => {
+			const params: Record<string, unknown> = {
+				delay: 0,
+				pipeline: "hdmi",
+				resolution: "1080p",
+				framerate: 30,
+			};
+
+			await expect(validateConfig(params)).rejects.not.toThrow(
+				"Pipeline does not support",
+			);
+			expect(params.resolution).toBe("1080p");
+			expect(params.framerate).toBe(30);
+		});
+	});
+
+	// ── The save path: the self-heal ───────────────────────────────────────────
+	describe("the save clears it from disk", () => {
+		test("switching the pipeline to an ingest one clears the stale overrides", async () => {
+			const config = getConfig();
+			config.pipeline = "hdmi";
+			config.resolution = "720p";
+			config.framerate = 30;
+
+			const result = await call(
+				setConfigProcedure,
+				{ pipeline: "rtmp" },
+				{ context: makeContext() },
+			);
+
+			expect(result.success).toBe(true);
+			expect(config.resolution).toBeUndefined();
+			expect(config.framerate).toBeUndefined();
+		});
+
+		test("a save on an ALREADY-ingest config heals it too", async () => {
+			const config = getConfig();
+			config.pipeline = "rtmp";
+			config.resolution = "720p";
+			config.framerate = 30;
+
+			const result = await call(
+				setConfigProcedure,
+				{ delay: 0 },
+				{ context: makeContext() },
+			);
+
+			expect(result.success).toBe(true);
+			expect(config.resolution).toBeUndefined();
+			expect(config.framerate).toBeUndefined();
+		});
+
+		test("a pipeline that honors the axes keeps the persisted values", async () => {
+			const config = getConfig();
+			config.pipeline = "hdmi";
+			config.resolution = "720p";
+			config.framerate = 30;
+
+			const result = await call(
+				setConfigProcedure,
+				{ delay: 0 },
+				{ context: makeContext() },
+			);
+
+			expect(result.success).toBe(true);
+			expect(config.resolution).toBe("720p");
+			expect(config.framerate).toBe(30);
+		});
+	});
+
+	// ── The operator's own action is still answered ────────────────────────────
+	test("an EXPLICIT override for such a pipeline is still REFUSED, not silently dropped", async () => {
+		const config = getConfig();
+		config.pipeline = "rtmp";
+		config.resolution = undefined;
+
+		const result = await call(
+			setConfigProcedure,
+			{ pipeline: "rtmp", resolution: "1080p" },
+			{ context: makeContext() },
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.error).toBe("Pipeline does not support resolution override");
+	});
+});

--- a/apps/backend/src/tests/pipeline-validation.test.ts
+++ b/apps/backend/src/tests/pipeline-validation.test.ts
@@ -155,10 +155,52 @@ describe("validateConfig capability + override rejection", () => {
 		).rejects.toThrow("Pipeline not found");
 	});
 
-	it("rejects a resolution override on a pipeline that does not support it", async () => {
-		await expect(
-			validateConfig({ delay: 0, pipeline: "rtmp", resolution: "1080p" }),
-		).rejects.toThrow("Pipeline does not support resolution override");
+	// Was a rejection until the residue fix. A start carries the WHOLE persisted
+	// config, so an override on a pipeline that cannot honor it is left over from
+	// a previous source and never something the operator typed — the UI does not
+	// offer the axis for an ingest row. Refusing it stranded the operator on a
+	// start that failed naming a field their own source row does not display.
+	it("drops a resolution override the pipeline cannot honor, instead of failing the start", async () => {
+		const params: Record<string, unknown> = {
+			delay: 0,
+			pipeline: "rtmp",
+			resolution: "1080p",
+		};
+
+		await expect(validateConfig(params)).rejects.not.toThrow(
+			"Pipeline does not support",
+		);
+		expect(params).not.toHaveProperty("resolution");
+	});
+
+	// Per-axis, against each axis's OWN flag: this fixture's rtmp refuses a
+	// resolution override and accepts a framerate one, so exactly one is dropped.
+	it("drops only the axis the pipeline cannot honor", async () => {
+		const params: Record<string, unknown> = {
+			delay: 0,
+			pipeline: "rtmp",
+			resolution: "1080p",
+			framerate: 30,
+		};
+
+		await expect(validateConfig(params)).rejects.not.toThrow(
+			"Pipeline does not support",
+		);
+		expect(params).not.toHaveProperty("resolution");
+		expect(params.framerate).toBe(30);
+	});
+
+	it("keeps an override the pipeline DOES honor", async () => {
+		const params: Record<string, unknown> = {
+			delay: 0,
+			pipeline: "camlink",
+			resolution: "1080p",
+		};
+
+		await expect(validateConfig(params)).rejects.not.toThrow(
+			"Pipeline does not support",
+		);
+		expect(params.resolution).toBe("1080p");
 	});
 
 	it("rejects an unknown audio codec", async () => {

--- a/packages/rpc/src/capabilities/index.ts
+++ b/packages/rpc/src/capabilities/index.ts
@@ -6,6 +6,7 @@ export * from './audio';
 export * from './capability-matrix';
 export * from './device-mode-truth';
 export * from './intersect-caps';
+export * from './pipeline-override-truth';
 export * from './preview';
 export * from './sim-bond-eligibility';
 export * from './wifi-station-security';

--- a/packages/rpc/src/capabilities/pipeline-override-truth.test.ts
+++ b/packages/rpc/src/capabilities/pipeline-override-truth.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	PIPELINE_OVERRIDE_FIELDS,
+	supportsPipelineOverride,
+	unsupportedPipelineOverrides,
+} from './pipeline-override-truth';
+
+const INGEST = {
+	supportsResolutionOverride: false,
+	supportsFramerateOverride: false,
+} as const;
+const CAPTURE = {
+	supportsResolutionOverride: true,
+	supportsFramerateOverride: true,
+} as const;
+
+describe('unsupportedPipelineOverrides', () => {
+	it('reports both axes an ingest pipeline cannot honor', () => {
+		expect(unsupportedPipelineOverrides(INGEST, { resolution: '720p', framerate: 30 })).toEqual([
+			'resolution',
+			'framerate',
+		]);
+	});
+
+	it('reports nothing for a pipeline that honors both', () => {
+		expect(unsupportedPipelineOverrides(CAPTURE, { resolution: '720p', framerate: 30 })).toEqual(
+			[],
+		);
+	});
+
+	// An absent override is nothing to reconcile: a config that never carried one
+	// must be left byte-identical, or every save on an ingest source would report
+	// a clear it did not perform.
+	it('reports nothing when no override is carried at all', () => {
+		expect(unsupportedPipelineOverrides(INGEST, {})).toEqual([]);
+		expect(
+			unsupportedPipelineOverrides(INGEST, { resolution: undefined, framerate: undefined }),
+		).toEqual([]);
+	});
+
+	it('reports only the carried axis', () => {
+		expect(unsupportedPipelineOverrides(INGEST, { resolution: '1080p' })).toEqual(['resolution']);
+		expect(unsupportedPipelineOverrides(INGEST, { framerate: 60 })).toEqual(['framerate']);
+	});
+
+	it('reports each axis against its OWN support flag', () => {
+		const resolutionOnly = {
+			supportsResolutionOverride: true,
+			supportsFramerateOverride: false,
+		};
+		expect(
+			unsupportedPipelineOverrides(resolutionOnly, { resolution: '720p', framerate: 30 }),
+		).toEqual(['framerate']);
+	});
+
+	it('answers per field through the shared predicate', () => {
+		expect(supportsPipelineOverride(INGEST, 'resolution')).toBe(false);
+		expect(supportsPipelineOverride(CAPTURE, 'framerate')).toBe(true);
+		expect(PIPELINE_OVERRIDE_FIELDS).toEqual(['resolution', 'framerate']);
+	});
+});

--- a/packages/rpc/src/capabilities/pipeline-override-truth.ts
+++ b/packages/rpc/src/capabilities/pipeline-override-truth.ts
@@ -1,0 +1,49 @@
+/**
+ * Which geometry overrides a pipeline can actually honor.
+ *
+ * `intersectCaps` already collapses a non-override source's offering to its own
+ * `default_resolution` / `default_framerate`, so the UI never presents a choice
+ * for such a source — an rtmp/srt ingest carries whatever the publisher sends.
+ * A `resolution`/`framerate` sitting on one of those configs is therefore always
+ * RESIDUE from a previous source, never an operator intent, and the device is
+ * the only party that can say so: the wire cannot distinguish a value the caller
+ * typed from one it merely echoed back.
+ *
+ * Shared by the save path and the start path for the reason `device-mode-truth`
+ * is shared: a start that dies on a field the save path was happy to persist —
+ * naming an axis the operator's own source row does not even display — is the
+ * defect this closes.
+ */
+
+export const PIPELINE_OVERRIDE_FIELDS = ['resolution', 'framerate'] as const;
+
+export type PipelineOverrideField = (typeof PIPELINE_OVERRIDE_FIELDS)[number];
+
+export interface PipelineOverrideSupport {
+	readonly supportsResolutionOverride: boolean;
+	readonly supportsFramerateOverride: boolean;
+}
+
+export function supportsPipelineOverride(
+	support: PipelineOverrideSupport,
+	field: PipelineOverrideField,
+): boolean {
+	return field === 'resolution'
+		? support.supportsResolutionOverride
+		: support.supportsFramerateOverride;
+}
+
+/**
+ * The carried override fields this pipeline cannot honor.
+ *
+ * Only fields that are actually PRESENT are reported — an absent override is
+ * nothing to reconcile, so a config that never had one is left untouched.
+ */
+export function unsupportedPipelineOverrides(
+	support: PipelineOverrideSupport,
+	carried: { resolution?: unknown; framerate?: unknown },
+): PipelineOverrideField[] {
+	return PIPELINE_OVERRIDE_FIELDS.filter(
+		(field) => carried[field] !== undefined && !supportsPipelineOverride(support, field),
+	);
+}


### PR DESCRIPTION
## What

A `config.json` carrying `resolution`/`framerate` from an earlier HDMI session, with an RTMP or SRT ingest source selected, failed **every** start:

```
PipelineOverrideError: Pipeline does not support resolution override
start_invalid  phase=params  retry=not_retriable
```

The start now drops the residue instead of dying on it, and the save clears it from disk so the config self-heals.

## Why

The operator could not clear it. `intersectCaps` collapses a non-override source's offering to its own default, so the Encoder dialog never renders the axis for an ingest row — the start failed naming a field their **own source row does not display**, with no affordance anywhere to unset it. Board-measured on a Rock 5B+ during PR #313's hardware verification; the device was unstreamable until the config was hand-edited over SSH.

An override on such a pipeline is residue from a previous source, never intent: the geometry is whatever the publisher sends, the UI never offered the axis, and a start carries the **whole** persisted config, so the wire cannot tell an echoed value from a typed one.

## How

`unsupportedPipelineOverrides` (`@ceraui/rpc` `capabilities/pipeline-override-truth.ts`) is the shared rule — same reason `device-mode-truth.ts` is shared, since a start that dies on a field the save path happily persisted is the same offering-vs-save disagreement one layer down. Two seams consume it:

- **The start drops it** (`validateConfig`) and warns. This is the operator-visible half.
- **The save clears it from disk** (`setConfig`) so the config self-heals on the next write of any kind — including the source switch that created the residue.

An **explicit** override for such a pipeline is still refused, unchanged — that is an operator action and answering it is the point. Only the carried-forward value is cleared, decided by whether `input` mentions the field. Each axis is judged against its own support flag, so a pipeline that refuses a resolution override while accepting a framerate one drops exactly one of them.

## How to verify

Board: select HDMI, configure 720p/30, switch to the RTMP row, press Start — it starts instead of failing `start_invalid`, and `config.json` no longer carries the overrides.

Locally:

```
bun run --filter backend check   # 0 errors
bun test                          # 5638 pass, 0 fail (apps/backend)
bun run --filter @ceraui/rpc test # 460 pass
```

Non-vacuity was checked rather than assumed: neutering both drops fails 5 tests across the two suites.

## Risks

Low. The only behaviour that changes is a refusal becoming a drop on a path where the refused value is provably unusable — the engine cannot apply it, and the UI never offered it. A pipeline that *does* honour an axis keeps its value on both paths (asserted). The explicit-write refusal, the device-ladder validation (`device_mode_unsupported`), and the persisted-mode clamp are all untouched.

**Rule E note — one existing test is inverted, not removed.** `pipeline-validation.test.ts`'s "rejects a resolution override on a pipeline that does not support it" asserted the start-path refusal, which is the defect itself. It now asserts the drop and carries a comment saying why. Every other override test is untouched: the explicit-write refusal they cover is unchanged.