### PR TITLE
test(frontend): settle the backend health tick before injecting stream-health frames

### DIFF
--- a/apps/frontend/tests/e2e/fixtures/page-rpc.ts
+++ b/apps/frontend/tests/e2e/fixtures/page-rpc.ts
@@ -24,9 +24,19 @@ interface ServerWaiter {
 	timeout: ReturnType<typeof setTimeout>;
 }
 
+interface PushWaiter {
+	type: string;
+	resolve(): void;
+	reject(error: Error): void;
+	timeout: ReturnType<typeof setTimeout>;
+}
+
 export class PageRpc {
 	private readonly pending = new Map<string, PendingCall>();
 	private readonly serverWaiters = new Set<ServerWaiter>();
+	private readonly pushWaiters = new Set<PushWaiter>();
+	/** Broadcast types observed on the CURRENT server connection. */
+	private readonly seenPushTypes = new Set<string>();
 	private nextId = 0;
 	private server: RpcServerRoute | null = null;
 
@@ -72,6 +82,7 @@ export class PageRpc {
 		if (this.server && this.server !== server) {
 			this.rejectPending("page RPC connection replaced");
 		}
+		this.seenPushTypes.clear();
 		this.server = server;
 		for (const waiter of this.serverWaiters) {
 			clearTimeout(waiter.timeout);
@@ -83,26 +94,73 @@ export class PageRpc {
 	disconnectServer(server: RpcServerRoute): void {
 		if (this.server !== server) return;
 		this.server = null;
+		this.seenPushTypes.clear();
 		this.rejectPending("page RPC connection closed");
 	}
 
 	acceptServerMessage(message: string | Buffer): void {
 		if (typeof message !== "string") return;
-		let response: RpcResponse;
+		let envelope: RpcResponse & Record<string, unknown>;
 		try {
-			response = JSON.parse(message) as RpcResponse;
+			envelope = JSON.parse(message) as RpcResponse & Record<string, unknown>;
 		} catch {
 			return;
 		}
-		const pending = this.pending.get(response.id);
-		if (!pending) return;
-		clearTimeout(pending.timeout);
-		this.pending.delete(response.id);
-		if (response.error) {
-			pending.reject(new Error(response.error.message ?? "RPC request failed"));
-		} else {
-			pending.resolve(response.result);
+		const pending = this.pending.get(envelope.id);
+		if (!pending) {
+			this.notePushedEvent(envelope);
+			return;
 		}
+		clearTimeout(pending.timeout);
+		this.pending.delete(envelope.id);
+		if (envelope.error) {
+			pending.reject(new Error(envelope.error.message ?? "RPC request failed"));
+		} else {
+			pending.resolve(envelope.result);
+		}
+	}
+
+	private notePushedEvent(envelope: Record<string, unknown>): void {
+		// An RPC reply the app made on its own socket still reaches this route
+		// with no matching pending call. It carries an `id`; a broadcast never
+		// does, so that is the discriminator — without it a reply's `result` key
+		// would be recorded as a broadcast type.
+		if (envelope.id !== undefined) return;
+		for (const type of Object.keys(envelope)) {
+			if (type === "seq") continue;
+			this.seenPushTypes.add(type);
+			for (const waiter of [...this.pushWaiters]) {
+				if (waiter.type !== type) continue;
+				this.pushWaiters.delete(waiter);
+				clearTimeout(waiter.timeout);
+				waiter.resolve();
+			}
+		}
+	}
+
+	/**
+	 * Resolve once the backend has PUSHED a `type` broadcast on the current page
+	 * socket — immediately when one already arrived since that socket attached.
+	 *
+	 * A broadcast envelope is `{ [type]: data, seq }` with no request id, so
+	 * `acceptServerMessage` has nothing to correlate it with and drops it. This is
+	 * the opt-in seam for a spec that must order its own `dev.emit` injections
+	 * against a SERVER-INITIATED frame.
+	 */
+	waitForPushedEvent(type: string, timeoutMs = 15_000): Promise<void> {
+		if (this.seenPushTypes.has(type)) return Promise.resolve();
+		return new Promise<void>((resolve, reject) => {
+			const waiter: PushWaiter = {
+				type,
+				resolve,
+				reject,
+				timeout: setTimeout(() => {
+					this.pushWaiters.delete(waiter);
+					reject(new Error(`timed out waiting for a pushed "${type}" event`));
+				}, timeoutMs),
+			};
+			this.pushWaiters.add(waiter);
+		});
 	}
 
 	private waitForServer(): Promise<RpcServerRoute> {
@@ -159,11 +217,17 @@ export class PageRpc {
 
 	close(): void {
 		this.server = null;
+		this.seenPushTypes.clear();
 		this.rejectPending("page RPC route closed");
 		for (const waiter of this.serverWaiters) {
 			clearTimeout(waiter.timeout);
 			waiter.reject(new Error("page RPC route closed"));
 		}
 		this.serverWaiters.clear();
+		for (const waiter of this.pushWaiters) {
+			clearTimeout(waiter.timeout);
+			waiter.reject(new Error("page RPC route closed"));
+		}
+		this.pushWaiters.clear();
 	}
 }

--- a/apps/frontend/tests/e2e/health-rollup.spec.ts
+++ b/apps/frontend/tests/e2e/health-rollup.spec.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import { expect, type Page } from "@playwright/test";
 
 import { test, type PageRpc } from "./fixtures/index.js";
+import { settleBackendHealthBroadcast } from "./helpers/backend-health.js";
 import { ensureAuthenticated, evidencePath, navigateTo } from "./helpers/index.js";
 
 /**
@@ -67,6 +68,12 @@ async function openHud(page: Page): Promise<void> {
 	await expect(page.getByRole("dialog", { name: "Status" })).toBeVisible();
 }
 
+async function closeHud(page: Page): Promise<void> {
+	const statusDialog = page.getByRole("dialog", { name: "Status" });
+	await statusDialog.getByRole("button", { name: "Close" }).click();
+	await expect(statusDialog).toBeHidden();
+}
+
 const evidence: string[] = [];
 function record(line: string): void {
 	evidence.push(line);
@@ -104,6 +111,7 @@ test.describe("stream-health rollup + tooltip (dev.emit driven)", () => {
 		await ensureAuthenticated(page);
 		await navigateTo(page, "live");
 		await expect(page.locator(HEALTH_INDICATOR).first()).toBeVisible({ timeout: 15_000 });
+		await settleBackendHealthBroadcast(pageRpc);
 
 		await driveHealth(page, pageRpc, "degraded");
 		await openHud(page);
@@ -135,6 +143,7 @@ test.describe("stream-health rollup + tooltip (dev.emit driven)", () => {
 		await ensureAuthenticated(page);
 		await navigateTo(page, "live");
 		await expect(page.locator(HEALTH_INDICATOR).first()).toBeVisible({ timeout: 15_000 });
+		await settleBackendHealthBroadcast(pageRpc);
 
 		// Seed healthy and pull it into the frozen snapshot via a manual refresh.
 		await driveHealth(page, pageRpc, "healthy");
@@ -151,9 +160,7 @@ test.describe("stream-health rollup + tooltip (dev.emit driven)", () => {
 		record("eink: live dot=degraded but frozen rollup HELD at healthy (Bond 2/2) — no auto-repaint ✓");
 
 		// Manual refresh is the single release path: now the rollup catches up.
-		const statusDialog = page.getByRole("dialog", { name: "Status" });
-		await statusDialog.getByRole("button", { name: "Close" }).click();
-		await expect(statusDialog).toBeHidden();
+		await closeHud(page);
 		await manualRefresh(page);
 		await openHud(page);
 		await expect(page.getByTestId("stream-health-detail")).toHaveAttribute("data-state", "degraded");
@@ -173,11 +180,11 @@ test.describe("stream-health dead-state cue (non-color, mono-legible)", () => {
 		await ensureAuthenticated(page);
 		await navigateTo(page, "live");
 		await expect(page.locator(HEALTH_INDICATOR).first()).toBeVisible({ timeout: 15_000 });
+		await settleBackendHealthBroadcast(pageRpc);
 
 		await driveHealth(page, pageRpc, "dead");
 		await manualRefresh(page);
-		await page.locator("[data-hud-region]").first().click();
-		await expect(page.getByRole("dialog", { name: "Status" })).toBeVisible();
+		await openHud(page);
 
 		const stateCell = page.getByTestId("stream-health-state");
 		await expect(page.getByTestId("stream-health-detail")).toHaveAttribute("data-state", "dead");

--- a/apps/frontend/tests/e2e/helpers/backend-health.ts
+++ b/apps/frontend/tests/e2e/helpers/backend-health.ts
@@ -1,0 +1,23 @@
+import type { PageRpc } from '../fixtures/page-rpc.js';
+
+/**
+ * Let the dev backend's OWN periodic `health` broadcast land before a spec
+ * injects one of its own.
+ *
+ * `broadcastHealthIfChanged()` (backend `modules/streaming/health.ts`) runs on
+ * the 5s heartbeat tick — right AFTER the `ping` that tick emits — and publishes
+ * only on a state TRANSITION. A worker backend boots with no last-broadcast
+ * state and its mock scenario never leaves `idle`, so it publishes EXACTLY ONE
+ * unsolicited `health: idle` frame per process. Left unaccounted for, that frame
+ * lands mid-test, replaces whatever the spec injected, and is never corrected: a
+ * `dev.emit` driver stops emitting the moment the dot settles, so every later
+ * assertion reads `idle` until the test times out.
+ *
+ * One socket delivers in order and a heartbeat tick is a synchronous block, so a
+ * `ping` the spec has observed proves that tick's `health` frame is already
+ * behind it. After it the backend can never broadcast health again (its state no
+ * longer transitions), which makes every injected frame the last word.
+ */
+export async function settleBackendHealthBroadcast(pageRpc: PageRpc): Promise<void> {
+	await pageRpc.waitForPushedEvent('ping');
+}

--- a/apps/frontend/tests/e2e/stream-health.spec.ts
+++ b/apps/frontend/tests/e2e/stream-health.spec.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import { expect, type Page } from "@playwright/test";
 
 import { test, type PageRpc } from "./fixtures/index.js";
+import { settleBackendHealthBroadcast } from "./helpers/backend-health.js";
 import { ensureAuthenticated, evidencePath, navigateTo } from "./helpers/index.js";
 
 /**
@@ -69,11 +70,11 @@ test.describe("stream-health HUD surfacing (dev.emit driven)", () => {
 
 	test.beforeEach(async ({ page, pageRpc }, testInfo) => {
 		test.skip(testInfo.project.name !== "desktop", "desktop layout exposes the persistent HUD bar");
-		void pageRpc;
 		await page.goto("/");
 		await ensureAuthenticated(page);
 		await navigateTo(page, "live");
 		await expect(healthIndicator(page)).toBeVisible({ timeout: 15_000 });
+		await settleBackendHealthBroadcast(pageRpc);
 	});
 
 	test.afterAll(() => {
@@ -125,11 +126,11 @@ test.describe("stream-health rapid flapping (failure-guard)", () => {
 
 	test.beforeEach(async ({ page, pageRpc }, testInfo) => {
 		test.skip(testInfo.project.name !== "desktop", "desktop layout exposes the persistent HUD bar");
-		void pageRpc;
 		await page.goto("/");
 		await ensureAuthenticated(page);
 		await navigateTo(page, "live");
 		await expect(healthIndicator(page)).toBeVisible({ timeout: 15_000 });
+		await settleBackendHealthBroadcast(pageRpc);
 	});
 
 	test("20 rapid transitions never crash; indicator settles on the final state", async ({ page, pageRpc }) => {


### PR DESCRIPTION
**Affected repo & language:** CeraUI — TypeScript (Playwright e2e only)

## What

Makes the two `dev.emit`-driven stream-health e2e specs wait for the device's own
periodic `health` broadcast before they inject one of their own.

Three files of test support, one new helper, no product code:

- `fixtures/page-rpc.ts` gains `waitForPushedEvent(type)`. The page-RPC route
  correlated every server frame against a pending call and dropped whatever did
  not match, so a spec had no way to observe a server-initiated broadcast at all.
- `helpers/backend-health.ts` (new) is that wait, named for what it is for.
- `stream-health.spec.ts` and `health-rollup.spec.ts` call it once in setup. Both
  already requested the `pageRpc` fixture; `stream-health.spec.ts` was discarding
  it with `void pageRpc;`.

No assertion changed. The e-ink freeze contract in `health-rollup.spec.ts` still
has to hold across a live `degraded` broadcast and still has to release on a
single manual refresh.

## Why

`main` is red. Build Check run
[34543743241](https://github.com/CERALIVE/CeraUI/actions/runs/34543743241) at
commit `6016a94a4`, job `E2E (desktop shard 1/3)`: 114 passed, 1 failed, 2 flaky.
All three failures are in `health-rollup.spec.ts` and all three are the same
shape — expected `dead`/`degraded`, read `idle`, retrying against a settled
`data-state="idle"` on `stream-health-detail`. **Re-running the failed jobs
reproduced them identically**, so this is a deterministic ordering bug that
merely looks flaky, not a random one that will clear itself.

**It is not a regression from #349.** That PR touched 69 files — `apps/backend/AGENTS.md`,
`apps/backend/README.md`, and modem capture fixtures under
`apps/backend/src/tests/fixtures/modems/` — and **zero** files under
`apps/frontend/`. `health-rollup.spec.ts` was last modified on 2026-07-13 in
`93ca1f88` (#146). The bug has been latent for two months and #349 only happened
to be the commit the window opened on.

**The mechanism.** `broadcastHealthIfChanged()` is registered as a heartbeat tick
listener, and the tick emits its `ping` and then runs its listeners in one
synchronous block — so the health frame follows the `ping` by a couple of
milliseconds. It publishes only on a state *transition*, and a worker backend
boots with no last-broadcast state while its mock scenario never leaves `idle`.
The result is exactly one unsolicited `health: idle` frame per worker process,
and then permanent silence, because the state never transitions again.

That single frame is enough. `driveHealth` re-emits only until the HUD dot
settles and then stops, so when the backend's `idle` lands after the last
injection it becomes the last word and nothing ever corrects it — every
subsequent assertion reads `idle` until the test times out.

It only reddens in a narrow band: the page must authenticate *before* the first
tick, and the test must still be running *when* it fires. CI's tests run ~10.6 s
against a 5 s tick, so CI sits squarely in that band.

The fix orders the two. One socket delivers in order and the tick is
synchronous, so a `ping` the spec has observed proves that tick's health frame is
already behind it; past that point the backend cannot speak again, which makes
every injected frame the last word.

## How to verify

**The evidence that matters** is a red/green pair on a throwaway probe that
forces the hazardous ordering instead of waiting for timing luck — drive health
to `degraded`, span one heartbeat period, assert the indicator still reads
`degraded`. Without the settle it fails; with it, it passes:

```
PROBE run 1:  ✘ PRE-FIX  Expected "degraded"  Received "idle"     ✓ POST-FIX
PROBE run 2:  ✘ PRE-FIX  Expected "degraded"  Received "idle"     ✓ POST-FIX
PROBE run 3:  ✘ PRE-FIX  Expected "degraded"  Received "idle"     ✓ POST-FIX
```

3/3 red before, 3/3 green after, reproducing the CI symptom exactly. Instrumenting
the WebSocket route to dump the frames confirms the ordering directly:

```
health idle       <- initial-state seed at auth
health degraded   <- the spec's dev.emit; dot settles, driver stops
ping              <- first heartbeat tick
health idle       <- same tick, 1 ms later, OVERWRITES the injection
ping              <- every later tick publishes nothing (no transition)
```

and with the fix in place the same run orders as `ping -> health idle -> health degraded`.

**Reproduce the green side:**

```
bun run --filter frontend test:e2e -- health-rollup.spec.ts stream-health.spec.ts --project=desktop
```

Repeat runs on this branch: 10/10 clean (0 flaky, 0 retries), plus 3 × 20 under
`--workers=8 --repeat-each=4` (60/60) to stretch each test past the tick.

**Honest limitation, stated plainly:** those repeat runs are evidence of
*no regression*, not evidence the fix works. On a 28-core host the specs finish
before the first heartbeat tick ever reaches the page — I confirmed via the frame
dump that zero pings arrived during those runs, so the failure window never
opened. The pre-fix code is green here too (8/8, and 60/60 under the same stress),
which is uninformative rather than contradictory. The forced-ordering probe above
is what covers the band CI actually lands in.

**Other gates, run on this branch:**

- `bunx biome check .` — 29 warnings / 3 infos, byte-identical to the pre-change
  baseline (stash-compared). `tests/e2e` is biome-ignored by repo config.
- `bun run --filter frontend check` — 0 errors, 0 warnings (`--fail-on-warnings`).
- `bun run --filter frontend test` — 379 files / 6274 tests passed; hardware
  preflight 4/4.

## Risks

Low, and contained to the e2e harness — no product code is touched.

- **Added wall time.** Each of the five affected tests now waits for one
  heartbeat, up to ~5.5 s (5 s ± 10 % jitter). Measured at roughly +2–3 s per
  test; the two specs run in ~29 s together on the desktop project.
- **New fixture surface.** `waitForPushedEvent` is additive — the existing
  request/response path is unchanged apart from a local rename. It is currently
  used by one helper.
- **If the wait itself hangs**, it fails at 15 s with a named message
  (`timed out waiting for a pushed "ping" event`) rather than surfacing as an
  opaque assertion timeout.
- **Rollback:** revert the four commits; they are layered fixture → helper →
  consumers and each is independently revertible.

---

**Checklist**

- [x] Docs updated if behavior or structure changed (Rule A) — n/a, test-only change with no behavioral or structural surface
- [x] Started from updated main; branch rebased on latest canonical branch (Rule B) — branched from `origin/main` at `6016a94a`
- [x] Rule D local-scratch reference check passes for tracked files — no path escapes the repo; evidence stays in the gitignored `test-results/`
- [x] Tests pass; QA evidence attached or linked — see How to verify
