### PR TITLE
THROWAWAY probe (workflow) — todo 4 docs-only gate

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -824,3 +824,4 @@ jobs:
             echo "### Build Artifacts:"
             for f in CeraUI/dist/*; do echo "- \`$(basename "$f")\`"; done
           } >> "$GITHUB_STEP_SUMMARY"
+# todo-4 workflow-only gate probe


### PR DESCRIPTION
Throwaway non-vacuity probe for the CeraUI docs-only Build Check gate (PR #333). Never merged; closed with its branch once the run is recorded.