### PR TITLE
chore(types): consolidate TypeScript declarations on catalog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,7 +304,7 @@ bun run build         # compile backend binary + frontend static
 bun run test:release-package-contracts   # provenance + release graph + dispatch-input security
 BUILD_ARCH=arm64 ./scripts/build/build-debian-package.sh   # .deb for ARM64
 BUILD_ARCH=amd64 ./scripts/build/build-debian-package.sh   # .deb for AMD64
-bun run --filter backend check   # type-check backend (TS 7 via scripts/tsc.mjs) + exec guards
+bun run --filter backend check   # type-check backend via scripts/tsc.mjs + exec guards
 bun run --filter frontend test   # vitest frontend unit tests
 bun run build:frontend && bun apps/frontend/scripts/check-precache.mjs   # PWA precache-manifest gate
 ```
@@ -1033,30 +1033,21 @@ handler or CORS plugin; the Bun WebSocket adapter navigates the router and invok
 The `call()`, `oc.router()`, `oc.input()`/`oc.output()`, and error-code lookup exports used here are
 unchanged; no `adapter.ts` compatibility edit is required.
 
-### TypeScript: two majors, deliberately
+### TypeScript: one catalog
 
-| Scope | Compiler | Why |
-|-------|----------|-----|
-| workspace catalog + `apps/frontend` | **6.0.3** | `svelte-check` refuses to start on TS 7 (`bin/ts-version-check.js`); its peer range is `^5.0.0 \|\| ^6.0.0` |
-| `apps/backend`, `packages/rpc`, `packages/i18n` | **7.0.2** (direct devDep) | plain `tsc --noEmit`, no compiler-API consumer |
+The workspace catalog is the single source of truth for **TypeScript 6.0.3**.
+Every workspace package declares `"typescript": "catalog:"`, including the
+backend, RPC, and i18n packages. This makes each package's declared compiler
+equal the version Bun resolves rather than leaving an unsatisfied direct range.
 
-TypeScript 7.0 does not ship the programmatic compiler API (expected in 7.1), which is the root cause of the
-one remaining TS6 holdout above. `packages/i18n` moved onto the shared 7.0.2 devDep with the rest of the
-non-Svelte packages once the Paraglide cutover (todo 24) retired the `typesafe-i18n` generator and its
-`ts.createProgram` postinstall hook — the earlier split-TS6/TS7 arrangement for this package (a bare 6.0.3
-dep plus a `typescript-7` npm-alias `check` gate) no longer exists. The former non-blocking
-`svelte-check --tsgo` canary is retired: under Bun 1.4.2 with released `typescript@7.0.2` it reported the
-same **0 errors and 5 warnings in 4 files** as the required frontend check, so it added no independent signal.
-Revisit the frontend TS6→TS7 move when `svelte-check` accepts the TS7 peer range and the released compiler
-provides the programmatic API it consumes; do not restore an advisory native/compiler canary merely to watch
-that transition.
+TypeScript 7 remains a separate major-version migration. Do not change the
+catalog until `svelte-check` supports its peer/API surface and the migration has
+an explicit owner decision and full gate run.
 
-Because two majors coexist, **never invoke a bare `tsc`** — whichever copy hoisting left in `node_modules/.bin`
-would win, silently and differently per machine. Every typecheck goes through [`scripts/tsc.mjs`](scripts/tsc.mjs),
-which resolves the compiler from the *invoking package's own* dependency graph (`--compiler-package <name>`
-selects the alias). The Bun 1.4.2 retest resolved the current TS 7 backend and TS 6
-frontend probes correctly, but `bun tsc` remains banned: only the wrapper guarantees
-package-local compiler selection (oven-sh/bun#37152).
+Never invoke a bare `tsc`; every typecheck goes through
+[`scripts/tsc.mjs`](scripts/tsc.mjs), which resolves the compiler from the
+invoking package's dependency graph. `bun tsc` remains banned: only the wrapper
+guarantees package-local compiler selection (oven-sh/bun#37152).
 
 Fast-reload development loop (dev-sync / dev-push): [`image-building-pipeline/v2/docs/fast-reload.md`](../image-building-pipeline/v2/docs/fast-reload.md)
 
@@ -1160,11 +1151,9 @@ Four further Build Check facts, all landed 2026-08-14:
   prerelease `vitest` pin is now load-bearing for a required lane, so bumping it to
   stable 5.0 means re-confirming the same-lockfile parity counts, not just editing
   the version.
-- **The former `tsgo-canary` is retired.** Released TypeScript 7 is already the
-  native compiler, and the Bun 1.4 probe produced no diagnostics beyond the
-  required TS6 frontend check. Revisit the frontend compiler when
-  `svelte-check` supports TS7's peer/API surface; do not recreate an advisory
-  canary without a demonstrated additional signal.
+- **The former `tsgo-canary` is retired.** TypeScript 7 remains a separately
+  owned major-version migration; do not recreate an advisory canary without a
+  demonstrated additional signal.
 - **`setup-e2e` typechecks and measures before it uploads**: `bun run --filter
   frontend check` gates the build, and `bun scripts/ci/bundle-report.mjs` fails
   the job when the initial-route JS gzip set exceeds its documented budget.

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -31,7 +31,7 @@
 		"@types/ws": "^8.18.1",
 		"@types/xml2js": "^0.4.14",
 		"npm-run-all2": "^9.0.3",
-		"typescript": "^7.0.2"
+		"typescript": "catalog:"
 	},
 	"scripts": {
 		"dev": "NODE_ENV=development bun --watch run src/main.ts",

--- a/bun.lock
+++ b/bun.lock
@@ -40,7 +40,7 @@
         "@types/ws": "^8.18.1",
         "@types/xml2js": "^0.4.14",
         "npm-run-all2": "^9.0.3",
-        "typescript": "^7.0.2",
+        "typescript": "catalog:",
       },
     },
     "apps/frontend": {
@@ -97,9 +97,9 @@
       "version": "2026.6.1",
       "devDependencies": {
         "@inlang/paraglide-js": "2.24.1",
-        "@types/bun": "^1.4.1",
+        "@types/bun": "^1.4.2",
         "svelte": "^5.56.10",
-        "typescript": "^7.0.2",
+        "typescript": "catalog:",
       },
     },
     "packages/rpc": {
@@ -112,7 +112,7 @@
       },
       "devDependencies": {
         "@types/bun": "1.4.2",
-        "typescript": "^7.0.2",
+        "typescript": "catalog:",
       },
     },
   },
@@ -628,46 +628,6 @@
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@types/xml2js": ["@types/xml2js@0.4.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ=="],
-
-    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
-
-    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
-
-    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
-
-    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
-
-    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
-
-    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
-
-    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
-
-    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
-
-    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
-
-    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
-
-    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
-
-    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
-
-    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
-
-    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
-
-    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
-
-    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
-
-    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
-
-    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
-
-    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
-
-    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "@vitest/mocker": ["@vitest/mocker@5.0.0", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.31", "@vitest/spy": "5.0.0", "estree-walker": "^3.0.3", "magic-string": "^1.2.3" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA=="],
 
@@ -1565,10 +1525,6 @@
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "@ceraui/i18n/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
-
-    "@ceraui/rpc/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
-
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@rollup/pluginutils/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
@@ -1604,8 +1560,6 @@
     "@types/xml2js/@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
 
     "@vitest/mocker/magic-string": ["magic-string@1.2.3", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g=="],
-
-    "backend/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "bits-ui/runed": ["runed@0.35.1", "", { "dependencies": { "dequal": "^2.0.3", "esm-env": "^1.0.0", "lz-string": "^1.5.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "svelte": "^5.7.0" }, "optionalPeers": ["@sveltejs/kit"] }, "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q=="],
 

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -32,9 +32,9 @@
 	},
 	"devDependencies": {
 		"@inlang/paraglide-js": "2.24.1",
-		"@types/bun": "^1.4.1",
+		"@types/bun": "^1.4.2",
 		"svelte": "^5.56.10",
-		"typescript": "^7.0.2"
+		"typescript": "catalog:"
 	},
 	"keywords": [
 		"i18n",

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -32,7 +32,7 @@
 	},
 	"devDependencies": {
 		"@types/bun": "1.4.2",
-		"typescript": "^7.0.2"
+		"typescript": "catalog:"
 	},
 	"keywords": [
 		"orpc",

--- a/scripts/tsc.mjs
+++ b/scripts/tsc.mjs
@@ -1,26 +1,14 @@
 #!/usr/bin/env node
 // Run the TypeScript compiler that the INVOKING package actually depends on.
 //
-// This workspace deliberately runs two TypeScript majors side by side. TS 7 is the
-// compiler for every plain `tsc --noEmit` gate (apps/backend, packages/rpc,
-// packages/i18n). TS 6 stays the workspace catalog default because svelte-check
-// (apps/frontend) imports the CLASSIC programmatic compiler API, which TS 7.0 does
-// not ship (it is expected in 7.1): it refuses to start outright, see
-// svelte-check/bin/ts-version-check.js — "TypeScript 7 support currently requires
-// both TypeScript 7 and TypeScript 6 installed ... and requires using the --tsgo
-// ... flag".
+// The workspace catalog provides TypeScript 6.0.3 to every package. A bare `tsc`
+// resolves through PATH, so a hoisted compiler could silently differ between a
+// developer machine and CI. Resolving from the invoking package's dependency graph
+// keeps the selected compiler explicit. `bun tsc` remains banned: only this wrapper
+// guarantees package-local compiler selection (oven-sh/bun#37152).
 //
-// A bare `tsc` resolves through PATH, so whichever copy hoisting happened to leave in
-// `node_modules/.bin` wins — silently, and differently on a developer machine than in
-// CI. Resolving from the invoking package's own dependency graph makes the choice
-// explicit instead. Bun 1.4.2 — the workspace pin — resolved both current package-major
-// probes correctly, but `bun tsc` remains banned: only this wrapper guarantees
-// package-local compiler selection (oven-sh/bun#37152).
-//
-// `<pkg>/package.json` is the anchor because TS 7 ships an `exports` map that does not
-// expose `./bin/tsc`: resolving that subpath directly throws
-// ERR_PACKAGE_PATH_NOT_EXPORTED. `./package.json` is exported, and the bin sits beside
-// it.
+// `<pkg>/package.json` is the anchor because TypeScript's exports map does not expose
+// `./bin/tsc`. The package metadata is exported, and the bin sits beside it.
 //
 // `--compiler-package <name>` selects a differently-named compiler package, for a
 // package that must keep a bare `typescript` on a different major than its gate.


### PR DESCRIPTION
## What this is NOT

It is not a TypeScript upgrade. The root catalog stays at `^6.0.3`, and the lockfile resolves `typescript@6.0.3` both before and after this branch. Nothing moves to TS 7 here.

## What

`apps/backend`, `packages/i18n` and `packages/rpc` each declared `typescript: ^7.0.2` in their manifests while the lockfile resolved `6.0.3`. All three now use `catalog:`, matching what `apps/frontend` already did. One other line rides along: `packages/i18n`'s `@types/bun` goes `^1.4.1` to `^1.4.2`, which is the workspace canon pin.

## Why

`^6` and `^7` do not overlap. Those three declarations were unsatisfied by the tree that was actually installed, and nothing anywhere warned about it. So the manifests claimed one compiler and the build tested another, quietly, for as long as the lockfile held.

The failure mode that matters is the next one, not the current one: a fresh install or a CI cache miss could have resolved those manifests honestly and jumped three packages a full TypeScript major with no review and no PR. Consolidating on the catalog closes that, and it makes any deliberate move to TS 7 a single reviewable line in one file instead of four scattered ranges that have to be kept in step by hand.

## How to verify

```
bun install --frozen-lockfile     # rc=0; this is the drift the branch fixes
bun pm ls | grep typescript       # resolves 6.0.3
bun run lint                      # biome, 2041 files
bun run check                     # svelte-check: 0 errors, 0 warnings
bun test                          # 6076 pass
```

The `--frozen-lockfile` run is the interesting one. It is the check that would have caught this in the first place, and it is green here.

## Risks

Low. Declaration only, no source changes.

One thing a reviewer should note rather than wave through: root `typescript` appears in **both** `devDependencies` and the catalog. Those two agree today. They are still a duplication that has to stay intentionally synced, and the same class of silent divergence this PR fixes could reopen there if someone edits one and not the other.

---

**Checklist**

- [x] Docs updated if behavior or structure changed (Rule A)
- [x] Started from updated main; branch rebased on latest `main` (Rule B)
- [x] Rule D local-scratch reference check passes for tracked files
- [x] Tests pass; gate evidence above
