### PR TITLE
fix(streaming): wait for engine stop acknowledgement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1398,11 +1398,16 @@ connect-phase `start_timeout` so a hung engine call cannot hold the lifecycle sl
 The prior launch must settle after cleanup before backoff is armed; if it does not
 settle within the cleanup bound, `start_cleanup_timeout` is terminal and no later
 attempt is launched.
-Cerastream stop is the deliberate exception to the backend IPC queue: it is sent
-immediately through the active client so cleanup cannot wait behind the launch it
-must interrupt. The client is then closed without waiting for a stop reply; this
-settles pending start/stop requests and releases the serialized queue even when a
-crashed engine can no longer answer.
+Cerastream stop is the deliberate exception to the backend IPC queue: it opens a
+fresh control connection and dispatches `stop` there before closing the session
+client. The engine serves only one request at a time per connection, so reusing the
+session client can leave `stop` unread behind `list-devices` or an in-flight start;
+closing that socket then discards the queued stop while the engine keeps streaming.
+The fresh connection lets CeraUI close the old client to interrupt local pending
+work without withdrawing the engine request. `onStopped` fires only after that
+request answers `state: "idle"`; connect/RPC failure leaves the callback unresolved
+and the orchestrator's 12-second bound returns typed `stop_failed` instead of a
+false success.
 Suppression reads only existing update, engine capability, and boot-uptime signals;
 suppressed attempts remain `starting` and emit no error toast. Structured retry and
 terminal records carry attempt id, phase, class, optional engine code, and retry

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1405,9 +1405,11 @@ session client can leave `stop` unread behind `list-devices` or an in-flight sta
 closing that socket then discards the queued stop while the engine keeps streaming.
 The fresh connection lets CeraUI close the old client to interrupt local pending
 work without withdrawing the engine request. `onStopped` fires only after that
-request answers `state: "idle"`; connect/RPC failure leaves the callback unresolved
-and the orchestrator's 12-second bound returns typed `stop_failed` instead of a
-false success.
+request answers `state: "idle"`. The connect-plus-acknowledgement budget is derived
+as 7 seconds, reserving the remaining 5 seconds of the unchanged 12-second stop
+bound for cleanup. A connection resolving after that request deadline is closed
+without dispatching `stop`, and a pending stop connection is closed, so neither can
+mutate the engine or invoke the callback after typed `stop_failed` has returned.
 Suppression reads only existing update, engine capability, and boot-uptime signals;
 suppressed attempts remain `starting` and emit no error toast. Structured retry and
 terminal records carry attempt id, phase, class, optional engine code, and retry

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1406,10 +1406,12 @@ closing that socket then discards the queued stop while the engine keeps streami
 The fresh connection lets CeraUI close the old client to interrupt local pending
 work without withdrawing the engine request. `onStopped` fires only after that
 request answers `state: "idle"`. The connect-plus-acknowledgement budget is derived
-as 7 seconds, reserving the remaining 5 seconds of the unchanged 12-second stop
-bound for cleanup. A connection resolving after that request deadline is closed
-without dispatching `stop`, and a pending stop connection is closed, so neither can
-mutate the engine or invoke the callback after typed `stop_failed` has returned.
+as 6.5 seconds, reserving 5 seconds for cleanup and a 0.5-second scheduling margin
+inside the unchanged 12-second outer bound. A connection resolving after that
+request deadline is closed without dispatching `stop`; a pending stop connection
+is closed and cannot invoke the callback. An already-dispatched request may still
+settle in the engine, so timeout leaves engine state unknown and reconciliation
+adopts its eventual truth after typed `stop_failed`.
 Suppression reads only existing update, engine capability, and boot-uptime signals;
 suppressed attempts remain `starting` and emit no error toast. Structured retry and
 terminal records carry attempt id, phase, class, optional engine code, and retry

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ A dev-only DevTools destination is available in development builds.
 - **Acknowledged stream stops**: the backend reports a stop only after cerastream
   confirms it is idle; an unrelated in-flight engine request cannot swallow Stop
   while the media session continues in the background. The request and cleanup
-  remain inside the existing 12-second bound, and a late connection is closed
-  without dispatching a stale stop.
+  budgets leave an explicit margin inside the existing 12-second bound, and a
+  late, undispatched connection is closed without sending a stale stop.
 - **Capability-gated AP+STA WiFi**: proven radios can keep their station link while
   hosting a hotspot; unsupported or unreadable drivers retain the honest exclusive
   switch. Physical-radio validation is still pending; see

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ A dev-only DevTools destination is available in development builds.
 - **Responsive**: desktop and mobile layouts with a persistent bottom HUD dock on mobile
 - **Acknowledged stream stops**: the backend reports a stop only after cerastream
   confirms it is idle; an unrelated in-flight engine request cannot swallow Stop
-  while the media session continues in the background.
+  while the media session continues in the background. The request and cleanup
+  remain inside the existing 12-second bound, and a late connection is closed
+  without dispatching a stale stop.
 - **Capability-gated AP+STA WiFi**: proven radios can keep their station link while
   hosting a hotspot; unsupported or unreadable drivers retain the honest exclusive
   switch. Physical-radio validation is still pending; see

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ A dev-only DevTools destination is available in development builds.
 - **Internationalization**: 10 languages with full RTL support
 - **Touch/kiosk mode**: `?mode=touch` URL flag scales touch targets to 44px minimum
 - **Responsive**: desktop and mobile layouts with a persistent bottom HUD dock on mobile
+- **Acknowledged stream stops**: the backend reports a stop only after cerastream
+  confirms it is idle; an unrelated in-flight engine request cannot swallow Stop
+  while the media session continues in the background.
 - **Capability-gated AP+STA WiFi**: proven radios can keep their station link while
   hosting a hotspot; unsupported or unreadable drivers retain the honest exclusive
   switch. Physical-radio validation is still pending; see

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -8195,12 +8195,15 @@ state where CeraUI returned `stopped`, the engine kept reconnecting egress, and 
 frame watchdog later aborted it. `CerastreamBackend.stop()` now connects a fresh
 client, dispatches stop there, closes the old session client, awaits the fresh
 client's `state: "idle"` response, closes it, and only then invokes `onStopped`.
