### PR TITLE
fix(audio): refuse an ambiguous ALSA alias instead of picking the first card

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -656,11 +656,57 @@ available and rejected for exactly that reason. An unreadable `/proc/asound/pcm`
 degrades to card-id-only aliases, i.e. the pre-existing single-name behaviour, and
 never loses a card.
 
+**…AND IT IS UNAMBIGUOUS, WHICH IS A SECOND PROPERTY, NOT A RESTATEMENT.** A PCM
+id is NOT unique: two identical-model USB sound cards enumerate as two kernel card
+ids (`snd_usb_audio` suffixes the second) and BOTH report the generic PCM id
+`USB Audio`, so that name is a real alias of two different cards. The first
+implementation resolved a name by taking the first card that claimed it — a
+`.find()` in `engineAudioDeviceForCard` and a first-match loop in
+`canonicalCardId` — so on the PipeWire arm, where the join key IS the PCM id,
+selecting the SECOND unit routed to the FIRST unit's engine node, and the second
+unit's OWN meter reading was then classified `foreign` and suppressed. Both halves
+came from one ambiguous lookup, and both contradicted this module's own
+"deterministic, never fuzzy" contract.
+
+`buildCardAliasOwners(aliases)` is the reverse index that closes it: every name
+this board answers to, mapped to the ONE card that owns it, or `null` when more
+than one does. Four rules are load-bearing:
+
+- **A shared name identifies NOBODY**, not the first claimant. `engineAudioDeviceForCard`
+  returns no match for either twin, so `engineAudioDeviceString` falls back to the
+  caller's own `hw:CARD=<kernel id>` through the UNCHANGED fail-soft path — a
+  translation nobody can vouch for is still never invented.
+- **On the meter side ambiguity is `unknown`, never `foreign`.** `canonicalCardId`
+  answers `undefined` for a shared name, and `classifyMeterIdentity`'s existing
+  tri-state then reports `unknown` — which proves nothing and SUPPRESSES nothing.
+  `foreign` is a positive claim of misidentification and would silence the very
+  device the operator picked; the two are different operator facts and collapsing
+  them is the defect.
+- **A KERNEL CARD ID still resolves, always.** It is unique by construction, so
+  `ownerOfName` checks it first and each twin keeps its own identity — which is
+  why an ALSA-arm engine (whose join key IS the kernel id) resolves both twins
+  correctly and is byte-unchanged.
+- **The card-id-only degrade is preserved by an EXPLICIT branch.**
+  `engineAudioDeviceForCard` short-circuits on `key === cardId` before consulting
+  the index, because an unreadable `/proc/asound/pcm` yields an alias table that
+  cannot answer for any card. It looks redundant with the index and is not:
+  removing it reddens 13 tests across three files (`audio-naming`,
+  `audio-device-naming-cleanup`, `audio-naming-pipewire-arm`).
+
+`isAliasOfCard` is deliberately NOT routed through the index — it is a MEMBERSHIP
+test ("is this string one of the names for this card"), used by `isHumanAudioName`
+to REJECT a non-human display name, and rejecting a shared generic name for both
+twins is exactly right.
+
 Coverage: `tests/audio-card-vocabulary.test.ts` (the parser against the board's own
 verbatim `/proc/asound/pcm`, the alias build, both canonicalisation directions, the
-translation with its ALSA byte-identical and engine-silent controls, and the
-tri-state matrix) + the retargeted `tests/audio-meter-bridge.test.ts` cases. Rule-E
-proof: restoring the bare-string comparison reddens 4 tests across the two files.
+translation with its ALSA byte-identical and engine-silent controls, the tri-state
+matrix, and the twin-card describe: the second twin never routed to the first, the
+fallback it falls to, `unknown`-not-`foreign` on the shared alias, each twin still
+answering to its own kernel id, the ALSA-arm control, and the unique-alias control)
++ the retargeted `tests/audio-meter-bridge.test.ts` cases. Rule-E proof both ways:
+restoring the bare-string comparison reddens 4 tests across the two files, and
+restoring the first-match lookup reddens the 3 twin cases.
 
 **It is a PREFERENCE, not a pin — and the engine is what guarantees that.** cerastream
 only moves the named card to the head of its candidate list; its delivery-confirmation
