### PR TITLE
fix(audio): keep the engine backend selector outside the pipeline gate

### DIFF
--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -694,20 +694,22 @@ FOUR rules carry it, and each one is a defect the module exists to prevent:
   promise is mechanically pinned by `lib/federation/host-contract.test.ts` (the
   REQUIRED set is frozen at `host`; every added member must be optional) and by the
   BUILT-bundle legs in `tests/federation/federation-abi.test.ts`.
-- **…AND THE AUDIO GATE IS ONE RULE, NOT TWO.** `hasAudioSupport` has always failed
+- **…AND THE CODEC/DELAY GATE IS ONE RULE, NOT TWO.** `hasAudioSupport` has always failed
   OPEN for a hosted mount (`hostAdapter !== undefined || gateState === 'enabled'`)
   — a federated bundle runs no `initSubscriptions()`, so `getSources()` there is
   permanently `undefined` and the pipeline gate has NO evidence to evaluate — but
   only the Save button read it. `AudioDialogContent` still read the raw
   `gateState`, so every hosted mount rendered "Select a pipeline first" beside an
-  ENABLED Save and offered no controls at all: codec, delay and the backend
-  selector alike, whatever the host passed. `contentGateState` applies the same
-  rule to the body. A DEVICE mount is byte-identical — there `hasAudioSupport` IS
-  `gateState === 'enabled'`, so the gate keeps deciding on real evidence. Do NOT
-  re-split the two, and do NOT "fix" a hosted mount by moving the selector outside
-  the gate: that would put a working control under a band telling the operator to
-  pick a pipeline first. Coverage: `AudioDialog.backend.test.ts` → the hosted
-  no-subscription leg with its DEVICE mirror control, and the built-bundle legs in
+  ENABLED Save and offered no codec or delay controls, whatever the host passed.
+  `contentGateState` applies the same rule to those controls. The backend selector
+  is deliberately OUTSIDE that gate: it changes which subsystem builds audio on
+  the NEXT start and may be the prerequisite for making that start possible, so it
+  remains reachable while codec/delay honestly show the no-pipeline or
+  no-audio-support band. Its own `audio_backends` capability remains the sole
+  visibility gate. Do NOT re-split the Save/content codec-delay gate, and do not
+  nest the backend selector beneath it again. Coverage: `AudioDialog.backend.test.ts`
+  → the hosted no-subscription leg and the device no-pipeline selector regression,
+  and the built-bundle legs in
   `tests/federation/federation-abi.test.ts`, which are what caught it (the jsdom
   tests mock the subscriptions the real bundle does not have).
 