-The connect-plus-acknowledgement request gets 7 seconds, derived by reserving
-`ENGINE_CLOSE_DEADLINE_MS` (5 seconds) inside the unchanged 12-second orchestrator
-bound. Expiry fences the request: a connection that resolves later is closed before
-it can dispatch, while an already-dispatched but unacknowledged stop connection is
-closed. Failure never invokes the callback, so no late operation can mutate the
-engine after the orchestrator reports `stop_failed`. Coverage:
+The connect-plus-acknowledgement request gets 6.5 seconds, derived by reserving
+`ENGINE_CLOSE_DEADLINE_MS` (5 seconds) plus
+`ENGINE_STOP_DEADLINE_MARGIN_MS` (0.5 seconds) inside the unchanged 12-second
+orchestrator bound. Expiry fences a connection that has not dispatched: if it
+resolves later, it is closed before `stop()` is called. An already-dispatched but
+unacknowledged stop connection is closed and never invokes the callback, but the
+engine may still finish work already written to that socket; its state is therefore
+unknown, and the orchestrator reports `stop_failed` before reconciliation adopts
+the eventual truth. Coverage:
 `tests/cerastream-stop-ack.test.ts` drives a blocked session request and controls
 the independent stop acknowledgement; `tests/cerastream-stop-deadline.test.ts`
 drives both late-connect and unacknowledged-RPC expiry.

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -8186,6 +8186,20 @@ clears `active` first) are all deliberately NOT proof.
 Net effect: the board lands in a real `idle` and the next `streaming.start` dials
 a fresh connection and succeeds — no `ceralive.service` restart.
 
+**STOP uses a second connection, and success means engine Idle.** The IPC server
+dispatches at most one request per connection. Reusing the session client for
+`stop`, then closing it to interrupt pending work, can leave the stop line unread
+behind `list-devices` or start; the server finishes the first call, fails its reply
+to the closed peer, and exits without dispatching stop. That produced a real board
+state where CeraUI returned `stopped`, the engine kept reconnecting egress, and the
+frame watchdog later aborted it. `CerastreamBackend.stop()` now connects a fresh
+client, dispatches stop there, closes the old session client, awaits the fresh
+client's `state: "idle"` response, closes it, and only then invokes `onStopped`.
+Failure never invokes the callback, so the orchestrator's stop deadline reports
+`stop_failed` instead of claiming teardown. Coverage:
+`tests/cerastream-stop-ack.test.ts` drives a blocked session request and controls
+the independent stop acknowledgement.
+
 **Scoped OUT, deliberately:** there is no transparent mid-session reconnect that
 resumes the running stream. It is not achievable against this engine — a
 restarted cerastream has no session to resume — and would need engine-side

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -8195,10 +8195,15 @@ state where CeraUI returned `stopped`, the engine kept reconnecting egress, and 
 frame watchdog later aborted it. `CerastreamBackend.stop()` now connects a fresh
 client, dispatches stop there, closes the old session client, awaits the fresh
 client's `state: "idle"` response, closes it, and only then invokes `onStopped`.
-Failure never invokes the callback, so the orchestrator's stop deadline reports
-`stop_failed` instead of claiming teardown. Coverage:
+The connect-plus-acknowledgement request gets 7 seconds, derived by reserving
+`ENGINE_CLOSE_DEADLINE_MS` (5 seconds) inside the unchanged 12-second orchestrator
+bound. Expiry fences the request: a connection that resolves later is closed before
+it can dispatch, while an already-dispatched but unacknowledged stop connection is
+closed. Failure never invokes the callback, so no late operation can mutate the
+engine after the orchestrator reports `stop_failed`. Coverage:
 `tests/cerastream-stop-ack.test.ts` drives a blocked session request and controls
-the independent stop acknowledgement.
+the independent stop acknowledgement; `tests/cerastream-stop-deadline.test.ts`
+drives both late-connect and unacknowledged-RPC expiry.
 
 **Scoped OUT, deliberately:** there is no transparent mid-session reconnect that
 resumes the running stream. It is not achievable against this engine — a

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -185,7 +185,10 @@ Stop uses a fresh, short-lived cerastream control connection. The engine process
 one request at a time per connection, so sending stop on the session connection and
 then closing it can discard an unread stop behind another RPC. The backend dispatches
 stop independently, closes the old session client to interrupt pending local work,
-and signals completion only after the engine replies with its idle state.
+and signals completion only after the engine replies with its idle state. The
+connect-plus-acknowledgement request is bounded at 7 seconds, leaving 5 seconds of
+the unchanged 12-second lifecycle bound for cleanup; a connection resolving after
+that request deadline is closed before it can dispatch a stale stop.
 
 ### Broadcast Events
 

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -186,9 +186,12 @@ one request at a time per connection, so sending stop on the session connection 
 then closing it can discard an unread stop behind another RPC. The backend dispatches
 stop independently, closes the old session client to interrupt pending local work,
 and signals completion only after the engine replies with its idle state. The
-connect-plus-acknowledgement request is bounded at 7 seconds, leaving 5 seconds of
-the unchanged 12-second lifecycle bound for cleanup; a connection resolving after
-that request deadline is closed before it can dispatch a stale stop.
+connect-plus-acknowledgement request is bounded at 6.5 seconds, leaving 5 seconds
+for cleanup and a 0.5-second scheduling margin inside the unchanged 12-second
+lifecycle bound. A connection resolving after the request deadline is closed
+before it can dispatch. If an already-dispatched request misses acknowledgement,
+its outcome is unknown and the lifecycle reconciles engine truth after
+`stop_failed`.
 
 ### Broadcast Events
 

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -181,6 +181,12 @@ reconciliation adopts a stream that survived a backend process restart. A timeou
 query error, or contradictory engine status stays `reconciling`; the reconnect-heal
 path retries instead of publishing a false idle state.
 
+Stop uses a fresh, short-lived cerastream control connection. The engine processes
+one request at a time per connection, so sending stop on the session connection and
+then closing it can discard an unread stop behind another RPC. The backend dispatches
+stop independently, closes the old session client to interrupt pending local work,
+and signals completion only after the engine replies with its idle state.
+
 ### Broadcast Events
 
 The backend pushes typed events to all connected clients via `src/rpc/events.ts`. Each event type carries a monotonic `seq` counter that resets on server restart.