@@ -8818,6 +8864,8 @@ config, an anchored path still held by its own device, and a live row with no
   SOFTWARE-UPDATE CHECK CONTRACT).
 - Don't send the idle-meter preference through the typed `reloadConfig()` — the published client Zod-strips `audio.meter_device`; it goes over `rawRequest` behind `supportsMeterDevicePreference`. And don't send `undefined` for "Auto": absent means *unchanged*, `null` means Auto.
 - Don't report a suppressed foreign-card level as `no_device` when CeraUI still lists the selected card AND that card owns a capture PCM (`isMeterPreferenceDevicePresent()`) — that makes a mis-bound meter indistinguishable from an unplugged cable — and don't try to fix a sustained mismatch by re-pushing the same preference value: `set_preferred_device` early-returns on an unchanged value, so the re-assert must pass through `null`.
+- Don't resolve an ALSA name to a card by taking the FIRST card that claims it — a PCM id is not unique, so two identical-model USB cards both answer to `USB Audio` and a first-match lookup routes the second unit to the first unit's engine node and then suppresses the second unit's own meter reading as `foreign`. Go through `buildCardAliasOwners`, which answers nothing for a shared name. And don't "fix" the resulting silence by falling back to the first claimant, by collapsing the ambiguous case into `foreign` (that is a positive claim of misidentification, where `unknown` is the honest one), or by deleting `engineAudioDeviceForCard`'s `key === cardId` short-circuit — it looks redundant with the index and is the card-id-only degrade an unreadable `/proc/asound/pcm` lands on.
+- Don't route `isAliasOfCard` through the owner index — it is a MEMBERSHIP test feeding `isHumanAudioName`'s rejection rule, and a generic name shared by two cards must be rejected for both.
 - Don't equate "the card is in `audioDevices`" with "the card can deliver audio" — a permanently-enumerated input with no capture PCM (idle HDMI-RX) is genuinely `no_device`, not `not_selected_device`. Gate presence on `audioCaptureCardIds`/`hasCapturePcmNode`, and don't "simplify" that by filtering the card out of the picker instead.
 - Don't identify the HDMI-RX audio card by ONE card id — the vendor 6.1 BSP calls it `rockchiphdmiin` and mainline/edge 7.1 calls the same physical port `hdmirx`, so a single hardcoded string makes rule 3 miss, fall through in silence, and never bind HDMI audio at all on the other kernel (board-proven: that card captures real, non-silent audio). Add every spelling to `HDMI_CARD_IDS` and to `ONBOARD_AUDIO_DISPLAY_RULES`, keep the first-enumerated-wins ordering, and ask the capture gate about the spelling that MATCHED. Don't "generalise" it into "bind whichever card can capture" either — that answers capability, not identity, and would hand an HDMI source somebody else's microphone. And don't add the second id to `RK3588_AUDIO_SRC_ALIASES`: that table is inverted by `getAudioSrcReverseAliases()`, so two ids under one label break the vendor board's `getAudioSrcId("HDMI")`.
 - Don't let Auto rule 3/4 bind their FIXED card on enumeration alone — that is the same "listed ≠ recordable" confusion one layer up, and it made every `asrc: "Auto"` start on the board's HDMI source die `audio-device-unavailable … not_retriable` even with a locked signal. Pass `captureCapableCardIds` and refuse with `no-capture-audio`. Keep the refusal FAIL-OPEN (an absent set binds exactly as before), keep it resolving to the `"No audio"` pseudo-source rather than a `null` asrcKey (a `null` OMITS `asrc` and hands the engine its legacy inference over the port that cannot deliver), and don't extend the gate to rule 5 — its candidates already come from the engine's `list-devices`, which never lists a capture-less card.

