### PR TITLE
chore(release): prepare CeraUI 2026.9.1 with schema 0.17 bindings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ setup.json are coerced to `"cerastream"` at parse time with a warning).
 The backend resolves both streaming deps as public-npm registry packages — no sibling checkout, no vendored tarball:
 
 ```
-"@ceralive/cerastream":  "2026.9.4"   (public npm, @ceralive scope)
+"@ceralive/cerastream":  "2026.9.5"   (public npm, @ceralive scope)
 "@ceralive/srtla-send":  "2026.8.0"   (public npm, @ceralive scope)
 ```
 
@@ -1134,7 +1134,7 @@ Options outside the offered set are shown **disabled with a reason tooltip** —
 hidden, so operators can see what the hardware doesn't support and why.
 
 **The encoder universe is engine-owned [EXISTS].** The published
-`@ceralive/cerastream@2026.9.4` binding carries `get-capabilities.encoders[]` with
+`@ceralive/cerastream@2026.9.5` binding carries `get-capabilities.encoders[]` with
 one entry per codec (`codec`, maximum resolution/framerate, accepted pixel formats,
 and `gates."4k60"`). `@ceraui/rpc` imports the producer schemas and types directly;
 it does not redeclare `PlatformCaps`, `VideoSourceCap`, or `EncoderCapability`.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ BUILD_ARCH=amd64 ./scripts/build/build-debian-package.sh
 Release assets are published through `publish-release.yml`; see
 [`docs/BUILD_PIPELINE.md`](docs/BUILD_PIPELINE.md) for the stable APT handoff.
 
+CeraUI 2026.9.1 pins the published `@ceralive/cerastream@2026.9.5` in both
+the backend and shared RPC package, matching cerastream 2026.9.2's schema 0.17.0.
+The bindings-skew gate checks the schema version and preservation of the three
+new HDMI capture causes. This release retains the documented early-import
+SIGUSR1 residual window; it does not claim full board qualification.
+
 ### Supported Hardware
 
 **ARM64**: Orange Pi 5/5+, Radxa Rock 5B

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -127,7 +127,7 @@ Bun/TypeScript HTTP + WebSocket server. Serves the frontend static bundle, expos
 
 ### Engine-owned encoder ladder [EXISTS]
 
