### PR TITLE
fix(streaming): hydrate empty and partial starts

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -142,7 +142,10 @@ The `streaming` router exposes these procedures:
 config through `streamingConfigInputSchema`, overlays the caller's stated fields,
 then validates the effective whole. Thus `{}` means “start exactly what is saved” —
 required by both the public RPC and `device.setProfile`'s direct reconnect path —
-while a partial call changes only what it states. The schema projection is the
+while a partial call changes only its defined fields; an explicit `undefined` is
+not a clear. A stated manual endpoint clears both saved managed-relay fields
+(`relay_server` and `relay_account`), while a stated managed server clears the
+saved manual address and port. The schema projection is the
 credential boundary: never replace it with `{...getConfig()}`, which would put
 non-stream fields such as device credentials on the applied-start object. Keep the
 merge below the RPC layer so every start origin receives identical behavior.

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -128,7 +128,7 @@ The `streaming` router exposes these procedures:
 
 | Procedure | Purpose |
 |-----------|---------|
-| `start(config)` | Validate config, launch stream, persist config |
+| `start(config)` | Overlay optional fields on persisted stream config, validate, launch, persist |
 | `stop()` | Stop active stream |
 | `setConfig(fields)` | Persist config fields **without** starting the stream (added Task 19) |
 | `setBitrate({ max_br })` | Hot-adjust bitrate while streaming |
@@ -137,6 +137,15 @@ The `streaming` router exposes these procedures:
 | `getConfig()` | Return current config snapshot |
 
 `setConfig` writes the provided fields onto the running config (same relay/manual mutual-exclusion logic as `updateConfig`, minus DNS/pipeline validation), then calls `saveConfig` and broadcasts a `config` message. Use this for all config-only dialogs that must not start the stream.
+
+`start` input is PARTIAL by contract. `updateConfig` projects the saved runtime
+config through `streamingConfigInputSchema`, overlays the caller's stated fields,
+then validates the effective whole. Thus `{}` means “start exactly what is saved” —
+required by both the public RPC and `device.setProfile`'s direct reconnect path —
+while a partial call changes only what it states. The schema projection is the
+credential boundary: never replace it with `{...getConfig()}`, which would put
+non-stream fields such as device credentials on the applied-start object. Keep the
+merge below the RPC layer so every start origin receives identical behavior.
 
 ## AUDIO-DEVICE NAMING [EXISTS]
 

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -154,7 +154,7 @@ Key streaming procedures:
 
 | Procedure | Purpose |
 |-----------|---------|
-| `streaming.start(config)` | Validate and admit one lifecycle attempt; concurrent/cancelled admission resolves as typed `busy`/`cancelled` plus `attemptId`, while established success/failure responses keep their legacy wire shape |
+| `streaming.start(config)` | Overlay optional fields on saved stream config, then validate and admit one lifecycle attempt; concurrent/cancelled admission resolves as typed `busy`/`cancelled` plus `attemptId` |
 | `streaming.stop()` | Cancel/stop the active lifecycle generation and return a typed stop result |
 | `streaming.setConfig(fields)` | Persist config fields without starting the stream |
 | `streaming.setBitrate({ max_br })` | Hot-adjust bitrate while streaming |
@@ -163,6 +163,11 @@ Key streaming procedures:
 | `streaming.getConfig()` | Return current config snapshot |
 
 All setters return `{ success: boolean, applied: <fields> }`. The `applied` object reflects post-validation values actually written to config. Clients must lock their UI to `applied`, not to the raw input.
+
+`streaming.start` accepts a partial config. An empty `{}` starts from the complete
+persisted stream configuration; stated fields override only their saved counterparts.
+The merge occurs in the shared streamloop update seam, so UI starts and control-channel
+reconnects have the same semantics.
 
 All start origins share `stream-session-orchestrator.ts`; UI, autostart, remote
 control, and set-profile cannot launch parallel engine sessions. The backend

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -165,7 +165,9 @@ Key streaming procedures:
 All setters return `{ success: boolean, applied: <fields> }`. The `applied` object reflects post-validation values actually written to config. Clients must lock their UI to `applied`, not to the raw input.
 
 `streaming.start` accepts a partial config. An empty `{}` starts from the complete
-persisted stream configuration; stated fields override only their saved counterparts.
+persisted stream configuration; defined fields override only their saved counterparts.
+A manual address/port switches away from both saved managed-relay fields, while a
+managed relay server switches away from the saved manual address/port.
 The merge occurs in the shared streamloop update seam, so UI starts and control-channel
 reconnects have the same semantics.
 