--- a/apps/frontend/src/main/dialogs/AudioDialog.backend.test.ts
+++ b/apps/frontend/src/main/dialogs/AudioDialog.backend.test.ts
@@ -43,7 +43,7 @@ vi.mock("$lib/rpc/subscriptions.svelte", () => ({
 }));
 
 const setConfig = vi.hoisted(() =>
-	vi.fn(async () => ({ success: true, applied: {} }) as unknown),
+	vi.fn(async (_input: unknown) => ({ success: true, applied: {} }) as unknown),
 );
 vi.mock("$lib/rpc", () => ({
 	rpc: { streaming: { setConfig } },
@@ -343,9 +343,7 @@ describe("AudioDialog — the federated mount reads the host's snapshot", () => 
 		);
 	});
 
-	it("MIRROR CONTROL: a DEVICE mount with no pipeline still gates the whole dialog", () => {
-		// The fail-open is the HOSTED branch and nothing else — on a device the
-		// pipeline gate has real evidence, so it keeps deciding.
+	it("keeps the device backend selector reachable when codec and delay have no pipeline", () => {
 		seedHostedBundle();
 		state.capabilities = {
 			audio_backends: { supported: ["alsa", "pipewire"], active: "alsa" },
@@ -357,7 +355,9 @@ describe("AudioDialog — the federated mount reads the host's snapshot", () => 
 		expect(document.body.textContent).toContain(
 			m["settings.selectPipelineFirst"](),
 		);
-		expect(section()).toBeNull();
+		expect(section()).not.toBeNull();
+		expect(rung("alsa")).not.toBeNull();
+		expect(rung("pipewire")).not.toBeNull();
 	});
 
 	it("offers the host's capability even when the device subscription is empty", () => {

--- a/apps/frontend/src/main/dialogs/AudioDialog.svelte
+++ b/apps/frontend/src/main/dialogs/AudioDialog.svelte
@@ -4,15 +4,18 @@
   Scoped to ENCODING knobs only (Task 15): the audio-source SELECTION now lives
   exclusively in the unified Source section (`SourceSection.svelte`, the sole
   `asrc` writer). This dialog is a read-only CONSUMER of the active audio source
-  and owns just two controls:
+  and owns three controls:
     • Audio codec  — Select (aac / opus) over the device-supported codecs.
     • Audio delay  — center-zero slider, bounds driven by
                      `streamingConstraints.audioDelay.{min,max}` (no literals).
+    • Audio backend — independent next-start selector, capability-gated and
+                      available even when codec/delay lack a pipeline.
 
   Above them a READ-ONLY line surfaces the active audio source (device label or
   the embedded-stream state) with a "change it in the Source section" hint — the
   operator changes the source there, not here. The `hasAudioSupport` gate (from
-  `resolveAudioGateState`) is preserved verbatim.
+  `resolveAudioGateState`) applies only to codec/delay; backend visibility follows
+  the engine's independent `audio_backends` capability.
 
   Persistence: Save persists the audio fields via `rpc.streaming.setConfig`
   (no stream restart) and also commits them optimistically to the caller via

--- a/apps/frontend/src/main/dialogs/audio/AudioDialogContent.svelte
+++ b/apps/frontend/src/main/dialogs/audio/AudioDialogContent.svelte
@@ -70,6 +70,7 @@ const backendDisabledReason = $derived(
 );
 </script>
 
+<div class="space-y-5">
 {#if gateState === 'no-pipeline'}
 	<div class="bg-muted/50 flex flex-col items-center gap-3 rounded-lg px-4 py-5 text-center">
 		<p class="text-muted-foreground text-sm">{m["settings.selectPipelineFirst"]()}</p>
@@ -126,16 +127,18 @@ const backendDisabledReason = $derived(
 			</Select.Root>
 		</div>
 		<AudioDelayControl value={draftDelay} min={delayMin} max={delayMax} step={delayStep} onChange={onDelayChange} />
+	</div>
+{/if}
 
-		<!-- Engine audio backend. Last, behind a rule: codec and delay are what an
-		     operator opens this dialog to change; which subsystem builds the audio
-		     path is a platform decision they visit rarely. It writes on selection
-		     (its own setConfig), so it is deliberately NOT behind the dialog's Save
-		     button — that button commits the codec/delay DRAFT, and folding a
-		     next-session platform switch into it would make one press mean two
-		     unrelated things. -->
-		{#if showBackend && backendView}
-			<div class="space-y-2 border-t pt-4" data-testid="audio-backend">
+	<!-- Engine audio backend. Last, behind a rule: codec and delay are what an
+	     operator opens this dialog to change; which subsystem builds the audio
+	     path is a platform decision they visit rarely. It writes on selection
+	     (its own setConfig), so it is deliberately NOT behind the dialog's Save
+	     button — that button commits the codec/delay DRAFT, and folding a
+	     next-session platform switch into it would make one press mean two
+	     unrelated things. -->
+	{#if showBackend && backendView}
+		<div class="space-y-2 border-t pt-4" data-testid="audio-backend">
 				<div class="flex items-center gap-1">
 					<Label class="text-sm font-medium">{m["settings.audioBackend.label"]()}</Label>
 					<InfoPopover
@@ -214,7 +217,6 @@ const backendDisabledReason = $derived(
 						<span>{backendError}</span>
 					</p>
 				{/if}
-			</div>
-		{/if}
-	</div>
-{/if}
+		</div>
+	{/if}
+</div>

--- a/apps/frontend/tests/e2e/audio-backend.spec.ts
+++ b/apps/frontend/tests/e2e/audio-backend.spec.ts
@@ -234,6 +234,20 @@ test.describe("Engine audio backend selector (functional)", () => {
 		await expect(dialog.getByTestId("audio-backend-alsa")).toHaveCount(0);
 		await expect(dialog.getByTestId("audio-backend-pipewire")).toHaveCount(0);
 	});
+
+	test("the selector remains reachable before a codec and delay pipeline is selected", async ({
+		page,
+	}) => {
+		baseConfig({ pipeline: undefined });
+		sendSources();
+		sendCapabilities({ supported: ["alsa", "pipewire"], active: "alsa" });
+
+		const dialog = await openAudioDialog(page);
+		await expect(dialog).toContainText("Please select a video source first");
+		await expect(dialog.getByTestId("audio-backend")).toBeVisible();
+		await expect(dialog.getByTestId("audio-backend-alsa")).toBeVisible();
+		await expect(dialog.getByTestId("audio-backend-pipewire")).toBeVisible();
+	});
 });
 
 async function installProxy(page: Page, pageRpc: PageRpc): Promise<void> {


### PR DESCRIPTION
## What

Moves the engine **audio backend** selector out from under the codec/delay pipeline gate in
the Audio dialog, so it stays reachable when no pipeline is selected. Codec and delay keep
their gate and keep showing the "select a pipeline first" band exactly as before.

Three things change together:

- `AudioDialogContent.svelte` — the backend block moves out of the gated `{#if}` branch into
  a sibling of it, wrapped in a shared spacing container. Its own `showBackend && backendView`
  capability check is untouched.
- `AudioDialog.svelte` / `apps/frontend/AGENTS.md` — the header comment and the module rule
  are corrected to describe three controls and two independent gates, not one gate over all
  three.
- Tests — one jsdom regression and one Playwright case now pin the selector as reachable with
  no pipeline.

## Why

The gate conflated two unrelated questions. Codec and delay are properties *of a pipeline*,
so gating them on having one is honest. The backend selector is not: it chooses which
subsystem (ALSA or PipeWire) builds the audio path on the **next** start, and its own
`audio_backends` capability already decides whether it should be visible at all.

That mattered in the one case where it hurts most. If audio is unavailable *because* the
wrong backend is active, the operator has to change the backend to make a working start
possible — and the old layout hid precisely that control behind a band telling them to pick
a pipeline first. The prerequisite was locked behind the thing it was a prerequisite for.

The previous AGENTS.md rule said not to move the selector outside the gate, on the grounds
that it would "put a working control under a band telling the operator to pick a pipeline
first". That reasoning held while the band covered the whole body. It no longer does: the
band now sits beside the codec/delay controls it actually describes, and the selector renders
as its own section. The rule is rewritten rather than quietly broken.

## How to verify

```bash
bun install --frozen-lockfile
bun run lint      # includes svelte-check — the markup restructure is the risk here
bun run test
```

Locally: `svelte-check` found 0 errors and 0 warnings; rpc 507, i18n 709, frontend 6274 and
backend 6060 tests all passed with 0 failures.

Behaviourally, with no pipeline selected and `audio_backends` advertised, the Audio dialog
should show the "select a pipeline first" band **and** a working ALSA/PipeWire selector
beneath it. With `audio_backends` absent, the selector must still not render at all — that
pre-existing case is covered by the untouched capability test above it.

## Risks

The real risk is markup, not logic: the backend block changes nesting depth, so a mis-balanced
`{#if}` would break the dialog. `svelte-check` and the jsdom suite both exercise the rendered
output and pass.

Worth flagging explicitly for review: this **inverts** one existing assertion.
`AudioDialog.backend.test.ts` previously asserted `expect(section()).toBeNull()` for a device
mount with no pipeline; it now asserts `not.toBeNull()` plus both backend rungs. That
inversion *is* the behaviour change, and it is a net tightening rather than a weakening —
that file goes 46 → 48 assertions over the same 15 tests, and the e2e spec goes 3 → 4 tests
and 25 → 29 assertions. No test is removed, skipped or loosened.

No backend, RPC or engine code is touched; the change is confined to the frontend dialog and
its docs.