-`@ceralive/cerastream@2026.9.4` parses the additive `encoders[]` block before
+`@ceralive/cerastream@2026.9.5` parses the additive `encoders[]` block before
 `capabilities.ts` caches or broadcasts it. The backend performs no codec-table
 reconstruction: live and cached snapshots retain the producer-owned
 `EncoderCapability[]`, while the minimal cold-start floor omits it so the frontend

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -9,7 +9,7 @@
 		"bun": ">=1.3.0"
 	},
 	"dependencies": {
-		"@ceralive/cerastream": "2026.9.4",
+		"@ceralive/cerastream": "2026.9.5",
 		"@ceralive/control-protocol": "2026.7.0",
 		"@ceralive/modem-control": "1.3.0",
 		"@ceralive/srtla-send": "2026.8.0",

--- a/apps/backend/src/tests/cerastream-bindings-skew.test.ts
+++ b/apps/backend/src/tests/cerastream-bindings-skew.test.ts
@@ -126,17 +126,10 @@ describe("cerastream bindings version-skew guard", () => {
 		expect(processErrorCodeSchema.options.length).toBe(8);
 	});
 
-	test("SCHEMA_VERSION is pinned to 0.16.0", () => {
-		// rk3588-media-island Todo 34: the 2026.9.4 pin ships schema 0.16.0,
-		// superseding the 0.14.0 of 2026.9.3. This is a deliberate VERSION-TRACKING
-		// edit, not a weakening: the value must equal what the on-device engine
-		// reports in `hello`, because capabilities.ts raises the advisory
-		// `schemaVersionMismatch` banner off exactly that comparison.
-		//
-		// The 9.3 -> 9.4 delta is additive-optional: the engine-owned `encoders[]`
-		// ladder plus the typed encoder/input-format refusal contract. Existing
-		// capability fields remain backward compatible.
-		expect(SCHEMA_VERSION).toBe("0.16.0");
+	test("SCHEMA_VERSION matches the released engine's 0.17.0 contract", () => {
+		// Package CalVer is independent of the hello schema version. The previous
+		// 2026.9.4 package still declared 0.16.0 and rejected the new HDMI causes.
+		expect(SCHEMA_VERSION).toBe("0.17.0");
 	});
 
 	test("a rejected start carries the engine's typed capture causes", () => {
@@ -179,8 +172,29 @@ describe("cerastream bindings version-skew guard", () => {
 			"software-pixel-path-rejected",
 			"composition-unsupported",
 			"secondary-unavailable",
+			"unsupported-format",
+			"interlaced-unsupported",
+			"source-changed",
 		]);
 	});
+
+	test.each(["unsupported-format", "interlaced-unsupported", "source-changed"])(
+		"retains %s when the engine rejects an HDMI capture",
+		(cause) => {
+			// Given a schema-0.17 rejection from the released engine.
+			const rejected = new bindings.CerastreamRpcError(
+				-32602,
+				"invalid params: capture-source-unavailable",
+				"cerastream.params.invalid",
+				null,
+				{ capture_causes: [{ device: "/dev/video0", cause }] },
+			);
+			// When the published client's accessor parses the error data.
+			const causes = rejected.captureCauses();
+			// Then the cause survives instead of silently becoming an empty list.
+			expect(causes).toEqual([{ device: "/dev/video0", cause }]);
+		},
+	);
 
 	test("audio-level topic + connect-error codes are on the surface (Todo 22)", () => {
 		const level = eventParamsSchema.parse({

--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -279,7 +279,7 @@ via `bun run build:federation` from the CeraUI root (delegates to the frontend
   the typed host adapter. Shared graph code is split into sibling chunks
   co-located at the same versioned path.
 - **`<ceraui-version>`** is read at build time from the workspace-root `package.json` `version`
-(CalVer, `2026.9.0` at time of writing) — the single source of truth, matching the platform's
+(CalVer, `2026.9.1` at time of writing) — the single source of truth, matching the platform's
   `ceraui-version` claim.
 - **The catalog is STATIC here, not lazy.** The SPA splits its ten-locale Paraglide
   catalog into per-namespace chunks it awaits in `main.ts`; a federation bundle is

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -19,7 +19,7 @@ Svelte 5 PWA for CeraUI — the on-device control plane for CeraLive streaming h
 The `backend` app consumes both streaming bindings as pinned public npm packages:
 
 ```
-"@ceralive/cerastream": "2026.9.4"   (public npm, @ceralive scope)
+"@ceralive/cerastream": "2026.9.5"   (public npm, @ceralive scope)
 "@ceralive/srtla-send": "2026.8.0"   (public npm, @ceralive scope)
 ```
 

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
       "name": "backend",
       "version": "2026.6.2",
       "dependencies": {
-        "@ceralive/cerastream": "2026.9.4",
+        "@ceralive/cerastream": "2026.9.5",
         "@ceralive/control-protocol": "2026.7.0",
         "@ceralive/modem-control": "1.3.0",
         "@ceralive/srtla-send": "2026.8.0",
@@ -105,7 +105,7 @@
       "name": "@ceraui/rpc",
       "version": "2026.6.1",
       "dependencies": {
-        "@ceralive/cerastream": "2026.9.4",
+        "@ceralive/cerastream": "2026.9.5",
         "@orpc/contract": "2.0.0-beta.31",
         "zod": "catalog:",
       },
@@ -338,7 +338,7 @@
 
     "@ceralive/biome-config": ["@ceralive/biome-config@2026.8.1", "", {}, "sha512-SAqNoi2sc21HMwtY1UqrVqJtNMdcfrjEqVI+RMbbr+nhRC/vPkbHfRzavrNA5IYXeL6wJNDVhFWlyWDw3R3TtA=="],
 
-    "@ceralive/cerastream": ["@ceralive/cerastream@2026.9.4", "", { "dependencies": { "zod": "^4.4.3" } }, "sha512-qtI3UmQ5CpwtsX9y0nrrf5T69QvHEesLe2jdG5PC7QZbI6+IsngC51v34D6n8Hhr3wx89pwhKkycnI55uE+HWw=="],
+    "@ceralive/cerastream": ["@ceralive/cerastream@2026.9.5", "", { "dependencies": { "zod": "^4.4.3" } }, "sha512-rjpYWb0KRXxPramWZUgj9UFTzMSBrUPHU6rKsWfb3rVdMyrD+BPh/qjXQvZ+DUyrcl/OEE59fNf7JgaZyiNpdw=="],
 
     "@ceralive/control-protocol": ["@ceralive/control-protocol@2026.7.0", "", { "dependencies": { "zod": "^4.3.5" } }, "sha512-/pLQpo3bTUzzxaQJK0zta4XKS6EJWr26p5jj2YST69ejxafQiCCjXKgdOkMWU9VjKm0XeMNQehxXOb6ylMGGHg=="],
 

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -93,6 +93,12 @@ It names no producer version, deliberately — it must pass against any pin that
 carries the manifest's fields. That is what keeps an additive bump a no-op and a
 field-retiring bump a loud failure.
 
+The separate `cerastream-bindings-skew.test.ts` gate pins schema `0.17.0` for
+the published `2026.9.5` binding consumed by CeraUI 2026.9.1. It also passes
+`unsupported-format`, `interlaced-unsupported`, and `source-changed` through
+the real `CerastreamRpcError.captureCauses()` accessor. Field-path existence
+alone cannot detect an older enum silently dropping these error causes.
+
 ### The three rules
 
 1. **Publish before consume.** A producer PR that adds or changes a field in a

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ceralive-workspace",
 	"private": true,
-	"version": "2026.9.0",
+	"version": "2026.9.1",
 	"description": "Monorepo workspace containing CeraUI frontend and CeraLive backend",
 	"type": "module",
 	"repository": {

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -26,7 +26,7 @@
 		"lint:fix": "echo 'RPC fixing handled by root Biome'"
 	},
 	"dependencies": {
-		"@ceralive/cerastream": "2026.9.4",
+		"@ceralive/cerastream": "2026.9.5",
 		"@orpc/contract": "2.0.0-beta.31",
 		"zod": "catalog:"
 	},


### PR DESCRIPTION
**Affected repo & language:** CeraUI — TypeScript/Bun

## What

Prepare CeraUI 2026.9.1 and pin both the backend and shared RPC package to the published `@ceralive/cerastream@2026.9.5`. Update the lockfile, dependency documentation, and the bindings-skew regression to require schema 0.17.0 and preserve the three new HDMI capture causes through the real error accessor.

## Why

Released cerastream 2026.9.2 reports schema 0.17.0. The previous 2026.9.4 binding declared 0.16.0 and dropped `unsupported-format`, `interlaced-unsupported`, and `source-changed` from `captureCauses()`. A package-version increase alone is not proof of schema compatibility.

## How to verify

- Install with Bun 1.4.0, then run `bun run lint`, `bun run test`, and `bun run test:release-package-contracts`.
- From `apps/backend`, run `bun test src/tests/producer-schema-drift.test.ts src/tests/cerastream-bindings-skew.test.ts`. Both files pass; the old installed binding failed the version/enum/accessor assertions before the bump.
- Run `BUILD_ARCH=arm64 bun run build` and the functional desktop/mobile E2E lanes from `build-check.yml`.

Full local unit suites, compiler checks, release-package contracts and production build passed. Functional E2E passed from an immutable clean snapshot using production preview and isolated ports: desktop 341 passed/4 skipped; mobile 73 passed/272 skipped. The committed tree equals that snapshot. One independent read-only gate review approved the scoped preparation.

## Risks

This publishes already-merged behavior as well as the dependency correction. The accepted SIGUSR1 residual window during early ESM imports remains unchanged; no wrapper redesign or claim of a clean hardware boot is included. Fresh release-pinned OTA and the media-island hardware matrix remain downstream validation.

Earlier local E2E attempts were not qualifying evidence: an active second checkout competed for the default ports, and two runners ended with SIGKILL before summaries. Isolation removed port reuse; a loopback-only namespace's browser-offline state was measured and corrected inside the namespace for the passing desktop run. The historical runner kills remain unexplained. No test assertion or timeout was weakened.

---

**Checklist**

- [x] Docs updated if behavior or structure changed
- [x] Started from updated main; canonical base verified current
- [x] No new tracked local-scratch references or sibling dependencies
- [x] Tests pass; QA evidence summarized above and CI provides shared logs
