### PR TITLE
fix(streaming): preserve the engine audio codec default

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -147,8 +147,11 @@ not a clear. A stated manual endpoint clears both saved managed-relay fields
 (`relay_server` and `relay_account`), while a stated managed server clears the
 saved manual address and port. The schema projection is the
 credential boundary: never replace it with `{...getConfig()}`, which would put
-non-stream fields such as device credentials on the applied-start object. Keep the
-merge below the RPC layer so every start origin receives identical behavior.
+non-stream fields such as device credentials on the applied-start object. `acodec`
+remains optional: when neither the request nor persisted config states one,
+validation leaves it absent so cerastream applies its engine default; an explicitly
+stated codec is still checked against the supported codec registry. Keep the merge
+below the RPC layer so every start origin receives identical behavior.
 
 ## AUDIO-DEVICE NAMING [EXISTS]
 

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -167,7 +167,9 @@ All setters return `{ success: boolean, applied: <fields> }`. The `applied` obje
 `streaming.start` accepts a partial config. An empty `{}` starts from the complete
 persisted stream configuration; defined fields override only their saved counterparts.
 A manual address/port switches away from both saved managed-relay fields, while a
-managed relay server switches away from the saved manual address/port.
+managed relay server switches away from the saved manual address/port. An omitted
+audio codec remains omitted and uses cerastream's engine default; only an explicitly
+stated codec is registry-validated.
 The merge occurs in the shared streamloop update seam, so UI starts and control-channel
 reconnects have the same semantics.
 

--- a/apps/backend/src/modules/streaming/streaming.ts
+++ b/apps/backend/src/modules/streaming/streaming.ts
@@ -164,9 +164,7 @@ export async function validateConfig(params: Partial<ConfigParameters>) {
 	}
 
 	// audio codec
-	if (pipeline.supportsAudio) {
-		if (typeof validated.acodec !== "string")
-			throw new Error("Invalid audio codec");
+	if (pipeline.supportsAudio && validated.acodec !== undefined) {
 		if (!(validated.acodec in AUDIO_CODECS))
 			throw new Error("Audio codec not found");
 	}

--- a/apps/backend/src/tests/streaming-start-optional-acodec.test.ts
+++ b/apps/backend/src/tests/streaming-start-optional-acodec.test.ts
@@ -1,0 +1,96 @@
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	expect,
+	test,
+} from "bun:test";
+
+import {
+	type GetCapabilitiesResult,
+	SCHEMA_VERSION,
+} from "@ceralive/cerastream";
+import { initMockService, stopMockService } from "../mocks/mock-service.ts";
+import { getConfig } from "../modules/config.ts";
+import {
+	initPipelines,
+	setMockHardware,
+} from "../modules/streaming/pipelines.ts";
+import { updateConfig } from "../modules/streaming/streaming.ts";
+
+const CAPS: GetCapabilitiesResult = {
+	platform: {
+		supports_h265: true,
+		hardware_accelerated: true,
+		max_resolution: "2160p",
+	},
+	encoder: {
+		codecs: ["h264", "h265"],
+		bitrate_range: { min: 500, max: 50000, unit: "kbps" },
+	},
+	sources: [
+		{
+			id: "hdmi",
+			supports_audio: true,
+			supports_resolution_override: true,
+			supports_framerate_override: true,
+			default_resolution: "1080p",
+			default_framerate: 30,
+		},
+	],
+};
+
+const savedMockMode = process.env.MOCK_MODE;
+let previousConfig: ReturnType<typeof getConfig>;
+let configFile = "";
+
+beforeAll(async () => {
+	process.env.MOCK_MODE = "true";
+	initMockService("caps-full");
+	setMockHardware("rk3588");
+	await initPipelines({
+		fetchEngineCapabilities: async () => ({
+			caps: CAPS,
+			schemaVersion: SCHEMA_VERSION,
+		}),
+		fetchEngineDevices: async () => ({ devices: [] }),
+	});
+});
+
+beforeEach(async () => {
+	previousConfig = structuredClone(getConfig());
+	configFile = await Bun.file("config.json").text();
+	Object.assign(getConfig(), {
+		delay: 0,
+		pipeline: "hdmi",
+		max_br: 5000,
+		srt_latency: 2000,
+		bitrate_overlay: false,
+		asrc: "Auto",
+		acodec: undefined,
+		srtla_addr: "127.0.0.1",
+		srtla_port: 5000,
+		srt_streamid: "persisted-stream",
+	});
+});
+
+afterEach(async () => {
+	Object.assign(getConfig(), previousConfig);
+	await Bun.write("config.json", configFile);
+});
+
+afterAll(async () => {
+	stopMockService();
+	setMockHardware("rk3588");
+	await initPipelines();
+	if (savedMockMode === undefined) delete process.env.MOCK_MODE;
+	else process.env.MOCK_MODE = savedMockMode;
+});
+
+test("empty start input leaves an omitted optional audio codec to the engine default", async () => {
+	const result = await updateConfig({});
+
+	expect(result.pipeline.source).toBe("hdmi");
+	expect(getConfig().acodec).toBeUndefined();
+});


### PR DESCRIPTION
## What
- allow persisted starts to omit `acodec` and leave codec choice to cerastream
- keep explicit codec parsing and registry validation intact
- add a regression test and document the optional-codec contract

## Why
After PR #315 fixed persisted-config hydration, a real Orange Pi config with no saved codec advanced to validation and failed `streaming.start({})` with `Invalid audio codec`. The wire and engine contracts already define the codec as optional.

## How to verify
- `bun test apps/backend/src/tests/streaming-start-persisted-config.test.ts apps/backend/src/tests/streaming-start-optional-acodec.test.ts apps/backend/src/tests/audio-codec-transport.test.ts`
- `bun run --filter backend check`
- `BUILD_ARCH=arm64 bun run build:backend`

## Risks
Low. The change only removes the mandatory-presence check. Explicit values still cross the strict Zod enum and codec registry, and codec persistence remains conditional.