### PR TITLE
THROWAWAY probe (fail-setup-e2e) — todo 4 docs-only gate

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -435,6 +435,9 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      - name: todo-4 non-vacuity probe — force setup-e2e to fail
+        run: exit 1
+
   test-e2e:
     name: E2E (${{ matrix.project }} shard ${{ matrix.shard }}/2)
     needs: [changes, setup-e2e]


### PR DESCRIPTION
Throwaway non-vacuity probe for the CeraUI docs-only Build Check gate (PR #333). Never merged; closed with its branch once the run is recorded.