### PR TITLE
docs: link the CeraLive Discord in Support the Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,5 +198,6 @@ bun run clean                          # Clean all build artifacts
 
 If you find CeraUI useful, consider supporting CeraLive development:
 
+- 💬 [Join the CeraLive Discord](https://discord.gg/Q2bvU49yx2)
 - ☕ [Ko-fi](https://ko-fi.com/andrescera)
 - 💳 [PayPal](https://www.paypal.com/donate/?business=7KKQS9KBSAMNE&no_recurring=0&item_name=CERALIVE+Development+Support&currency_code=USD)


### PR DESCRIPTION
## What
Adds a first bullet to the README's "Support the Project" section linking the new CeraLive Discord community server.

## Why
CeraLive's Discord server was restructured and is now live. Joining it is free and a lightweight way for users to support/engage with the project, so it belongs alongside Ko-fi and PayPal in that section.

## How to verify
README contains the literal invite URL `https://discord.gg/Q2bvU49yx2`. The invite resolves (`GET /invites/Q2bvU49yx2` -> 200) as of PR open time.

## Risks
One-line README change. No code, no build/config impact.