--- a/apps/backend/src/modules/streaming/cerastream-backend.ts
+++ b/apps/backend/src/modules/streaming/cerastream-backend.ts
@@ -822,11 +822,14 @@ export class CerastreamBackend implements StreamingBackend {
 		});
 		try {
 			await Promise.race([
-				client.close().catch((error: unknown) => {
-					this.deps.logger.debug("cerastream: control socket already closing", {
-						error,
-					});
-				}),
+				Promise.resolve()
+					.then(() => client.close())
+					.catch((error: unknown) => {
+						this.deps.logger.debug(
+							"cerastream: control socket already closing",
+							{ error },
+						);
+					}),
 				bound,
 			]);
 		} finally {

--- a/apps/backend/src/modules/streaming/cerastream-backend.ts
+++ b/apps/backend/src/modules/streaming/cerastream-backend.ts
@@ -134,7 +134,10 @@ import {
 	type LaunchTransaction,
 } from "./launch-transaction.ts";
 import { asRawRequestClient } from "./raw-request.ts";
-import { ENGINE_CLOSE_DEADLINE_MS } from "./start-lifecycle-timing.ts";
+import {
+	ENGINE_CLOSE_DEADLINE_MS,
+	ENGINE_STOP_REQUEST_DEADLINE_MS,
+} from "./start-lifecycle-timing.ts";
 import type {
 	BackendErrorListener,
 	BitrateParams,
@@ -831,6 +834,46 @@ export class CerastreamBackend implements StreamingBackend {
 		}
 	}
 
+	private async stopOnFreshConnection(
+		sessionClient: CerastreamClient | undefined,
+	): Promise<void> {
+		let deadlineExpired = false;
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		let stopClient: CerastreamClient | undefined;
+		let sessionClose: Promise<void> | undefined;
+		const request = (async () => {
+			const candidate = await this.deps.connect(this.deps.connectOptions);
+			if (deadlineExpired) {
+				await this.closeWithinDeadline(candidate);
+				throw new Error("stop_timeout");
+			}
+			stopClient = candidate;
+			const confirmation = candidate.stop();
+			sessionClose = this.closeWithinDeadline(sessionClient);
+			await confirmation;
+		})();
+		const deadline = new Promise<never>((_resolve, reject) => {
+			timer = this.deps.scheduleTimeout(() => {
+				deadlineExpired = true;
+				reject(new Error("stop_timeout"));
+			}, ENGINE_STOP_REQUEST_DEADLINE_MS);
+		});
+
+		try {
+			await Promise.race([request, deadline]);
+		} finally {
+			if (timer !== undefined) this.deps.cancelTimeout(timer);
+			const closeSession =
+				sessionClose ?? this.closeWithinDeadline(sessionClient);
+			await Promise.all([
+				closeSession,
+				stopClient === sessionClient
+					? Promise.resolve()
+					: this.closeWithinDeadline(stopClient),
+			]);
+		}
+	}
+
 	stop(onStopped: () => void): boolean {
 		if (!this.active) return false;
 		this.active = false;
@@ -846,16 +889,9 @@ export class CerastreamBackend implements StreamingBackend {
 		const subscription = this.subscription;
 		const operation = (async () => {
 			subscription?.close();
-			let stopClient: CerastreamClient | undefined;
-			let sessionCloseStarted = false;
 			try {
-				stopClient = await this.deps.connect(this.deps.connectOptions);
-				const stopConfirmation = stopClient.stop();
-				sessionCloseStarted = true;
-				await Promise.all([stopConfirmation, this.closeWithinDeadline(client)]);
+				await this.stopOnFreshConnection(client);
 			} finally {
-				if (!sessionCloseStarted) await this.closeWithinDeadline(client);
-				if (stopClient !== client) await this.closeWithinDeadline(stopClient);
 				if (this.client === client) this.client = undefined;
 				if (this.subscription === subscription) this.subscription = undefined;
 			}

--- a/apps/backend/src/modules/streaming/cerastream-backend.ts
+++ b/apps/backend/src/modules/streaming/cerastream-backend.ts
@@ -673,7 +673,7 @@ export class CerastreamBackend implements StreamingBackend {
 	// so a blind remove-by-name would retract whichever error happens to be
 	// standing rather than the one the recovery signal actually falsifies.
 	private standingEngineError: ResolvedCerastreamError | undefined;
-	// Serializes non-stop IPC ops; stop interrupts a pending start through its client.
+	// Serializes non-stop IPC ops; stop uses a fresh client so this queue cannot hide it.
 	private queue: Promise<void> = Promise.resolve();
 	private interrupt: Promise<void> = Promise.resolve();
 
@@ -803,10 +803,10 @@ export class CerastreamBackend implements StreamingBackend {
 	// A close that never answers is no more informative than one that rejects —
 	// which this path already treats as "proceed" — so bound it and let the stop
 	// complete either way rather than stranding the session.
-	private closeWithinDeadline(
+	private async closeWithinDeadline(
 		client: CerastreamClient | undefined,
 	): Promise<void> {
-		if (client === undefined) return Promise.resolve();
+		if (client === undefined) return;
 		let timer: ReturnType<typeof setTimeout> | undefined;
 		const bound = new Promise<void>((resolve) => {
 			timer = this.deps.scheduleTimeout(() => {
@@ -817,9 +817,18 @@ export class CerastreamBackend implements StreamingBackend {
 				resolve();
 			}, ENGINE_CLOSE_DEADLINE_MS);
 		});
-		return Promise.race([client.close(), bound]).finally(() => {
+		try {
+			await Promise.race([
+				client.close().catch((error: unknown) => {
+					this.deps.logger.debug("cerastream: control socket already closing", {
+						error,
+					});
+				}),
+				bound,
+			]);
+		} finally {
 			if (timer !== undefined) this.deps.cancelTimeout(timer);
-		});
+		}
 	}
 
 	stop(onStopped: () => void): boolean {
@@ -837,20 +846,20 @@ export class CerastreamBackend implements StreamingBackend {
 		const subscription = this.subscription;
 		const operation = (async () => {
 			subscription?.close();
-			void client?.stop().catch((error) => {
-				this.deps.logger.debug("cerastream: stop request interrupted", {
-					error,
-				});
-			});
+			let stopClient: CerastreamClient | undefined;
+			let sessionCloseStarted = false;
 			try {
-				await this.closeWithinDeadline(client);
-			} catch {
-				// already closing
+				stopClient = await this.deps.connect(this.deps.connectOptions);
+				const stopConfirmation = stopClient.stop();
+				sessionCloseStarted = true;
+				await Promise.all([stopConfirmation, this.closeWithinDeadline(client)]);
 			} finally {
+				if (!sessionCloseStarted) await this.closeWithinDeadline(client);
+				if (stopClient !== client) await this.closeWithinDeadline(stopClient);
 				if (this.client === client) this.client = undefined;
 				if (this.subscription === subscription) this.subscription = undefined;
-				onStopped();
 			}
+			onStopped();
 		})();
 		this.interrupt = operation.catch((error) =>
 			this.handleOpFailure("stop", error),

--- a/apps/backend/src/modules/streaming/start-lifecycle-timing.ts
+++ b/apps/backend/src/modules/streaming/start-lifecycle-timing.ts
@@ -30,6 +30,15 @@ export const STOP_DEADLINE_MS = 12_000;
 export const ENGINE_CLOSE_DEADLINE_MS = 5_000;
 
 /**
+ * Shared budget for opening the independent stop connection and receiving the
+ * engine's Idle acknowledgement. The remaining stop budget is reserved for
+ * bounded socket cleanup, so a timed-out connection can never dispatch a stale
+ * stop after the orchestrator has already reported `stop_failed`.
+ */
+export const ENGINE_STOP_REQUEST_DEADLINE_MS =
+	STOP_DEADLINE_MS - ENGINE_CLOSE_DEADLINE_MS;
+
+/**
  * Outer bound on `reconfiguring`: the engine's declared worst-case transaction
  * PLUS one stop bound, because a stop requested mid-transaction queues behind it
  * and must still get its own full deadline afterwards. Never apply

--- a/apps/backend/src/modules/streaming/start-lifecycle-timing.ts
+++ b/apps/backend/src/modules/streaming/start-lifecycle-timing.ts
@@ -29,14 +29,16 @@ export const STOP_DEADLINE_MS = 12_000;
  */
 export const ENGINE_CLOSE_DEADLINE_MS = 5_000;
 
+export const ENGINE_STOP_DEADLINE_MARGIN_MS = 500;
+
 /**
  * Shared budget for opening the independent stop connection and receiving the
- * engine's Idle acknowledgement. The remaining stop budget is reserved for
- * bounded socket cleanup, so a timed-out connection can never dispatch a stale
- * stop after the orchestrator has already reported `stop_failed`.
+ * engine's Idle acknowledgement. The remaining stop budget covers bounded
+ * socket cleanup plus an explicit scheduling margin, so internal timers settle
+ * ahead of the orchestrator's outer deadline.
  */
 export const ENGINE_STOP_REQUEST_DEADLINE_MS =
-	STOP_DEADLINE_MS - ENGINE_CLOSE_DEADLINE_MS;
+	STOP_DEADLINE_MS - ENGINE_CLOSE_DEADLINE_MS - ENGINE_STOP_DEADLINE_MARGIN_MS;
 
 /**
  * Outer bound on `reconfiguring`: the engine's declared worst-case transaction

--- a/apps/backend/src/tests/cerastream-stop-ack.test.ts
+++ b/apps/backend/src/tests/cerastream-stop-ack.test.ts
@@ -1,0 +1,214 @@
+import { expect, test } from "bun:test";
+
+import type {
+	CaptureDevice,
+	CerastreamClient,
+	EventParams,
+	ListDevicesResult,
+	StartResult,
+} from "@ceralive/cerastream";
+import type { RuntimeConfig } from "../helpers/config-schemas.ts";
+import {
+	CerastreamBackend,
+	type CerastreamBackendDeps,
+} from "../modules/streaming/cerastream-backend.ts";
+import type { StreamRunOptions } from "../modules/streaming/streaming-backend.ts";
+
+const STREAM_CONFIG: RuntimeConfig = {
+	max_br: 8_000,
+	srt_latency: 2_000,
+	balancer: "adaptive",
+	pipeline: "test",
+};
+
+const RUN_OPTIONS: StreamRunOptions = {
+	pipeline: "test",
+	host: "127.0.0.1",
+	port: 9_000,
+	streamid: "test",
+};
+
+const CAPTURE_DEVICE: CaptureDevice = {
+	input_id: "cam0",
+	device_path: "/dev/video0",
+	display_name: "Capture 0",
+	media_class: "video",
+};
+
+interface Deferred<Value> {
+	readonly promise: Promise<Value>;
+	readonly resolve: (value: Value) => void;
+	readonly reject: (error: Error) => void;
+}
+
+function deferred<Value>(): Deferred<Value> {
+	let resolvePromise: (value: Value) => void = () => undefined;
+	let rejectPromise: (error: Error) => void = () => undefined;
+	const promise = new Promise<Value>((resolve, reject) => {
+		resolvePromise = resolve;
+		rejectPromise = reject;
+	});
+	return { promise, resolve: resolvePromise, reject: rejectPromise };
+}
+
+interface FakeClientOptions {
+	readonly name: string;
+	readonly trace: string[];
+	readonly stopGate?: Promise<{ state: "idle" }>;
+	readonly listGate?: Promise<ListDevicesResult>;
+}
+
+function makeClient(options: FakeClientOptions): CerastreamClient {
+	const closed = deferred<never>();
+	const record = (operation: string): void => {
+		options.trace.push(`${options.name}:${operation}`);
+	};
+	return {
+		hello: {
+			protocol: "cerastream-ipc/1",
+			schema_version: "0.1.0",
+			engine_version: "test",
+		},
+		start: async (): Promise<StartResult> => {
+			record("start");
+			return { session_id: "session-1", state: "streaming" };
+		},
+		stop: async () => {
+			record("stop");
+			if (options.stopGate === undefined) return { state: "idle" };
+			return await Promise.race([options.stopGate, closed.promise]);
+		},
+		reloadConfig: async (params) => ({ applied: params }),
+		setBitrate: async (params) => ({
+			applied: { max_bitrate: params.max_bitrate },
+		}),
+		switchInput: async (params) => ({
+			active_input: params.input_id,
+			mode: params.mode,
+		}),
+		listDevices: async () => {
+			record("list-devices");
+			if (options.listGate === undefined) {
+				return { devices: [CAPTURE_DEVICE] };
+			}
+			return await Promise.race([options.listGate, closed.promise]);
+		},
+		getCapabilities: async () => ({
+			platform: {
+				supports_h265: true,
+				hardware_accelerated: true,
+				max_resolution: "1920x1080",
+			},
+			encoder: {
+				codecs: ["h264", "h265"],
+				bitrate_range: { min: 500, max: 50_000, unit: "kbps" },
+			},
+			sources: [],
+		}),
+		changeConfig: async () => ({
+			attempt_id: "change-1",
+			phase: "applied",
+			state: "streaming",
+		}),
+		previewSession: async () => ({
+			session_id: "preview-1",
+			tier: "webcodecs",
+			transport: {
+				kind: "uds-binary",
+				socket: "/run/cerastream/preview.sock",
+			},
+		}),
+		subscribeEvents: async (
+			_params,
+			_listener: (event: EventParams) => void,
+		) => ({
+			result: { subscribed: ["status"] },
+			close: () => record("unsubscribe"),
+		}),
+		close: async () => {
+			record("close");
+			closed.reject(new Error(`${options.name}_closed`));
+		},
+	};
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+	for (let attempt = 0; attempt < 50; attempt += 1) {
+		if (predicate()) return;
+		await Bun.sleep(0);
+	}
+	expect(predicate()).toBe(true);
+}
+
+test("stop is not acknowledged until a separately dispatched engine stop reaches idle", async () => {
+	// Given one session connection occupied by a device-list request and a fresh
+	// stop connection whose engine acknowledgement is controlled by the test.
+	const trace: string[] = [];
+	const pendingList = deferred<ListDevicesResult>();
+	const queuedSessionStop = deferred<{ state: "idle" }>();
+	const stopAcknowledgement = deferred<{ state: "idle" }>();
+	const sessionClient = makeClient({
+		name: "session",
+		trace,
+		listGate: pendingList.promise,
+		stopGate: queuedSessionStop.promise,
+	});
+	const stopClient = makeClient({
+		name: "stop",
+		trace,
+		stopGate: stopAcknowledgement.promise,
+	});
+	let connection = 0;
+	const logger: CerastreamBackendDeps["logger"] = {
+		debug() {},
+		info() {},
+		warn() {},
+		error() {},
+	};
+	const backend = new CerastreamBackend({
+		connect: async () => {
+			connection += 1;
+			return connection === 1 ? sessionClient : stopClient;
+		},
+		connectOptions: {},
+		getConfig: () => STREAM_CONFIG,
+		saveConfig: () => undefined,
+		bridge: {
+			notify: () => undefined,
+			notificationExists: () => false,
+			removeNotification: () => undefined,
+			broadcastStatus: () => undefined,
+			broadcastBuffering: () => undefined,
+		},
+		execPath: "cerastream",
+		configPath: "/tmp/cerastream-stop-ack.json",
+		logger,
+	});
+	await backend.start(STREAM_CONFIG, RUN_OPTIONS);
+	const listing = backend.listDevices().catch((error: unknown) => error);
+	await waitFor(() => trace.includes("session:list-devices"));
+	let stopped = false;
+
+	// When stop begins while the original connection cannot read another request.
+	expect(
+		backend.stop(() => {
+			stopped = true;
+		}),
+	).toBe(true);
+	await waitFor(() => trace.includes("session:close"));
+	await Bun.sleep(0);
+	const acknowledgedBeforeIdle = stopped;
+	const stopConnectionClosedBeforeIdle = trace.includes("stop:close");
+	stopAcknowledgement.resolve({ state: "idle" });
+	await backend.settle();
+	await listing;
+
+	// Then CeraUI reports stopped only after the independent stop reaches Idle.
+	expect(acknowledgedBeforeIdle).toBe(false);
+	expect(stopConnectionClosedBeforeIdle).toBe(false);
+	expect(trace).toContain("stop:stop");
+	expect(trace).not.toContain("session:stop");
+	expect(trace).toContain("stop:close");
+	expect(connection).toBe(2);
+	expect(stopped).toBe(true);
+});

--- a/apps/backend/src/tests/cerastream-stop-deadline.test.ts
+++ b/apps/backend/src/tests/cerastream-stop-deadline.test.ts
@@ -1,0 +1,201 @@
+import { expect, test } from "bun:test";
+
+import type {
+	CerastreamClient,
+	EventParams,
+	StartResult,
+} from "@ceralive/cerastream";
+import type { RuntimeConfig } from "../helpers/config-schemas.ts";
+import {
+	CerastreamBackend,
+	type CerastreamBackendDeps,
+} from "../modules/streaming/cerastream-backend.ts";
+import { ENGINE_STOP_REQUEST_DEADLINE_MS } from "../modules/streaming/start-lifecycle-timing.ts";
+
+const CONFIG: RuntimeConfig = {
+	max_br: 8_000,
+	srt_latency: 2_000,
+	balancer: "adaptive",
+	pipeline: "test",
+};
+
+interface Deferred<Value> {
+	readonly promise: Promise<Value>;
+	readonly resolve: (value: Value) => void;
+}
+
+function deferred<Value>(): Deferred<Value> {
+	let resolvePromise: (value: Value) => void = () => undefined;
+	const promise = new Promise<Value>((resolve) => {
+		resolvePromise = resolve;
+	});
+	return { promise, resolve: resolvePromise };
+}
+
+function fakeClient(
+	name: string,
+	trace: string[],
+	stopGate?: Promise<{ state: "idle" }>,
+): CerastreamClient {
+	const closed = deferred<never>();
+	return {
+		hello: {
+			protocol: "cerastream-ipc/1",
+			schema_version: "0.1.0",
+			engine_version: "test",
+		},
+		start: async (): Promise<StartResult> => ({
+			session_id: "session-1",
+			state: "streaming",
+		}),
+		stop: async () => {
+			trace.push(`${name}:stop`);
+			return stopGate === undefined
+				? { state: "idle" }
+				: await Promise.race([stopGate, closed.promise]);
+		},
+		reloadConfig: async (params) => ({ applied: params }),
+		setBitrate: async (params) => ({
+			applied: { max_bitrate: params.max_bitrate },
+		}),
+		switchInput: async (params) => ({
+			active_input: params.input_id,
+			mode: params.mode,
+		}),
+		listDevices: async () => ({ devices: [] }),
+		getCapabilities: async () => ({
+			platform: {
+				supports_h265: true,
+				hardware_accelerated: true,
+				max_resolution: "1920x1080",
+			},
+			encoder: {
+				codecs: ["h264", "h265"],
+				bitrate_range: { min: 500, max: 50_000, unit: "kbps" },
+			},
+			sources: [],
+		}),
+		changeConfig: async () => ({
+			attempt_id: "change-1",
+			phase: "applied",
+			state: "streaming",
+		}),
+		previewSession: async () => ({
+			session_id: "preview-1",
+			tier: "webcodecs",
+			transport: {
+				kind: "uds-binary",
+				socket: "/run/cerastream/preview.sock",
+			},
+		}),
+		subscribeEvents: async (
+			_params,
+			_listener: (event: EventParams) => void,
+		) => ({ result: { subscribed: ["status"] }, close: () => undefined }),
+		close: async () => {
+			trace.push(`${name}:close`);
+		},
+	};
+}
+
+function backendWithTimers(
+	connect: CerastreamBackendDeps["connect"],
+	deadlines: Map<number, () => void>,
+): CerastreamBackend {
+	const logger: CerastreamBackendDeps["logger"] = {
+		debug() {},
+		info() {},
+		warn() {},
+		error() {},
+	};
+	return new CerastreamBackend({
+		connect,
+		connectOptions: {},
+		getConfig: () => CONFIG,
+		saveConfig: () => undefined,
+		bridge: {
+			notify: () => undefined,
+			notificationExists: () => false,
+			removeNotification: () => undefined,
+			broadcastStatus: () => undefined,
+			broadcastBuffering: () => undefined,
+		},
+		execPath: "cerastream",
+		configPath: "/tmp/cerastream-stop-deadline.json",
+		logger,
+		scheduleTimeout: (callback, delayMs) => {
+			deadlines.set(delayMs, callback);
+			return setTimeout(() => undefined, 60_000);
+		},
+		cancelTimeout: (timer) => clearTimeout(timer),
+	});
+}
+
+async function start(backend: CerastreamBackend): Promise<void> {
+	await backend.start(CONFIG, {
+		pipeline: "test",
+		host: "127.0.0.1",
+		port: 9_000,
+		streamid: "test",
+	});
+}
+
+test("a stop connection that resolves after the deadline is closed without dispatch", async () => {
+	const trace: string[] = [];
+	const deadlines = new Map<number, () => void>();
+	const lateConnection = deferred<CerastreamClient>();
+	const sessionClient = fakeClient("session", trace);
+	const lateClient = fakeClient("late", trace);
+	let connection = 0;
+	const backend = backendWithTimers(async () => {
+		connection += 1;
+		return connection === 1 ? sessionClient : await lateConnection.promise;
+	}, deadlines);
+	await start(backend);
+	let stopped = false;
+
+	expect(backend.stop(() => (stopped = true))).toBe(true);
+	await Bun.sleep(0);
+	const expire = deadlines.get(ENGINE_STOP_REQUEST_DEADLINE_MS);
+	expect(expire).toBeDefined();
+	expire?.();
+	await backend.settle();
+	lateConnection.resolve(lateClient);
+	await Bun.sleep(0);
+
+	expect(stopped).toBe(false);
+	expect(trace).toContain("session:close");
+	expect(trace).toContain("late:close");
+	expect(trace).not.toContain("late:stop");
+});
+
+test("an unacknowledged stop is closed at the deadline and never calls back late", async () => {
+	const trace: string[] = [];
+	const deadlines = new Map<number, () => void>();
+	const acknowledgement = deferred<{ state: "idle" }>();
+	const clients = [
+		fakeClient("session", trace),
+		fakeClient("stop", trace, acknowledgement.promise),
+	];
+	const backend = backendWithTimers(async () => {
+		const client = clients.shift();
+		if (client === undefined) throw new Error("unexpected connection");
+		return client;
+	}, deadlines);
+	await start(backend);
+	let stopped = false;
+
+	expect(backend.stop(() => (stopped = true))).toBe(true);
+	await Bun.sleep(0);
+	expect(trace).toContain("stop:stop");
+	const expire = deadlines.get(ENGINE_STOP_REQUEST_DEADLINE_MS);
+	expect(expire).toBeDefined();
+	expire?.();
+	await backend.settle();
+	acknowledgement.resolve({ state: "idle" });
+	await Bun.sleep(0);
+
+	expect(stopped).toBe(false);
+	expect(trace).toContain("session:close");
+	expect(trace).toContain("stop:close");
+});

--- a/apps/backend/src/tests/cerastream-stop-deadline.test.ts
+++ b/apps/backend/src/tests/cerastream-stop-deadline.test.ts
@@ -10,7 +10,12 @@ import {
 	CerastreamBackend,
 	type CerastreamBackendDeps,
 } from "../modules/streaming/cerastream-backend.ts";
-import { ENGINE_STOP_REQUEST_DEADLINE_MS } from "../modules/streaming/start-lifecycle-timing.ts";
+import {
+	ENGINE_CLOSE_DEADLINE_MS,
+	ENGINE_STOP_DEADLINE_MARGIN_MS,
+	ENGINE_STOP_REQUEST_DEADLINE_MS,
+	STOP_DEADLINE_MS,
+} from "../modules/streaming/start-lifecycle-timing.ts";
 
 const CONFIG: RuntimeConfig = {
 	max_br: 8_000,
@@ -139,6 +144,17 @@ async function start(backend: CerastreamBackend): Promise<void> {
 		streamid: "test",
 	});
 }
+
+test("the request and cleanup budgets finish before the outer stop deadline", () => {
+	expect(
+		ENGINE_STOP_REQUEST_DEADLINE_MS +
+			ENGINE_CLOSE_DEADLINE_MS +
+			ENGINE_STOP_DEADLINE_MARGIN_MS,
+	).toBe(STOP_DEADLINE_MS);
+	expect(
+		ENGINE_STOP_REQUEST_DEADLINE_MS + ENGINE_CLOSE_DEADLINE_MS,
+	).toBeLessThan(STOP_DEADLINE_MS);
+});
 
 test("a stop connection that resolves after the deadline is closed without dispatch", async () => {
 	const trace: string[] = [];

--- a/apps/backend/src/tests/engine-session-connection-loss.test.ts
+++ b/apps/backend/src/tests/engine-session-connection-loss.test.ts
@@ -108,6 +108,12 @@ function makeFakeClient(): FakeClient {
 				},
 				sources: [],
 			}),
+		changeConfig: async () =>
+			guard("change-config", {
+				attempt_id: "change-1",
+				phase: "applied" as const,
+				state: "streaming" as const,
+			}),
 		subscribeEvents: async (_params, eventListener) => {
 			calls.push("subscribe-events");
 			listener = eventListener;
@@ -252,8 +258,8 @@ describe("engine restart mid-session — the session control connection is the s
 		liveSession(h).killConnection();
 		await expect(h.backend.listDevicesIfActive()).resolves.toBeNull();
 
-		// The operator's recovery path: stop, then start. Both must work against an
-		// engine CeraUI can no longer reach through the retired client.
+		// The operator's recovery path: stop on an independent connection, then
+		// start on another. Neither may reuse the retired session client.
 		await new Promise<void>((resolve) => {
 			h.backend.stop(resolve);
 		});
@@ -262,8 +268,11 @@ describe("engine restart mid-session — the session control connection is the s
 		await h.backend.start(STREAM_CONFIG, RUN_OPTS);
 		await h.backend.settle();
 
-		expect(h.connectCount()).toBe(2);
-		const revived = h.clients[1];
+		expect(h.connectCount()).toBe(3);
+		const stopClient = h.clients[1];
+		expect(stopClient?.calls).toContain("stop");
+		expect(stopClient?.calls).not.toContain("start");
+		const revived = h.clients[2];
 		expect(revived?.calls).toContain("start");
 		await expect(
 			h.backend.switchInput({ input_id: "cam2", mode: "manual" }),

--- a/apps/backend/src/tests/stop-wedge-recovery.test.ts
+++ b/apps/backend/src/tests/stop-wedge-recovery.test.ts
@@ -52,7 +52,7 @@ function makeConfig(): RuntimeConfig {
  * where the engine stops answering while it hands `/dev/videoN` back to
  * `uvcvideo`.
  */
-function makeHangingCloseClient(): CerastreamClient {
+function makeHangingCloseClient(closeHangs: boolean): CerastreamClient {
 	return {
 		hello: {
 			protocol: "cerastream-ipc/1",
@@ -60,7 +60,7 @@ function makeHangingCloseClient(): CerastreamClient {
 			engine_version: "test",
 		},
 		start: async () => ({ session_id: "s1", state: "streaming" as const }),
-		stop: async () => new Promise<never>(() => {}),
+		stop: async () => ({ state: "idle" as const }),
 		reloadConfig: async (params: unknown) => ({ applied: params }),
 		setBitrate: async (params: { max_bitrate: number }) => ({
 			applied: { max_bitrate: params.max_bitrate },
@@ -74,17 +74,22 @@ function makeHangingCloseClient(): CerastreamClient {
 			result: { subscribed: [] as never[] },
 			close: () => {},
 		}),
-		// The defect under test: this promise never settles.
-		close: () => new Promise<void>(() => {}),
+		// The defect under test: the session connection never closes.
+		close: () => (closeHangs ? new Promise<void>(() => {}) : Promise.resolve()),
 	} as unknown as CerastreamClient;
 }
 
 describe("a stop that never settles must not poison the session", () => {
-	test("the engine close is bounded, so the stop still reports completion", async () => {
-		// Given a started session whose engine will never answer the close.
+	test("the session close is bounded, so an acknowledged stop still reports completion", async () => {
+		// Given a started session whose control socket will never answer close,
+		// while the independent stop connection remains usable.
 		const deadlines: Array<{ callback: () => void; delayMs: number }> = [];
+		let connections = 0;
 		const backend = new CerastreamBackend({
-			connect: async () => makeHangingCloseClient(),
+			connect: async () => {
+				connections += 1;
+				return makeHangingCloseClient(connections === 1);
+			},
 			connectOptions: {},
 			getConfig: makeConfig,
 			saveConfig: () => {},
@@ -119,7 +124,7 @@ describe("a stop that never settles must not poison the session", () => {
 		await Promise.resolve();
 
 		// Then a bound was armed for the close...
-		const closeDeadline = deadlines.at(-1);
+		const closeDeadline = deadlines[deadlines.length - 1];
 		expect(closeDeadline).toBeDefined();
 		closeDeadline?.callback();
 		for (let i = 0; i < 10; i += 1) await Promise.resolve();

--- a/apps/backend/src/tests/stop-wedge-recovery.test.ts
+++ b/apps/backend/src/tests/stop-wedge-recovery.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { CerastreamClient } from "@ceralive/cerastream";
 import type { RuntimeConfig } from "../helpers/config-schemas.ts";
 import { CerastreamBackend } from "../modules/streaming/cerastream-backend.ts";
+import { ENGINE_CLOSE_DEADLINE_MS } from "../modules/streaming/start-lifecycle-timing.ts";
 import { createStreamSessionOrchestrator } from "../modules/streaming/stream-session-orchestrator.ts";
 import type { StreamRunOptions } from "../modules/streaming/streaming-backend.ts";
 
@@ -121,13 +122,22 @@ describe("a stop that never settles must not poison the session", () => {
 				stopped = true;
 			}),
 		).toBe(true);
-		await Promise.resolve();
+		for (let i = 0; i < 10; i += 1) {
+			if (
+				deadlines.some(({ delayMs }) => delayMs === ENGINE_CLOSE_DEADLINE_MS)
+			) {
+				break;
+			}
+			await Promise.resolve();
+		}
 
 		// Then a bound was armed for the close...
-		const closeDeadline = deadlines[deadlines.length - 1];
+		const closeDeadline = deadlines.find(
+			({ delayMs }) => delayMs === ENGINE_CLOSE_DEADLINE_MS,
+		);
 		expect(closeDeadline).toBeDefined();
 		closeDeadline?.callback();
-		for (let i = 0; i < 10; i += 1) await Promise.resolve();
+		await backend.settle();
 
 		// ...and the stop completes rather than hanging forever.
 		expect(stopped).toBe(true);

--- a/apps/backend/src/tests/streaming-backend-contract.test.ts
+++ b/apps/backend/src/tests/streaming-backend-contract.test.ts
@@ -158,6 +158,14 @@ function makeFakeClient(options: FakeClientOptions = {}): FakeClientHarness {
 			},
 			sources: [],
 		}),
+		changeConfig: async (params) => {
+			calls.push({ op: "change-config", params });
+			return {
+				attempt_id: "change-1",
+				phase: "applied",
+				state: "streaming",
+			};
+		},
 		subscribeEvents: async (params, eventListener) => {
 			calls.push({ op: "subscribe-events", params });
 			listener = eventListener;
@@ -510,28 +518,20 @@ describe("CerastreamBackend behavioural contract", () => {
 		});
 		const deadOps = dead.calls.map(({ op }) => op);
 		expect(deadOps.filter((op) => op === "start")).toHaveLength(1);
-		expect(deadOps.filter((op) => op === "stop")).toHaveLength(2);
+		expect(deadOps.filter((op) => op === "stop")).toHaveLength(1);
 		expect(deadOps.filter((op) => op === "close")).toHaveLength(2);
 		expect(deadOps.filter((op) => op === "unsubscribe")).toHaveLength(2);
 
-		// A second owner must reach the recovered connect path and terminate; it
-		// must not park behind generation one's dead queue and make a third RPC busy.
-		const second = orchestrator.start({ origin: "ui", launch });
-		for (let tick = 0; tick < 10; tick += 1) await Bun.sleep(0);
-		expect(await second).toMatchObject({ result: "failed" });
-		expect(streaming).toBe(false);
-		expect(orchestrator.snapshot()).toEqual({
-			state: "idle",
-			generation: 2,
-		});
-		const third = await orchestrator.start({ origin: "ui", launch });
-		expect(third).toMatchObject({ result: "started" });
-		expect(connections).toBe(3);
+		// A second owner must reach the recovered connect path and start; it must
+		// not park behind generation one's dead queue or need a third launch.
+		const second = await orchestrator.start({ origin: "ui", launch });
+		expect(second).toMatchObject({ result: "started" });
 		expect(streaming).toBe(true);
 		expect(orchestrator.snapshot()).toEqual({
 			state: "streaming",
-			generation: 3,
+			generation: 2,
 		});
+		expect(connections).toBe(3);
 
 		await orchestrator.stop("operator");
 		await backend.settle();

--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -188,7 +188,7 @@ via `bun run build:federation` from the CeraUI root (delegates to the frontend
   the typed host adapter. Shared graph code is split into sibling chunks
   co-located at the same versioned path.
 - **`<ceraui-version>`** is read at build time from the workspace-root `package.json` `version`
-(CalVer, `2026.8.8` at time of writing) — the single source of truth, matching the platform's
+(CalVer, `2026.8.9` at time of writing) — the single source of truth, matching the platform's
   `ceraui-version` claim.
 - **The catalog is STATIC here, not lazy.** The SPA splits its ten-locale Paraglide
   catalog into per-namespace chunks it awaits in `main.ts`; a federation bundle is

--- a/docs/START-LIFECYCLE.md
+++ b/docs/START-LIFECYCLE.md
@@ -211,12 +211,14 @@ per-attempt launch deadline, AND a total-time budget
   closing that client would then discard the unread request. CeraUI dispatches stop
   on the fresh connection first, closes the session client to settle its pending
   work, and reports `stopped` only after the independent request answers
-  `state: "idle"`. The fresh connect plus acknowledgement has a derived 7-second
-  budget, reserving the remaining 5 seconds of the unchanged 12-second stop bound
-  for socket cleanup. If that request budget expires, a connection that resolves
-  later is closed without dispatching `stop`; a pending stop connection is also
-  closed. No late completion can mutate the engine or invoke the completion
-  callback after the orchestrator has returned `stop_failed`.
+  `state: "idle"`. The fresh connect plus acknowledgement has a derived
+  6.5-second budget, reserving 5 seconds for socket cleanup and 0.5 seconds for
+  scheduling inside the unchanged 12-second outer bound. If that request budget
+  expires, a connection that resolves later is closed without dispatching `stop`;
+  a pending stop connection is also closed and cannot invoke the completion
+  callback. An already-dispatched request may still settle inside the engine after
+  its client is closed, so its outcome is deliberately UNKNOWN: the caller gets
+  `stop_failed` and reconciliation adopts the engine's eventual truth.
 - A scheduled retry logs `attemptId`, phase, class, engine code when present, and
   retry state. It emits a class-keyed localized warning only outside a suppression
   window. Terminal exhaustion/non-retriable failure emits exactly one keyed error

--- a/docs/START-LIFECYCLE.md
+++ b/docs/START-LIFECYCLE.md
@@ -211,8 +211,12 @@ per-attempt launch deadline, AND a total-time budget
   closing that client would then discard the unread request. CeraUI dispatches stop
   on the fresh connection first, closes the session client to settle its pending
   work, and reports `stopped` only after the independent request answers
-  `state: "idle"`. A connect/RPC failure reaches the 12-second stop deadline as
-  `stop_failed` rather than being acknowledged as success.
+  `state: "idle"`. The fresh connect plus acknowledgement has a derived 7-second
+  budget, reserving the remaining 5 seconds of the unchanged 12-second stop bound
+  for socket cleanup. If that request budget expires, a connection that resolves
+  later is closed without dispatching `stop`; a pending stop connection is also
+  closed. No late completion can mutate the engine or invoke the completion
+  callback after the orchestrator has returned `stop_failed`.
 - A scheduled retry logs `attemptId`, phase, class, engine code when present, and
   retry state. It emits a class-keyed localized warning only outside a suppression
   window. Terminal exhaustion/non-retriable failure emits exactly one keyed error

--- a/docs/START-LIFECYCLE.md
+++ b/docs/START-LIFECYCLE.md
@@ -205,11 +205,14 @@ per-attempt launch deadline, AND a total-time budget
   cleanup cannot make it settle within the stop bound, the result is terminal
   `start_cleanup_timeout` and no next attempt launches. A late completion remains
   fenced to that cancelled launch and cannot declare the session started.
-- Engine stop bypasses `CerastreamBackend`'s ordinary IPC queue and uses the active
-  client immediately. This lets deadline cleanup interrupt the in-flight start
-  instead of deadlocking behind it. After dispatching stop, CeraUI closes the
-  client without waiting for a reply; closure settles pending start/stop requests
-  and releases the serialized queue before another generation is admitted.
+- Engine stop bypasses `CerastreamBackend`'s ordinary IPC queue and opens a fresh
+  control connection. The engine accepts one in-flight request per connection, so
+  sending stop on the session client can queue it behind `list-devices` or start;
+  closing that client would then discard the unread request. CeraUI dispatches stop
+  on the fresh connection first, closes the session client to settle its pending
+  work, and reports `stopped` only after the independent request answers
+  `state: "idle"`. A connect/RPC failure reaches the 12-second stop deadline as
+  `stop_failed` rather than being acknowledged as success.
 - A scheduled retry logs `attemptId`, phase, class, engine code when present, and
   retry state. It emits a class-keyed localized warning only outside a suppression
   window. Terminal exhaustion/non-retriable failure emits exactly one keyed error


### PR DESCRIPTION
## What

- Dispatch cerastream `stop` on a fresh control connection before closing the occupied session connection.
- Report success only after the engine acknowledges `state: "idle"`.
- Fence late, undispatched connections and bound request/cleanup work inside the existing 12-second lifecycle deadline.
- Add deterministic acknowledgement, timeout, session-loss, and wedge-recovery coverage; update lifecycle documentation.

## Why

Cerastream serves one request at a time per connection. When the session connection was occupied, queuing `stop` there and then closing it could discard the unread request. CeraUI would report `stopped` while the engine continued streaming.

## How to verify

- `bun run --filter backend check`
- `bun run --filter backend test` — 5,651 passed, 2 skipped, 0 failed
- `bun run build`
- Board drill: streamed for 65 seconds, held 62 of 64 device-list RPCs pending at stop dispatch, received idle acknowledgement in 206 ms, and remained idle for a fresh 180-second observation with stable engine PID and zero restarts.

## Risks

- A stop already written to the engine may settle after its acknowledgement deadline. That outcome is intentionally treated as unknown: the RPC returns `stop_failed`, and lifecycle reconciliation adopts the engine state.
- No public RPC shape, wire schema, dependency, or engine API changes.