### PR TITLE
THROWAWAY probe (code) — todo 4 docs-only gate

### DIFF
--- a/apps/backend/src/modules/streaming/streamloop.ts
+++ b/apps/backend/src/modules/streaming/streamloop.ts
@@ -22,3 +22,5 @@
 // resolving to the same symbols.
 
 export * from "./streamloop/index.ts";
+
+// todo-4 code-gate probe


### PR DESCRIPTION
Throwaway non-vacuity probe for the CeraUI docs-only Build Check gate (PR #333). Never merged; closed with its branch once the run is recorded.