--- a/apps/backend/src/modules/streaming/audio-card-vocabulary.ts
+++ b/apps/backend/src/modules/streaming/audio-card-vocabulary.ts
@@ -44,6 +44,13 @@
 // CARD INDEX, and `/sys/class/sound/cardN` gives that same index its card id. No
 // name similarity, no prefix matching, no vendor table.
 //
+// It is also UNAMBIGUOUS, and that is a second property rather than a
+// restatement of the first. A PCM id is not unique — two identical-model USB
+// cards both report `USB Audio` — so a name resolves to a card only when exactly
+// ONE card owns it. A shared name identifies nobody and is answered with nothing,
+// because the alternative is picking whichever card was scanned first and
+// attributing one device's audio to another's.
+//
 // Everything here is pure so the whole rule is testable with no sysfs and no
 // engine.
 
@@ -112,7 +119,13 @@ export function buildCardAliases(
 	return aliases;
 }
 
-/** Is `name` one of the names this board uses for `cardId`? */
+/**
+ * Is `name` one of the names this board uses for `cardId`?
+ *
+ * MEMBERSHIP, not identity: several cards can answer to one name (see
+ * `buildCardAliasOwners`), so this must never be used to decide WHICH card a
+ * name refers to.
+ */
 export function isAliasOfCard(
 	cardId: string,
 	name: string,
@@ -123,21 +136,66 @@ export function isAliasOfCard(
 }
 
 /**
+ * The reverse index: each name this board answers to, mapped to the ONE card
+ * that owns it — or `null` when more than one does.
+ *
+ * A PCM id is NOT unique. Two identical-model USB sound cards both report the
+ * generic `USB Audio`, so that name names a PAIR; resolving it to whichever card
+ * happens to come first attributes the second device to the first one's identity.
+ * Recording the collision as `null` is what lets every consumer refuse instead.
+ */
+export function buildCardAliasOwners(
+	aliases: CardAliases,
+): ReadonlyMap<string, string | null> {
+	const owners = new Map<string, string | null>();
+	for (const [cardId, names] of aliases) {
+		for (const name of names) {
+			owners.set(name, owners.has(name) ? null : cardId);
+		}
+	}
+	return owners;
+}
+
+/**
+ * The card `name` PROVABLY refers to, or `undefined` when nothing does — which
+ * covers both a name from no known vocabulary and a name several cards share.
+ *
+ * A kernel card id is checked first because it is unique by construction, so it
+ * still identifies its own card even where some other card's PCM id collides
+ * with it.
+ */
+function ownerOfName(
+	name: string,
+	aliases: CardAliases,
+	owners: ReadonlyMap<string, string | null>,
+): string | undefined {
+	if (aliases.has(name)) return name;
+	return owners.get(name) ?? undefined;
+}
+
+/**
  * The engine's OWN audio row for a card CeraUI names `cardId`, or `undefined`
  * when the engine lists nothing this board would call that card.
  *
- * Matched on `alsa_card_id` against the card's alias set, so the kernel id (the
+ * Matched on `alsa_card_id` through the reverse index, so the kernel id (the
  * ALSA arm) and the PCM id (the PipeWire arm) both resolve — and neither is
- * guessed at.
+ * guessed at. A row whose key names SEVERAL cards matches none of them: on the
+ * PipeWire arm two identical USB cards share one PCM id, and answering either
+ * with the first row would hand the second device the first one's identity.
  */
 export function engineAudioDeviceForCard(
 	cardId: string,
 	engineAudio: readonly EngineAudioDevice[],
 	aliases: CardAliases,
 ): EngineAudioDevice | undefined {
+	const owners = buildCardAliasOwners(aliases);
 	return engineAudio.find((device) => {
 		const key = device.alsa_card_id;
-		return key !== undefined && isAliasOfCard(cardId, key, aliases);
+		if (key === undefined) return false;
+		// A card's own kernel id identifies it with no vocabulary at all, which is
+		// what a board with an unreadable `/proc/asound/pcm` degrades to.
+		if (key === cardId) return true;
+		return ownerOfName(key, aliases, owners) === cardId;
 	});
 }
 
@@ -181,17 +239,20 @@ export type MeterIdentityVerdict = "match" | "foreign" | "unknown";
 /**
  * The card this board files `name` under, whichever of its vocabularies `name` is
  * drawn from — or `undefined` when it belongs to none of them (an opaque
- * `bluealsa:` PCM, an engine that named something this scan has never seen).
+ * `bluealsa:` PCM, an engine that named something this scan has never seen) and
+ * equally when it belongs to SEVERAL of them.
+ *
+ * That second case is why the answer is not merely "the first card that claims
+ * it": a shared PCM id canonicalises to nothing, so `classifyMeterIdentity`
+ * reports `unknown` — which proves nothing and suppresses nothing — instead of
+ * asserting a `foreign` mismatch it cannot support.
  */
 export function canonicalCardId(
 	name: string | undefined,
 	aliases: CardAliases,
 ): string | undefined {
 	if (name === undefined) return undefined;
-	for (const [cardId, names] of aliases) {
-		if (cardId === name || names.has(name)) return cardId;
-	}
-	return undefined;
+	return ownerOfName(name, aliases, buildCardAliasOwners(aliases));
 }
 
 export function classifyMeterIdentity(

--- a/apps/backend/src/tests/audio-card-vocabulary.test.ts
+++ b/apps/backend/src/tests/audio-card-vocabulary.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { CardAliases } from "../modules/streaming/audio-card-vocabulary.ts";
 import {
 	buildCardAliases,
+	buildCardAliasOwners,
 	canonicalCardId,
 	classifyMeterIdentity,
 	engineAudioDeviceForCard,
@@ -221,6 +222,129 @@ describe("classifyMeterIdentity — suppress only what is PROVEN foreign", () =>
 		);
 		expect(classifyMeterIdentity("usbaudio", "hdmirx", new Map())).toBe(
 			"unknown",
+		);
+	});
+});
+
+// TWO identical-model USB sound cards. The kernel gives each its own card id
+// (`snd_usb_audio` suffixes the second), and BOTH report the generic PCM id
+// `USB Audio` — so that name is a real alias of two different cards.
+const TWIN_PROC_ASOUND_PCM = `01-00: USB Audio : USB Audio : capture 1
+02-00: USB Audio : USB Audio : capture 1
+`;
+
+const TWIN_CARDS = [
+	{ index: 1, id: "usbaudio" },
+	{ index: 2, id: "usbaudio_1" },
+];
+
+// The PipeWire arm resolves BOTH nodes' join key to that same PCM id.
+const TWIN_ENGINE_AUDIO: EngineAudioDevice[] = [
+	{
+		input_id: "alsa_input.usb-first",
+		alsa_card_id: "USB Audio",
+		stable_id: "node.first",
+	},
+	{
+		input_id: "alsa_input.usb-second",
+		alsa_card_id: "USB Audio",
+		stable_id: "node.second",
+	},
+];
+
+function twinAliases(): CardAliases {
+	return buildCardAliases(TWIN_CARDS, parseProcAsoundPcm(TWIN_PROC_ASOUND_PCM));
+}
+
+describe("an AMBIGUOUS alias identifies nobody", () => {
+	test("the reverse index records the collision instead of a winner", () => {
+		const owners = buildCardAliasOwners(twinAliases());
+		expect(owners.get("USB Audio")).toBeNull();
+		expect(owners.get("usbaudio")).toBe("usbaudio");
+		expect(owners.get("usbaudio_1")).toBe("usbaudio_1");
+		expect(buildCardAliasOwners(boardAliases()).get("USB Audio")).toBe(
+			"usbaudio",
+		);
+	});
+
+	test("the SECOND twin is never routed to the FIRST one's engine row", () => {
+		const aliases = twinAliases();
+		// The defect: `USB Audio` is an alias of BOTH cards, so a first-match
+		// lookup answered the second card with the first card's node.
+		expect(
+			engineAudioDeviceForCard("usbaudio_1", TWIN_ENGINE_AUDIO, aliases),
+		).toBeUndefined();
+		// …and it must not silently claim the first card either — the shared name
+		// proves nothing about which unit the engine is describing.
+		expect(
+			engineAudioDeviceForCard("usbaudio", TWIN_ENGINE_AUDIO, aliases),
+		).toBeUndefined();
+	});
+
+	test("the unresolved card falls back to the caller's own device string", () => {
+		const aliases = twinAliases();
+		expect(
+			engineAudioDeviceString(
+				"usbaudio_1",
+				"hw:CARD=usbaudio_1",
+				TWIN_ENGINE_AUDIO,
+				aliases,
+			),
+		).toBe("hw:CARD=usbaudio_1");
+	});
+
+	test("a meter reading on the shared alias is UNKNOWN, never foreign", () => {
+		const aliases = twinAliases();
+		// `foreign` asserts a mismatch this board cannot prove and SUPPRESSES the
+		// reading; `unknown` is the honest verdict for a genuinely ambiguous name.
+		expect(classifyMeterIdentity("usbaudio_1", "USB Audio", aliases)).toBe(
+			"unknown",
+		);
+		expect(classifyMeterIdentity("USB Audio", "usbaudio_1", aliases)).toBe(
+			"unknown",
+		);
+		expect(canonicalCardId("USB Audio", aliases)).toBeUndefined();
+	});
+
+	test("each twin still answers to its OWN kernel card id", () => {
+		const aliases = twinAliases();
+		expect(canonicalCardId("usbaudio_1", aliases)).toBe("usbaudio_1");
+		expect(classifyMeterIdentity("usbaudio_1", "usbaudio_1", aliases)).toBe(
+			"match",
+		);
+		// Two DIFFERENT kernel ids are still provably foreign.
+		expect(classifyMeterIdentity("usbaudio", "usbaudio_1", aliases)).toBe(
+			"foreign",
+		);
+	});
+
+	test("an ALSA-arm engine names the twins apart, so both still resolve", () => {
+		const aliases = twinAliases();
+		const alsaArm: EngineAudioDevice[] = [
+			{ input_id: "hw:CARD=usbaudio", alsa_card_id: "usbaudio" },
+			{ input_id: "hw:CARD=usbaudio_1", alsa_card_id: "usbaudio_1" },
+		];
+		expect(
+			engineAudioDeviceForCard("usbaudio", alsaArm, aliases)?.input_id,
+		).toBe("hw:CARD=usbaudio");
+		expect(
+			engineAudioDeviceForCard("usbaudio_1", alsaArm, aliases)?.input_id,
+		).toBe("hw:CARD=usbaudio_1");
+	});
+
+	test("a genuinely UNIQUE alias is unaffected — the board's own case", () => {
+		const aliases = boardAliases();
+		expect(canonicalCardId("USB Audio", aliases)).toBe("usbaudio");
+		expect(
+			engineAudioDeviceForCard("usbaudio", BOARD_ENGINE_AUDIO, aliases)
+				?.stable_id,
+		).toBe("card:USB Audio");
+		expect(
+			engineAudioDeviceForCard("hdmirx", BOARD_ENGINE_AUDIO, aliases)
+				?.stable_id,
+		).toBe("card:fddf8000.i2s-i2s-hifi i2s-hifi-0");
+		expect(classifyMeterIdentity("usbaudio", "USB Audio", aliases)).toBe(
+			"match",
 		);
 	});
 });