--- a/apps/backend/src/modules/streaming/start-config-merge.ts
+++ b/apps/backend/src/modules/streaming/start-config-merge.ts
@@ -1,0 +1,39 @@
+import {
+	type StreamingConfigInput,
+	streamingConfigInputSchema,
+} from "@ceraui/rpc/schemas";
+
+function definedFields(input: StreamingConfigInput): StreamingConfigInput {
+	return Object.fromEntries(
+		Object.entries(input).filter(([, value]) => value !== undefined),
+	) as StreamingConfigInput;
+}
+
+export function mergePersistedStartConfig(
+	persistedConfig: unknown,
+	requestedConfig: unknown,
+): StreamingConfigInput {
+	const persisted = streamingConfigInputSchema.parse(persistedConfig);
+	const requested = definedFields(
+		streamingConfigInputSchema.parse(requestedConfig),
+	);
+	const effective: StreamingConfigInput = { ...persisted, ...requested };
+
+	const requestsManualEndpoint =
+		requested.srtla_addr !== undefined || requested.srtla_port !== undefined;
+	if (requested.relay_server !== undefined) {
+		effective.srtla_addr = undefined;
+		effective.srtla_port = undefined;
+	} else if (requestsManualEndpoint) {
+		effective.relay_server = undefined;
+		effective.relay_account = undefined;
+	}
+
+	if (!requestsManualEndpoint && requested.relay_account !== undefined) {
+		effective.srt_streamid = undefined;
+	} else if (requested.srt_streamid !== undefined) {
+		effective.relay_account = undefined;
+	}
+
+	return effective;
+}

