### PR TITLE
fix(frontend): stop inline-size containment starving the media-load hint

### DIFF
--- a/apps/frontend/src/lib/components/custom/MediaLoadHint.svelte
+++ b/apps/frontend/src/lib/components/custom/MediaLoadHint.svelte
@@ -24,7 +24,17 @@ const legacyEncoder = $derived(!groups.some((group) => group.block === 'rkvenc')
 const activity = $derived(deriveEncoderActivity(reading));
 </script>
 
-<div class={cn('@container min-w-0 space-y-1.5', density === 'panel' && !compact && 'bg-card rounded-xl border p-3.5')}
+<!--
+	`@container` sits on the GRID, never on this root: `container-type: inline-size`
+	applies inline-size CONTAINMENT, so a contained element reports ZERO intrinsic
+	width to its parent. On the root it zeroed the whole widget, header row included,
+	and any content-sized parent starved it — in the Live cockpit's `flex-wrap`
+	telemetry strip the cell collapsed to the 58px of its own "ENCODER" caption, the
+	query then measured that 58px, and 19px columns garbled the headers into each
+	other and split every reading into per-character lines. Scoped to the grid, the
+	header row's max-content becomes this widget's content-derived floor.
+-->
+<div class={cn('min-w-0 space-y-1.5', density === 'panel' && !compact && 'bg-card rounded-xl border p-3.5')}
 	data-testid="media-load-hint" data-core-count={count} data-stale={stale} data-density={density}>
 	<div class="flex flex-wrap items-center gap-x-3 gap-y-1">
 		<p class="text-sm font-semibold">{m['settings.mediaLoad.title']()}</p>
@@ -47,29 +57,42 @@ const activity = $derived(deriveEncoderActivity(reading));
 		</Button>
 	</div>
 	{#if legacyEncoder}<LegacyEncoderStatus {reading} density="inline" compact />{/if}
-	<div class="grid min-w-0 gap-x-4 gap-y-3 @xl:grid-cols-2 @3xl:grid-cols-4">
+	<div class="@container min-w-0">
+		<!-- The four-up rung is `@4xl`, not `@3xl`: at 768px each of four columns holds
+		     183px, which is under the width a full `fdbd0000` identity plus both
+		     readings needs, so it bought a fourth column by ellipsing every row label. -->
+		<div class="grid min-w-0 gap-x-4 gap-y-3 @xl:grid-cols-2 @4xl:grid-cols-4">
 		{#each groups as group (group.block)}
 			<section class="min-w-0" data-testid="media-load-group" data-block={group.block} data-core-count={group.cores.length}>
 				<div class="mb-1 flex items-baseline justify-between gap-2 text-xs">
 					<h4 class="font-medium">{group.block === 'rga' ? 'RGA' : resolveMessageKey(MEDIA_GROUP_LABELS[group.block])}</h4>
 					<span class="text-muted-foreground">{m['settings.mediaLoad.coreCount']({ count: group.cores.length })}</span>
 				</div>
-				<div class="border-t pt-1">
-					<table class="w-full table-fixed text-xs" aria-label={resolveMessageKey(MEDIA_GROUP_LABELS[group.block])}>
+				<!--
+					`table-auto` + `whitespace-nowrap` readings, and the IDENTITY column is the
+					only one that yields (`w-full max-w-0 truncate`). A reading is the thing this
+					table exists to state, so it is never the part that breaks: under the previous
+					`table-fixed` thirds a squeezed column wrapped `87.75%` down four lines as
+					`87`/`.7`/`5%` and let a nowrap-less `Utilization` header bleed across `Load`.
+					Nowrap columns cannot fall below their own header, so no header can overflow
+					its cell, and the wrapper scrolls rather than letting anything overlap.
+				-->
+				<div class="min-w-0 overflow-x-auto border-t pt-1">
+					<table class="w-full table-auto text-xs" aria-label={resolveMessageKey(MEDIA_GROUP_LABELS[group.block])}>
 						<thead class="text-muted-foreground"><tr>
-							<th scope="col" class="w-1/3 text-start font-normal"><span class="sr-only">{resolveMessageKey(MEDIA_GROUP_LABELS[group.block])}</span></th>
-							<th scope="col" class="text-end font-normal">{m['settings.mediaLoad.load']()}</th>
-							{#if group.source !== 'rkrga'}<th scope="col" class="text-end font-normal">{m['settings.mediaLoad.utilization']()}</th>{/if}
+							<th scope="col" class="w-full max-w-0 text-start font-normal"><span class="sr-only">{resolveMessageKey(MEDIA_GROUP_LABELS[group.block])}</span></th>
+							<th scope="col" class="ps-2 text-end font-normal whitespace-nowrap">{m['settings.mediaLoad.load']()}</th>
+							{#if group.source !== 'rkrga'}<th scope="col" class="ps-2 text-end font-normal whitespace-nowrap">{m['settings.mediaLoad.utilization']()}</th>{/if}
 						</tr></thead>
 						<tbody>
 						{#each group.cores as core (core.core)}
 							<tr data-media-core={core.core}>
-								<th scope="row" class="text-muted-foreground truncate py-0.5 pe-2 text-start font-mono font-normal" title={core.core}><bdi>{mediaCoreHintLabel(core.core)}</bdi></th>
-								<td class={cn('text-end break-words', core.load !== null ? 'font-mono tabular-nums' : 'text-muted-foreground', (stale || core.load === 0) && 'text-muted-foreground', !stale && core.load !== null && core.load > 0 && 'text-primary')} data-metric="load">
+								<th scope="row" class="text-muted-foreground w-full max-w-0 truncate py-0.5 pe-2 text-start font-mono font-normal" title={core.core}><bdi>{mediaCoreHintLabel(core.core)}</bdi></th>
+								<td class={cn('ps-2 text-end whitespace-nowrap', core.load !== null ? 'font-mono tabular-nums' : 'text-muted-foreground', (stale || core.load === 0) && 'text-muted-foreground', !stale && core.load !== null && core.load > 0 && 'text-primary')} data-metric="load">
 									{core.load === null ? m['settings.mediaLoad.unknown']() : `${core.load.toFixed(2)}%`}
 								</td>
 								{#if group.source !== 'rkrga'}
-								<td class={cn('text-end break-words', core.utilization !== null ? 'font-mono tabular-nums' : 'text-muted-foreground', (stale || core.utilization === 0) && 'text-muted-foreground')} data-metric="utilization">
+								<td class={cn('ps-2 text-end whitespace-nowrap', core.utilization !== null ? 'font-mono tabular-nums' : 'text-muted-foreground', (stale || core.utilization === 0) && 'text-muted-foreground')} data-metric="utilization">
 									{core.utilization === null ? m['settings.mediaLoad.unknown']() : `${core.utilization.toFixed(2)}%`}
 								</td>
 								{/if}
@@ -80,5 +103,6 @@ const activity = $derived(deriveEncoderActivity(reading));
 				</div>
 			</section>
 		{/each}
+		</div>
 	</div>
 </div>

--- a/apps/frontend/src/lib/streaming/encoder-load-island-mock.ts
+++ b/apps/frontend/src/lib/streaming/encoder-load-island-mock.ts
@@ -1,6 +1,14 @@
 import type { EncoderLoadReading } from "./encoder-load";
 
-/** Illustrative queue/ownership data, not board measurements; never a wire publisher. */
+/**
+ * Illustrative queue/ownership data, not board measurements; never a wire publisher.
+ *
+ * The core IDENTITIES are the real ones, read from an Orange Pi 5+ running the
+ * mainline media island (`/proc/mpp_service/load`, `/proc/rkrga/load`): one JPEG
+ * decoder, not two, and `fdc40100.video-codec` rather than the invented
+ * `fdc48100`. A fixture whose identities no board publishes cannot stand in for
+ * one during layout QA, which is the job this fixture is actually asked to do.
+ */
 export function mockIslandLoadAt(t: number): EncoderLoadReading {
 	return {
 		source: "mpp-service",
@@ -43,7 +51,7 @@ export function mockIslandLoadAt(t: number): EncoderLoadReading {
 						sessions: [{ pid: 5380, index: 2 }],
 					},
 					{
-						core: "fdc48100.video-codec",
+						core: "fdc40100.video-codec",
 						load: null,
 						utilization: 0,
 						sessions: null,
@@ -54,8 +62,7 @@ export function mockIslandLoadAt(t: number): EncoderLoadReading {
 				source: "mpp-service",
 				block: "jpgdec",
 				cores: [
-					{ core: "fdba0000.jpegd", load: 7.5, utilization: 5, sessions: [] },
-					{ core: "fdba4000.jpegd", load: 0, utilization: 0, sessions: [] },
+					{ core: "fdb90000.jpegd", load: 7.5, utilization: 5, sessions: [] },
 				],
 			},
 			{

--- a/apps/frontend/src/main/dialogs/device-health/MediaLoadPanel.svelte
+++ b/apps/frontend/src/main/dialogs/device-health/MediaLoadPanel.svelte
@@ -50,14 +50,14 @@ const legacyEncoder = $derived(!groups.some((group) => group.block === 'rkvenc')
 						<p class="break-all font-mono text-xs" dir="ltr">{core.core}</p>
 						<dl class="grid grid-cols-2 gap-x-5 gap-y-3 text-xs sm:grid-cols-[1fr_1fr_2fr]">
 							<div class="min-w-0 space-y-1">
-								<dt class="text-muted-foreground">{m['settings.mediaLoad.load']()}</dt>
-								<dd class={cn(core.load !== null && 'font-mono text-base tabular-nums', stale && 'text-muted-foreground')} data-metric="load">
+								<dt class="truncate text-muted-foreground">{m['settings.mediaLoad.load']()}</dt>
+								<dd class={cn(core.load !== null && 'font-mono text-base tabular-nums whitespace-nowrap', stale && 'text-muted-foreground')} data-metric="load">
 									{core.load === null ? m['settings.mediaLoad.unknown']() : `${core.load.toFixed(2)}%`}
 								</dd>
 							</div>
 							<div class="min-w-0 space-y-1">
-								<dt class="text-muted-foreground">{m['settings.mediaLoad.utilization']()}</dt>
-								<dd class={cn(core.utilization !== null && 'font-mono text-base tabular-nums', stale && 'text-muted-foreground')} data-metric="utilization">
+								<dt class="truncate text-muted-foreground">{m['settings.mediaLoad.utilization']()}</dt>
+								<dd class={cn(core.utilization !== null && 'font-mono text-base tabular-nums whitespace-nowrap', stale && 'text-muted-foreground')} data-metric="utilization">
 									{group.source === 'rkrga' ? m['settings.mediaLoad.notPublished']() : core.utilization === null ? m['settings.mediaLoad.unknown']() : `${core.utilization.toFixed(2)}%`}
 								</dd>
 							</div>

--- a/apps/frontend/src/main/live/StreamTelemetryStrip.svelte
+++ b/apps/frontend/src/main/live/StreamTelemetryStrip.svelte
@@ -116,8 +116,14 @@ const {
 			Sheet is that cap's overflow rather than a general telemetry drawer.
 			This container already wraps, so the fourth cell degrades by wrapping
 			instead of overflowing the 1024x600 kiosk viewport.
+
+			It takes a FULL BASIS rather than sharing a line with the three scalar
+			chips beside it. Those are single readings; this is a multi-column table
+			per media block, and it is inline-size-contained, so it reports no
+			intrinsic width of its own — on a shared line it was sized by its
+			"ENCODER" caption alone and rendered 19px columns.
 		-->
-		<div class="min-w-0 space-y-1" data-testid="telemetry-encoder">
+		<div class="min-w-0 basis-full space-y-1" data-testid="telemetry-encoder">
 			<p class="text-muted-foreground text-xs font-medium tracking-wide uppercase">
 				{m["hud.encoder"]()}
 			</p>

--- a/apps/frontend/src/tests/media-load-ui.test.ts
+++ b/apps/frontend/src/tests/media-load-ui.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@testing-library/svelte";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import EncoderStatus from "$lib/components/custom/EncoderStatus.svelte";
+import { mockIslandLoadAt } from "$lib/streaming/encoder-load-island-mock";
 import MediaLoadDialog from "../main/dialogs/MediaLoadDialog.svelte";
 
 vi.mock("$lib/rpc/subscriptions.svelte", () => ({
@@ -74,6 +75,8 @@ const reading: EncoderLoad = {
 		},
 	],
 };
+
+const islandReading = mockIslandLoadAt(1234) as EncoderLoad;
 
 afterEach(cleanup);
 beforeAll(() => {
@@ -274,5 +277,73 @@ describe("media load hint", () => {
 				.getByTestId("encoder-status-headline")
 				.getAttribute("data-activity"),
 		).toBe("unreported");
+	});
+});
+
+/**
+ * jsdom lays nothing out, so these assert the STRUCTURE the browser gate measures
+ * — the cheap half of a two-part lock whose expensive half is
+ * `tests/e2e/visual/device-telemetry-v2.visual.spec.ts` -> the blocks leg.
+ *
+ * PR #328 put `@container` on the widget ROOT. `container-type: inline-size`
+ * applies inline-size CONTAINMENT, so a contained element reports ZERO intrinsic
+ * width to its parent — and the Live cockpit's telemetry strip sizes its cells
+ * from their content, so the widget was starved to the 58px of its own caption
+ * and drew 19px columns that overlapped their headers and split every reading
+ * into per-character lines.
+ */
+describe("media load hint — the layout contract", () => {
+	it("keeps inline-size containment off the root, so the widget reports a real width", () => {
+		render(EncoderStatus, { reading });
+		const root = screen.getByTestId("media-load-hint");
+		expect(root.className).not.toMatch(/(^|\s)@container(\s|$)/);
+		const container = root.querySelector(".\\@container");
+		expect(container, "the grid still needs a query container").not.toBeNull();
+		expect(
+			container?.contains(root),
+			"the container must be INSIDE the root, never the root itself",
+		).toBe(false);
+	});
+
+	it("never lets a reading wrap, and never lets a header outrank its own column", () => {
+		render(EncoderStatus, { reading });
+		const root = screen.getByTestId("media-load-hint");
+
+		for (const cell of root.querySelectorAll("td[data-metric]")) {
+			expect(
+				cell.className,
+				`reading ${cell.textContent?.trim()} may wrap — it must be nowrap`,
+			).toContain("whitespace-nowrap");
+			expect(cell.className).not.toContain("break-words");
+		}
+		// A nowrap column cannot shrink below its own header, so a nowrap header is
+		// exactly what makes overflow — and therefore overlap — unreachable. The
+		// first column is the identity's and is deliberately the one that yields.
+		const headers = [...root.querySelectorAll("thead th:not(:first-child)")];
+		expect(headers.length).toBeGreaterThan(0);
+		for (const header of headers) {
+			expect(
+				header.className,
+				`header ${header.textContent?.trim()} may wrap or overflow`,
+			).toContain("whitespace-nowrap");
+		}
+		// The identity is the one column that yields, and it keeps its full value
+		// in `title` so truncation never costs the operator the reading's subject.
+		for (const label of root.querySelectorAll("tbody th")) {
+			expect(label.className).toContain("truncate");
+			expect(label.getAttribute("title")).toBeTruthy();
+		}
+	});
+
+	it("states a real board's identities, not invented ones", () => {
+		render(EncoderStatus, { reading: islandReading });
+		const hint = screen.getByTestId("media-load-hint");
+		expect(hint.getAttribute("data-core-count")).toBe("8");
+		const identities = [...hint.querySelectorAll("tbody th")].map((th) =>
+			th.getAttribute("title"),
+		);
+		expect(identities).toContain("fdb90000.jpegd");
+		expect(identities).toContain("fdc40100.video-codec");
+		expect(identities).not.toContain("fdba4000.jpegd");
 	});
 });

--- a/apps/frontend/src/tests/media-load.test.ts
+++ b/apps/frontend/src/tests/media-load.test.ts
@@ -161,7 +161,9 @@ describe("media presentation facts", () => {
 			"jpgdec",
 			"rga",
 		]);
-		expect(mediaLoadCoreCount(fixture.blocks ?? [])).toBe(9);
+		// The Orange Pi 5+ inventory the fixture now mirrors: two encode cores, two
+		// decode, ONE JPEG decoder, three RGA schedulers.
+		expect(mediaLoadCoreCount(fixture.blocks ?? [])).toBe(8);
 	});
 
 	it.each([0, 1, 5])("counts %i reported cores without padding", (count) => {

--- a/apps/frontend/tests/e2e/media-load.spec.ts
+++ b/apps/frontend/tests/e2e/media-load.spec.ts
@@ -12,7 +12,7 @@ test('media detail follows the wire, then degrades to the legacy clock reading',
 	const snapshot = encoderLoadSchema.parse(mockIslandLoadAt(Date.now()));
 	await pageRpc.call(['dev', 'emit'], { type: 'encoder-load', payload: snapshot });
 	const hint = page.getByTestId('media-load-hint');
-	await expect(hint).toHaveAttribute('data-core-count', '9');
+	await expect(hint).toHaveAttribute('data-core-count', '8');
 	await expect(hint).not.toContainText('4242');
 	const trigger = hint.getByRole('button', { name: 'Media details', exact: true });
 	await trigger.focus();
@@ -21,13 +21,13 @@ test('media detail follows the wire, then degrades to the legacy clock reading',
 	await expect(dialog).toBeVisible();
 	await dialog.getByTestId('media-load-detail').focus();
 	await expect(dialog.getByTestId('media-load-detail')).toBeFocused();
-	await expect(dialog.getByTestId('media-detail-core')).toHaveCount(9);
+	await expect(dialog.getByTestId('media-detail-core')).toHaveCount(8);
 	await expect(dialog).toContainText('145.53%');
 	await expect(dialog).toContainText('121.08%');
 	await expect(dialog).toContainText('PID 4242 · index 7');
 	await expect(dialog).toContainText('PID 4242 · index 9');
 	await expect(dialog.locator('[data-block="rga"]')).toContainText('Not published by this driver');
-	await expect(dialog.locator('[data-core="fdc48100.video-codec"]')).toContainText('Unknown');
+	await expect(dialog.locator('[data-core="fdc40100.video-codec"]')).toContainText('Unknown');
 	await page.keyboard.press('Escape');
 	await expect(dialog).toBeHidden();
 	await expect(trigger).toBeFocused();
@@ -45,3 +45,81 @@ test('media detail follows the wire, then degrades to the legacy clock reading',
 	await expect(dialog).toContainText('Utilization and session ownership are unknown');
 	expect(errors).toEqual([]);
 });
+
+/**
+ * The layout gate, asserted on RENDERED GEOMETRY rather than on class names — the
+ * regression it guards is a CSS one, and a class assertion walks straight through
+ * it (the `expectCoresStackVertically` precedent in device-telemetry-v2).
+ *
+ * PR #328 shipped this widget with `@container` on its ROOT. `container-type:
+ * inline-size` applies inline-size CONTAINMENT, so the whole widget reported ZERO
+ * intrinsic width and every content-sized parent starved it. In the Live cockpit's
+ * `flex-wrap` telemetry strip the cell collapsed to the 58px of its own "ENCODER"
+ * caption; the container query then measured that 58px and drew 19px columns, in
+ * which `Utilization` bled across `Load` and `87.75%` broke into `87`/`.7`/`5%`
+ * down four lines. Fixture QA never saw it because the island fixture is reachable
+ * from Settings and Device Health, where a grid track hands the widget a real
+ * width — and the one spec that did reach the strip pushed a LEGACY (block-less)
+ * reading, so `MediaLoadHint` never rendered there at all.
+ *
+ * Three invariants, at both breakpoints:
+ *  1. the widget is not starved — its box is a real fraction of its parent's;
+ *  2. no column header's ink exceeds its own cell (overlap is what garbles them);
+ *  3. every reading occupies exactly one line (wrapping is what fragments them).
+ */
+for (const [label, viewport] of [
+	['desktop', { width: 1280, height: 900 }],
+	['mobile', { width: 375, height: 812 }],
+] as const) {
+	test(`media load stays legible at every mount — ${label}`, async ({ page, pageRpc }) => {
+		await page.setViewportSize(viewport);
+		await page.goto('/');
+		await ensureAuthenticated(page);
+		await navigateTo(page, 'settings');
+		await pageRpc.call(['dev', 'emit'], {
+			type: 'encoder-load',
+			payload: encoderLoadSchema.parse(mockIslandLoadAt(Date.now())),
+		});
+		await expect(page.getByTestId('media-load-hint')).toBeVisible();
+
+		const geometry = await page.getByTestId('media-load-hint').evaluate((root) => {
+			const heads = [...root.querySelectorAll('thead th')].map((th) => ({
+				text: th.textContent?.trim() ?? '',
+				box: th.clientWidth,
+				ink: th.scrollWidth,
+			}));
+			const readings = [...root.querySelectorAll('td[data-metric]')].map((td) => {
+				const rect = td.getBoundingClientRect();
+				const lineHeight = Number.parseFloat(getComputedStyle(td).lineHeight) || 16;
+				return {
+					text: td.textContent?.trim() ?? '',
+					lines: Math.max(1, Math.round(rect.height / lineHeight)),
+				};
+			});
+			return {
+				width: root.getBoundingClientRect().width,
+				parentWidth: root.parentElement?.getBoundingClientRect().width ?? 0,
+				heads,
+				readings,
+			};
+		});
+
+		expect(geometry.readings.length, 'fixture rendered no readings to measure').toBeGreaterThan(0);
+		expect(
+			geometry.width,
+			'the widget was starved by its parent — inline-size containment must not sit on its root',
+		).toBeGreaterThan(geometry.parentWidth * 0.5);
+		for (const head of geometry.heads) {
+			expect(
+				head.ink,
+				`column header ${JSON.stringify(head.text)} overflows its cell and overlaps its neighbour`,
+			).toBeLessThanOrEqual(head.box + 1);
+		}
+		for (const reading of geometry.readings) {
+			expect(
+				reading.lines,
+				`reading ${JSON.stringify(reading.text)} wrapped across ${reading.lines} lines`,
+			).toBe(1);
+		}
+	});
+}

--- a/apps/frontend/tests/e2e/visual/device-telemetry-v2.visual.spec.ts
+++ b/apps/frontend/tests/e2e/visual/device-telemetry-v2.visual.spec.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 
 import type { Page, WebSocketRoute } from "@playwright/test";
 
+import { mockIslandLoadAt } from "../../../src/lib/streaming/encoder-load-island-mock";
 import { expect, test } from "../fixtures/index.js";
 import { EVIDENCE_DIR, ensureAuthenticated, navigateTo } from "../helpers/index.js";
 
@@ -72,6 +73,9 @@ const ENCODER_IDLE = {
 	updatedAt: Date.now(),
 	simulated: false,
 };
+
+/** The media-island shape — the arm that selects `MediaLoadHint` over the legacy renderer. */
+const ENCODER_BLOCKS = mockIslandLoadAt(Date.now());
 
 const ENCODER_BINARY_IDLE = {
 	source: "clk-enable-count",
@@ -453,6 +457,70 @@ test.describe("@visual device telemetry v2", () => {
 			);
 			await strip.screenshot({
 				path: path.join(EVIDENCE_DIR, `telemetry-v2-live-strip-idle-${label}.png`),
+			});
+
+			/**
+			 * The media-island BLOCKS reading, in the same cell. This leg exists
+			 * because its absence is what let PR #328 ship broken: every reading
+			 * pushed above is LEGACY-shaped, so `EncoderStatus` took its
+			 * `LegacyEncoderStatus` arm and `MediaLoadHint` — the only renderer
+			 * that carries a container query — never rendered at this mount at all.
+			 *
+			 * `container-type: inline-size` applies inline-size CONTAINMENT, so a
+			 * contained element reports ZERO intrinsic width. With the query on the
+			 * widget root, this flex cell sized itself from its own "ENCODER"
+			 * caption alone (58px measured), the query then read that 58px, and the
+			 * resulting 19px columns bled `Utilization` across `Load` and split
+			 * `87.75%` into `87`/`.7`/`5%` down four lines.
+			 */
+			await push(page, { "encoder-load": ENCODER_BLOCKS });
+			const hint = cell.getByTestId("media-load-hint");
+			await expect(hint).toBeVisible();
+
+			const geometry = await hint.evaluate((root) => ({
+				width: root.getBoundingClientRect().width,
+				stripWidth:
+					root.closest("section")?.getBoundingClientRect().width ?? 0,
+				heads: [...root.querySelectorAll("thead th")].map((th) => ({
+					text: th.textContent?.trim() ?? "",
+					box: th.clientWidth,
+					ink: th.scrollWidth,
+				})),
+				readings: [...root.querySelectorAll("td[data-metric]")].map((td) => {
+					const lineHeight =
+						Number.parseFloat(getComputedStyle(td).lineHeight) || 16;
+					return {
+						text: td.textContent?.trim() ?? "",
+						lines: Math.max(
+							1,
+							Math.round(td.getBoundingClientRect().height / lineHeight),
+						),
+					};
+				}),
+			}));
+
+			expect(
+				geometry.readings.length,
+				"no readings rendered — the blocks arm did not mount",
+			).toBeGreaterThan(0);
+			expect(
+				geometry.width,
+				`${label}: the widget was starved by the strip — inline-size containment must not sit on its root`,
+			).toBeGreaterThan(geometry.stripWidth * 0.5);
+			for (const head of geometry.heads) {
+				expect(
+					head.ink,
+					`${label}: header ${JSON.stringify(head.text)} overflows its cell and overlaps its neighbour`,
+				).toBeLessThanOrEqual(head.box + 1);
+			}
+			for (const reading of geometry.readings) {
+				expect(
+					reading.lines,
+					`${label}: reading ${JSON.stringify(reading.text)} wrapped across ${reading.lines} lines`,
+				).toBe(1);
+			}
+			await strip.screenshot({
+				path: path.join(EVIDENCE_DIR, `telemetry-v2-live-strip-blocks-${label}.png`),
 			});
 		}
 	});


### PR DESCRIPTION
## What

The media-load readings rendered garbled on a real streaming board: the `Load`
and `Utilization` column headers overlapped into "Loadtilization", each reading
broke into per-character lines (`87.75%` → `87` / `.7` / `5%`) with both columns
interleaving, row identities clipped to a single character, and RGA showed
`33.00 %` beside a neighbouring `0.00%`.

## Why

`MediaLoadHint` carried `@container` on its **root**. `container-type:
inline-size` applies inline-size **containment**, so a contained element reports
**zero** intrinsic width to its parent — and any parent that sizes itself from
its content therefore starves it.

Measured in a browser against a faithful replica of `StreamTelemetryStrip`: in a
1353px strip the `telemetry-encoder` flex cell collapsed to **58px** (the
max-content of its own "ENCODER" caption, the one uncontained thing left in it),
the container query then measured that 58px, and the `table-fixed` thirds became
**19px columns**. In 19px, `Utilization` (58px of ink) bleeds across `Load`,
`truncate` eats the identity down to one character, and `break-words` fragments
every reading. Every reported symptom falls out of that single measurement — the
stray space in `33.00 %` is just `%` wrapping alone onto the next line.

**Why the fixture QA that shipped this passed, and it is not value length.** The
island fixture already carried longer values than the board's (`145.53` vs
`87.75`). The gap is mount-site coverage, twice: `?health-mock=island` is
reachable from Settings and Device Health, where a grid track hands the widget an
externally-determined width so it never collapses (re-confirmed read-only against
the board at 1280x900, 1024x600 and 390x844 — all clean); and the one e2e that
does reach the Live strip pushed only legacy-shaped readings, so `EncoderStatus`
took its `LegacyEncoderStatus` arm and `MediaLoadHint` — the only renderer
carrying a container query — never rendered at that mount at all. The broken
surface exists only while streaming, which fixture QA never entered.

## How

- **The query moves off the root** onto a wrapper around the grid, so the header
  row sits outside the containment and its max-content becomes the widget's
  honest, content-derived floor (416px in the same strip, up from 58px). A
  container query never matches its own container element, so the wrapper and the
  grid have to be two elements.
- **The table is `table-auto` with nowrap readings and headers**, leaving the
  identity column as the only one that yields (`w-full max-w-0 truncate`, full
  value kept in `title`). A nowrap column cannot shrink below its own header, so
  header overflow — and therefore overlap — is unreachable by construction.
- **The four-up rung moves `@3xl` → `@4xl`**: at 768px four columns are 183px
  each, under what a full `fdbd0000` identity plus both readings needs, so it was
  buying a fourth column by ellipsing every row label.
- **The strip's encoder cell takes `basis-full`** — it is a multi-column block,
  not a scalar chip, and it was competing with three of them.
- The island fixture now states the identities the board actually publishes, read
  read-only from `/proc/mpp_service/load` and `/proc/rkrga/load`: one JPEG decoder
  (`fdb90000.jpegd`, not two invented `fdba*` cores) and `fdc40100.video-codec`
  (not `fdc48100`). Core count 9 → 8, and the two shape assertions naming 9 follow.

## How to verify

- Swept in a browser from 1100px down to 120px: zero header ink overflow, every
  reading on exactly one line, only the identity ever ellipsing (below 200px).
- New gates assert **rendered geometry**, not class names — a CSS regression walks
  straight through a class assertion (the `expectCoresStackVertically` precedent).
  A blocks leg was added to `device-telemetry-v2.visual.spec.ts`'s live-cockpit
  test asserting the widget is not starved, that no header's ink exceeds its cell,
  and that every reading is one line; `media-load.spec.ts` gained the same three
  invariants at desktop and mobile; `media-load-ui.test.ts` gained the cheap jsdom
  half.
- Rule E falsifiability: reverting `MediaLoadHint.svelte` reddens 2 of that file's
  15 tests.
- Full frontend suite green: **364 files / 6004 tests**, plus hardware-preflight
  4/4. `svelte-check` 0 errors. Biome clean on every changed file. The e2e
  typecheck is unchanged at its 23 pre-existing errors.

## Risks

- Low and layout-scoped. No wire, schema, RPC or logic change; no test was
  weakened or skipped.
- `@4xl` trades the four-up rung between 768px and 896px containers for two
  columns that can hold a full identity — denser at that band, legible instead of
  ellipsed.
- Board access during this work was read-only: HTTP page loads and two `cat`
  reads of `/proc`. No service or config was touched.