### PR DESCRIPTION
## What

`audio-card-vocabulary.ts` relates the two names one ALSA card has — the kernel card id CeraUI uses, and the PCM id the engine's PipeWire arm publishes as `alsa_card_id`. It resolved a name to a card by taking the **first card that claimed it**: a `.find()` in `engineAudioDeviceForCard` and a first-match loop in `canonicalCardId`.

That is only safe while a name identifies one card, and a PCM id does not. Two identical-model USB sound cards enumerate as two kernel card ids and **both** report the generic PCM id `USB Audio`, so that name is a real alias of two different cards.

This adds `buildCardAliasOwners` — a reverse index mapping every name the board answers to onto the one card that owns it, or `null` when more than one does — and routes both lookups through it.

## Why

On the PipeWire arm the engine's join key *is* the PCM id, so with two identical cards attached:

- selecting the **second** card resolved to the **first** card's engine node, so `audio.device` / `audio.meter_device` were pointed at the wrong physical device;
- the second card's **own** meter reading then canonicalised to the first card and was classified `foreign` — a positive claim of misidentification, which suppresses the reading. The operator's selected microphone showed "Not the selected device" while a different unit's node was being opened.

Both halves came out of the same ambiguous lookup, and both contradicted this module's own documented contract of being "deterministic, never fuzzy" and fail-soft.

