### PR TITLE
test(modems): own every wire source in the connection-state contract

### DIFF
--- a/apps/backend/src/tests/modem-connection-state-contract.test.ts
+++ b/apps/backend/src/tests/modem-connection-state-contract.test.ts
@@ -12,6 +12,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { modemListSchema } from "@ceraui/rpc/schemas";
 
+import { resetCellularStack } from "../modules/cellular/cellular-stack.ts";
 import { getUdevProvisionalCache } from "../modules/cellular/udev-provisional-cache.ts";
 import { buildModemsWireMessage } from "../modules/modems/modem-status.ts";
 import { resetModemWireProducer } from "../modules/modems/modem-wire-producer.ts";
@@ -22,6 +23,8 @@ import {
 	setModem,
 } from "../modules/modems/modems-state.ts";
 import { setModemsState } from "../modules/modems/state/modems-state-cache.ts";
+import { resetDongleMetadata } from "../modules/network/dongle-metadata.ts";
+import { resetUsbNetMarkers } from "../modules/network/router-cellular-scan.ts";
 
 /** Every state ModemManager can report through `modem.generic.state`. */
 const MM_STATES = [
@@ -41,10 +44,20 @@ const MM_STATES = [
 ] as const;
 
 /**
- * `buildModemsWireMessage` also reads the udev provisional cache (optimistic
- * rows keyed from `SYNTHETIC_ID_BASE`) and the producer's retained id map, so
- * both are cleared here — on ENTRY too, since Bun shares one process across
- * test files and an earlier file's leftovers precede this file's first test.
+ * This file asserts the wire message's EXACT key set, so it has to own EVERY
+ * source `buildModemsWireMessage` collects — not just the modem map. The
+ * composition root also reads the udev provisional cache, the netns dongle
+ * records, the classified router-dongle markers, the committed cellular backend,
+ * and its own retained synthetic-id map; each is process-wide module state, and
+ * Bun shares one process across test files, so an earlier file's leftovers
+ * precede this file's first test. Everything is therefore cleared on ENTRY as
+ * well as on exit.
+ *
+ * The router-dongle marker cache is the one that actually bit: an earlier file
+ * left a `eth1` marker behind and another left an `eth1` netif entry, so
+ * `collectRouterCellularSources` produced a real row and the roster gained a
+ * synthetic `1000` key — in CI's file order only, which is why the file passed
+ * locally.
  */
 function cleanupModems(): void {
 	for (const id of getModemIds()) {
@@ -52,6 +65,9 @@ function cleanupModems(): void {
 	}
 	setModemsState({});
 	getUdevProvisionalCache().reset();
+	resetDongleMetadata();
+	resetUsbNetMarkers();
+	resetCellularStack();
 	resetModemWireProducer();
 }
 

--- a/apps/backend/src/tests/usb-net-scan-fencing.test.ts
+++ b/apps/backend/src/tests/usb-net-scan-fencing.test.ts
@@ -8,7 +8,7 @@
  * a slow machine could invert.
  */
 
-import { beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 import {
 	getRouterCellularMarker,
@@ -160,6 +160,14 @@ function fixture(tree: FixtureTree, gate?: Gate): Fixture {
 
 describe("refreshUsbNetMarkers — generation-fenced single flight", () => {
 	beforeEach(() => {
+		resetUsbNetMarkers();
+	});
+
+	// The marker cache is process-wide and Bun shares one process across test
+	// files, so clearing only on entry leaves this file's LAST sweep behind for
+	// every later file — which is exactly how a `eth1` marker reached the
+	// `modems` wire projection and gave its roster a synthetic row.
+	afterEach(() => {
 		resetUsbNetMarkers();
 	});
 


### PR DESCRIPTION
## What

The `modems` roster contract test (`modem-connection-state-contract.test.ts`) asserts the wire message's **exact key set**, so it has to own every source `buildModemsWireMessage()` collects. It owned only three of them: the modem map, the udev provisional cache, and the producer's retained synthetic-id map.

The composition root also reads the netns dongle records, the classified router-dongle markers, and the committed cellular backend. All of those are process-wide module state, and Bun shares one process across test files.

Two files change:

- `modem-connection-state-contract.test.ts` — `cleanupModems()` additionally clears `resetDongleMetadata()`, `resetUsbNetMarkers()` and `resetCellularStack()`, on entry **and** on exit.
- `usb-net-scan-fencing.test.ts` — gains an `afterEach(resetUsbNetMarkers)`; it cleared the marker cache on entry only, so its last sweep outlived the file.

## Why

`publish-release.yml` run [33657773807](https://github.com/CERALIVE/CeraUI/actions/runs/33657773807) failed its release gate with exactly one failure out of 5793:

```
(fail) modem connection state reaches the wire > the board roster that used to blank the whole list now reaches the wire
  [ "2", "4", + "1000" ]
```

`1000` is `SYNTHETIC_ID_BASE`. Root cause, reproduced locally:

1. `usb-net-scan-fencing` left an `eth1` router-cellular marker behind (reset on entry only).
2. An earlier netif-touching file (`ethernet-role`, `netif-dup-ip-notice`) left an `eth1` interface in the netif map.
3. `collectRouterCellularSources()` needs exactly those two, so it produced a real router-dongle row and the roster gained a synthetic key.

It only fires in CI's file order, which is why the file is green locally — the same class as the udev-provisional leak fixed in #323, hitting a different cache.

## How to verify

Drive the leaking files ahead of the contract file (Bun sorts explicit file args, so the contract file was copied under a `zz-` name to force it last):

```
# previous cleanup, leaker unfixed -> reproduces the CI failure verbatim
bun test ethernet-role usb-net-scan-fencing zz-old  ->  1 fail, + "1000", same test name

# new cleanup, leaker still unfixed -> passes against the identical leak
bun test ethernet-role usb-net-scan-fencing zz-new  ->  0 fail
```

Full gate, twice:

```
bun run --filter backend test   ->  5791 pass / 2 skip / 0 fail  (5793 across 446 files)
bun run lint                    ->  clean (svelte-check 0 errors / 5 warnings, documented baseline)
bun run --filter backend check  ->  clean
```

## Risks

Test-hygiene only — no source file, no assertion, and no wire behaviour changes. No test was deleted, skipped or weakened; the failing assertion is byte-identical. The only risk would be a test that *relies* on those caches surviving `modem-connection-state-contract.test.ts`, which the two full-suite runs rule out.