### PR TITLE
docs(audio): align Bluetooth audio module overview

### DIFF
--- a/apps/backend/src/modules/streaming/bluetooth-audio.ts
+++ b/apps/backend/src/modules/streaming/bluetooth-audio.ts
@@ -283,12 +283,12 @@ export interface DeriveBluetoothAudioSourcesInput {
 }
 
 /**
- * Fold the BlueZ registry and the BlueALSA PCM objects into source rows.
+ * Fold the BlueZ registry into backend-specific capture source rows.
  *
- * A row requires ALL THREE of connected, `scoCapable`, and a live capture PCM.
- * The PCM is the presence oracle, so a device the registry never mentioned
- * yields nothing — a PCM CeraUI cannot name is one it cannot label honestly, and
- * an unnamed microphone in the picker is worse than none.
+ * PipeWire rows require a connected SCO-capable BlueZ device and an engine audio
+ * node with the same `device_address`; BlueALSA is not consulted. Legacy rows
+ * instead require that device plus a live BlueALSA capture PCM. In either case,
+ * a capture endpoint CeraUI cannot name is not shown in the picker.
  */
 export function deriveBluetoothAudioSources(
 	input: DeriveBluetoothAudioSourcesInput,
@@ -460,7 +460,7 @@ function defaultEngineSupportsPipewireCapture(): boolean {
 }
 
 /**
- * Re-read the BlueALSA PCM objects and rebuild the cached source list.
+ * Re-read the selected backend's source-presence data and rebuild the cached list.
  *
  * Answers whether the published list CHANGED, so the caller can keep the audio
  * broadcast on its on-change cadence. Never throws.
@@ -522,7 +522,7 @@ export function findBluetoothAudioSource(
  *
  * The probe's failure detail reads this so an operator learns WHICH microphone
  * is missing and whether BlueZ still sees it at all. It can never make a device
- * present — only the capture PCM does that.
+ * present — the selected backend's matching capture endpoint does that.
  */
 export function describeBluetoothAudioTarget(
 	id: string,

--- a/apps/backend/src/modules/streaming/bluetooth-audio.ts
+++ b/apps/backend/src/modules/streaming/bluetooth-audio.ts
@@ -20,29 +20,32 @@
  * Bluetooth microphones as selectable audio sources.
  *
  * ─────────────────────────────────────────────────────────────────────────────
- * THE PRESENCE ORACLE IS THE BlueALSA CAPTURE PCM, NEVER BlueZ `Connected`
+ * THE PRESENCE ORACLE FOLLOWS THE ENGINE AUDIO BACKEND; NEVER BlueZ `Connected`
  * ─────────────────────────────────────────────────────────────────────────────
  *
  * `org.bluez.Device1.Connected` says a link exists. It does NOT say the board
  * can open a microphone: a headset connects over A2DP alone, a SCO transport is
- * negotiated separately, and `bluealsad` may not be running at all. So a row is
- * published ONLY when `org.bluealsa` exports a capture PCM object for it —
- * exactly the object `alsasrc device=bluealsa:...` will go on to open. The BlueZ
- * registry contributes two things and nothing else: the operator-facing name,
- * and the `scoCapable` UUID verdict that keeps an A2DP-source-only phone (todo
- * 12's forcing case) from ever being offered a `PROFILE=sco` row whose every
- * open would fail.
+ * negotiated separately, and `bluealsad` may not be running at all. With
+ * `pipewire-capture`, a matching engine audio node is the oracle: its
+ * `device_address` is matched to the registry MAC and its `input_id` becomes
+ * the capture target. The BlueALSA bus is not consulted on that path. Without
+ * that feature, a row is published only when `org.bluealsa` exports a capture
+ * PCM object for it — exactly the object `alsasrc device=bluealsa:...` opens.
+ * The BlueZ registry contributes the operator-facing name and `scoCapable`
+ * UUID verdict, which keeps an A2DP-source-only phone from being offered a
+ * `PROFILE=sco` row whose every open would fail.
  *
  * The same asymmetry governs FAILURE: the registry's connection state ENRICHES
  * the probe's message so an operator is told which device is missing and whether
  * BlueZ still sees it, but it can never SATISFY the probe.
  *
  * ─────────────────────────────────────────────────────────────────────────────
- * THE WHOLE AFFORDANCE IS GATED ON THE ENGINE'S `audio-pcm-spec` FEATURE
+ * THE LEGACY BLUEALSA AFFORDANCE IS GATED ON `audio-pcm-spec`
  * ─────────────────────────────────────────────────────────────────────────────
  *
- * A BlueALSA address is an OPAQUE plugin PCM, not a card. An engine that predates
- * todo 4 resolves `audio.device` through its card registry, so it would answer a
+ * On the legacy arm, a BlueALSA address is an OPAQUE plugin PCM, not a card.
+ * An engine that predates todo 4 resolves `audio.device` through its card
+ * registry, so it would answer a
  * `bluealsa:` string with a card lookup that finds nothing — a start that fails
  * at the leg, seconds after the operator committed. `features` is cerastream's
  * own fail-closed negotiation contract, so the row is rendered DISABLED with the


### PR DESCRIPTION
## What\nUpdate the bluetooth-audio module header to describe both supported presence oracles: PipeWire engine nodes via device_address/pipewire-capture and legacy BlueALSA capture PCM via audio-pcm-spec.\n\n## Why\nThe module overview still described BlueALSA as universal even though PR #320 corrected the implementation and function-level comments for both backend paths.\n\n## How to verify\nBackend TypeScript LSP diagnostics are clean; the existing CeraUI lint hook completed successfully.\n\n## Risks\nComment-only; function-level comments and runtime behavior are unchanged.