--- a/apps/backend/src/modules/streaming/streaming.ts
+++ b/apps/backend/src/modules/streaming/streaming.ts
@@ -22,6 +22,7 @@ import {
 	AUDIO_SOURCE_AUTO,
 	RIST_TRANSPORT,
 	SRTLA_MIN_LATENCY_MS,
+	streamingConfigInputSchema,
 } from "@ceraui/rpc/schemas";
 import type WebSocket from "ws";
 import {
@@ -228,7 +229,19 @@ export async function validateConfig(params: Partial<ConfigParameters>) {
 	return { pipeline, srtlaAddr, srtlaPort, streamid };
 }
 
-export async function updateConfig(_conn: WebSocket, params: ConfigParameters) {
+export async function updateConfig(params: ConfigParameters) {
+	// Every start is a partial update over the persisted stream config. Keep the
+	// merge at this shared seam: UI starts arrive through session.start, while a
+	// set-profile reconnect calls it directly with {}. Parsing through the wire
+	// schema projects only stream fields, so credentials in runtime config can
+	// never ride the applied start object.
+	const requested = { ...params };
+	const persisted = streamingConfigInputSchema.parse(getConfig());
+	if (requested.srtla_addr !== undefined || requested.srtla_port !== undefined)
+		persisted.relay_server = undefined;
+	if (requested.srt_streamid !== undefined) persisted.relay_account = undefined;
+	Object.assign(params, persisted, requested);
+
 	const {
 		pipeline,
 		srtlaAddr: initialAddr,

--- a/apps/backend/src/modules/streaming/streaming.ts
+++ b/apps/backend/src/modules/streaming/streaming.ts
@@ -22,7 +22,6 @@ import {
 	AUDIO_SOURCE_AUTO,
 	RIST_TRANSPORT,
 	SRTLA_MIN_LATENCY_MS,
-	streamingConfigInputSchema,
 } from "@ceraui/rpc/schemas";
 import type WebSocket from "ws";
 import {
@@ -53,6 +52,7 @@ import { AUDIO_CODECS } from "./pipeline-sources.ts";
 import { searchPipelines } from "./pipelines.ts";
 import { noteSourceSelectionWrite } from "./sources.ts";
 import { resolveSrtla } from "./srtla.ts";
+import { mergePersistedStartConfig } from "./start-config-merge.ts";
 import { resolveStreamEndpoint } from "./transport/resolve-endpoint.ts";
 
 export type StartMessage = { start: ConfigParameters };
@@ -229,18 +229,16 @@ export async function validateConfig(params: Partial<ConfigParameters>) {
 	return { pipeline, srtlaAddr, srtlaPort, streamid };
 }
 
-export async function updateConfig(params: ConfigParameters) {
+export async function updateConfig(requestedParams: ConfigParameters) {
 	// Every start is a partial update over the persisted stream config. Keep the
 	// merge at this shared seam: UI starts arrive through session.start, while a
 	// set-profile reconnect calls it directly with {}. Parsing through the wire
 	// schema projects only stream fields, so credentials in runtime config can
 	// never ride the applied start object.
-	const requested = { ...params };
-	const persisted = streamingConfigInputSchema.parse(getConfig());
-	if (requested.srtla_addr !== undefined || requested.srtla_port !== undefined)
-		persisted.relay_server = undefined;
-	if (requested.srt_streamid !== undefined) persisted.relay_account = undefined;
-	Object.assign(params, persisted, requested);
+	const params: ConfigParameters = mergePersistedStartConfig(
+		getConfig(),
+		requestedParams,
+	);
 
 	const {
 		pipeline,

--- a/apps/backend/src/modules/streaming/streamloop/session.ts
+++ b/apps/backend/src/modules/streaming/streamloop/session.ts
@@ -97,7 +97,7 @@ export async function start(
 		streamid: string;
 	};
 	try {
-		c = await updateConfig(conn, params);
+		c = await updateConfig(params);
 	} catch (err) {
 		if (typeof err === "string") {
 			startError(conn, err, senderId);

--- a/apps/backend/src/tests/streaming-start-persisted-config.test.ts
+++ b/apps/backend/src/tests/streaming-start-persisted-config.test.ts
@@ -1,0 +1,112 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+
+import {
+	type GetCapabilitiesResult,
+	SCHEMA_VERSION,
+} from "@ceralive/cerastream";
+import { initMockService, stopMockService } from "../mocks/mock-service.ts";
+import { getConfig } from "../modules/config.ts";
+import {
+	initPipelines,
+	setMockHardware,
+} from "../modules/streaming/pipelines.ts";
+import { updateConfig } from "../modules/streaming/streaming.ts";
+
+const CAPS: GetCapabilitiesResult = {
+	platform: {
+		supports_h265: true,
+		hardware_accelerated: true,
+		max_resolution: "2160p",
+	},
+	encoder: {
+		codecs: ["h264", "h265"],
+		bitrate_range: { min: 500, max: 50000, unit: "kbps" },
+	},
+	sources: [
+		{
+			id: "test",
+			supports_audio: false,
+			supports_resolution_override: true,
+			supports_framerate_override: true,
+			default_resolution: "1080p",
+			default_framerate: 30,
+		},
+	],
+};
+
+const provide = () => ({
+	fetchEngineCapabilities: async () => ({
+		caps: CAPS,
+		schemaVersion: SCHEMA_VERSION,
+	}),
+	fetchEngineDevices: async () => ({ devices: [] }),
+});
+
+const savedMockMode = process.env.MOCK_MODE;
+
+beforeAll(async () => {
+	process.env.MOCK_MODE = "true";
+	initMockService("caps-full");
+	setMockHardware("rk3588");
+	await initPipelines(provide());
+});
+
+afterAll(async () => {
+	stopMockService();
+	setMockHardware("rk3588");
+	await initPipelines();
+	if (savedMockMode === undefined) delete process.env.MOCK_MODE;
+	else process.env.MOCK_MODE = savedMockMode;
+});
+
+test("empty start input hydrates every required field from persisted config", async () => {
+	const config = getConfig();
+	const previous = {
+		delay: config.delay,
+		pipeline: config.pipeline,
+		max_br: config.max_br,
+		srt_latency: config.srt_latency,
+		bitrate_overlay: config.bitrate_overlay,
+		srtla_addr: config.srtla_addr,
+		srtla_port: config.srtla_port,
+		srt_streamid: config.srt_streamid,
+		relay_server: config.relay_server,
+		relay_account: config.relay_account,
+		relay_protocol: config.relay_protocol,
+	};
+	const configFile = await Bun.file("config.json").text();
+
+	try {
+		config.delay = 137;
+		config.pipeline = "test";
+		config.max_br = 4321;
+		config.srt_latency = 2456;
+		config.bitrate_overlay = true;
+		config.srtla_addr = "127.0.0.1";
+		config.srtla_port = 5000;
+		config.srt_streamid = "persisted-stream";
+		config.relay_server = undefined;
+		config.relay_account = undefined;
+		config.relay_protocol = "srtla";
+
+		const params = {};
+		const result = await updateConfig(params);
+
+		expect(result.pipeline.source).toBe("test");
+		expect(params).toEqual(
+			expect.objectContaining({
+				delay: 137,
+				pipeline: "test",
+				max_br: 4321,
+				srt_latency: 2456,
+				bitrate_overlay: true,
+				srtla_addr: "127.0.0.1",
+				srtla_port: 5000,
+				srt_streamid: "persisted-stream",
+			}),
+		);
+	} finally {
+		Object.assign(config, previous);
+		await Bun.write("config.json", configFile);
+	}
+});

--- a/apps/backend/src/tests/streaming-start-persisted-config.test.ts
+++ b/apps/backend/src/tests/streaming-start-persisted-config.test.ts
@@ -1,15 +1,28 @@
-import { afterAll, beforeAll, expect, test } from "bun:test";
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	expect,
+	test,
+} from "bun:test";
 
 import {
 	type GetCapabilitiesResult,
 	SCHEMA_VERSION,
 } from "@ceralive/cerastream";
+import type { RelaysCache } from "../helpers/config-schemas.ts";
 import { initMockService, stopMockService } from "../mocks/mock-service.ts";
 import { getConfig } from "../modules/config.ts";
+import {
+	getRelays,
+	setRelaysCacheMock,
+} from "../modules/remote/remote-relays.ts";
 import {
 	initPipelines,
 	setMockHardware,
 } from "../modules/streaming/pipelines.ts";
+import { mergePersistedStartConfig } from "../modules/streaming/start-config-merge.ts";
 import { updateConfig } from "../modules/streaming/streaming.ts";
 
 const CAPS: GetCapabilitiesResult = {
@@ -34,6 +47,20 @@ const CAPS: GetCapabilitiesResult = {
 	],
 };
 
+const RELAYS = {
+	servers: {
+		managed: {
+			type: "srtla",
+			name: "Managed relay",
+			addr: "127.0.0.3",
+			port: 7000,
+		},
+	},
+	accounts: {
+		account: { name: "Managed account", ingest_key: "managed-stream" },
+	},
+};
+
 const provide = () => ({
 	fetchEngineCapabilities: async () => ({
 		caps: CAPS,
@@ -43,12 +70,45 @@ const provide = () => ({
 });
 
 const savedMockMode = process.env.MOCK_MODE;
+let previousConfig: ReturnType<typeof getConfig>;
+let previousRelays: RelaysCache | undefined;
+let configFile = "";
+
+function setValidManualConfig(): void {
+	Object.assign(getConfig(), {
+		delay: 137,
+		pipeline: "test",
+		max_br: 4321,
+		srt_latency: 2456,
+		bitrate_overlay: true,
+		relay_protocol: "srtla",
+		relay_server: undefined,
+		relay_account: undefined,
+		srtla_addr: "127.0.0.1",
+		srtla_port: 5000,
+		srt_streamid: "persisted-stream",
+	});
+}
 
 beforeAll(async () => {
 	process.env.MOCK_MODE = "true";
 	initMockService("caps-full");
 	setMockHardware("rk3588");
 	await initPipelines(provide());
+});
+
+beforeEach(async () => {
+	previousConfig = structuredClone(getConfig());
+	previousRelays = structuredClone(getRelays());
+	configFile = await Bun.file("config.json").text();
+	setRelaysCacheMock(structuredClone(RELAYS));
+	setValidManualConfig();
+});
+
+afterEach(async () => {
+	Object.assign(getConfig(), previousConfig);
+	setRelaysCacheMock(previousRelays);
+	await Bun.write("config.json", configFile);
 });
 
 afterAll(async () => {
@@ -59,54 +119,157 @@ afterAll(async () => {
 	else process.env.MOCK_MODE = savedMockMode;
 });
 
-test("empty start input hydrates every required field from persisted config", async () => {
-	const config = getConfig();
-	const previous = {
-		delay: config.delay,
-		pipeline: config.pipeline,
-		max_br: config.max_br,
-		srt_latency: config.srt_latency,
-		bitrate_overlay: config.bitrate_overlay,
-		srtla_addr: config.srtla_addr,
-		srtla_port: config.srtla_port,
-		srt_streamid: config.srt_streamid,
-		relay_server: config.relay_server,
-		relay_account: config.relay_account,
-		relay_protocol: config.relay_protocol,
+test("empty start input hydrates every required field without mutating its caller", async () => {
+	const params = {};
+	const result = await updateConfig(params);
+
+	expect(result).toMatchObject({
+		srtlaAddr: "127.0.0.1",
+		srtlaPort: 5000,
+		streamid: "persisted-stream",
+	});
+	expect(result.pipeline.source).toBe("test");
+	expect(params).toEqual({});
+	expect(getConfig()).toMatchObject({
+		delay: 137,
+		pipeline: "test",
+		max_br: 4321,
+		srt_latency: 2456,
+		bitrate_overlay: true,
+	});
+});
+
+test("only defined request fields override persisted values", () => {
+	const effective = mergePersistedStartConfig(getConfig(), {
+		delay: 222,
+		pipeline: undefined,
+	});
+
+	expect(effective.delay).toBe(222);
+	expect(effective.pipeline).toBe("test");
+});
+
+test("manual endpoint input clears a persisted managed relay and account", async () => {
+	Object.assign(getConfig(), {
+		relay_server: "managed",
+		relay_account: "account",
+		srtla_addr: undefined,
+		srtla_port: undefined,
+		srt_streamid: undefined,
+	});
+	const requested = {
+		srtla_addr: "127.0.0.2",
+		srtla_port: 6000,
+		srt_streamid: "manual-stream",
 	};
-	const configFile = await Bun.file("config.json").text();
+
+	const result = await updateConfig(requested);
+
+	expect(result).toMatchObject({
+		srtlaAddr: "127.0.0.2",
+		srtlaPort: 6000,
+		streamid: "manual-stream",
+	});
+	expect(getConfig()).toMatchObject({
+		srtla_addr: "127.0.0.2",
+		srtla_port: 6000,
+		srt_streamid: "manual-stream",
+	});
+	expect(getConfig().relay_server).toBeUndefined();
+	expect(getConfig().relay_account).toBeUndefined();
+	expect(requested).toEqual({
+		srtla_addr: "127.0.0.2",
+		srtla_port: 6000,
+		srt_streamid: "manual-stream",
+	});
+});
+
+test("managed relay input clears persisted manual endpoint fields", async () => {
+	const result = await updateConfig({
+		relay_server: "managed",
+		relay_account: "account",
+	});
+
+	expect(result).toMatchObject({
+		srtlaAddr: "127.0.0.3",
+		srtlaPort: 7000,
+		streamid: "managed-stream",
+	});
+	expect(getConfig()).toMatchObject({
+		relay_server: "managed",
+		relay_account: "account",
+	});
+	expect(getConfig().srtla_addr).toBeUndefined();
+	expect(getConfig().srtla_port).toBeUndefined();
+	expect(getConfig().srt_streamid).toBeUndefined();
+});
+
+test("unrelated partial input preserves the saved managed destination", async () => {
+	Object.assign(getConfig(), {
+		relay_server: "managed",
+		relay_account: "account",
+		srtla_addr: undefined,
+		srtla_port: undefined,
+		srt_streamid: undefined,
+	});
+
+	const result = await updateConfig({ max_br: 5678 });
+
+	expect(result).toMatchObject({
+		srtlaAddr: "127.0.0.3",
+		srtlaPort: 7000,
+		streamid: "managed-stream",
+	});
+	expect(getConfig()).toMatchObject({
+		max_br: 5678,
+		relay_server: "managed",
+		relay_account: "account",
+	});
+});
+
+test("explicit stream id overrides a persisted managed account", async () => {
+	Object.assign(getConfig(), {
+		relay_server: "managed",
+		relay_account: "account",
+		srtla_addr: undefined,
+		srtla_port: undefined,
+		srt_streamid: undefined,
+	});
+
+	const result = await updateConfig({ srt_streamid: "override-stream" });
+
+	expect(result.streamid).toBe("override-stream");
+	expect(getConfig().relay_account).toBeUndefined();
+	expect(getConfig().srt_streamid).toBe("override-stream");
+});
+
+test("schema projection excludes credential and unknown fields", () => {
+	const effective = mergePersistedStartConfig(
+		{
+			...getConfig(),
+			password_hash: "persisted-secret",
+			remote_key: "persisted-token",
+		},
+		{ max_br: 5555, password_hash: "request-secret" },
+	);
+
+	expect(effective.max_br).toBe(5555);
+	expect(effective).not.toHaveProperty("password_hash");
+	expect(effective).not.toHaveProperty("remote_key");
+});
+
+test("an invalid effective persisted config still fails validation", async () => {
+	getConfig().delay = undefined;
+	let failure: unknown;
 
 	try {
-		config.delay = 137;
-		config.pipeline = "test";
-		config.max_br = 4321;
-		config.srt_latency = 2456;
-		config.bitrate_overlay = true;
-		config.srtla_addr = "127.0.0.1";
-		config.srtla_port = 5000;
-		config.srt_streamid = "persisted-stream";
-		config.relay_server = undefined;
-		config.relay_account = undefined;
-		config.relay_protocol = "srtla";
-
-		const params = {};
-		const result = await updateConfig(params);
-
-		expect(result.pipeline.source).toBe("test");
-		expect(params).toEqual(
-			expect.objectContaining({
-				delay: 137,
-				pipeline: "test",
-				max_br: 4321,
-				srt_latency: 2456,
-				bitrate_overlay: true,
-				srtla_addr: "127.0.0.1",
-				srtla_port: 5000,
-				srt_streamid: "persisted-stream",
-			}),
-		);
-	} finally {
-		Object.assign(config, previous);
-		await Bun.write("config.json", configFile);
+		await updateConfig({});
+	} catch (error: unknown) {
+		failure = error;
 	}
+
+	expect(failure).toBeInstanceOf(Error);
+	if (!(failure instanceof Error))
+		throw new Error("expected updateConfig to fail");
+	expect(failure.message).toContain("Invalid audio delay");
 });

--- a/docs/RPC_COMMUNICATION.md
+++ b/docs/RPC_COMMUNICATION.md
@@ -525,6 +525,12 @@ The `reauthInFlight` flag prevents concurrent re-auth attempts.
 
 Setter procedures (`streaming.start`, `streaming.setConfig`, `streaming.setBitrate`, `network.configure`, etc.) return an `applied` object containing the post-clamp, server-validated values that were actually written. The client must not assume the input values were accepted verbatim.
 
+`streaming.start` is a partial-update exception to “send the whole form”: the server
+first projects the persisted stream configuration through the public input schema,
+then overlays the fields in the request. Sending `{}` therefore starts the saved
+configuration, while a partial object changes only the fields it states. Persisted
+non-stream fields never enter the start payload.
+
 Example — `streaming.setBitrate`:
 
 ```json

--- a/docs/RPC_COMMUNICATION.md
+++ b/docs/RPC_COMMUNICATION.md
@@ -528,8 +528,10 @@ Setter procedures (`streaming.start`, `streaming.setConfig`, `streaming.setBitra
 `streaming.start` is a partial-update exception to “send the whole form”: the server
 first projects the persisted stream configuration through the public input schema,
 then overlays the fields in the request. Sending `{}` therefore starts the saved
-configuration, while a partial object changes only the fields it states. Persisted
-non-stream fields never enter the start payload.
+configuration, while a partial object changes only its defined fields. A manual
+address/port clears the saved managed relay server and account; a managed server
+clears the saved manual address/port. Persisted non-stream fields never enter the
+start payload.
 
 Example — `streaming.setBitrate`:
 


### PR DESCRIPTION
## What

- Build each stream start from the persisted streaming configuration plus defined request overrides.
- Keep the merge behind the shared streamloop seam used by UI starts and `device.setProfile` reconnects.
- Preserve managed/manual endpoint and account/stream-ID precedence without mutating the caller input.
- Project both inputs through the public streaming schema so credentials and unrelated runtime fields cannot enter the effective start object.
- Document and regression-test the partial-start contract.

## Why

A real device calling `streaming.start({})` failed with `Invalid audio delay` because the backend validated the empty request directly instead of treating it as “start the saved configuration.” Partial requests had the same gap.

## How to verify

- `bun test apps/backend/src/tests/streaming-start-persisted-config.test.ts`
- `bun run --filter backend check`
- `bun run build:backend`
- Five-lane post-implementation review: goal, QA, code quality, security, and context all passed.

The broader backend suite previously completed with 5,637 passing tests and two unrelated `ENOSPC` inotify failures in the real-hotplug suite; the focused and adjacent streaming suites are green.

## Risks

The behavior change is limited to start-config assembly. A stated manual endpoint now drops a saved managed server/account pair, while a stated managed server drops saved manual address/port fields. The regression matrix covers both transitions, unrelated partial updates, explicit `undefined`, account/stream-ID precedence, credential exclusion, and invalid persisted configuration.