## How it behaves now

- **A shared name identifies nobody.** `engineAudioDeviceForCard` matches neither card, so `engineAudioDeviceString` falls back to the caller's own `hw:CARD=<kernel id>` through the **unchanged** fail-soft path — a translation nobody can vouch for is still never invented.
- **On the meter side, ambiguity is `unknown`, not `foreign`.** `canonicalCardId` answers `undefined`, so `classifyMeterIdentity`'s existing tri-state reports `unknown`, which proves nothing and suppresses nothing. `foreign` and `unknown` are different operator facts; collapsing them is the defect.
- **A kernel card id still resolves, always.** It is unique by construction, so each card keeps its own identity and an ALSA-arm engine (whose join key *is* the kernel id) is byte-unchanged.
- **The non-ambiguous case is untouched**, including the board's own single-`USB Audio` roster.

Two deliberate non-changes:

- `engineAudioDeviceForCard` keeps an explicit `key === cardId` short-circuit. It looks redundant with the index and is not — it is the card-id-only state an unreadable `/proc/asound/pcm` degrades to. Removing it reddens 13 tests across three files.
- `isAliasOfCard` is left alone. It is a *membership* test feeding `isHumanAudioName`'s rejection rule, where rejecting a shared generic name for both cards is correct.

## How to verify

