### PR TITLE
THROWAWAY probe (docs-only) — todo 4 docs-only gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,3 +217,5 @@ If you find CeraUI useful, consider supporting CeraLive development:
 - 💬 [Join the CeraLive Discord](https://discord.gg/Q2bvU49yx2)
 - ☕ [Ko-fi](https://ko-fi.com/andrescera)
 - 💳 [PayPal](https://www.paypal.com/donate/?business=7KKQS9KBSAMNE&no_recurring=0&item_name=CERALIVE+Development+Support&currency_code=USD)
+
+<!-- todo-4 docs-only gate probe -->


### PR DESCRIPTION
Throwaway non-vacuity probe for the CeraUI docs-only Build Check gate (PR #333). Never merged; closed with its branch once the run is recorded.