### PR TITLE
test(backend): make the parallel suite deterministic

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -240,6 +240,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           path: CeraUI
+          fetch-depth: 0 # The source-routing regression compares against historical commits.
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -213,6 +213,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           path: CeraUI
+          fetch-depth: 0 # This job runs the same history-dependent backend suite as Build Check.
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/apps/backend/.gitignore
+++ b/apps/backend/.gitignore
@@ -22,6 +22,7 @@ auth_tokens.json
 .e2e-auth-token
 config.json
 config.inflight.json
+stream.armed.json
 dns_cache.json
 debug.log
 gsm_operator_cache.json

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -5959,6 +5959,15 @@ USB enumeration cannot spend the NM-timeout case's budget through host schedulin
 delay. Only the unresolved NM reader advances time, including the failure-path
 re-probe; teardown restores the real clock. Production polling is unchanged.
 
+The add-on shell/GPG suite and historical source-routing Git guard use
+`tests/helpers/run-test-command.ts`: asynchronous spawn, concurrent stdout/stderr
+drains and exit observation, with scoped disposal. Bun 1.4.2's synchronous spawn
+loop can lose poll accounting when GC finalizes main-loop resources during the
+wait (oven-sh/bun#40078), stalling later children even after they exited.
+The helper's regression reproduces that state in a disposable process; do not
+replace real shell/GPG verification or Git history with mocks, or switch these
+calls back to `spawnSync`. No test or production timeout was increased.
+
 Backend tests inject procedure launch/source dependencies through
 `setStreamingProcedureDepsForTest()` and stream-start process/telemetry/engine
 dependencies through `setStartStreamDepsForTest()`. Every test that overrides

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -5322,9 +5322,11 @@ guard covers the rest. Nothing else changes: `modems.setUsbMode`'s existing
   as a typed `failed`, so it exercises the ordinary return path — the `finally`
   needs its own fixture (a dep that throws mid-admission).
 - **`admitLifecycle` is an OPTIONAL orchestrator dep, wired only at the
-  production singleton.** The lease is process-wide and `bun test` runs one
-  process, so defaulting it on inside the factory would let any unit test that
-  leaves a start pending strand every later test's admission.
+  production singleton.** The lease is process-wide. Bun 1.4.2 `--parallel`
+  runs files in isolated worker processes, but tests within each file still
+  share module state: a pending start can strand later admissions in that file.
+  Keep explicit lease cleanup and use a per-file `mkdtemp` root for persisted
+  fixtures; worker isolation does not isolate shared filesystem paths.
 
 **The `"modem-transition"` holder is now acquired by `modems.setUsbMode`**
 (`rpc/procedures/modems.procedure.ts`, gate 4 — see USB-COMPOSITION SWITCH above).
@@ -5936,13 +5938,21 @@ are gated by `shouldUseMocks()` or `isDevelopment()` — never active in product
 
 ### Backend per-file test isolation
 
-The backend `test` script remains serial: the formal parallel stability gate
-finished 9/10 after one isolation pass. `sim-autounlock.test.ts` now seeds a
-private working-directory config and restores cwd after each test, so its
-byte-preservation assertion cannot observe another worker's config writes.
-The remaining observed hazard is `usb-tether-fence.test.ts` enumerating a runtime
-`stream.armed.json` that another worker removes before the scan reads it.
-Do not adopt parallel execution on the strength of isolated passing reruns.
+The backend `test` script remains serial. Bun 1.4.2 `bun test --parallel`
+runs files across worker processes and implies per-file isolation; it does not
+make tests within a file concurrent. Each file writing fixtures must own a
+`mkdtemp` root and redirect the existing path seam, never use a fixed shared
+path. `sim-autounlock.test.ts` uses `setConfigFilePath()` and absolute reads
+instead of changing cwd. `usb-tether-fence.test.ts` scans a private source
+snapshot: tracked plus new non-ignored working-tree files, not runtime state.
+The transient `stream.armed.json` is ignored beside the other backend runtime
+files. Source copy/read failures remain fatal; only snapshot teardown tolerates
+`ENOENT`.
+
+The 2026-09-07 adoption batches finished 19/20 and 18/20, not the required
+20/20. Both repaired files passed throughout, but unchanged add-on helper,
+modem-transition, and source-routing tests failed. Parallel adoption remains
+blocked; isolated passing reruns do not discharge the stability gate.
 
 Backend tests inject procedure launch/source dependencies through
 `setStreamingProcedureDepsForTest()` and stream-start process/telemetry/engine
@@ -9458,7 +9468,7 @@ config, an anchored path still held by its own device, and a live row with no
 - Don't let anything but VERIFIED-ROLLBACK or FORCE-REBASELINE unblock a failed mutation, and don't archive before the `acknowledged` write commits — that ordering is what makes a crash between the two replayable instead of a lost operator decision.
 - Don't make `decommissioned` terminal, and don't let it hold GLOBAL streaming: identity is PORT-based for serial-less devices, so a replacement modem inherits the key and must be caught as `recommission-pending`, while a destroyed modem must never strand the remaining links.
 - Don't release the `modem.reconfig` mutation lease when the handler returns — its 30 s confirm/auto-revert watchdog is still live, and that window is precisely when the modem is half-applied.
-- Don't acquire the lifecycle interlock ahead of the orchestrator's duplicate-start rejection — a second `streaming.start` would then answer a generic lease-busy refusal instead of its own `START_IN_PROGRESS`, and the duplicate is the one case the operator can act on. Don't move the acquisition into `streaming.procedure.ts` either (four other launch origins bypass it), don't default `admitLifecycle` on inside the orchestrator factory (the lease is process-wide and `bun test` is one process), and don't release by HOLDER instead of by grant token — a stale `finally` would then free whoever holds it now.
+- Don't acquire the lifecycle interlock ahead of the orchestrator's duplicate-start rejection — a second `streaming.start` would then answer a generic lease-busy refusal instead of its own `START_IN_PROGRESS`, and the duplicate is the one case the operator can act on. Don't move the acquisition into `streaming.procedure.ts` either (four other launch origins bypass it), don't default `admitLifecycle` on inside the orchestrator factory (parallel workers isolate files, not tests sharing a file's lease), and don't release by HOLDER instead of by grant token — a stale `finally` would then free whoever holds it now. Persisted fixtures additionally need per-file `mkdtemp` roots; separate workers still share the filesystem.
 - Don't move either cellular guard below `initModemUpdateLoop` in `main.ts`, and don't reorder them relative to each other — the loop's first discovery + `modems` broadcast fire immediately, and `initCellularStack` publishes `{ready:false}` synchronously, so a reordered boot puts the operator's first modem snapshot inside the window where every modem procedure refuses `CELLULAR_STACK_INITIALIZING`. Don't reclassify either as `runCritical` either: the dbus→mmcli fallback lives INSIDE the stack, so reaching the guard means the cellular subsystem is down and the device must still keep its UI.
 - Don't rewrite `buildModemsMessage` in terms of the projection, and don't delete it as dead — it is NOT on the wire (`buildModemsWireMessage` is) precisely so it can stay the independent implementation `modem-wire-projection.test.ts` asserts byte-compat against. "De-duplicating" it makes that assertion compare the projector to itself. And don't drop the fail-safe fallback: the additive fields are enrichment, the legacy ones are the operator's whole modem list.
 - Don't fabricate a `stable_key` for a modem whose `ID_PATH` did not resolve, and don't clear the id-path cache when a refresh FAILS — absence yields the pre-Phase-B wire (honest), while a cleared cache makes every row look like new hardware to a frontend correlating a USB-mode switch. Don't refresh it on the 30 s status poll either: an `ID_PATH` names where a device is plugged in, so only presence edges can move it.
@@ -9585,7 +9595,7 @@ config, an anchored path still held by its own device, and a live row with no
 - Don't resolve a persisted selection through a node path more than one remembered device answers to — `findRememberingId`'s holder-beats-alias preference picks a camera rather than proving one. Use `unambiguousStableId`, keep the refusal suppression-only (the literal id must still reach the engine), and don't "unify" it with `findRememberingId`, which correctly keeps that preference for `collectLostCandidates`.
 - Don't let the v4l2 scan's `deriveKind()` guess overwrite a kind the engine has already reported for that device, and don't clear `lastEngineVideoDevices` when a device leaves the list — a `usb` guess bridges to no pipeline, so the row is dropped and its coarse slot renders "not connected" for a device that is physically present. Don't relax the display-name gate on the restore to an `input_id`-only lookup either: node paths are recycled, and a fabricated identity is worse than a coarse one. And don't widen that restore past IDENTITY (`kind`/`stable_id`) back onto the remembered `caps`/`signal` — re-asserting a past probe's verdict is how a device that loses its signal keeps claiming it has one, forever.
 - Don't let the periodic signal recheck start a second probe while its own is still out (`signalRecheckInFlight`) — a fixed-interval loop whose probe outlives its interval supersedes ITSELF on every tick and publishes nothing at all, and a link-losing receiver is exactly what makes an enumeration slow.
-- Don't assert a GLOBAL call count on a process-wide seam like `helpers/run.ts` — `bun test` loads every file into ONE process, and background work started by an earlier file keeps issuing OS commands. `wifiUpdateDevices()` is the known offender: while any Wi-Fi adapter reads unavailable it re-arms itself every 3 s for a five-minute budget (`modules/wifi/wifi-interfaces.ts`), firing several `run("nmcli", …)` calls per pass. Filter the spy's calls to the binary under test instead (`logs-injection.test.ts`), which asserts the same property and cannot be flipped by a foreign command.
+- Don't assert a GLOBAL call count on a process-wide seam like `helpers/run.ts` — Bun's parallel mode isolates each file in a worker, but background work still outlives individual tests within that file (and serial runs can share it across files). `wifiUpdateDevices()` can re-arm every 3 s for a five-minute unavailable-adapter budget. Cancel it with `stopWifiUpdateLoopForTest()` in teardown and filter spies to the binary under test (`logs-injection.test.ts`). Filesystem fixtures need per-file `mkdtemp` roots independently of the worker model; a process boundary does not protect a shared path.
 - Don't make an address-family choice PERSISTENT. Not `/etc/apt/apt.conf`, not `gai.conf`, not a sysctl, not `disable_ipv6`, not an interface binding — a verdict about one apt run must expire with that run, or a device whose IPv6 comes back stays pinned to IPv4 by a file nothing remembers writing. The option goes on the argv, per run (see APT REACHES THE REPOSITORY OVER THE FAMILY THAT WORKS).
 - Don't match a detached apt service's argv by substring, `arrayContaining`, or a "contains the option" test. The predicate exists to refuse a foreign same-named unit, so it matches the exact flags-first prefix and admits at most one pair from a CLOSED option set; widening it to accept the new family flag by looseness rather than by enumeration is how an adopted unit stops being ours.
 - Don't stop-and-disable a service in `prerm` without gating on `$1`, and don't "simplify" `postinst`'s unconditional `systemctl enable … || true` back into a `deb-systemd-helper` conditional. The helper's `enable` is a silent no-op once its installation state exists, so on the second upgrade of a real board the old `prerm`'s disable wins and the unit never comes back — board-proven on the Rock 5B+, with both helper binaries present.

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -5970,6 +5970,21 @@ The helper's regression reproduces that state in a disposable process; do not
 replace real shell/GPG verification or Git history with mocks, or switch these
 calls back to `spawnSync`. No test or production timeout was increased.
 
+The historical source-routing Git guard requires a full checkout. At a depth-one
+boundary Git reports the checkout commit as the file's addition; its parent is
+unavailable, so `git diff <addition>^` exits 128. The guard checks exit status and
+prints stderr rather than accepting an empty failed diff. Both Build Check's
+`test-be` checkout and `publish-release.yml`'s `release-package-contracts` checkout
+use `fetch-depth: 0`, enforced by `scripts/ci/build-check-shape.test.mjs`.
+Twenty local passes are stability evidence, not a substitute for the complete
+hosted PR gate. Readiness requires every check on the current hosted run to pass.
+
+The optional-audio-codec start fixture also owns a `mkdtemp` config root through
+`setConfigFilePath`, installed before mock initialization. It must not read or
+restore a shared cwd `config.json`: a fresh checkout has none, and another file
+creating it is not a test prerequisite. Teardown restores the path and removes
+only this fixture's directory.
+
 Backend tests inject procedure launch/source dependencies through
 `setStreamingProcedureDepsForTest()` and stream-start process/telemetry/engine
 dependencies through `setStartStreamDepsForTest()`. Every test that overrides

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -5954,6 +5954,11 @@ The 2026-09-07 adoption batches finished 19/20 and 18/20, not the required
 modem-transition, and source-routing tests failed. Parallel adoption remains
 blocked; isolated passing reruns do not discharge the stability gate.
 
+The transition-engine fixture controls `Date.now()` with `setSystemTime`:
+USB enumeration cannot spend the NM-timeout case's budget through host scheduling
+delay. Only the unresolved NM reader advances time, including the failure-path
+re-probe; teardown restores the real clock. Production polling is unchanged.
+
 Backend tests inject procedure launch/source dependencies through
 `setStreamingProcedureDepsForTest()` and stream-start process/telemetry/engine
 dependencies through `setStartStreamDepsForTest()`. Every test that overrides

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -5938,8 +5938,9 @@ are gated by `shouldUseMocks()` or `isDevelopment()` — never active in product
 
 ### Backend per-file test isolation
 
-The backend `test` script remains serial. Bun 1.4.2 `bun test --parallel`
-runs files across worker processes and implies per-file isolation; it does not
+The backend `test` script runs `bun test --parallel`, adopted after five full
+smoke runs and twenty consecutive clean acceptance runs on Bun 1.4.2. It
+runs files across worker processes with per-file isolated globals; it does not
 make tests within a file concurrent. Each file writing fixtures must own a
 `mkdtemp` root and redirect the existing path seam, never use a fixed shared
 path. `sim-autounlock.test.ts` uses `setConfigFilePath()` and absolute reads
@@ -5949,10 +5950,11 @@ The transient `stream.armed.json` is ignored beside the other backend runtime
 files. Source copy/read failures remain fatal; only snapshot teardown tolerates
 `ENOENT`.
 
-The 2026-09-07 adoption batches finished 19/20 and 18/20, not the required
-20/20. Both repaired files passed throughout, but unchanged add-on helper,
-modem-transition, and source-routing tests failed. Parallel adoption remains
-blocked; isolated passing reruns do not discharge the stability gate.
+The initial 2026-09-07 adoption batches finished 19/20 and 18/20: both original
+isolation repairs passed, but add-on helper, modem-transition and source-routing
+tests exposed two more failure modes. The clock and child-command fixes below
+then passed 20/20 at default 28-worker parallelism (6,033 passed tests and two
+unchanged skips per run). No timeout was widened and no assertion was removed.
 
 The transition-engine fixture controls `Date.now()` with `setSystemTime`:
 USB enumeration cannot spend the NM-timeout case's budget through host scheduling

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -139,6 +139,13 @@ test-command helper to avoid Bun 1.4.2's GC-sensitive synchronous-loop defect
 (oven-sh/bun#40078), retaining real child execution and all existing assertions.
 See `AGENTS.md` → Backend per-file test isolation for these contracts.
 
+Run the complete suite from a full Git checkout. The historical source-routing
+guard needs the commit that introduced `sources.ts` and its parent, so a shallow
+clone cannot run that assertion. Build Check's backend job and the release/package
+contract job both fetch full history; Git failures remain test failures, never an
+empty diff. Local stability runs do not establish PR readiness: every hosted check
+on the current PR revision must succeed before the change is handed off.
+
 ## Build
 
 The backend compiles to a single self-contained binary. Architecture is controlled by `BUILD_ARCH`:

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -127,6 +127,15 @@ bun run check
 bun test
 ```
 
+The package's `test` script remains serial until the parallel stability gate
+passes. For an opt-in probe, use `bun test --parallel` on Bun 1.4.2: files run
+in isolated worker processes, but filesystem paths are still shared. Tests that
+persist fixtures must use per-file `mkdtemp` roots and the existing path setters
+(runtime config: `setConfigFilePath`). The USB-tether source fence scans its own
+temporary snapshot of tracked and new non-ignored source, excluding runtime
+markers; missing source remains an error. See `AGENTS.md` → Backend per-file
+test isolation for the outstanding adoption failures.
+
 ## Build
 
 The backend compiles to a single self-contained binary. Architecture is controlled by `BUILD_ARCH`:

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -124,17 +124,20 @@ bun run check
 ### Tests
 
 ```bash
-bun test
+bun run test
 ```
 
-The package's `test` script remains serial until the parallel stability gate
-passes. For an opt-in probe, use `bun test --parallel` on Bun 1.4.2: files run
-in isolated worker processes, but filesystem paths are still shared. Tests that
+The package's `test` script runs `bun test --parallel` on Bun 1.4.2, adopted
+after five smoke runs and twenty consecutive clean full-suite runs. Files run
+in isolated worker globals across worker processes, but filesystem paths are still shared. Tests that
 persist fixtures must use per-file `mkdtemp` roots and the existing path setters
 (runtime config: `setConfigFilePath`). The USB-tether source fence scans its own
 temporary snapshot of tracked and new non-ignored source, excluding runtime
-markers; missing source remains an error. See `AGENTS.md` → Backend per-file
-test isolation for the outstanding adoption failures.
+markers; missing source remains an error. The modem-transition fixture controls
+its polling clock. Real add-on/GPG and source-routing Git checks use an async
+test-command helper to avoid Bun 1.4.2's GC-sensitive synchronous-loop defect
+(oven-sh/bun#40078), retaining real child execution and all existing assertions.
+See `AGENTS.md` → Backend per-file test isolation for these contracts.
 
 ## Build
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -42,7 +42,7 @@
 		"dev:bt-mic-paired": "NODE_ENV=development MOCK_SCENARIO=bt-mic-paired bun --watch run src/main.ts",
 		"build": "rm -rf ../../dist/ && bash -c 'BUN_TARGET=${BUILD_ARCH:-arm64}; case $BUN_TARGET in amd64) BUN_TARGET=\"bun-linux-x64\" ;; arm64) BUN_TARGET=\"bun-linux-arm64\" ;; *) echo \"Unsupported architecture: $BUN_TARGET\"; exit 1 ;; esac; NODE_ENV=production bun build --compile --minify --sourcemap --target=$BUN_TARGET src/main.ts --outfile ../../dist/ceralive' && cd ../.. && bun run build:frontend",
 		"build:backend-only": "rm -rf ../../dist/ceralive ../../dist/deployment && bash -c 'BUN_TARGET=${BUILD_ARCH:-arm64}; case $BUN_TARGET in amd64) BUN_TARGET=\"bun-linux-x64\" ;; arm64) BUN_TARGET=\"bun-linux-arm64\" ;; *) echo \"Unsupported architecture: $BUN_TARGET\"; exit 1 ;; esac; NODE_ENV=production bun build --compile --minify --sourcemap --target=$BUN_TARGET src/main.ts --outfile ../../dist/ceralive'",
-		"test": "bun test",
+		"test": "bun test --parallel",
 		"modem-latency-harness": "bun scripts/modem-latency-harness.ts",
 		"check": "bun ../../scripts/tsc.mjs --noEmit && bash scripts/check-exec-guard.sh",
 		"check:exec-guard": "bash scripts/check-exec-guard.sh",

--- a/apps/backend/src/tests/addon-helper-script.test.ts
+++ b/apps/backend/src/tests/addon-helper-script.test.ts
@@ -24,6 +24,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { runTestCommand as sh } from "./helpers/run-test-command.ts";
 
 const HELPER = join(import.meta.dir, "..", "..", "ceralive-addon-helper");
 
@@ -38,23 +39,7 @@ let LEGIT_HOME = "";
 let ATTACKER_HOME = "";
 let KEYRING = "";
 
-function sh(
-	cmd: string[],
-	opts: { env?: Record<string, string> } = {},
-): { code: number; stdout: string; stderr: string } {
-	const proc = Bun.spawnSync(cmd, {
-		env: opts.env ? { ...process.env, ...opts.env } : process.env,
-		stdout: "pipe",
-		stderr: "pipe",
-	});
-	return {
-		code: proc.exitCode,
-		stdout: proc.stdout.toString(),
-		stderr: proc.stderr.toString(),
-	};
-}
-
-function gpgGenKey(home: string, name: string): void {
+async function gpgGenKey(home: string, name: string): Promise<void> {
 	mkdirSync(home, { recursive: true });
 	chmodSync(home, 0o700);
 	const params = join(home, "params");
@@ -62,23 +47,34 @@ function gpgGenKey(home: string, name: string): void {
 		params,
 		`%no-protection\nKey-Type: RSA\nKey-Length: 2048\nKey-Usage: sign\nName-Real: ${name}\nExpire-Date: 0\n%commit\n`,
 	);
-	const r = sh(["gpg", "--homedir", home, "--batch", "--gen-key", params]);
+	const r = await sh([
+		"gpg",
+		"--homedir",
+		home,
+		"--batch",
+		"--gen-key",
+		params,
+	]);
 	if (r.code !== 0) throw new Error(`gpg gen-key failed: ${r.stderr}`);
 }
 
-function gpgExportPub(home: string, out: string): void {
-	const proc = Bun.spawnSync(["gpg", "--homedir", home, "--export"], {
-		stdout: "pipe",
-		stderr: "pipe",
-	});
-	if (proc.exitCode !== 0) {
-		throw new Error(`gpg export failed: ${proc.stderr.toString()}`);
+async function gpgExportPub(home: string, out: string): Promise<void> {
+	const proc = await sh([
+		"gpg",
+		"--homedir",
+		home,
+		"--batch",
+		"--output",
+		out,
+		"--export",
+	]);
+	if (proc.code !== 0) {
+		throw new Error(`gpg export failed: ${proc.stderr}`);
 	}
-	writeFileSync(out, proc.stdout);
 }
 
-function gpgSign(home: string, raw: string, sig: string): void {
-	const r = sh([
+async function gpgSign(home: string, raw: string, sig: string): Promise<void> {
+	const r = await sh([
 		"gpg",
 		"--homedir",
 		home,
@@ -92,9 +88,10 @@ function gpgSign(home: string, raw: string, sig: string): void {
 	if (r.code !== 0) throw new Error(`gpg sign failed: ${r.stderr}`);
 }
 
-function sha256(file: string): string {
-	const proc = Bun.spawnSync(["sha256sum", file], { stdout: "pipe" });
-	return proc.stdout.toString().split(/\s+/)[0] ?? "";
+async function sha256(file: string): Promise<string> {
+	const proc = await sh(["sha256sum", file]);
+	if (proc.code !== 0) throw new Error(`sha256sum failed: ${proc.stderr}`);
+	return proc.stdout.split(/\s+/)[0] ?? "";
 }
 
 type Descriptor = {
@@ -135,7 +132,7 @@ type Sandbox = {
 };
 
 /** A fresh, fully wired sandbox with one baked, validly-signed `debug-toolset`. */
-function mkSandbox(): Sandbox {
+async function mkSandbox(): Promise<Sandbox> {
 	const dir = mkdtempSync(join(ROOT, "sb-"));
 	const registry = join(dir, "registry");
 	const cache = join(dir, "cache");
@@ -160,10 +157,10 @@ function mkSandbox(): Sandbox {
 	// A baked, validly-signed add-on with units to exercise the lifecycle.
 	const raw = join(cache, "debug-toolset.raw");
 	writeFileSync(raw, "SYSEXT-RAW-debug-toolset-v1");
-	gpgSign(LEGIT_HOME, raw, `${raw}.sig`);
+	await gpgSign(LEGIT_HOME, raw, `${raw}.sig`);
 	writeDescriptor(join(registry, "debug-toolset.json"), {
 		id: "debug-toolset",
-		sha256: sha256(raw),
+		sha256: await sha256(raw),
 		units: {
 			unmask: ["debug-toolset.service"],
 			enable: ["debug-toolset.service"],
@@ -186,20 +183,20 @@ function mkSandbox(): Sandbox {
 function helper(
 	sb: Sandbox,
 	args: string[],
-): { code: number; stdout: string; stderr: string } {
+): Promise<{ code: number; stdout: string; stderr: string }> {
 	return sh([HELPER, ...args], { env: sb.env });
 }
 
-beforeAll(() => {
+beforeAll(async () => {
 	if (!HAVE_TOOLS) return;
 	ROOT = mkdtempSync(join(tmpdir(), "addon-helper-"));
 	LEGIT_HOME = join(ROOT, "gnupg-legit");
 	ATTACKER_HOME = join(ROOT, "gnupg-attacker");
 	KEYRING = join(ROOT, "addon-keyring.gpg");
-	gpgGenKey(LEGIT_HOME, "CeraLive Add-on Signing (test)");
-	gpgGenKey(ATTACKER_HOME, "Attacker (test)");
+	await gpgGenKey(LEGIT_HOME, "CeraLive Add-on Signing (test)");
+	await gpgGenKey(ATTACKER_HOME, "Attacker (test)");
 	// The baked keyring holds ONLY the legitimate public key.
-	gpgExportPub(LEGIT_HOME, KEYRING);
+	await gpgExportPub(LEGIT_HOME, KEYRING);
 });
 
 afterAll(() => {
@@ -221,8 +218,8 @@ afterAll(() => {
  */
 describe.skipIf(!HAVE_TOOLS)("ceralive-addon-helper — happy path", () => {
 	it("enable verifies + activates a baked, validly-signed add-on", async () => {
-		const sb = mkSandbox();
-		const r = helper(sb, ["enable", "debug-toolset"]);
+		const sb = await mkSandbox();
+		const r = await helper(sb, ["enable", "debug-toolset"]);
 
 		expect(r.code).toBe(0);
 		const out = JSON.parse(r.stdout) as { ok: boolean; action: string };
@@ -241,10 +238,10 @@ describe.skipIf(!HAVE_TOOLS)("ceralive-addon-helper — happy path", () => {
 	});
 
 	it("status emits JSON with the baked registry + installed flag", async () => {
-		const sb = mkSandbox();
+		const sb = await mkSandbox();
 
 		// Before enable: present in registry, not installed.
-		const before = JSON.parse(helper(sb, ["status"]).stdout) as {
+		const before = JSON.parse((await helper(sb, ["status"])).stdout) as {
 			ok: boolean;
 			addons: Array<{ id: string; installed: boolean; units: unknown }>;
 		};
@@ -253,8 +250,8 @@ describe.skipIf(!HAVE_TOOLS)("ceralive-addon-helper — happy path", () => {
 		expect(a0?.installed).toBe(false);
 
 		// After enable: installed flips true, units surfaced from the descriptor.
-		expect(helper(sb, ["enable", "debug-toolset"]).code).toBe(0);
-		const after = JSON.parse(helper(sb, ["status"]).stdout) as {
+		expect((await helper(sb, ["enable", "debug-toolset"])).code).toBe(0);
+		const after = JSON.parse((await helper(sb, ["status"])).stdout) as {
 			addons: Array<{
 				id: string;
 				installed: boolean;
@@ -267,10 +264,10 @@ describe.skipIf(!HAVE_TOOLS)("ceralive-addon-helper — happy path", () => {
 	});
 
 	it("disable reverses enable: stop/disable/mask, removes .raw, refresh", async () => {
-		const sb = mkSandbox();
-		expect(helper(sb, ["enable", "debug-toolset"]).code).toBe(0);
+		const sb = await mkSandbox();
+		expect((await helper(sb, ["enable", "debug-toolset"])).code).toBe(0);
 
-		const r = helper(sb, ["disable", "debug-toolset"]);
+		const r = await helper(sb, ["disable", "debug-toolset"]);
 		expect(r.code).toBe(0);
 		expect((JSON.parse(r.stdout) as { action: string }).action).toBe("disable");
 
@@ -282,8 +279,8 @@ describe.skipIf(!HAVE_TOOLS)("ceralive-addon-helper — happy path", () => {
 	});
 
 	it("refresh runs systemd-sysext refresh only", async () => {
-		const sb = mkSandbox();
-		const r = helper(sb, ["refresh"]);
+		const sb = await mkSandbox();
+		const r = await helper(sb, ["refresh"]);
 		expect(r.code).toBe(0);
 		expect((JSON.parse(r.stdout) as { action: string }).action).toBe("refresh");
 		expect((await Bun.file(sb.callsLog).text()).trim()).toBe("sysext refresh");
@@ -295,57 +292,57 @@ describe.skipIf(!HAVE_TOOLS)("ceralive-addon-helper — happy path", () => {
  * details on the gate and how to install required tools.
  */
 describe.skipIf(!HAVE_TOOLS)("ceralive-addon-helper — G-trust refusals", () => {
-	it("refuses an id with no baked descriptor (allowlist = baked registry only)", () => {
-		const sb = mkSandbox();
-		const r = helper(sb, ["enable", "ghost-addon"]);
+	it("refuses an id with no baked descriptor (allowlist = baked registry only)", async () => {
+		const sb = await mkSandbox();
+		const r = await helper(sb, ["enable", "ghost-addon"]);
 		expect(r.code).not.toBe(0);
 		expect(r.stderr).toMatch(/not in baked registry/);
 		// Nothing was staged.
 		expect(existsSync(join(sb.ext, "ghost-addon.raw"))).toBe(false);
 	});
 
-	it("refuses a tampered artifact (sha256 no longer matches the baked descriptor)", () => {
-		const sb = mkSandbox();
+	it("refuses a tampered artifact (sha256 no longer matches the baked descriptor)", async () => {
+		const sb = await mkSandbox();
 		// Tamper AFTER signing + hashing: the descriptor's sha256 is now stale.
 		writeFileSync(join(sb.cache, "debug-toolset.raw"), "TAMPERED-PAYLOAD");
 
-		const r = helper(sb, ["enable", "debug-toolset"]);
+		const r = await helper(sb, ["enable", "debug-toolset"]);
 		expect(r.code).not.toBe(0);
 		expect(r.stderr).toMatch(/sha256 mismatch/);
 		expect(existsSync(join(sb.ext, "debug-toolset.raw"))).toBe(false);
 	});
 
-	it("refuses a sysext-injected descriptor: a non-baked key cannot pass gpgv", () => {
-		const sb = mkSandbox();
+	it("refuses a sysext-injected descriptor: a non-baked key cannot pass gpgv", async () => {
+		const sb = await mkSandbox();
 		// Simulate an attacker who shadows a descriptor into the registry (as a
 		// merged sysext overlaying /usr could) AND supplies a matching-sha256
 		// artifact — but signs it with a key NOT in the baked keyring.
 		const evilRaw = join(sb.cache, "evil-addon.raw");
 		writeFileSync(evilRaw, "EVIL-PAYLOAD");
-		gpgSign(ATTACKER_HOME, evilRaw, `${evilRaw}.sig`);
+		await gpgSign(ATTACKER_HOME, evilRaw, `${evilRaw}.sig`);
 		writeDescriptor(join(sb.registry, "evil-addon.json"), {
 			id: "evil-addon",
-			sha256: sha256(evilRaw), // sha256 deliberately CORRECT — isolates gpg gate
+			sha256: await sha256(evilRaw), // sha256 deliberately CORRECT — isolates gpg gate
 		});
 
-		const r = helper(sb, ["enable", "evil-addon"]);
+		const r = await helper(sb, ["enable", "evil-addon"]);
 		expect(r.code).not.toBe(0);
 		expect(r.stderr).toMatch(/GPG verify failed/);
 		expect(existsSync(join(sb.ext, "evil-addon.raw"))).toBe(false);
 	});
 
-	it("refuses when the cached artifact is missing", () => {
-		const sb = mkSandbox();
+	it("refuses when the cached artifact is missing", async () => {
+		const sb = await mkSandbox();
 		rmSync(join(sb.cache, "debug-toolset.raw"));
-		const r = helper(sb, ["enable", "debug-toolset"]);
+		const r = await helper(sb, ["enable", "debug-toolset"]);
 		expect(r.code).not.toBe(0);
 		expect(r.stderr).toMatch(/artifact not present/);
 	});
 
-	it("rejects a traversal / malformed id before any filesystem access", () => {
-		const sb = mkSandbox();
+	it("rejects a traversal / malformed id before any filesystem access", async () => {
+		const sb = await mkSandbox();
 		for (const bad of ["../../etc/passwd", "Debug", "a/b", "-rf"]) {
-			const r = helper(sb, ["enable", bad]);
+			const r = await helper(sb, ["enable", bad]);
 			expect(r.code).not.toBe(0);
 			expect(r.stderr).toMatch(/invalid add-on id/);
 		}

--- a/apps/backend/src/tests/helpers/run-test-command.test.ts
+++ b/apps/backend/src/tests/helpers/run-test-command.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test";
+import { runTestCommand } from "./run-test-command.ts";
+
+test("collects both output pipes and preserves a failed command's exit status", async () => {
+	const result = await runTestCommand([
+		process.execPath,
+		"-e",
+		'process.stdout.write("o".repeat(262144)); process.stderr.write("e".repeat(262144)); process.exitCode = 7;',
+	]);
+	expect(result).toEqual({
+		code: 7,
+		stdout: "o".repeat(262144),
+		stderr: "e".repeat(262144),
+	});
+});
+
+test("collects a real child after GC poisons Bun's synchronous spawn loop", async () => {
+	const helperUrl = new URL("./run-test-command.ts", import.meta.url).href;
+	// Upstream reproducer: oven-sh/bun#40078. Keep poisoning inside a disposable VM.
+	const result = await runTestCommand(
+		[
+			process.execPath,
+			"-e",
+			`
+import { runTestCommand } from ${JSON.stringify(helperUrl)};
+globalThis.writers = [];
+const refs = [];
+for (let i = 0; i < 3; i++) {
+  const writer = Bun.stderr.writer();
+  writer.write("");
+  writer.flush();
+  globalThis.writers.push(writer);
+  refs.push(new WeakRef(writer));
+}
+await Bun.sleep(0);
+const warmup = { cmd: ["echo", "first"], stdout: "pipe", stderr: "ignore", timeout: 2000 };
+Bun.spawnSync(warmup);
+globalThis.writers = null;
+Bun.spawnSync(warmup);
+let collectedDuringCall = 0;
+for (const ref of refs) if (ref.deref() === undefined) collectedDuringCall++;
+const child = await runTestCommand(["sh", "-c", "sleep 0.3; echo second"]);
+console.log(JSON.stringify({ collectedDuringCall, ...child }));
+`,
+		],
+		{ env: { BUN_JSC_slowPathAllocsBetweenGCs: "5" } },
+	);
+	expect(result.code).toBe(0);
+	expect(JSON.parse(result.stdout)).toEqual({
+		collectedDuringCall: 3,
+		code: 0,
+		stdout: "second\n",
+		stderr: "",
+	});
+});

--- a/apps/backend/src/tests/helpers/run-test-command.ts
+++ b/apps/backend/src/tests/helpers/run-test-command.ts
@@ -1,0 +1,19 @@
+export async function runTestCommand(
+	cmd: string[],
+	opts: { readonly cwd?: string; readonly env?: Record<string, string> } = {},
+): Promise<{ code: number; stdout: string; stderr: string }> {
+	// Bun 1.4.2 spawnSync can corrupt its private loop during GC (oven-sh/bun#40078).
+	await using proc = Bun.spawn(cmd, {
+		...opts,
+		env: { ...process.env, ...opts.env },
+		stdin: "ignore",
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr, code] = await Promise.all([
+		proc.stdout.text(),
+		proc.stderr.text(),
+		proc.exited,
+	]);
+	return { code, stdout, stderr };
+}

--- a/apps/backend/src/tests/modem-transition-engine.test.ts
+++ b/apps/backend/src/tests/modem-transition-engine.test.ts
@@ -11,7 +11,14 @@
  * engine would: an AT `OK` proves nothing, and a device that answers `OK` and
  * re-enumerates as the WRONG thing has to fail. Both are asserted.
  */
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	setSystemTime,
+	test,
+} from "bun:test";
 
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -205,6 +212,8 @@ function useDispatch(
 }
 
 beforeEach(async () => {
+	// Both polling layers read Date.now(); only the fixture may advance them.
+	setSystemTime(new Date(1_000));
 	dir = await mkdtemp(join(tmpdir(), "ceraui-transition-engine-"));
 	setMutationJournalDeps({
 		fs: defaultMutationJournalFs,
@@ -219,6 +228,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+	setSystemTime();
 	resetUsbModeDispatchDeps();
 	resetMutationJournalDeps();
 	resetMutationCaptureDeps();
@@ -314,11 +324,22 @@ describe("the full gate chain with the engine wired", () => {
 
 	test("an NM interface that never appears times out and keeps the rollback armed", async () => {
 		const bus = scriptedBus(MBIM_IFACES, undefined);
+		const activated: string[] = [];
+		let resolutionAttempts = 0;
 		useDispatch({
 			createEngine: (identity) =>
 				createTransitionEngine(
 					{ stableKey: identity.stableKey, ports: identity.ports },
-					engineDeps(bus, [], () => Promise.resolve(undefined), 15),
+					engineDeps(
+						bus,
+						activated,
+						() => {
+							resolutionAttempts += 1;
+							setSystemTime(new Date(Date.now() + 1));
+							return Promise.resolve(undefined);
+						},
+						15,
+					),
 				),
 		});
 
@@ -341,6 +362,9 @@ describe("the full gate chain with the engine wired", () => {
 		expect(entry?.detail).toContain(
 			"post-switch NetworkManager interface did not resolve within 15ms",
 		);
+		// The transaction re-probes once after failure, spending the same NM bound.
+		expect(resolutionAttempts).toBe(30);
+		expect(activated).toEqual([]);
 	});
 
 	test("an OK that re-enumerates as the WRONG thing FAILS and stays blocked", async () => {

--- a/apps/backend/src/tests/sim-autounlock.test.ts
+++ b/apps/backend/src/tests/sim-autounlock.test.ts
@@ -18,7 +18,6 @@
 
 import {
 	afterAll,
-	afterEach,
 	beforeAll,
 	beforeEach,
 	describe,
@@ -30,6 +29,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { runtimeConfigSchema } from "../helpers/config-schemas.ts";
+import { getConfigFilePath, setConfigFilePath } from "../modules/config.ts";
 import type { SimUnlockResult } from "../modules/modems/mmcli.ts";
 import {
 	type LockedModem,
@@ -44,14 +44,17 @@ import {
 } from "../modules/modems/sim-secrets.ts";
 
 const ORIGINAL_RUN_DIR = process.env.CERALIVE_RUN_DIR;
-const ORIGINAL_CWD = process.cwd();
+const ORIGINAL_CONFIG_PATH = getConfigFilePath();
 const RUN_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "ceralive-sim-"));
+const CONFIG_PATH = path.join(RUN_DIR, "config.json");
 
 beforeAll(() => {
 	process.env.CERALIVE_RUN_DIR = RUN_DIR;
+	setConfigFilePath(CONFIG_PATH);
 });
 
 afterAll(() => {
+	setConfigFilePath(ORIGINAL_CONFIG_PATH);
 	fs.rmSync(RUN_DIR, { recursive: true, force: true });
 	if (ORIGINAL_RUN_DIR === undefined) {
 		delete process.env.CERALIVE_RUN_DIR;
@@ -66,12 +69,7 @@ beforeEach(() => {
 		fs.rmSync(path.join(RUN_DIR, entry), { recursive: true, force: true });
 	}
 	// Parallel workers must not supply or mutate this test's config snapshot.
-	process.chdir(RUN_DIR);
-	fs.writeFileSync("config.json", '{"max_br":5000}\n');
-});
-
-afterEach(() => {
-	process.chdir(ORIGINAL_CWD);
+	fs.writeFileSync(CONFIG_PATH, '{"max_br":5000}\n');
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -87,11 +85,9 @@ describe("sim-secrets store", () => {
 	});
 
 	it("stores an opted-in PIN to a 0600 tmpfs file, leaving config.json unchanged", async () => {
-		// The on-disk config.json (cwd) is the persisted runtime config — capture
+		// The injected config.json is the persisted runtime config — capture
 		// its exact bytes so we can prove the PIN write never touches it.
-		const configBefore = fs.existsSync("config.json")
-			? fs.readFileSync("config.json", "utf8")
-			: null;
+		const configBefore = fs.readFileSync(getConfigFilePath(), "utf8");
 
 		await storeSimPin("1234");
 
@@ -108,14 +104,10 @@ describe("sim-secrets store", () => {
 		const mode = fs.statSync(secretPath).mode & 0o777;
 		expect(mode).toBe(0o600);
 
-		const configAfter = fs.existsSync("config.json")
-			? fs.readFileSync("config.json", "utf8")
-			: null;
+		const configAfter = fs.readFileSync(getConfigFilePath(), "utf8");
 		expect(configAfter).toBe(configBefore);
 		// And config.json gained no PIN field.
-		if (configAfter !== null) {
-			expect(JSON.parse(configAfter)).not.toHaveProperty("simPin");
-		}
+		expect(JSON.parse(configAfter)).not.toHaveProperty("simPin");
 	});
 
 	it("round-trips load and clears idempotently", async () => {

--- a/apps/backend/src/tests/sources.test.ts
+++ b/apps/backend/src/tests/sources.test.ts
@@ -660,7 +660,7 @@ describe("engine-device cache", () => {
 describe("source routing stays isolated from cerastream-backend.ts", () => {
 	async function git(args: string[], cwd: string): Promise<string> {
 		const proc = await runTestCommand(["git", "--no-pager", ...args], { cwd });
-		expect(proc.code).toBe(0);
+		expect(proc.code, `git ${args.join(" ")}: ${proc.stderr}`).toBe(0);
 		return proc.stdout;
 	}
 

--- a/apps/backend/src/tests/sources.test.ts
+++ b/apps/backend/src/tests/sources.test.ts
@@ -23,6 +23,7 @@ import {
 	SOURCE_UNAVAILABLE_ERROR,
 	UNKNOWN_SOURCE_ERROR,
 } from "../modules/streaming/sources.ts";
+import { runTestCommand } from "./helpers/run-test-command.ts";
 
 type CapabilitySource = GetCapabilitiesResult["sources"][number];
 
@@ -657,15 +658,15 @@ describe("engine-device cache", () => {
 });
 
 describe("source routing stays isolated from cerastream-backend.ts", () => {
-	function git(args: string[], cwd: string): string {
-		const proc = Bun.spawnSync(["git", ...args], { cwd });
-		return new TextDecoder().decode(proc.stdout);
+	async function git(args: string[], cwd: string): Promise<string> {
+		const proc = await runTestCommand(["git", "--no-pager", ...args], { cwd });
+		expect(proc.code).toBe(0);
+		return proc.stdout;
 	}
 
-	it("Todo 26 lifecycle changes do not import or rebuild source routing", () => {
-		const repoRoot = git(
-			["rev-parse", "--show-toplevel"],
-			process.cwd(),
+	it("Todo 26 lifecycle changes do not import or rebuild source routing", async () => {
+		const repoRoot = (
+			await git(["rev-parse", "--show-toplevel"], process.cwd())
 		).trim();
 		expect(repoRoot.length).toBeGreaterThan(0);
 
@@ -676,13 +677,17 @@ describe("source routing stays isolated from cerastream-backend.ts", () => {
 		// baseline = the commit that ADDED sources.ts, minus one (this todo's parent
 		// tree). Before that commit exists (initial local run), sources.ts is
 		// untracked, so fall back to HEAD (working-tree vs the last commit).
-		const addCommit = git(
-			["log", "--diff-filter=A", "--format=%H", "-1", "--", SOURCES_REL],
-			repoRoot,
+		const addCommit = (
+			await git(
+				["log", "--diff-filter=A", "--format=%H", "-1", "--", SOURCES_REL],
+				repoRoot,
+			)
 		).trim();
 		const baseline = addCommit.length > 0 ? `${addCommit}^` : "HEAD";
 
-		const diff = git(["diff", baseline, "--", BACKEND_REL], repoRoot).trim();
+		const diff = (
+			await git(["diff", baseline, "--", BACKEND_REL], repoRoot)
+		).trim();
 		// The guard's scope is the START ASSEMBLY routing (buildStartParams /
 		// encodeInputAudioFields) and the no-sources-import rule — not whole-file
 		// byte-equality. Telemetry reads like extractActiveEncode evolve

--- a/apps/backend/src/tests/streaming-start-optional-acodec.test.ts
+++ b/apps/backend/src/tests/streaming-start-optional-acodec.test.ts
@@ -7,12 +7,19 @@ import {
 	test,
 } from "bun:test";
 
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
 	type GetCapabilitiesResult,
 	SCHEMA_VERSION,
 } from "@ceralive/cerastream";
 import { initMockService, stopMockService } from "../mocks/mock-service.ts";
-import { getConfig } from "../modules/config.ts";
+import {
+	getConfig,
+	getConfigFilePath,
+	setConfigFilePath,
+} from "../modules/config.ts";
 import {
 	initPipelines,
 	setMockHardware,
@@ -42,10 +49,13 @@ const CAPS: GetCapabilitiesResult = {
 };
 
 const savedMockMode = process.env.MOCK_MODE;
+const savedConfigPath = getConfigFilePath();
 let previousConfig: ReturnType<typeof getConfig>;
-let configFile = "";
+let configRoot: string | undefined;
 
 beforeAll(async () => {
+	configRoot = await mkdtemp(join(tmpdir(), "ceraui-optional-acodec-"));
+	setConfigFilePath(join(configRoot, "config.json"));
 	process.env.MOCK_MODE = "true";
 	initMockService("caps-full");
 	setMockHardware("rk3588");
@@ -58,9 +68,8 @@ beforeAll(async () => {
 	});
 });
 
-beforeEach(async () => {
+beforeEach(() => {
 	previousConfig = structuredClone(getConfig());
-	configFile = await Bun.file("config.json").text();
 	Object.assign(getConfig(), {
 		delay: 0,
 		pipeline: "hdmi",
@@ -75,17 +84,22 @@ beforeEach(async () => {
 	});
 });
 
-afterEach(async () => {
+afterEach(() => {
 	Object.assign(getConfig(), previousConfig);
-	await Bun.write("config.json", configFile);
 });
 
 afterAll(async () => {
-	stopMockService();
-	setMockHardware("rk3588");
-	await initPipelines();
-	if (savedMockMode === undefined) delete process.env.MOCK_MODE;
-	else process.env.MOCK_MODE = savedMockMode;
+	try {
+		stopMockService();
+		setMockHardware("rk3588");
+		await initPipelines();
+	} finally {
+		if (savedMockMode === undefined) delete process.env.MOCK_MODE;
+		else process.env.MOCK_MODE = savedMockMode;
+		setConfigFilePath(savedConfigPath);
+		if (configRoot !== undefined)
+			await rm(configRoot, { recursive: true, force: true });
+	}
 });
 
 test("empty start input leaves an omitted optional audio codec to the engine default", async () => {

--- a/apps/backend/src/tests/usb-tether-fence.test.ts
+++ b/apps/backend/src/tests/usb-tether-fence.test.ts
@@ -19,13 +19,34 @@
  * where it has to be argued.
  */
 
-import { describe, expect, it } from "bun:test";
-import { readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import {
+	copyFileSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+} from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 
 import { CERTIFIED_CATALOG } from "@ceralive/modem-control";
 
 const REPO_ROOT = join(import.meta.dir, "..", "..", "..", "..");
+const SCAN_ROOT = mkdtempSync(join(tmpdir(), "ceraui-usb-fence-"));
+
+afterAll(async () => {
+	try {
+		await rm(SCAN_ROOT, { recursive: true });
+	} catch (error) {
+		if (
+			!(error instanceof Error && "code" in error && error.code === "ENOENT")
+		) {
+			throw error;
+		}
+	}
+});
 
 /**
  * The files allowed to name the verb in EXECUTABLE code, because naming it is
@@ -115,14 +136,37 @@ function stripComments(source: string): string {
 		.join("\n");
 }
 
-const FILES = collectFiles(REPO_ROOT);
+let FILES: string[] = [];
+
+beforeAll(() => {
+	// Snapshot working-tree source, including new files, but not ignored runtime
+	// state that other workers create/remove (notably stream.armed.json).
+	const inventory = Bun.spawnSync(
+		["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
+		{
+			cwd: REPO_ROOT,
+		},
+	);
+	expect(inventory.exitCode, inventory.stderr.toString()).toBe(0);
+	for (const relative of inventory.stdout
+		.toString()
+		.split("\0")
+		.filter(Boolean)) {
+		if (relative.split("/").some((part) => SKIP_DIRS.has(part))) continue;
+		if (!SCANNED_EXTENSIONS.some((ext) => relative.endsWith(ext))) continue;
+		const target = join(SCAN_ROOT, relative);
+		mkdirSync(dirname(target), { recursive: true });
+		copyFileSync(join(REPO_ROOT, relative), target);
+	}
+	FILES = collectFiles(SCAN_ROOT);
+});
 
 describe("the UFI usb-tether write is absent from every surface, permanently", () => {
 	it("scans the whole repo, not a subdirectory of it", () => {
 		// Guards the gate itself: a moved root or an over-broad skip list would
 		// otherwise make every assertion below pass vacuously.
 		expect(FILES.length).toBeGreaterThan(500);
-		const relative = FILES.map((path) => path.slice(REPO_ROOT.length + 1));
+		const relative = FILES.map((path) => path.slice(SCAN_ROOT.length + 1));
 		for (const surface of [
 			"apps/backend/src/rpc/procedures/modems.procedure.ts",
 			"apps/frontend/src/main/dialogs/ModemConfigDialog.svelte",
@@ -134,6 +178,7 @@ describe("the UFI usb-tether write is absent from every surface, permanently", (
 			relative.some((path) => path.startsWith("apps/frontend/tests/e2e/")),
 			"the e2e suite must be in scan scope",
 		).toBe(true);
+		expect(relative).not.toContain("apps/backend/stream.armed.json");
 		expect(
 			relative.some((path) => path.startsWith(".github/workflows/")),
 			"CI automation must be in scan scope",
@@ -143,7 +188,7 @@ describe("the UFI usb-tether write is absent from every surface, permanently", (
 	it("appears in NO catalog, RPC, UI, test or automation file", () => {
 		const offenders = FILES.filter((path) =>
 			FORBIDDEN.test(stripComments(readFileSync(path, "utf8"))),
-		).map((path) => path.slice(REPO_ROOT.length + 1));
+		).map((path) => path.slice(SCAN_ROOT.length + 1));
 
 		expect(offenders).toEqual([]);
 	});

--- a/scripts/ci/build-check-shape.test.mjs
+++ b/scripts/ci/build-check-shape.test.mjs
@@ -9,6 +9,24 @@ import { assertBuildCheckContract } from './build-check-contract.mjs';
 const workflowUrl = new URL('../../.github/workflows/build-check.yml', import.meta.url);
 const workflowSource = await file(workflowUrl).text();
 const repoRoot = new URL('../../', import.meta.url).pathname;
+for (const filename of ['build-check.yml', 'publish-release.yml']) {
+	test(`${filename} supplies full history to every backend unit-test job`, async () => {
+		const source = await file(
+			new URL(`../../.github/workflows/${filename}`, import.meta.url),
+		).text();
+		const workflow = YAML.parse(source);
+		const backendJobs = Object.values(workflow.jobs).filter((job) =>
+			job.steps?.some((step) => String(step.run ?? '').includes('bun run --filter backend test')),
+		);
+		expect(backendJobs.length).toBeGreaterThan(0);
+		for (const job of backendJobs) {
+			const checkouts = job.steps.filter((step) => step.uses?.startsWith('actions/checkout@'));
+			expect(checkouts).toHaveLength(1);
+			expect(checkouts[0].with?.['fetch-depth']).toBe(0);
+		}
+	});
+}
+
 test('every Build Check Bun runner matches the workspace runtime pin', async () => {
 	// Given the workspace runtime and every job in the merged workflow
 	const { packageManager } = await file(new URL('../../package.json', import.meta.url)).json();


### PR DESCRIPTION
**Affected repo & language:** CeraUI backend tests, TypeScript

**Hosted gate confirmed green at `a52617b5`:**
[run 34173970092](https://github.com/CERALIVE/CeraUI/actions/runs/34173970092)
completed with all 17 GitHub Actions jobs successful, including backend, all
frontend/E2E lanes, both builds and the terminal summary. `gh pr checks --watch`
returned success; all 18 listed checks report pass (CodeRabbit's entry reports
automatic reviews disabled, not a code-review approval).
The earlier readiness claim was premature: run 34171621189 failed the backend
and summary jobs. That failed run remains recorded; local 20/20 was never a
substitute for the new hosted pass.

## What

- Preserve the SIM fixture's private config-path fix and the USB-tether fence's private source snapshot.
- Control the modem-transition fixture's clock so its NM-timeout case cannot accidentally expire the preceding USB-enumeration poll under host contention.
- Run the add-on helper/GPG commands and historical source-routing Git checks through an async test-command helper that drains both pipes and observes exit, with scoped disposal.
- Enable `bun test --parallel` in the backend package only after five clean smoke runs and twenty consecutive clean full-suite runs.
- Fetch full history in both CI jobs that run backend tests, enforced by workflow regressions; retain the historical Git assertion and include stderr on failure.
- Isolate the optional-audio-codec fixture's config path so a fresh checkout does not depend on another test creating `config.json`.

## Why

Worker isolation does not isolate filesystem paths. The original fixes retain per-file temporary roots and the existing config path setter; missing source still fails, and only snapshot teardown tolerates ENOENT.

The modem test had two nested real-clock polling deadlines. A temporary 25ms delay on its scripted empty USB snapshot reproduced the exact wrong error: `device did not re-enumerate within 15ms`, before the intended NM-interface timeout could run. A controlled `Date.now()` clock passes the same delayed fixture; only the unresolved NM reader advances it, and teardown restores real time. Production polling is unchanged.

The child timeouts match Bun 1.4.2's GC-sensitive synchronous-loop accounting defect, documented in [oven-sh/bun#40078](https://github.com/oven-sh/bun/pull/40078). Main-loop resources finalized inside `spawnSync` can decrement its private loop's poll count, stalling later children in that worker even after they exited. This explains the consecutive 5-second failures better than scheduling latency.

The reduced upstream reproducer was run locally: after collecting the same three writers, synchronous spawn twice timed out with empty stdout despite exit 0; async spawn returned the expected output in 312–331ms. The original failed worker's internal counter was not directly observed. The committed regression recreates the bad runtime state inside a disposable process, then exercises the async helper. Temporarily switching only that child back to synchronous execution makes the output assertion fail.

Real shell execution, signing, GPGV verification, hashing and Git history remain—not mocks. A second helper regression drains 256KiB from each output pipe and preserves exit 7. Git commands additionally assert successful exit before their output is trusted.

## How to verify

### Hosted failure correction

The 26.35ms failure was `git diff` exiting **128**, not a timeout. Build Check
checked out merge `f5500d9` at depth one. Git therefore treated that boundary as
the commit that added `sources.ts`, then could not resolve `<addition>^`.
The newly added exit-code assertion exposed the old helper's false green:
previously it ignored the error and checked an empty diff.

An exact depth-one checkout of that hosted merge reproduces the unchanged test
failure in 4.39ms. Fetching the missing history, without changing HEAD or source,
makes the same test pass and resolves the real addition commit `3a6fb08`.
Both Build Check's backend checkout and the release/package-contract checkout now
use `fetch-depth: 0`; two new workflow tests failed on the old configurations and
the complete shape suite now passes 80 tests. No assertion was weakened.

The fresh-checkout full-suite probe separately exposed the optional-codec fixture
reading an absent shared `config.json`. It now uses a private temporary config root
and restores the path during teardown; its original assertions pass from an empty
cwd. The updated local full backend suite passes, and the entire new hosted run
34173970092 is now successful.

With Bun 1.4.2 installed, from the repository root:

```sh
bunx biome check apps/backend
bun run test:build-check-shape
bun run --filter backend check
BUILD_ARCH=amd64 bun run --filter backend build:backend-only
```

From `apps/backend`:

```sh
bun run test
for i in $(seq 1 20); do bun test --parallel || echo FAIL-$i; done
```

**Local acceptance: 20/20**, following **5/5 smoke** runs, at default 28-worker parallelism. Every acceptance run: **6,033 pass, 2 unchanged skips, 0 failures; 6,035 tests across 462 files**. Durations: 18.24–24.70 seconds. No `FAIL-N` or dangling-process markers, no retries, filtering, timeout override or reduced worker count. The package script stayed serial until that batch finished; the final commit changes only the script and adoption documentation.

Backend lint, typecheck/exec guards, amd64 compile and changed-file LSP diagnostics passed. Four focused files passed 66 tests / 205 assertions. The full unabridged acceptance transcript is appended to the existing task-6 convergence evidence record and retained in repo-local `test-results/task6-acceptance-20.log`; smoke and RED/GREEN logs are adjacent.

The earlier 19/20 and 18/20 batches remain recorded as failures, not relabeled. The earlier SIM-only RED attempt did not reproduce that original filesystem race; its prior evidence and limitation remain intact.

## Risks

- This avoids the affected synchronous-spawn call sites; it does not patch Bun itself. The runtime pin is unchanged.
- The source fence and historical Git guard require a Git checkout. The snapshot includes tracked and new non-ignored working-tree source, excluding runtime/build artifacts.
- No production source, frontend files, Vitest configuration or board changed. No timeout increased, assertion removed or skip added.
- Frontend/browser gates were not rerun for this backend-only task. Hosted CI is separate from the local acceptance evidence; no hosted pass is claimed here.

## Checklist

- [x] Original isolation fixes preserved
- [x] Both additional failure mechanisms diagnosed with runtime evidence
- [x] Backend documentation updated
- [x] Backend lint, typecheck, build and changed-file diagnostics passed
- [x] Five clean smoke runs followed by twenty clean full parallel runs
- [x] Package script flipped only after acceptance
- [x] Existing evidence appended, not overwritten
- [x] Entire current hosted PR run is SUCCESS (34173970092, a52617b5)