Backend unit tests carry the whole contract — `apps/backend/src/tests/audio-card-vocabulary.test.ts`:

```
cd apps/backend && bun test src/tests/audio-card-vocabulary.test.ts
```

The new `an AMBIGUOUS alias identifies nobody` block covers: the reverse index recording the collision, the second card never routed to the first, the fallback it lands on, `unknown`-not-`foreign` on the shared alias, each card still answering to its own kernel id, an ALSA-arm control where both cards still resolve, and a control proving a genuinely unique alias is unaffected.

Reverting the fix and re-running reproduces the reported behaviour directly: `engineAudioDeviceForCard` returns the first card's node for the second card, and the meter verdict is `foreign`.

Gates run locally:

- `bun run lint` (biome + backend/rpc/i18n/frontend typecheck + svelte-check) — clean, 0 errors
- backend `bun test` — 5657 pass / 0 fail
- frontend `bun run --filter frontend test` — 357 files / 5818 tests / 0 fail
- `@ceraui/rpc` 460 pass, `@ceraui/i18n` 704 pass, `check:tech-debt` OK

E2E could not be run on this machine: an unrelated desktop application is holding 521,037 of the host's 524,288 inotify watches, so the Vite dev server the harness starts dies with `ENOSPC`. That failure reproduces identically on a clean `origin/main` checkout with this branch's changes stashed, so it is environmental and pre-existing. CI runs the E2E matrix.

## Risk

Low, and narrow. The change is confined to one pure module with no I/O; every consumer keeps the fallback it already had. The direction of change is strictly toward refusing to answer: the only behaviour that moves is a lookup that was previously answered with an unprovable guess. The non-ambiguous path — which is every board with one card per model, i.e. the whole fleet today — is unchanged, and that is asserted rather than assumed.

Not covered here: no board with two identical-model USB audio devices attached has run this. The reproduction and the fix are proven by unit tests against the module contract.
